### PR TITLE
[docs] Hackathon coding rules — minimal tests + env var simplicity

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,7 +23,8 @@ CONVEX_URL=
 ANTHROPIC_API_KEY=
 
 # --- World mini app (server-side World ID verify, webhook secret) ---
-WORLD_ID_APP_ID=
+# Server-side base name; browser variant is VITE_WORLD_APP_ID below. ONE concept.
+WORLD_APP_ID=
 
 # --- Tick + heartbeat ---
 TICK_DURATION_MS=20000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,14 @@ Submission 1 is a thin wrapper — MiniKit + idkit are listed as deps and mentio
 - All 3 local reviewers (Claude subagent → Codex → Gemini flash) must be GREEN before opening a PR. Cloud is a single sanity pass per the cloud-thrift policy.
 - Full rules: `docs/conventions/gitflow.md`.
 
-## 4. Integration Boundaries (the contract)
+## 4. Hackathon Coding Rules
+
+Hackathon time is the bottleneck. Two rules override default coding instincts. Full rationale + examples: `docs/conventions/hackathon-rules.md`.
+
+- **Minimal tests only.** Happy-path + a few important error cases. NO regression tests, exhaustive coverage, edge-case spam, or "test for completeness" suites. A failing happy-path test is the only kind that should block a PR. Applies to vitest, playwright, forge test in any package.
+- **Env var simplicity.** ONE env var per concept, with sensible defaults. NO duplicate env vars for the same value. NO backwards-compat shims when renaming/upgrading — this codebase has no production users yet, break things freely. Minimum config to deploy. Applies to `.env.template`, every adapter factory, every config file.
+
+## 5. Integration Boundaries (the contract)
 
 Every parallel stream talks to its dependencies through one of four adapter interfaces in `packages/shared/src/adapters/`. Stubs and reals coexist; the factory chooses based on env vars.
 
@@ -52,7 +59,7 @@ Every parallel stream talks to its dependencies through one of four adapter inte
 
 Pattern + worked example: `docs/conventions/adapter-interfaces.md`.
 
-## 5. Validated Architecture Decisions
+## 6. Validated Architecture Decisions
 
 Per `docs/planning/V1/07 clanworld_v4_5_alignment_addendum.md` (authoritative; supersedes prior specs).
 
