### PR TITLE
feat(contracts): deploy IClanWorld stub on World Chain Sepolia

### DIFF
--- a/packages/contracts/.gitignore
+++ b/packages/contracts/.gitignore
@@ -1,0 +1,4 @@
+out/
+cache/
+broadcast/
+lib/

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1,0 +1,3487 @@
+{
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "tokens",
+          "type": "address[6]",
+          "internalType": "address[6]"
+        },
+        {
+          "name": "pools",
+          "type": "address[4]",
+          "internalType": "address[4]"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "finalizeSeason",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "getActiveBanditView",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct ActiveBanditView",
+          "components": [
+            {
+              "name": "exists",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "banditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum BanditState"
+            },
+            {
+              "name": "currentRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackAttemptsMade",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "maxAttemptsRemaining",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "stateEnteredTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextActionTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "tier",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackPower",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "projectedTargetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "projectedTargetLootValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getActiveDefenders",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getActiveMission",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct Mission",
+          "components": [
+            {
+              "name": "active",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "nonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "startRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "targetRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "action",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "startTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "arrivalTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "actionStartTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "missionSeed",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "marketMode",
+              "type": "uint8",
+              "internalType": "enum MarketExecutionMode"
+            },
+            {
+              "name": "targetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "marketToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "marketAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "maxGoldIn",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getBanditTargetPreview",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getBanditTroop",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct BanditTroop",
+          "components": [
+            {
+              "name": "banditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum BanditState"
+            },
+            {
+              "name": "currentRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackAttemptsMade",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "stateEnteredTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextActionTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "tier",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackPower",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getClan",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct Clan",
+          "components": [
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "iftTokenId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "clanState",
+              "type": "uint8",
+              "internalType": "enum ClanState"
+            },
+            {
+              "name": "baseRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "baseLevel",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "wallLevel",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "monumentLevel",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "livingClansmen",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "lastSettledTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "starvationStartsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "coldDamage",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "goldBalance",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "blueprintBalance",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getClanFullView",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct ClanFullView",
+          "components": [
+            {
+              "name": "clan",
+              "type": "tuple",
+              "internalType": "struct DerivedClanState",
+              "components": [
+                {
+                  "name": "clan",
+                  "type": "tuple",
+                  "internalType": "struct Clan",
+                  "components": [
+                    {
+                      "name": "clanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "iftTokenId",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "owner",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "clanState",
+                      "type": "uint8",
+                      "internalType": "enum ClanState"
+                    },
+                    {
+                      "name": "baseRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "baseLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "wallLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "monumentLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "livingClansmen",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "lastSettledTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "starvationStartsAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "coldDamage",
+                      "type": "uint16",
+                      "internalType": "uint16"
+                    },
+                    {
+                      "name": "goldBalance",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "blueprintBalance",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultWood",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultIron",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultWheat",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultFish",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "name": "isStarving",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "lootValue",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "derivedAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "clansmen",
+              "type": "tuple[]",
+              "internalType": "struct ClansmanFullView[]",
+              "components": [
+                {
+                  "name": "clansman",
+                  "type": "tuple",
+                  "internalType": "struct DerivedClansmanState",
+                  "components": [
+                    {
+                      "name": "clansman",
+                      "type": "tuple",
+                      "internalType": "struct Clansman",
+                      "components": [
+                        {
+                          "name": "clansmanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "clanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "state",
+                          "type": "uint8",
+                          "internalType": "enum ClansmanState"
+                        },
+                        {
+                          "name": "currentRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "cooldownEndsAtTs",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "lastMissionNonce",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "carryWood",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryIron",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryWheat",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryFish",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "activeMission",
+                      "type": "tuple",
+                      "internalType": "struct Mission",
+                      "components": [
+                        {
+                          "name": "active",
+                          "type": "bool",
+                          "internalType": "bool"
+                        },
+                        {
+                          "name": "nonce",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "clansmanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "startRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "targetRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "action",
+                          "type": "uint8",
+                          "internalType": "enum ActionType"
+                        },
+                        {
+                          "name": "startTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "arrivalTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "actionStartTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "missionSeed",
+                          "type": "bytes32",
+                          "internalType": "bytes32"
+                        },
+                        {
+                          "name": "marketMode",
+                          "type": "uint8",
+                          "internalType": "enum MarketExecutionMode"
+                        },
+                        {
+                          "name": "targetClanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "marketToken",
+                          "type": "address",
+                          "internalType": "address"
+                        },
+                        {
+                          "name": "marketAmount",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "maxGoldIn",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "effectiveRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "derivedAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    }
+                  ]
+                },
+                {
+                  "name": "activeMission",
+                  "type": "tuple",
+                  "internalType": "struct Mission",
+                  "components": [
+                    {
+                      "name": "active",
+                      "type": "bool",
+                      "internalType": "bool"
+                    },
+                    {
+                      "name": "nonce",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "clansmanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "startRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "targetRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "action",
+                      "type": "uint8",
+                      "internalType": "enum ActionType"
+                    },
+                    {
+                      "name": "startTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "arrivalTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "actionStartTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "missionSeed",
+                      "type": "bytes32",
+                      "internalType": "bytes32"
+                    },
+                    {
+                      "name": "marketMode",
+                      "type": "uint8",
+                      "internalType": "enum MarketExecutionMode"
+                    },
+                    {
+                      "name": "targetClanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "marketToken",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "marketAmount",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "maxGoldIn",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "westPlot",
+              "type": "tuple",
+              "internalType": "struct WheatPlot",
+              "components": [
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum WheatPlotState"
+                },
+                {
+                  "name": "region",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "remainingWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "regrowUntilTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "eastPlot",
+              "type": "tuple",
+              "internalType": "struct WheatPlot",
+              "components": [
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum WheatPlotState"
+                },
+                {
+                  "name": "region",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "remainingWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "regrowUntilTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "incomingDefenderIds",
+              "type": "uint32[]",
+              "internalType": "uint32[]"
+            },
+            {
+              "name": "thisClanDefendingBaseId",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getClansman",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct Clansman",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum ClansmanState"
+            },
+            {
+              "name": "currentRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "cooldownEndsAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "lastMissionNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getDerivedClanState",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct DerivedClanState",
+          "components": [
+            {
+              "name": "clan",
+              "type": "tuple",
+              "internalType": "struct Clan",
+              "components": [
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "iftTokenId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "owner",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "clanState",
+                  "type": "uint8",
+                  "internalType": "enum ClanState"
+                },
+                {
+                  "name": "baseRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "baseLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "wallLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "monumentLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "livingClansmen",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "lastSettledTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "starvationStartsAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "coldDamage",
+                  "type": "uint16",
+                  "internalType": "uint16"
+                },
+                {
+                  "name": "goldBalance",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "blueprintBalance",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultWood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultIron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultFish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "isStarving",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "lootValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "derivedAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getDerivedClansmanState",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct DerivedClansmanState",
+          "components": [
+            {
+              "name": "clansman",
+              "type": "tuple",
+              "internalType": "struct Clansman",
+              "components": [
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum ClansmanState"
+                },
+                {
+                  "name": "currentRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "cooldownEndsAtTs",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "lastMissionNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "carryWood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryIron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryFish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "activeMission",
+              "type": "tuple",
+              "internalType": "struct Mission",
+              "components": [
+                {
+                  "name": "active",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "startRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "targetRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "startTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "arrivalTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "actionStartTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "missionSeed",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "marketMode",
+                  "type": "uint8",
+                  "internalType": "enum MarketExecutionMode"
+                },
+                {
+                  "name": "targetClanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "effectiveRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "derivedAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMarketState",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct MarketState",
+          "components": [
+            {
+              "name": "wood",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "wheat",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "fish",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "iron",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "currentTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "currentTickQueue",
+              "type": "tuple[]",
+              "internalType": "struct ScheduledMarketAction[]",
+              "components": [
+                {
+                  "name": "executeAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "commitSequence",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "nextTickQueue",
+              "type": "tuple[]",
+              "internalType": "struct ScheduledMarketAction[]",
+              "components": [
+                {
+                  "name": "executeAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "commitSequence",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRegionPopulation",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct RegionOccupant[]",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum ClansmanState"
+            },
+            {
+              "name": "currentAction",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "missionNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getScheduledMarketActionsForTick",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct ScheduledMarketAction[]",
+          "components": [
+            {
+              "name": "executeAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "commitSequence",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "action",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "marketToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "marketAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "maxGoldIn",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getTreasuryState",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct TreasuryState",
+          "components": [
+            {
+              "name": "treasuryOwner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "prizePotGold",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "poolsSeeded",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "woodToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "wheatToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "fishToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "ironToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "goldToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "blueprintToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "woodGoldPool",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "wheatGoldPool",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "fishGoldPool",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "ironGoldPool",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getWheatPlots",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "west",
+          "type": "tuple",
+          "internalType": "struct WheatPlot",
+          "components": [
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum WheatPlotState"
+            },
+            {
+              "name": "region",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "remainingWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "regrowUntilTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        },
+        {
+          "name": "east",
+          "type": "tuple",
+          "internalType": "struct WheatPlot",
+          "components": [
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum WheatPlotState"
+            },
+            {
+              "name": "region",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "remainingWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "regrowUntilTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getWorldSnapshot",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct WorldSnapshot",
+          "components": [
+            {
+              "name": "currentTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonStartTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonEndTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonFinalized",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "winterActive",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "winterStartsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "winterEndsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "activeBanditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "currentTickSeed",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "leaderboard",
+              "type": "tuple[]",
+              "internalType": "struct LeaderboardEntry[]",
+              "components": [
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "owner",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "monumentLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "baseLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "wallLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "livingClansmen",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum ClanState"
+                },
+                {
+                  "name": "lootValue",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getWorldState",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct WorldState",
+          "components": [
+            {
+              "name": "currentTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonStartTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonEndTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonFinalized",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "nextHeartbeatAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextBanditSpawnEligibleTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "currentBanditSpawnChanceBps",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "currentTickSeed",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "activeBanditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "winterActive",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "winterStartsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "winterEndsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextCommitSequence",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "heartbeat",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "mintClan",
+      "inputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "quoteLootValueRaw",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "quoteLootValueSettled",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "quoteTravel",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "",
+          "type": "bytes8",
+          "internalType": "bytes8"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "seedPools",
+      "inputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct PoolSeedConfig",
+          "components": [
+            {
+              "name": "woodSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "wheatSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "fishSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "ironSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "settleClan",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "submitClanOrders",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "orders",
+          "type": "tuple[]",
+          "internalType": "struct ClanOrder[]",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "gotoRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "action",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "targetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "marketToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "marketAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "maxGoldIn",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "results",
+          "type": "tuple[]",
+          "internalType": "struct OrderResult[]",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "status",
+              "type": "uint8",
+              "internalType": "enum StatusCode"
+            },
+            {
+              "name": "cooldownEndsAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "missionNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferBlueprint",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferBundle",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferGold",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferVaultResource",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint8",
+          "internalType": "enum ResourceType"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "BanditAttackResolved",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "targetClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "defended",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        },
+        {
+          "name": "attackPower",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "totalDefense",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "wallLevelAfter",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "stolenWood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "stolenIron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "stolenWheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "stolenFish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditDefeated",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "targetClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditEscaped",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditMoved",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "fromRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "toRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditSpawned",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "region",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "tier",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "attackPower",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditStateChanged",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldState",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum BanditState"
+        },
+        {
+          "name": "newState",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum BanditState"
+        },
+        {
+          "name": "region",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BaseLevelChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BlueprintAwarded",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BlueprintTransferred",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanEliminated",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanSettled",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "settledToTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanSpawned",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "iftTokenId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "baseRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanStarvationChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "isStarving",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClansmanDiedFromCold",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ColdDamageApplied",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldDamage",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "newDamage",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "GoldTransferred",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ImmediateMarketActionExecuted",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tokenIn",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "tokenOut",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "amountIn",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "amountOut",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "LootDistributedToDefender",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "wood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "iron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MarketActionFailed",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "reason",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum StatusCode"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MissionAssigned",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "missionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "startRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "targetRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "startTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "arrivalTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MissionCompleted",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "missionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MissionInterrupted",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldMissionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "newMissionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MonumentLevelChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PoolsSeeded",
+      "inputs": [
+        {
+          "name": "woodGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "wheatGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "fishGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "ironGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ResourcesDeposited",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "wood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "iron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ResourcesGathered",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "woodGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "ironGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheatGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fishGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "goldBonus",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ScheduledMarketActionCommitted",
+      "inputs": [
+        {
+          "name": "executeAtTick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "commitSequence",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "marketToken",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "marketAmount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "maxGoldIn",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ScheduledMarketActionExecuted",
+      "inputs": [
+        {
+          "name": "executeAtTick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "commitSequence",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tokenIn",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "tokenOut",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "amountIn",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "amountOut",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SeasonFinalized",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "rankedClanIds",
+          "type": "uint32[]",
+          "indexed": false,
+          "internalType": "uint32[]"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TickAdvanced",
+      "inputs": [
+        {
+          "name": "closedTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "openedTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "tickSeed",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "VaultResourceTransferred",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "resource",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ResourceType"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WallLevelChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WinterEnded",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WinterStarted",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WorkerArrived",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "region",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/packages/contracts/deployments/worldchain-sepolia.json
+++ b/packages/contracts/deployments/worldchain-sepolia.json
@@ -1,0 +1,18 @@
+{
+  "chainId": 4801,
+  "ClanWorldStub": "0xC012275376b867944cd874FB2d600d6dA3B4A56e",
+  "tokens": {
+    "wood": "0x994aAef88d06fbea7D99E0F3Ae6f04B59b829669",
+    "iron": "0x55c1857EAe48c03c31A0ca533A893Ae113bfBc0c",
+    "wheat": "0x93108a0494a6C160ffD20Cf27A4904E9ea0145ad",
+    "fish": "0xE2c55D1967F45AF90120a80FA82918FB530566FD",
+    "gold": "0xf0D6CFe1c8733eF2b8D45A6bB59E022f20cbE2ea",
+    "blueprint": "0xf9eD9605cFDE5D1BE2fac9024c6794F8c6e03D0A"
+  },
+  "pools": {
+    "woodGold": "0xfCDFD3f29fEeCa7a409Ade1C863E1D75bB9F285E",
+    "wheatGold": "0x94c49504053D8074265cC237A73080cb338E7f0B",
+    "fishGold": "0x29FCbf0f17eB8f91eE9eb554a7f9D074243BCd0C",
+    "ironGold": "0x9630Ab52756Cc090b058860436961F06688d871a"
+  }
+}

--- a/packages/contracts/foundry.lock
+++ b/packages/contracts/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "lib/forge-std": {
+    "tag": {
+      "name": "v1.16.0",
+      "rev": "8987040ede9553cea20c95ad40d0455930f9c8e0"
+    }
+  }
+}

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console} from "forge-std/Script.sol";
+import {MinimalERC20} from "../src/MinimalERC20.sol";
+import {StubPool} from "../src/StubPool.sol";
+import {ClanWorldStub} from "../src/ClanWorldStub.sol";
+
+contract Deploy is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // 1. Deploy 6 resource tokens
+        MinimalERC20 wood      = new MinimalERC20("ClanWorld Wood",      "WOOD");
+        MinimalERC20 iron      = new MinimalERC20("ClanWorld Iron",      "IRON");
+        MinimalERC20 wheat     = new MinimalERC20("ClanWorld Wheat",     "WHEAT");
+        MinimalERC20 fish      = new MinimalERC20("ClanWorld Fish",      "FISH");
+        MinimalERC20 gold      = new MinimalERC20("ClanWorld Gold",      "GOLD");
+        MinimalERC20 blueprint = new MinimalERC20("ClanWorld Blueprint", "BPRT");
+
+        console.log("wood:     ", address(wood));
+        console.log("iron:     ", address(iron));
+        console.log("wheat:    ", address(wheat));
+        console.log("fish:     ", address(fish));
+        console.log("gold:     ", address(gold));
+        console.log("blueprint:", address(blueprint));
+
+        // 2. Deploy 4 stub LP pools
+        StubPool woodGold  = new StubPool(address(wood),  address(gold));
+        StubPool wheatGold = new StubPool(address(wheat), address(gold));
+        StubPool fishGold  = new StubPool(address(fish),  address(gold));
+        StubPool ironGold  = new StubPool(address(iron),  address(gold));
+
+        console.log("woodGoldPool: ", address(woodGold));
+        console.log("wheatGoldPool:", address(wheatGold));
+        console.log("fishGoldPool: ", address(fishGold));
+        console.log("ironGoldPool: ", address(ironGold));
+
+        // 3. Deploy ClanWorldStub
+        address[6] memory tokens = [
+            address(wood),
+            address(iron),
+            address(wheat),
+            address(fish),
+            address(gold),
+            address(blueprint)
+        ];
+        address[4] memory pools = [
+            address(woodGold),
+            address(wheatGold),
+            address(fishGold),
+            address(ironGold)
+        ];
+
+        ClanWorldStub stub = new ClanWorldStub(tokens, pools);
+        console.log("ClanWorldStub:", address(stub));
+
+        vm.stopBroadcast();
+    }
+}

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./IClanWorld.sol";
+
+/// @notice Stub implementation of IClanWorld for World Chain Sepolia deployment.
+///         Stores tick state and token/pool addresses. All game logic is no-op.
+contract ClanWorldStub is IClanWorld {
+    WorldState private _world;
+    TreasuryState private _treasury;
+
+    constructor(address[6] memory tokens, address[4] memory pools) {
+        _world.currentTick = 1;
+        _world.nextHeartbeatAtTs = uint64(block.timestamp);
+
+        _treasury.woodToken      = tokens[0];
+        _treasury.ironToken      = tokens[1];
+        _treasury.wheatToken     = tokens[2];
+        _treasury.fishToken      = tokens[3];
+        _treasury.goldToken      = tokens[4];
+        _treasury.blueprintToken = tokens[5];
+
+        _treasury.woodGoldPool   = pools[0];
+        _treasury.wheatGoldPool  = pools[1];
+        _treasury.fishGoldPool   = pools[2];
+        _treasury.ironGoldPool   = pools[3];
+
+        _treasury.treasuryOwner = msg.sender;
+    }
+
+    // -------------------------------------------------------------------------
+    // World progression
+    // -------------------------------------------------------------------------
+
+    function heartbeat() external override {
+        uint64 closed = _world.currentTick;
+        _world.currentTick += 1;
+        _world.nextHeartbeatAtTs = uint64(block.timestamp);
+        emit TickAdvanced(closed, _world.currentTick, bytes32(0));
+    }
+
+    function settleClan(uint32) external override {}
+
+    function finalizeSeason() external override {}
+
+    // -------------------------------------------------------------------------
+    // Clan lifecycle
+    // -------------------------------------------------------------------------
+
+    function mintClan(address) external payable override returns (uint32, uint256) {
+        return (1, 1);
+    }
+
+    function submitClanOrders(uint32, ClanOrder[] calldata orders)
+        external
+        override
+        returns (OrderResult[] memory results)
+    {
+        results = new OrderResult[](orders.length);
+    }
+
+    // -------------------------------------------------------------------------
+    // Treasury
+    // -------------------------------------------------------------------------
+
+    function seedPools(PoolSeedConfig calldata) external override {}
+
+    // -------------------------------------------------------------------------
+    // OTC transfers
+    // -------------------------------------------------------------------------
+
+    function transferGold(uint32, uint32, uint256) external override {}
+
+    function transferVaultResource(uint32, uint32, ResourceType, uint256) external override {}
+
+    function transferBlueprint(uint32, uint32, uint256) external override {}
+
+    function transferBundle(uint32, uint32, uint256, uint256, uint256, uint256, uint256, uint256)
+        external
+        override
+    {}
+
+    // -------------------------------------------------------------------------
+    // Raw read getters
+    // -------------------------------------------------------------------------
+
+    function getWorldState() external view override returns (WorldState memory) {
+        return _world;
+    }
+
+    function getTreasuryState() external view override returns (TreasuryState memory) {
+        return _treasury;
+    }
+
+    function getClan(uint32) external pure override returns (Clan memory) {
+        return Clan({
+            clanId: 0,
+            iftTokenId: 0,
+            owner: address(0),
+            clanState: ClanState.ACTIVE,
+            baseRegion: 0,
+            baseLevel: 0,
+            wallLevel: 0,
+            monumentLevel: 0,
+            livingClansmen: 0,
+            lastSettledTick: 0,
+            starvationStartsAtTick: 0,
+            coldDamage: 0,
+            goldBalance: 0,
+            blueprintBalance: 0,
+            vaultWood: 0,
+            vaultIron: 0,
+            vaultWheat: 0,
+            vaultFish: 0
+        });
+    }
+
+    function getClansman(uint32) external pure override returns (Clansman memory) {
+        return Clansman({
+            clansmanId: 0,
+            clanId: 0,
+            state: ClansmanState.WAITING,
+            currentRegion: 0,
+            cooldownEndsAtTs: 0,
+            lastMissionNonce: 0,
+            carryWood: 0,
+            carryIron: 0,
+            carryWheat: 0,
+            carryFish: 0
+        });
+    }
+
+    function getActiveMission(uint32) external pure override returns (Mission memory) {
+        return Mission({
+            active: false,
+            nonce: 0,
+            clansmanId: 0,
+            startRegion: 0,
+            targetRegion: 0,
+            action: ActionType.None,
+            startTick: 0,
+            arrivalTick: 0,
+            actionStartTick: 0,
+            missionSeed: bytes32(0),
+            marketMode: MarketExecutionMode.None,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+    }
+
+    function getBanditTroop(uint32) external pure override returns (BanditTroop memory) {
+        return BanditTroop({
+            banditId: 0,
+            state: BanditState.NONE,
+            currentRegion: 0,
+            attackAttemptsMade: 0,
+            stateEnteredTick: 0,
+            nextActionTick: 0,
+            tier: 0,
+            attackPower: 0,
+            carryWood: 0,
+            carryIron: 0,
+            carryWheat: 0,
+            carryFish: 0
+        });
+    }
+
+    function getWheatPlots(uint32)
+        external
+        pure
+        override
+        returns (WheatPlot memory west, WheatPlot memory east)
+    {
+        west = WheatPlot({ state: WheatPlotState.Harvestable, region: 0, remainingWheat: 0, regrowUntilTick: 0 });
+        east = WheatPlot({ state: WheatPlotState.Harvestable, region: 0, remainingWheat: 0, regrowUntilTick: 0 });
+    }
+
+    function getScheduledMarketActionsForTick(uint64)
+        external
+        pure
+        override
+        returns (ScheduledMarketAction[] memory)
+    {
+        return new ScheduledMarketAction[](0);
+    }
+
+    function getActiveDefenders(uint32)
+        external
+        pure
+        override
+        returns (uint32[] memory)
+    {
+        return new uint32[](0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Derived read getters
+    // -------------------------------------------------------------------------
+
+    function getDerivedClanState(uint32) external view override returns (DerivedClanState memory) {
+        Clan memory c = this.getClan(0);
+        return DerivedClanState({ clan: c, isStarving: false, lootValue: 0, derivedAtTick: _world.currentTick });
+    }
+
+    function getDerivedClansmanState(uint32) external view override returns (DerivedClansmanState memory) {
+        Clansman memory cm = this.getClansman(0);
+        Mission memory m = this.getActiveMission(0);
+        return DerivedClansmanState({ clansman: cm, activeMission: m, effectiveRegion: 0, derivedAtTick: _world.currentTick });
+    }
+
+    function getBanditTargetPreview(uint32) external pure override returns (uint32) {
+        return 0;
+    }
+
+    function quoteTravel(uint8, uint8) external pure override returns (uint8, bytes8) {
+        return (0, bytes8(0));
+    }
+
+    function quoteLootValueRaw(uint32) external pure override returns (uint256) {
+        return 0;
+    }
+
+    function quoteLootValueSettled(uint32) external pure override returns (uint256) {
+        return 0;
+    }
+
+    // -------------------------------------------------------------------------
+    // UI indexer aggregator getters
+    // -------------------------------------------------------------------------
+
+    function getWorldSnapshot() external view override returns (WorldSnapshot memory) {
+        return WorldSnapshot({
+            currentTick: _world.currentTick,
+            seasonStartTick: _world.seasonStartTick,
+            seasonEndTick: _world.seasonEndTick,
+            seasonFinalized: false,
+            winterActive: false,
+            winterStartsAtTick: 0,
+            winterEndsAtTick: 0,
+            activeBanditId: 0,
+            currentTickSeed: bytes32(0),
+            leaderboard: new LeaderboardEntry[](0)
+        });
+    }
+
+    function getClanFullView(uint32) external view override returns (ClanFullView memory) {
+        return ClanFullView({
+            clan: DerivedClanState({
+                clan: this.getClan(0),
+                isStarving: false,
+                lootValue: 0,
+                derivedAtTick: _world.currentTick
+            }),
+            clansmen: new ClansmanFullView[](0),
+            westPlot: WheatPlot({ state: WheatPlotState.Harvestable, region: 0, remainingWheat: 0, regrowUntilTick: 0 }),
+            eastPlot: WheatPlot({ state: WheatPlotState.Harvestable, region: 0, remainingWheat: 0, regrowUntilTick: 0 }),
+            incomingDefenderIds: new uint32[](0),
+            thisClanDefendingBaseId: 0
+        });
+    }
+
+    function getMarketState() external view override returns (MarketState memory) {
+        return MarketState({
+            wood: PoolReserves({ resourceToken: _treasury.woodToken, resourceReserve: 0, goldReserve: 0, spotPriceGoldPerResource: 0 }),
+            wheat: PoolReserves({ resourceToken: _treasury.wheatToken, resourceReserve: 0, goldReserve: 0, spotPriceGoldPerResource: 0 }),
+            fish: PoolReserves({ resourceToken: _treasury.fishToken, resourceReserve: 0, goldReserve: 0, spotPriceGoldPerResource: 0 }),
+            iron: PoolReserves({ resourceToken: _treasury.ironToken, resourceReserve: 0, goldReserve: 0, spotPriceGoldPerResource: 0 }),
+            currentTick: _world.currentTick,
+            currentTickQueue: new ScheduledMarketAction[](0),
+            nextTickQueue: new ScheduledMarketAction[](0)
+        });
+    }
+
+    function getActiveBanditView() external pure override returns (ActiveBanditView memory) {
+        return ActiveBanditView({
+            exists: false,
+            banditId: 0,
+            state: BanditState.NONE,
+            currentRegion: 0,
+            attackAttemptsMade: 0,
+            maxAttemptsRemaining: 0,
+            stateEnteredTick: 0,
+            nextActionTick: 0,
+            tier: 0,
+            attackPower: 0,
+            carryWood: 0,
+            carryIron: 0,
+            carryWheat: 0,
+            carryFish: 0,
+            projectedTargetClanId: 0,
+            projectedTargetLootValue: 0
+        });
+    }
+
+    function getRegionPopulation(uint8) external pure override returns (RegionOccupant[] memory) {
+        return new RegionOccupant[](0);
+    }
+}

--- a/packages/contracts/src/MinimalERC20.sol
+++ b/packages/contracts/src/MinimalERC20.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @notice Minimal ERC20 with owner-only mint. No external deps.
+contract MinimalERC20 {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+
+    uint256 public totalSupply;
+    address public immutable owner;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner_, address indexed spender, uint256 value);
+
+    constructor(string memory name_, string memory symbol_) {
+        name = name_;
+        symbol = symbol_;
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        totalSupply += amount;
+        balanceOf[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+}

--- a/packages/contracts/src/StubPool.sol
+++ b/packages/contracts/src/StubPool.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @notice Minimal stub LP pool. Stores token pair addresses only.
+contract StubPool {
+    address public immutable tokenA;
+    address public immutable tokenB;
+
+    constructor(address tokenA_, address tokenB_) {
+        tokenA = tokenA_;
+        tokenB = tokenB_;
+    }
+}

--- a/packages/contracts/test/ClanWorldStub.t.sol
+++ b/packages/contracts/test/ClanWorldStub.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorldStub} from "../src/ClanWorldStub.sol";
+import {MinimalERC20} from "../src/MinimalERC20.sol";
+import {StubPool} from "../src/StubPool.sol";
+
+contract ClanWorldStubTest is Test {
+    ClanWorldStub stub;
+
+    function setUp() public {
+        // Deploy mock tokens
+        address[6] memory tokens;
+        for (uint256 i = 0; i < 6; i++) {
+            tokens[i] = address(new MinimalERC20("T", "T"));
+        }
+        // Deploy mock pools
+        address[4] memory pools;
+        for (uint256 i = 0; i < 4; i++) {
+            pools[i] = address(new StubPool(tokens[i], tokens[4]));
+        }
+        stub = new ClanWorldStub(tokens, pools);
+    }
+
+    function test_heartbeat_increments_tick() public {
+        assertEq(stub.getWorldState().currentTick, 1);
+        stub.heartbeat();
+        assertEq(stub.getWorldState().currentTick, 2);
+    }
+
+    function test_getWorldSnapshot_returns_current_tick() public {
+        stub.heartbeat();
+        assertEq(stub.getWorldSnapshot().currentTick, 2);
+    }
+}


### PR DESCRIPTION
## Summary

- Deploy ClanWorldStub contract implementing full `IClanWorld` interface to World Chain Sepolia (chainId 4801)
- Deploy 6 ERC20 resource tokens (wood, iron, wheat, fish, gold, blueprint) using `MinimalERC20`
- Deploy 4 stub LP pools (wood-gold, wheat-gold, fish-gold, iron-gold) using `StubPool`
- Export deployment addresses to `packages/contracts/deployments/worldchain-sepolia.json`
- Export ABI to `packages/contracts/abi/IClanWorld.json`

## Deployed Addresses

| Contract | Address |
|---|---|
| ClanWorldStub | `0xC012275376b867944cd874FB2d600d6dA3B4A56e` |
| wood | `0x994aAef88d06fbea7D99E0F3Ae6f04B59b829669` |
| iron | `0x55c1857EAe48c03c31A0ca533A893Ae113bfBc0c` |
| wheat | `0x93108a0494a6C160ffD20Cf27A4904E9ea0145ad` |
| fish | `0xE2c55D1967F45AF90120a80FA82918FB530566FD` |
| gold | `0xf0D6CFe1c8733eF2b8D45A6bB59E022f20cbE2ea` |
| blueprint | `0xf9eD9605cFDE5D1BE2fac9024c6794F8c6e03D0A` |

## Checkpoint Status

- [x] `forge build` succeeds (no errors, warnings only)
- [x] `forge test` passes (2/2 tests: heartbeat increments tick, snapshot returns tick)
- [x] `forge script Deploy --broadcast` deployed to World Chain Sepolia
- [x] `deployments/worldchain-sepolia.json` written with all addresses
- [x] `abi/IClanWorld.json` extracted from build artifact
- [x] `getWorldState().currentTick` returns `5` from RPC (heartbeat called 4x)
- [x] `heartbeat()` callable and increments tick (confirmed on-chain)
- [x] `ENGINE_ADDRESS` set in `.env.local`

Closes #5