### PR TITLE
feat(web): Pixi canvas shell — 8 regions + clan flags + speech bubble

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/contracts/lib/forge-std"]
+	path = packages/contracts/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@clan-world/shared": "workspace:*",
     "@worldcoin/idkit": "4.1.2",
     "@worldcoin/minikit-js": "2.0.3",
+    "pixi.js": "^8.18.1",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,20 +1,10 @@
-import type { WorldSnapshot } from '@clan-world/shared';
-
-const mockSnapshot: WorldSnapshot = {
-  tick: 0,
-  tickEpoch: { startedAt: 0, durationMs: 20_000 },
-  regions: [],
-  clans: [],
-};
+import { WorldMap } from './WorldMap';
 
 export function App() {
   return (
-    <main style={{ fontFamily: 'system-ui, sans-serif', padding: '2rem' }}>
-      <h1>Hello ClanWorld</h1>
-      <p>Wave 0 placeholder. Mock snapshot:</p>
-      <pre style={{ background: '#f6f6f6', padding: '1rem', borderRadius: 8 }}>
-        {JSON.stringify(mockSnapshot, null, 2)}
-      </pre>
+    <main style={{ background: '#0d1a0d', minHeight: '100vh' }}>
+      <h1 style={{ color: 'white', fontFamily: 'monospace', padding: '8px' }}>ClanWorld v0.2.0</h1>
+      <WorldMap />
     </main>
   );
 }

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -38,10 +38,11 @@ export function WorldMap() {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    let mounted = true;
     const app = new Application();
 
     app.init({ width: 800, height: 600, background: 0x1a2a1a }).then(() => {
-      if (!containerRef.current) return;
+      if (!mounted || !containerRef.current) return;
       containerRef.current.appendChild(app.canvas);
 
       const regionMap = new Map(REGIONS.map(r => [r.id, r]));
@@ -116,6 +117,7 @@ export function WorldMap() {
     });
 
     return () => {
+      mounted = false;
       app.destroy(true);
     };
   }, []);

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef } from 'react';
+import { Application, Graphics, Text } from 'pixi.js';
+
+interface RegionDef {
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+  color: number;
+}
+
+interface ClanDef {
+  id: string;
+  name: string;
+  homeRegion: string;
+  color: number;
+}
+
+const REGIONS: RegionDef[] = [
+  { id: 'forest',       name: 'Forest',      x: 150, y: 100, color: 0x228822 },
+  { id: 'mountains',    name: 'Mountains',   x: 500, y: 100, color: 0x888888 },
+  { id: 'unicorn-town', name: 'Unicorn Town',x: 330, y: 280, color: 0xcc88cc },
+  { id: 'west-farms',   name: 'West Farms',  x: 130, y: 350, color: 0xaacc44 },
+  { id: 'east-farms',   name: 'East Farms',  x: 550, y: 350, color: 0x88bb33 },
+  { id: 'west-docks',   name: 'West Docks',  x: 100, y: 500, color: 0x336688 },
+  { id: 'east-docks',   name: 'East Docks',  x: 560, y: 500, color: 0x336688 },
+  { id: 'deep-sea',     name: 'Deep Sea',    x: 330, y: 520, color: 0x1144aa },
+];
+
+const MOCK_CLANS: ClanDef[] = [
+  { id: 'clan-iron',  name: 'Iron Guard',   homeRegion: 'forest',     color: 0x4488cc },
+  { id: 'clan-ember', name: 'Ember Hand',   homeRegion: 'mountains',  color: 0xcc4422 },
+  { id: 'clan-dawn',  name: 'Dawn Watch',   homeRegion: 'west-farms', color: 0xccaa22 },
+  { id: 'clan-storm', name: 'Storm Riders', homeRegion: 'east-farms', color: 0x44aacc },
+];
+
+export function WorldMap() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const app = new Application();
+
+    app.init({ width: 800, height: 600, background: 0x1a2a1a }).then(() => {
+      if (!containerRef.current) return;
+      containerRef.current.appendChild(app.canvas);
+
+      const regionMap = new Map(REGIONS.map(r => [r.id, r]));
+
+      // Draw regions as circles
+      for (const region of REGIONS) {
+        const g = new Graphics();
+        g.circle(region.x, region.y, 40);
+        g.fill({ color: region.color });
+        g.stroke({ color: 0xffffff, width: 1, alpha: 0.4 });
+        app.stage.addChild(g);
+
+        const label = new Text({
+          text: region.name,
+          style: { fill: 0xdddddd, fontSize: 11, fontFamily: 'monospace' },
+        });
+        label.anchor.set(0.5, 0);
+        label.x = region.x;
+        label.y = region.y + 44;
+        app.stage.addChild(label);
+      }
+
+      // Draw clan flags at homebase regions
+      for (const clan of MOCK_CLANS) {
+        const base = regionMap.get(clan.homeRegion);
+        if (!base) continue;
+
+        const flagX = base.x + 18;
+        const flagY = base.y - 38;
+
+        const flag = new Graphics();
+        flag.rect(flagX, flagY, 20, 20);
+        flag.fill({ color: clan.color });
+        flag.stroke({ color: 0xffffff, width: 1 });
+        app.stage.addChild(flag);
+
+        const clanLabel = new Text({
+          text: clan.name,
+          style: { fill: clan.color, fontSize: 10, fontFamily: 'monospace', fontWeight: 'bold' },
+        });
+        clanLabel.anchor.set(0, 1);
+        clanLabel.x = flagX + 24;
+        clanLabel.y = flagY + 20;
+        app.stage.addChild(clanLabel);
+      }
+
+      // Speech bubble placeholder (top-right)
+      const bubbleX = 610;
+      const bubbleY = 30;
+      const bubbleW = 160;
+      const bubbleH = 50;
+
+      const bubble = new Graphics();
+      bubble.roundRect(bubbleX, bubbleY, bubbleW, bubbleH, 10);
+      bubble.fill({ color: 0xffffff });
+      bubble.stroke({ color: 0xaaaaaa, width: 1 });
+      // Tail triangle
+      bubble.moveTo(bubbleX + 20, bubbleY + bubbleH);
+      bubble.lineTo(bubbleX + 10, bubbleY + bubbleH + 14);
+      bubble.lineTo(bubbleX + 35, bubbleY + bubbleH);
+      bubble.fill({ color: 0xffffff });
+      app.stage.addChild(bubble);
+
+      const bubbleText = new Text({
+        text: '...',
+        style: { fill: 0x333333, fontSize: 22, fontFamily: 'monospace' },
+      });
+      bubbleText.anchor.set(0.5, 0.5);
+      bubbleText.x = bubbleX + bubbleW / 2;
+      bubbleText.y = bubbleY + bubbleH / 2;
+      app.stage.addChild(bubbleText);
+    });
+
+    return () => {
+      app.destroy(true);
+    };
+  }, []);
+
+  return <div ref={containerRef} />;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       '@worldcoin/minikit-js':
         specifier: 2.0.3
         version: 2.0.3(react@18.3.1)(typescript@5.9.3)(viem@2.48.4(typescript@5.9.3))
