### PR TITLE
feat(shared): implement RealChainClient with viem (#8)

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,5 +17,8 @@
   },
   "devDependencies": {
     "typescript": "5.9.3"
+  },
+  "dependencies": {
+    "viem": "^2.48.4"
   }
 }

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -1,5 +1,4 @@
-import { createPublicClient, http } from 'viem';
-import { defineChain } from 'viem';
+import { createPublicClient, http, fallback, defineChain } from 'viem';
 import type { ClanFullView, ClanOrder, Tick } from '../types';
 import { readEnv } from './_env';
 
@@ -221,20 +220,24 @@ class StubChainClient implements IChainClient {
 }
 
 class RealChainClient implements IChainClient {
-  private readonly client;
+  private readonly client: ReturnType<typeof createPublicClient>;
   private readonly contractAddress: `0x${string}`;
 
   constructor() {
     const primaryRpc = readEnv('RPC_URL_PRIMARY');
     const fallbackRpc = readEnv('RPC_URL_FALLBACK');
-    const rpcUrl = primaryRpc ?? fallbackRpc;
+
+    const transport =
+      primaryRpc && fallbackRpc
+        ? fallback([http(primaryRpc), http(fallbackRpc)])
+        : http(primaryRpc ?? fallbackRpc);
 
     this.contractAddress = (readEnv('CLAN_WORLD_CONTRACT_ADDRESS') ??
       DEFAULT_CONTRACT_ADDRESS) as `0x${string}`;
 
     this.client = createPublicClient({
       chain: worldChainSepolia,
-      transport: http(rpcUrl),
+      transport,
     });
   }
 
@@ -244,7 +247,7 @@ class RealChainClient implements IChainClient {
       abi: CLAN_WORLD_ABI,
       functionName: 'getWorldSnapshot',
     });
-    return Number(snapshot.currentTick);
+    return Number(snapshot.currentTick); // safe: tick values are small enough to fit Number precisely in Wave 0
   }
 
   async submitOrders(_clanId: string, _orders: ClanOrder[]): Promise<{ txHash: string }> {
@@ -269,7 +272,7 @@ class RealChainClient implements IChainClient {
         treasury: String(inner.goldBalance),
       },
       // controlledRegions, pendingOrders, whispers not available in Wave 0 contract read
-      controlledRegions: [],
+      controlledRegions: [], // Wave 0: omit base region from controlledRegions; populated in Wave 1 from on-chain data
       pendingOrders: [],
       whispers: [],
     };

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -1,3 +1,5 @@
+import { createPublicClient, http } from 'viem';
+import { defineChain } from 'viem';
 import type { ClanFullView, ClanOrder, Tick } from '../types';
 import { readEnv } from './_env';
 
@@ -6,6 +8,200 @@ export interface IChainClient {
   submitOrders(clanId: string, orders: ClanOrder[]): Promise<{ txHash: string }>;
   getClanFullView(clanId: string): Promise<ClanFullView>;
 }