@@ -69,7 +76,7 @@ Per `docs/planning/V1/07 clanworld_v4_5_alignment_addendum.md` (authoritative; s
 
 Full extraction: `docs/reference/architecture-decisions.md`.
 
-## 6. Environment & Secrets
+## 7. Environment & Secrets
 
 - `.env.template` at repo root lists every variable the system reads.
 - Copy to `.env.local` (gitignored) and fill values. Never commit real secrets.
@@ -77,7 +84,7 @@ Full extraction: `docs/reference/architecture-decisions.md`.
 - Two-wallet model for Submission 2: agent wallets hold no real funds; treasury wallet is offline-signed only.
 - For the do-box / shared host: per-package OAuth via Claude Code session, not API keys (per `~/claudes-world` ADR 0013).
 
-## 7. Progressive Discovery Index
+## 8. Progressive Discovery Index
 
 Start at the package-level `AGENTS.md` for whatever you're touching, then dive into `docs/` only when you need the deeper context.
 
@@ -108,7 +115,7 @@ Start at the package-level `AGENTS.md` for whatever you're touching, then dive i
 
 **Build plan:** `BUILD_PLAN.md` (Submission 1 hour-by-hour). Submission 2 plan written when S1 ships.
 
-## 8. PR / Code Review
+## 9. PR / Code Review
 
 - One PR per issue. PR body must include `Closes #N`.
 - Run the local 3-tier swarm before opening the PR (Claude subagent + Codex + Gemini flash). All three GREEN.
@@ -116,7 +123,7 @@ Start at the package-level `AGENTS.md` for whatever you're touching, then dive i
 - Conventional commit messages, scope tagged: `feat(scope): …`, `fix(scope): …`, `docs(scope): …`, `chore(scope): …`.
 - Hackathon discipline: speed > polish, but every gate commit must be on a branch that builds and typechecks.
 
-## 9. Security
+## 10. Security
 
 - **No real funds in agent wallets.** Agents transact with testnet faucet funds only.
 - **Two-wallet model (S2):** treasury wallet for high-value ops is offline-signed; agent wallets are hot but capped.

--- a/BUILD_PLAN.md
+++ b/BUILD_PLAN.md
@@ -118,6 +118,8 @@ If `Gate 4 (soft)` hasn't fired by H5:
 
 - **Time-box every task.** If a task takes >25 min over its slot estimate, **cut and use the stub.**
 - **Commit at every gate.** Even partial work — branches must build.
+- **Minimal tests only.** Happy-path + a few important error cases. No regression suites, no coverage chasing. Full rule: `docs/conventions/hackathon-rules.md`.
+- **Env var simplicity.** ONE env var per concept, sensible defaults, no duplicates, no backwards-compat shims. Full rule: `docs/conventions/hackathon-rules.md`.
 - **Cut if behind** (priority order):
   1. Real Elders → mock Elders (orchestrator emits canned orders).
   2. Pixi sprites → SVG region polygons only.

--- a/docs/conventions/hackathon-rules.md
+++ b/docs/conventions/hackathon-rules.md
@@ -1,0 +1,122 @@
+# Hackathon Coding Rules
+
+These two rules override default "good engineering" instincts for the duration of the hackathon (Submission 1 — 2026-04-26, Submission 2 — 2026-05-05). Hackathon time is the bottleneck. After Submission 2 ships and the codebase has real users, these rules can be revisited.
+
+The rules are normative. PR reviewers (human + agent) reject changes that violate them.
+
+---
+
+## Rule 1 — Minimal tests only
+
+**Write happy-path tests + a few important error cases. Nothing else.**
+
+A failing happy-path test is the only kind that should block a PR.
+
+### What this means
+
+- Each public function/component/route gets ONE happy-path test that exercises the success route end-to-end.
+- A few critical error cases get a test each — only the ones that would corrupt state or silently lose user input. Examples that qualify: missing required env var, malformed onchain payload, Convex mutation rejected by schema. Examples that do NOT qualify: every possible enum branch, every off-by-one, every type-coercion edge.
+- Integration over unit when both fit. One test that proves the seam works beats five mocks proving the units mock correctly.
+- If a test takes >10 minutes to write, it's probably not happy-path. Stop and ask.
+
+### What to skip
+
+- **Regression tests** for bugs that haven't happened. We will add these post-hackathon when bugs surface.
+- **Exhaustive coverage** of branches, enum values, error-message strings, defensive null checks.
+- **"Coverage for completeness"** suites. Coverage % is not a hackathon goal.
+- **Snapshot tests** unless the snapshot is a contract artifact (e.g., a Solidity ABI).
+- **Property-based tests** unless the function is a pure data transform that's central to the demo.
+- **Mocking everything.** Prefer real adapters with stub backends (we have stubs for a reason).
+
+### Applies to
+
+- `vitest` in `apps/web`, `apps/server`, `apps/orchestrator`, `packages/agents`, `packages/shared`.
+- `playwright` if/when added.
+- `forge test` in `packages/contracts` — same principle: deploy + heartbeat + getCurrentTick. Skip fuzz tests on every getter.
+
+### Anti-patterns
+
+```ts
+// BAD — testing every branch of an enum
+describe('regionStatus', () => {
+  it('handles ACTIVE', () => { /* ... */ });
+  it('handles DORMANT', () => { /* ... */ });
+  it('handles CONTESTED', () => { /* ... */ });
+  it('handles RUINED', () => { /* ... */ });
+  it('handles UNKNOWN', () => { /* ... */ });
+});
+
+// GOOD — one happy path, one critical error
+describe('regionStatus', () => {
+  it('returns the region status from a snapshot', () => { /* ... */ });
+  it('throws on a malformed snapshot (would corrupt state)', () => { /* ... */ });
+});
+```
+
+---
+
+## Rule 2 — Env var simplicity
+
+**ONE env var per concept. Sensible defaults. No duplicates. No backwards-compat shims.**
+
+This codebase has no production users yet. Break env-var names freely when something better appears.
+
+### What this means
+
+- Each conceptual configuration value has exactly ONE name. If a value reaches both server and browser, the browser variant uses the Vite-required `VITE_` prefix on the SAME base name (e.g., `WORLD_APP_ID` server / `VITE_WORLD_APP_ID` browser). That is one concept, two transport names — fine. What's NOT fine is `WORLD_ID_APP_ID` AND `WORLD_APP_ID` both meaning "the World mini app's app id."
+- Sensible defaults baked into code so most users can deploy with an empty `.env.local`. Required-no-default values are the exception, not the rule.
+- When you rename or restructure: rename in all readers, delete the old name, ship. Do NOT add a fallback like `readEnv('NEW_NAME') ?? readEnv('OLD_NAME')`. That fallback becomes permanent technical debt within a week.
+- Complex config (nested objects, JSON-encoded blobs) only when truly needed. When needed: colocated with the consumer, with a sensible default and a one-line comment explaining the shape.
+
+### What to skip
+
+- **Duplicate env vars** that mean the same thing under different names.
+- **Backwards-compat shims.** Delete the old name. Update every reader. Move on.
+- **Required env vars without a working default** if a stub default would let the system boot.
+- **Config-file generators, env-var validators, "12-factor app" scaffolding.** Hackathon doesn't pay for this.
+
+### Server-vs-browser duality (the legitimate case)
+
+Vite only exposes vars prefixed with `VITE_` to the browser bundle. Some values legitimately need to reach both contexts. The pattern is:
+
+- ONE base name (e.g., `WORLD_APP_ID`).
+- Server-side: `WORLD_APP_ID` in `.env.local`, read directly via `process.env`.
+- Browser-side: `VITE_WORLD_APP_ID` in `.env.local`, read via `import.meta.env.VITE_WORLD_APP_ID`.
+- Code uses the `readEnv('WORLD_APP_ID')` helper in `packages/shared/src/adapters/_env.ts`, which tries both transport prefixes transparently.
+
+This is one concept with two transport names. It's allowed. What violates Rule 2 is having BOTH `WORLD_APP_ID` and `WORLD_ID_APP_ID` server-side, or `VITE_WORLD_APP_ID` and `VITE_WORLD_MINI_APP_ID` browser-side.
+
+### Applies to
+
+- `.env.template` at repo root.
+- Every adapter factory in `packages/shared/src/adapters/`.
+- Every Convex config under `apps/server/`.
+- Foundry deploy scripts that read env (`packages/contracts/script/`).
+- Orchestrator and agent CLI flag/env handling.
+
+### Anti-patterns
+
+```bash
+# BAD — two names for the same World mini app id
+WORLD_ID_APP_ID=...
+VITE_WORLD_APP_ID=...
+
+# GOOD — one base name, with the Vite-required browser variant
+WORLD_APP_ID=...
+VITE_WORLD_APP_ID=...
+```
+
+```ts
+// BAD — backwards-compat shim
+const appId = readEnv('WORLD_APP_ID') ?? readEnv('WORLD_ID_APP_ID');
+
+// GOOD — one canonical name, hard fail if unset and required
+const appId = readEnv('WORLD_APP_ID');
+if (!appId) throw new Error('WORLD_APP_ID is required for World mini app integration');
+```
+
+---
+
+## When to revisit
+
+Both rules expire when ClanWorld has live users. Until then: speed, clarity, and minimum config win every tradeoff. If a reviewer feels strongly that a rule should not apply to a specific PR, they raise it on the PR — they don't carve out a side workflow.


### PR DESCRIPTION
## Summary

Codify two hackathon-specific coding norms that override default engineering instincts. Refs #1.

Liam's verbatim direction:

> **Rule 1 — Minimal tests only**
> Write minimal happy-path tests + a few important error cases. Do NOT write regression tests, exhaustive coverage, edge-case spam, or "test for completeness" suites. Hackathon time is the bottleneck. A failing happy-path test is the only kind that should block a PR.

> **Rule 2 — Env var simplicity**
> Env vars must be simple, with sensible defaults. ONE env var per concept. No duplicate env vars for the same thing. No backwards-compat shims when upgrading anything (this codebase has no production users yet — break things freely). Minimum config to deploy. Complex config only when truly needed, and when needed, MUST be obvious + colocated with sensible defaults.

## Changes

- **`AGENTS.md` §4 (new)** — ~10-line index-level summary, pointer to canonical doc. Section numbers 5–9 shift to 6–10. Total file 133 lines (well under 500).
- **`docs/conventions/hackathon-rules.md` (new)** — full rationale, anti-patterns, worked examples for both rules. ~120 lines.
- **`BUILD_PLAN.md` §5 Guardrails** — two one-liners pointing at the canonical doc, so PMs see the rules at planning time.
- **`.env.template`** — applied Rule 2 inline: `WORLD_ID_APP_ID` renamed to `WORLD_APP_ID`. The browser-side `VITE_WORLD_APP_ID` is the same concept via Vite's required transport-prefix; `readEnv('WORLD_APP_ID')` in `packages/shared/src/adapters/_env.ts` already resolves both transparently. Zero live readers of `WORLD_ID_APP_ID` — pure rename, no backwards-compat shim per the rule itself.

## Constraint adherence

- Surgical scope. No edits outside the four allowed targets.
- AGENTS.md stays under 500 lines (133 / 500).
- No eslint/prettier/CI tooling added — this is a behavioral norm.
- Conventions doc included (Liam wanted this codified, not just mentioned).

## Test plan

- [ ] AGENTS.md renders cleanly (sections 1–10, no orphan numbers)
- [ ] BUILD_PLAN.md Guardrails §5 has both new bullets pointing at the conventions doc
- [ ] `docs/conventions/hackathon-rules.md` exists with both rules + examples
- [ ] `.env.template` has `WORLD_APP_ID` (server-side base), `VITE_WORLD_APP_ID` (browser variant), and no `WORLD_ID_APP_ID`
- [ ] `grep -rn WORLD_ID_APP_ID` across the repo returns zero results
- [ ] Orchestrator review for tone/scope alignment

## Notes

DO NOT merge — orchestrator decides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)