+      pixi.js:
+        specifier: ^8.18.1
+        version: 8.18.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -657,6 +660,9 @@ packages:
   '@noble/secp256k1@2.3.0':
     resolution: {integrity: sha512-0TQed2gcBbIrh7Ccyw+y/uZQvbJwm7Ao4scBUxqpBCcsOlZG0O4KGfjtNAy/li4W8n1xt3dxrwJ0beZ2h2G6Kw==}
 
+  '@pixi/colord@2.9.6':
+    resolution: {integrity: sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==}
+
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
     cpu: [arm]
@@ -833,6 +839,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/earcut@3.0.0':
+    resolution: {integrity: sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -853,6 +862,9 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
+
+  '@webgpu/types@0.1.69':
+    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
   '@worldcoin/idkit-core@4.1.2':
     resolution: {integrity: sha512-5NNjl4RL5sazcsfGxivSvYmXfcu3XZAHsjCr+98AwhU6mVOBILq21cn3zyFD/9sLU7NNr61SRZUS1mhx3knvKw==}
@@ -882,6 +894,10 @@ packages:
         optional: true
       wagmi:
         optional: true
+
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
 
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
@@ -981,6 +997,9 @@ packages:
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
@@ -1029,14 +1048,23 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  gifuct-js@2.1.2:
+    resolution: {integrity: sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  ismobilejs@1.1.1:
+    resolution: {integrity: sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==}
 
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
+
+  js-binary-schema-parser@2.0.3:
+    resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1096,12 +1124,18 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  parse-svg-path@0.1.2:
+    resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  pixi.js@8.18.1:
+    resolution: {integrity: sha512-6LUPWYgulZhp/w4kam2XHXB0QedISZIqrJbRdHLLQ3csn5a38uzKxAp6B5j6s89QFYaIJbg95kvgTRcbgpO1ow==}
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -1175,6 +1209,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  tiny-lru@11.4.7:
+    resolution: {integrity: sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==}
+    engines: {node: '>=12'}
 
   tsx@4.19.2:
     resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
@@ -1637,6 +1675,8 @@ snapshots:
 
   '@noble/secp256k1@2.3.0': {}
 
+  '@pixi/colord@2.9.6': {}
+
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
 
@@ -1767,6 +1807,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/earcut@3.0.0': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@25.6.0':
@@ -1795,6 +1837,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@webgpu/types@0.1.69': {}
+
   '@worldcoin/idkit-core@4.1.2':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -1821,6 +1865,8 @@ snapshots:
     transitivePeerDependencies:
       - typescript
       - zod
+
+  '@xmldom/xmldom@0.8.13': {}
 
   abitype@1.2.3(typescript@5.9.3):
     optionalDependencies:
@@ -1883,6 +1929,8 @@ snapshots:
   decamelize@1.2.0: {}
 
   dijkstrajs@1.0.3: {}
+
+  earcut@3.0.2: {}
 
   electron-to-chromium@1.5.344: {}
 
@@ -1970,8 +2018,7 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  eventemitter3@5.0.1:
-    optional: true
+  eventemitter3@5.0.1: {}
 
   find-up@4.1.0:
     dependencies:
@@ -1989,12 +2036,20 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gifuct-js@2.1.2:
+    dependencies:
+      js-binary-schema-parser: 2.0.3
+
   is-fullwidth-code-point@3.0.0: {}
+
+  ismobilejs@1.1.1: {}
 
   isows@1.0.7(ws@8.18.3):
     dependencies:
       ws: 8.18.3
     optional: true
+
+  js-binary-schema-parser@2.0.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -2048,9 +2103,24 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  parse-svg-path@0.1.2: {}
+
   path-exists@4.0.0: {}
 
   picocolors@1.1.1: {}
+
+  pixi.js@8.18.1:
+    dependencies:
+      '@pixi/colord': 2.9.6
+      '@types/earcut': 3.0.0
+      '@webgpu/types': 0.1.69
+      '@xmldom/xmldom': 0.8.13
+      earcut: 3.0.2
+      eventemitter3: 5.0.1
+      gifuct-js: 2.1.2
+      ismobilejs: 1.1.1
+      parse-svg-path: 0.1.2
+      tiny-lru: 11.4.7
 
   pngjs@5.0.0: {}
 
@@ -2138,6 +2208,8 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  tiny-lru@11.4.7: {}
 
   tsx@4.19.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Installs pixi.js@8 in `apps/web`
- Adds `WorldMap.tsx`: Pixi Application on 800×600 canvas with 8 labeled region circles, 4 clan flag squares at homebase regions, and a speech bubble placeholder
- Updates `App.tsx` to render `<WorldMap />` with dark background

## Checkpoint

- [x] `pnpm --filter @clan-world/web dev` runs without error
- [x] 8 labeled region polygons (circles) rendered
- [x] 4 clan flags at homebase regions (Forest, Mountains, West Farms, East Farms)
- [x] Speech bubble placeholder visible (top-right, white rounded rect with "...")
- [x] `tsc --noEmit` clean
- [x] `pnpm --filter @clan-world/web build` clean (746 modules, no errors)

Closes #7