+
+const DEFAULT_CONTRACT_ADDRESS = '0xC012275376b867944cd874FB2d600d6dA3B4A56e' as const;
+
+const worldChainSepolia = defineChain({
+  id: 4801,
+  name: 'World Chain Sepolia',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: { http: ['https://worldchain-sepolia.g.alchemy.com/public'] },
+  },
+});
+
+// Minimal ABI — only the two read functions we call.
+const CLAN_WORLD_ABI = [
+  {
+    type: 'function',
+    name: 'getWorldSnapshot',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        components: [
+          { name: 'currentTick', type: 'uint64' },
+          { name: 'seasonStartTick', type: 'uint64' },
+          { name: 'seasonEndTick', type: 'uint64' },
+          { name: 'seasonFinalized', type: 'bool' },
+          { name: 'winterActive', type: 'bool' },
+          { name: 'winterStartsAtTick', type: 'uint64' },
+          { name: 'winterEndsAtTick', type: 'uint64' },
+          { name: 'activeBanditId', type: 'uint32' },
+          { name: 'currentTickSeed', type: 'bytes32' },
+          {
+            name: 'leaderboard',
+            type: 'tuple[]',
+            components: [
+              { name: 'clanId', type: 'uint32' },
+              { name: 'owner', type: 'address' },
+              { name: 'monumentLevel', type: 'uint8' },
+              { name: 'baseLevel', type: 'uint8' },
+              { name: 'wallLevel', type: 'uint8' },
+              { name: 'livingClansmen', type: 'uint8' },
+              { name: 'state', type: 'uint8' },
+              { name: 'lootValue', type: 'uint256' },
+            ],
+          },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'getClanFullView',
+    inputs: [{ name: '', type: 'uint32' }],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        components: [
+          {
+            name: 'clan',
+            type: 'tuple',
+            components: [
+              {
+                name: 'clan',
+                type: 'tuple',
+                components: [
+                  { name: 'clanId', type: 'uint32' },
+                  { name: 'iftTokenId', type: 'uint256' },
+                  { name: 'owner', type: 'address' },
+                  { name: 'clanState', type: 'uint8' },
+                  { name: 'baseRegion', type: 'uint8' },
+                  { name: 'baseLevel', type: 'uint8' },
+                  { name: 'wallLevel', type: 'uint8' },
+                  { name: 'monumentLevel', type: 'uint8' },
+                  { name: 'livingClansmen', type: 'uint8' },
+                  { name: 'lastSettledTick', type: 'uint64' },
+                  { name: 'starvationStartsAtTick', type: 'uint64' },
+                  { name: 'coldDamage', type: 'uint16' },
+                  { name: 'goldBalance', type: 'uint256' },
+                  { name: 'blueprintBalance', type: 'uint256' },
+                  { name: 'vaultWood', type: 'uint256' },
+                  { name: 'vaultIron', type: 'uint256' },
+                  { name: 'vaultWheat', type: 'uint256' },
+                  { name: 'vaultFish', type: 'uint256' },
+                ],
+              },
+              { name: 'isStarving', type: 'bool' },
+              { name: 'lootValue', type: 'uint256' },
+              { name: 'derivedAtTick', type: 'uint64' },
+            ],
+          },
+          // clansmen, westPlot, eastPlot etc. omitted — not needed for Wave 0 mapping
+          {
+            name: 'clansmen',
+            type: 'tuple[]',
+            components: [
+              {
+                name: 'clansman',
+                type: 'tuple',
+                components: [
+                  {
+                    name: 'clansman',
+                    type: 'tuple',
+                    components: [
+                      { name: 'clansmanId', type: 'uint32' },
+                      { name: 'clanId', type: 'uint32' },
+                      { name: 'state', type: 'uint8' },
+                      { name: 'currentRegion', type: 'uint8' },
+                      { name: 'cooldownEndsAtTs', type: 'uint64' },
+                      { name: 'lastMissionNonce', type: 'uint64' },
+                      { name: 'carryWood', type: 'uint256' },
+                      { name: 'carryIron', type: 'uint256' },
+                      { name: 'carryWheat', type: 'uint256' },
+                      { name: 'carryFish', type: 'uint256' },
+                    ],
+                  },
+                  {
+                    name: 'activeMission',
+                    type: 'tuple',
+                    components: [
+                      { name: 'active', type: 'bool' },
+                      { name: 'nonce', type: 'uint64' },
+                      { name: 'clansmanId', type: 'uint32' },
+                      { name: 'startRegion', type: 'uint8' },
+                      { name: 'targetRegion', type: 'uint8' },
+                      { name: 'action', type: 'uint8' },
+                      { name: 'startTick', type: 'uint64' },
+                      { name: 'arrivalTick', type: 'uint64' },
+                      { name: 'actionStartTick', type: 'uint64' },
+                      { name: 'missionSeed', type: 'bytes32' },
+                      { name: 'marketMode', type: 'uint8' },
+                      { name: 'targetClanId', type: 'uint32' },
+                      { name: 'marketToken', type: 'address' },
+                      { name: 'marketAmount', type: 'uint256' },
+                      { name: 'maxGoldIn', type: 'uint256' },
+                    ],
+                  },
+                  { name: 'effectiveRegion', type: 'uint8' },
+                  { name: 'derivedAtTick', type: 'uint64' },
+                ],
+              },
+              {
+                name: 'activeMission',
+                type: 'tuple',
+                components: [
+                  { name: 'active', type: 'bool' },
+                  { name: 'nonce', type: 'uint64' },
+                  { name: 'clansmanId', type: 'uint32' },
+                  { name: 'startRegion', type: 'uint8' },
+                  { name: 'targetRegion', type: 'uint8' },
+                  { name: 'action', type: 'uint8' },
+                  { name: 'startTick', type: 'uint64' },
+                  { name: 'arrivalTick', type: 'uint64' },
+                  { name: 'actionStartTick', type: 'uint64' },
+                  { name: 'missionSeed', type: 'bytes32' },
+                  { name: 'marketMode', type: 'uint8' },
+                  { name: 'targetClanId', type: 'uint32' },
+                  { name: 'marketToken', type: 'address' },
+                  { name: 'marketAmount', type: 'uint256' },
+                  { name: 'maxGoldIn', type: 'uint256' },
+                ],
+              },
+            ],
+          },
+          {
+            name: 'westPlot',
+            type: 'tuple',
+            components: [
+              { name: 'state', type: 'uint8' },
+              { name: 'region', type: 'uint8' },
+              { name: 'remainingWheat', type: 'uint256' },
+              { name: 'regrowUntilTick', type: 'uint64' },
+            ],
+          },
+          {
+            name: 'eastPlot',
+            type: 'tuple',
+            components: [
+              { name: 'state', type: 'uint8' },
+              { name: 'region', type: 'uint8' },
+              { name: 'remainingWheat', type: 'uint256' },
+              { name: 'regrowUntilTick', type: 'uint64' },
+            ],
+          },
+          { name: 'incomingDefenderIds', type: 'uint32[]' },
+          { name: 'thisClanDefendingBaseId', type: 'uint32' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+] as const;
 
 class StubChainClient implements IChainClient {
   async getCurrentTick(): Promise<Tick> {
@@ -25,14 +221,58 @@ class StubChainClient implements IChainClient {
 }
 
 class RealChainClient implements IChainClient {
+  private readonly client;
+  private readonly contractAddress: `0x${string}`;
+
+  constructor() {
+    const primaryRpc = readEnv('RPC_URL_PRIMARY');
+    const fallbackRpc = readEnv('RPC_URL_FALLBACK');
+    const rpcUrl = primaryRpc ?? fallbackRpc;
+
+    this.contractAddress = (readEnv('CLAN_WORLD_CONTRACT_ADDRESS') ??
+      DEFAULT_CONTRACT_ADDRESS) as `0x${string}`;
+
+    this.client = createPublicClient({
+      chain: worldChainSepolia,
+      transport: http(rpcUrl),
+    });
+  }
+
   async getCurrentTick(): Promise<Tick> {
-    throw new Error('RealChainClient: not implemented (Wave 1+)');
+    const snapshot = await this.client.readContract({
+      address: this.contractAddress,
+      abi: CLAN_WORLD_ABI,
+      functionName: 'getWorldSnapshot',
+    });
+    return Number(snapshot.currentTick);
   }
+
   async submitOrders(_clanId: string, _orders: ClanOrder[]): Promise<{ txHash: string }> {
-    throw new Error('RealChainClient: not implemented (Wave 1+)');
+    throw new Error(
+      'RealChainClient: submitOrders not supported — use agents package for tx signing',
+    );
   }
-  async getClanFullView(_clanId: string): Promise<ClanFullView> {
-    throw new Error('RealChainClient: not implemented (Wave 1+)');
+
+  async getClanFullView(clanId: string): Promise<ClanFullView> {
+    const result = await this.client.readContract({
+      address: this.contractAddress,
+      abi: CLAN_WORLD_ABI,
+      functionName: 'getClanFullView',
+      args: [parseInt(clanId, 10)],
+    });
+
+    const inner = result.clan.clan;
+    return {
+      clan: {
+        id: String(inner.clanId),
+        name: `clan-${inner.clanId}`,
+        treasury: String(inner.goldBalance),
+      },
+      // controlledRegions, pendingOrders, whispers not available in Wave 0 contract read
+      controlledRegions: [],
+      pendingOrders: [],
+      whispers: [],
+    };
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,10 @@ importers:
   packages/contracts: {}
 
   packages/shared:
+    dependencies:
+      viem:
+        specifier: ^2.48.4
+        version: 2.48.4(typescript@5.9.3)
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -1311,8 +1315,7 @@ packages:
 
 snapshots:
 
-  '@adraffy/ens-normalize@1.11.1':
-    optional: true
+  '@adraffy/ens-normalize@1.11.1': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1658,18 +1661,15 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@noble/ciphers@1.3.0':
-    optional: true
+  '@noble/ciphers@1.3.0': {}
 
   '@noble/curves@1.9.1':
     dependencies:
       '@noble/hashes': 1.8.0
-    optional: true
 
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
-    optional: true
 
   '@noble/hashes@1.8.0': {}
 
@@ -1752,21 +1752,18 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
-  '@scure/base@1.2.6':
-    optional: true
+  '@scure/base@1.2.6': {}
 
   '@scure/bip32@1.7.0':
     dependencies:
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
-    optional: true
 
   '@scure/bip39@1.6.0':
     dependencies:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
-    optional: true
 
   '@turbo/darwin-64@2.9.6':
     optional: true
@@ -1871,7 +1868,6 @@ snapshots:
   abitype@1.2.3(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
-    optional: true
 
   abitype@1.2.4(typescript@5.9.3):
     optionalDependencies:
@@ -2047,7 +2043,6 @@ snapshots:
   isows@1.0.7(ws@8.18.3):
     dependencies:
       ws: 8.18.3
-    optional: true
 
   js-binary-schema-parser@2.0.3: {}
 
@@ -2091,7 +2086,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
-    optional: true
 
   p-limit@2.3.0:
     dependencies:
@@ -2253,7 +2247,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
       - zod
-    optional: true
 
   vite@5.4.11(@types/node@25.6.0):
     dependencies:
@@ -2272,8 +2265,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  ws@8.18.3:
-    optional: true
+  ws@8.18.3: {}
 
   y18n@4.0.3: {}
 


### PR DESCRIPTION
## Summary

- Adds `viem` dep to `@clan-world/shared`
- `RealChainClient` reads from ClanWorldStub at `0xC012275376b867944cd874FB2d600d6dA3B4A56e` on World Chain Sepolia (chainId 4801)
- `getCurrentTick()`: calls `getWorldSnapshot()`, returns `Number(snapshot.currentTick)`
- `getClanFullView(clanId)`: calls `getClanFullView(uint32)`, maps `clan.goldBalance` → `treasury`, returns empty `controlledRegions`/`pendingOrders`/`whispers` (Wave 0 read-only; Wave 1 populates from on-chain data)
- `submitOrders()`: throws — tx signing belongs in agents package, not shared read-only client
- Transport: `fallback([http(primary), http(fallback)])` when both env vars set; single transport otherwise
- Inline ABI (getWorldSnapshot + getClanFullView only) — verified against compiled `IClanWorld.json`
- `CLAN_WORLD_CONTRACT_ADDRESS` env override supported; hardcoded default is the deployed stub address

## Known limitation (LOW)
If neither `RPC_URL_PRIMARY` nor `RPC_URL_FALLBACK` is set, viem will error at call time rather than at construction — acceptable for Wave 0 where env vars are always configured.

## Review status
- Codex: CLEAN (post-fix; HIGH finding was false-positive — ABI already matched canonical)
- Gemini: CLEAN
- Claude: CLEAN

Closes #8