### PR TITLE
feat(contracts,scripts): Foundry Heartbeat script + start-heartbeat-loop.sh (#10)

### DIFF
--- a/packages/contracts/script/Heartbeat.s.sol
+++ b/packages/contracts/script/Heartbeat.s.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console} from "forge-std/Script.sol";
+import {IClanWorld} from "../src/IClanWorld.sol";
+
+contract Heartbeat is Script {
+    function run() external {
+        uint256 pk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address stub = vm.envAddress("CLAN_WORLD_STUB_ADDRESS");
+
+        vm.startBroadcast(pk);
+        IClanWorld(stub).heartbeat();
+        vm.stopBroadcast();
+
+        console.log("heartbeat() fired on", stub);
+    }
+}

--- a/scripts/start-heartbeat-loop.sh
+++ b/scripts/start-heartbeat-loop.sh
@@ -2,6 +2,9 @@
 # chmod +x scripts/start-heartbeat-loop.sh
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
 # Source .env.local from repo root if it exists
 if [ -f .env.local ]; then
   set -a
@@ -43,13 +46,17 @@ echo "  convex: $CONVEX_DEPLOY_URL"
 
 while true; do
   forge script packages/contracts/script/Heartbeat.s.sol \
+    --root packages/contracts \
     --broadcast \
     --rpc-url "$RPC_URL_PRIMARY"
 
-  curl -sS -X POST "$CONVEX_DEPLOY_URL/api/heartbeat-webhook" \
+  curl -sS --fail -X POST "$CONVEX_DEPLOY_URL/api/heartbeat-webhook" \
     -H "Authorization: Bearer $WEBHOOK_SHARED_SECRET" \
     -H "Content-Type: application/json" \
-    -d "{\"chain\":\"worldchain-sepolia\",\"engineAddress\":\"$CLAN_WORLD_STUB_ADDRESS\",\"firedAtTs\":$(date +%s),\"source\":\"foundry-loop\"}"
+    -d "{\"chain\":\"worldchain-sepolia\",\"engineAddress\":\"$CLAN_WORLD_STUB_ADDRESS\",\"firedAtTs\":$(date +%s),\"source\":\"foundry-loop\"}" \
+    || echo "webhook POST failed (continuing)" >&2
 
+  # Note: actual cadence = forge_time + curl_time + 20s
+  # For Submission 1 this is fine; the on-chain interval guard in the contract handles overlap
   sleep 20
 done

--- a/scripts/start-heartbeat-loop.sh
+++ b/scripts/start-heartbeat-loop.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# chmod +x scripts/start-heartbeat-loop.sh
+set -euo pipefail
+
+# Source .env.local from repo root if it exists
+if [ -f .env.local ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source .env.local
+  set +a
+fi
+
+# Validate required env vars
+REQUIRED_VARS=(
+  RPC_URL_PRIMARY
+  CONVEX_DEPLOY_URL
+  WEBHOOK_SHARED_SECRET
+  DEPLOYER_PRIVATE_KEY
+  CLAN_WORLD_STUB_ADDRESS
+)
+
+missing=0
+for var in "${REQUIRED_VARS[@]}"; do
+  if [ -z "${!var:-}" ]; then
+    echo "ERROR: required env var $var is not set" >&2
+    missing=1
+  fi
+done
+
+if [ "$missing" -eq 1 ]; then
+  echo ""
+  echo "Usage: set the following env vars before running (or put them in .env.local):"
+  for var in "${REQUIRED_VARS[@]}"; do
+    echo "  $var"
+  done
+  exit 1
+fi
+
+echo "Starting heartbeat loop (interval: 20s)"
+echo "  stub:  $CLAN_WORLD_STUB_ADDRESS"
+echo "  rpc:   $RPC_URL_PRIMARY"
+echo "  convex: $CONVEX_DEPLOY_URL"
+
+while true; do
+  forge script packages/contracts/script/Heartbeat.s.sol \
+    --broadcast \
+    --rpc-url "$RPC_URL_PRIMARY"
+
+  curl -sS -X POST "$CONVEX_DEPLOY_URL/api/heartbeat-webhook" \
+    -H "Authorization: Bearer $WEBHOOK_SHARED_SECRET" \
+    -H "Content-Type: application/json" \
+    -d "{\"chain\":\"worldchain-sepolia\",\"engineAddress\":\"$CLAN_WORLD_STUB_ADDRESS\",\"firedAtTs\":$(date +%s),\"source\":\"foundry-loop\"}"
+
+  sleep 20
+done


### PR DESCRIPTION
## Summary

- `packages/contracts/script/Heartbeat.s.sol` — Foundry script calling `IClanWorld.heartbeat()` on ClanWorldStub; reads `DEPLOYER_PRIVATE_KEY` + `CLAN_WORLD_STUB_ADDRESS` from env via `vm.envUint`/`vm.envAddress`
- `scripts/start-heartbeat-loop.sh` — 20s bash loop: forge broadcast → webhook POST → sleep 20
  - `set -euo pipefail`, `SCRIPT_DIR` anchor (works from any cwd)
  - `--root packages/contracts` flag so forge resolves `foundry.toml` correctly
  - Validates all 5 required env vars before entering loop
  - `curl --fail` with `|| echo` — non-2xx logged to stderr, loop continues (webhook is optional safety net)
  - Sources `.env.local` if present

## Review status
- Codex: CLEAN (post-fix)
- Gemini: CLEAN
- Claude: CLEAN

Closes #10