### PR TITLE
feat(server): Convex heartbeat-webhook HTTP action + safety-net cron (#11)

### DIFF
--- a/apps/server/convex/crons.ts
+++ b/apps/server/convex/crons.ts
@@ -1,0 +1,6 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+crons.interval("heartbeat-safety-net", { seconds: 5 }, internal.heartbeat.advanceTick, {});
+export default crons;

--- a/apps/server/convex/heartbeat.ts
+++ b/apps/server/convex/heartbeat.ts
@@ -3,33 +3,48 @@ import { internal } from "./_generated/api";
 
 export const heartbeatWebhook = httpAction(async (ctx, request) => {
   if (request.method !== "POST") {
-    return new Response("Method Not Allowed", { status: 405 });
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { "Content-Type": "application/json", Allow: "POST" },
+    });
   }
 
   const secret = process.env.WEBHOOK_SHARED_SECRET;
   const auth = request.headers.get("Authorization");
   if (!secret || auth !== `Bearer ${secret}`) {
-    return new Response("Unauthorized", { status: 401 });
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
-  const newTick = await ctx.runMutation(internal.heartbeat.advanceTick, {});
-  if (newTick === null) {
-    return new Response(
-      JSON.stringify({ status: "no-op", reason: "no snapshot to refresh" }),
-      { status: 200, headers: { "Content-Type": "application/json" } }
-    );
-  }
+  const result = await ctx.runMutation(internal.heartbeat.advanceTick, {});
 
-  return new Response(
-    JSON.stringify({ status: "ok", tick: newTick }),
-    { status: 200, headers: { "Content-Type": "application/json" } }
-  );
+  return new Response(JSON.stringify(result), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
 });
 
+type AdvanceTickResult =
+  | { status: "ok"; tick: number }
+  | { status: "no-op"; reason: string };
+
 export const advanceTick = internalMutation({
-  handler: async (ctx): Promise<number | null> => {
+  handler: async (ctx): Promise<AdvanceTickResult> => {
     const snap = await ctx.db.query("worldSnapshot").order("desc").first();
-    if (!snap) return null;
+    if (!snap) return { status: "no-op", reason: "no snapshot to refresh" };
+
+    // Staleness gate: only advance if the current epoch has elapsed.
+    // Prevents cron from double-advancing (fires 4x/epoch) and concurrent
+    // calls from inserting duplicate tick rows.
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const epochEndSeconds =
+      snap.tickEpochStartedAt +
+      Math.floor(snap.tickEpochDurationMs / 1000);
+    if (nowSeconds < epochEndSeconds) {
+      return { status: "no-op", reason: "epoch not yet elapsed" };
+    }
 
     const newTick = snap.tick + 1;
     await ctx.db.insert("worldSnapshot", {
@@ -45,6 +60,6 @@ export const advanceTick = internalMutation({
       timestamp: Date.now(),
     });
 
-    return newTick;
+    return { status: "ok", tick: newTick };
   },
 });

--- a/apps/server/convex/heartbeat.ts
+++ b/apps/server/convex/heartbeat.ts
@@ -1,0 +1,50 @@
+import { httpAction, internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+export const heartbeatWebhook = httpAction(async (ctx, request) => {
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  const secret = process.env.WEBHOOK_SHARED_SECRET;
+  const auth = request.headers.get("Authorization");
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const newTick = await ctx.runMutation(internal.heartbeat.advanceTick, {});
+  if (newTick === null) {
+    return new Response(
+      JSON.stringify({ status: "no-op", reason: "no snapshot to refresh" }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  return new Response(
+    JSON.stringify({ status: "ok", tick: newTick }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+});
+
+export const advanceTick = internalMutation({
+  handler: async (ctx): Promise<number | null> => {
+    const snap = await ctx.db.query("worldSnapshot").order("desc").first();
+    if (!snap) return null;
+
+    const newTick = snap.tick + 1;
+    await ctx.db.insert("worldSnapshot", {
+      tick: newTick,
+      tickEpochStartedAt: Math.floor(Date.now() / 1000),
+      tickEpochDurationMs: snap.tickEpochDurationMs,
+      regions: snap.regions,
+      clans: snap.clans,
+    });
+    await ctx.db.insert("agentLogs", {
+      level: "info",
+      message: `heartbeat: tick ${snap.tick} → ${newTick}`,
+      timestamp: Date.now(),
+    });
+
+    return newTick;
+  },
+});

--- a/apps/server/convex/http.ts
+++ b/apps/server/convex/http.ts
@@ -1,0 +1,6 @@
+import { httpRouter } from "convex/server";
+import { heartbeatWebhook } from "./heartbeat";
+
+const http = httpRouter();
+http.route({ path: "/api/heartbeat-webhook", method: "POST", handler: heartbeatWebhook });
+export default http;


### PR DESCRIPTION
## Summary

- Adds `POST /api/heartbeat-webhook` Convex HTTP action with Bearer auth (`WEBHOOK_SHARED_SECRET` env var)
- Advances `worldSnapshot` by inserting a new row with `tick+1`, updated `tickEpochStartedAt`, same regions/clans
- Staleness gate: skips if current epoch hasn't elapsed (`tickEpochStartedAt + tickEpochDurationMs/1000 > now`) — prevents double-advancement from concurrent cron + webhook calls
- `advanceTick` internal mutation holds all logic; HTTP action delegates via `ctx.runMutation` (single source of truth)
- Safety-net cron fires every 5 seconds (`convex/crons.ts`) — advances only if epoch has genuinely elapsed
- HTTP router (`convex/http.ts`) registers the route

## Review status
- Codex: CLEAN (post-fix)
- Gemini: CLEAN
- Claude: CLEAN

Closes #11