### PR TITLE
[landing] Add clan-world.com landing page (apps/landing)

### DIFF
--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -1,0 +1,92 @@
+# Clan World: Ælder Whispers — Landing & Chronicle
+
+Marketing site for the hackathon submission, themed as an illuminated
+manuscript. Two pages:
+
+- **`/`** — landing folio: hero map, premise, demo hook, codex of powers
+  (sponsor tech), tales of emergent behaviour, path to the chronicle
+- **`/lore`** — the chronicle: lore (4 chapters) + game rules (9 sections),
+  combined as a single long scroll
+
+## Running locally
+
+```bash
+cd clanworld-landing
+npm install
+npm run dev
+```
+
+Production build:
+
+```bash
+npm run build
+npm run preview
+```
+
+## Stack
+
+- Vite + React 19 + TypeScript
+- React Router (`/` and `/lore`)
+- Plain CSS with custom properties — no Tailwind, no UI libraries
+- Custom inline-SVG illustrations for the map, heraldic shields, diagrams,
+  charts, and ornaments
+- `motion` is installed but not currently wired in — the reveal animations
+  use a small IntersectionObserver hook (`src/hooks/useReveal.ts`) to keep
+  bundle size honest
+
+## Theme
+
+- **Aesthetic:** illuminated manuscript meets 16-bit JRPG overworld
+- **Palette:** parchment, ink, vermillion, gold leaf, lapis (CSS variables
+  in `src/styles/global.css`)
+- **Typography:** IM Fell English (display), EB Garamond (body), VT323
+  (pixel margin annotations) — all from Google Fonts
+- **Sponsor logos** are loaded from official URLs; if any fail
+  (cross-origin, etc.) the SponsorCard component falls back to a
+  text-initials wax-seal automatically
+
+## Customising
+
+### Sponsor data
+
+`src/data/sponsors.ts` — edit the eight `POWERS` entries to change names,
+copy, links, or logo URLs. Logos can be set to `null` to use the text
+fallback explicitly.
+
+### Houses / lore content
+
+`src/pages/LorePage.tsx` — `HOUSES` and `BANDIT_TIERS` arrays are at the
+top of the file. Yield/travel/market tables are inline JSX in their
+respective chapters.
+
+### Repo / app links
+
+`src/constants.ts` — `APP_URL` and `GITHUB_URL`.
+
+### Custom artwork
+
+The repo's image folder at `https://github.com/OmniPass-world/clan-world/tree/main/images`
+isn't currently referenced; the page uses inline SVG illustrations so it
+works standalone. If you want to swap in repo images, the easiest places:
+
+- **Hero map** — replace `<RealmMap />` in `LandingPage.tsx` with an
+  `<img>` pointing at a raw GitHub URL
+- **Tale cards** — add an `<img>` element inside each `tale-frame`
+- **Sponsor wax seals** — already pulling official logos via URL; can be
+  swapped to repo images by editing `logoUrl` in `sponsors.ts`
+
+## Routes
+
+```
+/        →  LandingPage
+/lore    →  LorePage  (lore + rules combined)
+```
+
+For SPA hosting, configure your host to serve `index.html` for unknown
+routes (Vercel does this automatically; on Netlify add a `_redirects`
+file with `/* /index.html 200`).
+
+## Deploy target
+
+CTA buttons link to `https://app.clan-world.com`. Repository at
+`https://github.com/OmniPass-world/clan-world`.

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Clan World: Ælder Whispers — A realm of autonomous agents, ruined fortunes, and unforgiving winters. An onchain strategy game where AI Elders command clans, betray rivals, and remember everything." />
+    <meta property="og:title" content="Clan World: Ælder Whispers" />
+    <meta property="og:description" content="A realm of autonomous agents, ruined fortunes, and unforgiving winters." />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&family=IM+Fell+DW+Pica:ital@0;1&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=VT323&display=swap" rel="stylesheet">
+    <title>Clan World: Ælder Whispers</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@clan-world/landing",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo 'lint stub'",
+    "clean": "rm -rf dist .turbo node_modules/.vite"
+  },
+  "dependencies": {
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "react-router-dom": "^7.14.2"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "~5.9.3",
+    "vite": "^8.0.10"
+  }
+}

--- a/apps/landing/public/favicon.svg
+++ b/apps/landing/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#9B2A2F" stroke="#2A1810" stroke-width="2"/>
+  <circle cx="32" cy="32" r="24" fill="none" stroke="#A87C2F" stroke-width="1"/>
+  <text x="32" y="44" text-anchor="middle" font-family="serif" font-style="italic" font-size="32" fill="#E8D8B5" font-weight="400">Æ</text>
+</svg>

--- a/apps/landing/src/components/Footer.tsx
+++ b/apps/landing/src/components/Footer.tsx
@@ -1,0 +1,60 @@
+import { Link } from 'react-router-dom'
+import { APP_URL, GITHUB_URL } from '../constants'
+
+export default function Footer() {
+  return (
+    <footer className="site-footer">
+      <div className="site-footer-inner">
+        <div className="site-footer-grid">
+          <div>
+            <h4>Clan World <i>: Ælder Whispers</i></h4>
+            <p style={{ color: 'var(--ink-soft)', fontSize: '0.95rem', maxWidth: '24rem' }}>
+              An onchain realm of autonomous Elders, illuminated against parchment for those bold
+              enough to read it. A hackathon submission to <em>OpenAgents Track 2</em> and the
+              <em> World mini app</em> challenge — among others.
+            </p>
+            <p style={{ marginTop: '1rem' }} className="pixel">
+              ⌬ Built on Base · 0G · World Chain
+            </p>
+          </div>
+
+          <div>
+            <h4>Realm</h4>
+            <ul>
+              <li><a href={APP_URL}>Enter the realm</a></li>
+              <li><Link to="/">Landing folio</Link></li>
+              <li><Link to="/lore">The chronicle</Link></li>
+            </ul>
+          </div>
+
+          <div>
+            <h4>The Codex</h4>
+            <ul>
+              <li><a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">GitHub repository</a></li>
+              <li><a href={`${GITHUB_URL}/tree/main/images`} target="_blank" rel="noopener noreferrer">Image archive</a></li>
+              <li><a href="https://docs.0g.ai/developer-hub/building-on-0g/inft/erc7857" target="_blank" rel="noopener noreferrer">ERC-7857 spec</a></li>
+            </ul>
+          </div>
+
+          <div>
+            <h4>Powers</h4>
+            <ul>
+              <li><a href="https://uniswap.org" target="_blank" rel="noopener noreferrer">Uniswap</a></li>
+              <li><a href="https://0g.ai" target="_blank" rel="noopener noreferrer">0G Labs</a></li>
+              <li><a href="https://base.org" target="_blank" rel="noopener noreferrer">Base</a></li>
+              <li><a href="https://world.org" target="_blank" rel="noopener noreferrer">World</a></li>
+              <li><a href="https://gensyn.ai" target="_blank" rel="noopener noreferrer">Gensyn</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="colophon">
+          <em>
+            ✦ Inscribed in the year of our agents 2026 · forged in pen and pixel · 
+            offered freely to scholars of emergent behaviour ✦
+          </em>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/apps/landing/src/components/Header.tsx
+++ b/apps/landing/src/components/Header.tsx
@@ -1,0 +1,31 @@
+import { Link } from 'react-router-dom'
+import { GITHUB_URL } from '../constants'
+
+const REPO_LINK = GITHUB_URL
+
+export default function Header() {
+  return (
+    <header className="site-header">
+      <div className="site-header-inner">
+        <Link to="/" className="site-brand" aria-label="Clan World home">
+          <svg className="site-brand-mark" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M16 2 L28 8 L28 18 C28 24 22 28 16 30 C10 28 4 24 4 18 L4 8 Z"
+              stroke="currentColor" strokeWidth="1.5" fill="rgba(168,124,47,0.12)" />
+            <path d="M16 9 L20 16 L16 23 L12 16 Z" fill="currentColor" />
+            <circle cx="16" cy="16" r="1.5" fill="var(--parchment)" />
+          </svg>
+          <span>Clan World <i style={{ color: 'var(--vermillion)' }}>: Ælder Whispers</i></span>
+        </Link>
+        <nav className="site-nav">
+          <Link to="/lore" className="desktop-only">The Chronicle</Link>
+          <a href={REPO_LINK} target="_blank" rel="noopener noreferrer" className="pixel-link" aria-label="GitHub repository">
+            ▲ GITHUB
+          </a>
+          <a href="https://app.clan-world.com" className="cta-secondary">
+            Enter Realm
+          </a>
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/apps/landing/src/components/HeraldicShield.tsx
+++ b/apps/landing/src/components/HeraldicShield.tsx
@@ -1,0 +1,124 @@
+import type { CSSProperties } from 'react'
+
+interface Props {
+  color: string
+  /** Decorative pattern variant 1-8 */
+  variant?: number
+  size?: number
+  style?: CSSProperties
+}
+
+/**
+ * Heraldic shield with one of 8 charge variants.
+ * Used in the lore page Eight Houses table.
+ */
+export default function HeraldicShield({ color, variant = 1, size = 64, style }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size * 1.2}
+      viewBox="0 0 64 78"
+      style={style}
+      aria-hidden="true"
+    >
+      {/* Shield body */}
+      <path
+        d="M 4 6 L 60 6 L 60 38 Q 60 60 32 74 Q 4 60 4 38 Z"
+        fill={color}
+        stroke="#2A1810"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      {/* Shading band */}
+      <path
+        d="M 4 6 L 60 6 L 60 12 L 4 12 Z"
+        fill="#2A1810"
+        opacity="0.18"
+      />
+      {/* Charges by variant */}
+      <g fill="#E8D8B5" stroke="#2A1810" strokeWidth="0.7">
+        {variant === 1 && (
+          // Sword
+          <g>
+            <rect x="30" y="22" width="4" height="32" />
+            <rect x="24" y="22" width="16" height="3" />
+            <path d="M 32 54 L 28 60 L 36 60 Z" />
+          </g>
+        )}
+        {variant === 2 && (
+          // Wave / ship
+          <g>
+            <path d="M 16 38 Q 24 32 32 38 Q 40 44 48 38" fill="none" strokeWidth="1.5" />
+            <path d="M 16 46 Q 24 40 32 46 Q 40 52 48 46" fill="none" strokeWidth="1.5" />
+            <path d="M 22 30 L 42 30 L 38 36 L 26 36 Z" />
+            <path d="M 32 22 L 32 30" strokeWidth="1.2" />
+            <path d="M 32 22 L 39 28 L 32 28 Z" />
+          </g>
+        )}
+        {variant === 3 && (
+          // Sun / coin
+          <g>
+            <circle cx="32" cy="38" r="9" />
+            {Array.from({ length: 8 }).map((_, i) => {
+              const a = (i * Math.PI) / 4
+              const x1 = 32 + Math.cos(a) * 13
+              const y1 = 38 + Math.sin(a) * 13
+              const x2 = 32 + Math.cos(a) * 18
+              const y2 = 38 + Math.sin(a) * 18
+              return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth="1.2" />
+            })}
+          </g>
+        )}
+        {variant === 4 && (
+          // Tree
+          <g>
+            <rect x="30" y="44" width="4" height="14" />
+            <path d="M 32 18 L 22 38 L 42 38 Z" />
+            <path d="M 32 26 L 24 44 L 40 44 Z" />
+          </g>
+        )}
+        {variant === 5 && (
+          // Stars
+          <g>
+            {[
+              { x: 22, y: 28 },
+              { x: 42, y: 28 },
+              { x: 32, y: 42 },
+              { x: 22, y: 56 },
+              { x: 42, y: 56 },
+            ].map((p, i) => (
+              <path
+                key={i}
+                d={`M ${p.x} ${p.y - 4} L ${p.x + 1} ${p.y - 1} L ${p.x + 4} ${p.y - 1} L ${p.x + 1.5} ${p.y + 1} L ${p.x + 2.5} ${p.y + 4} L ${p.x} ${p.y + 2} L ${p.x - 2.5} ${p.y + 4} L ${p.x - 1.5} ${p.y + 1} L ${p.x - 4} ${p.y - 1} L ${p.x - 1} ${p.y - 1} Z`}
+              />
+            ))}
+          </g>
+        )}
+        {variant === 6 && (
+          // Anvil / hammer
+          <g>
+            <rect x="20" y="42" width="24" height="6" />
+            <rect x="22" y="48" width="20" height="4" />
+            <rect x="28" y="22" width="3" height="20" />
+            <rect x="22" y="20" width="15" height="6" />
+          </g>
+        )}
+        {variant === 7 && (
+          // Tower / monument
+          <g>
+            <rect x="22" y="50" width="20" height="14" />
+            <rect x="24" y="38" width="16" height="12" />
+            <rect x="26" y="26" width="12" height="12" />
+            <path d="M 26 26 L 32 18 L 38 26 Z" />
+          </g>
+        )}
+        {variant === 8 && (
+          // Wolf / fang
+          <g>
+            <path d="M 18 28 L 32 60 L 46 28 L 38 36 L 32 30 L 26 36 Z" />
+          </g>
+        )}
+      </g>
+    </svg>
+  )
+}

--- a/apps/landing/src/components/RealmMap.tsx
+++ b/apps/landing/src/components/RealmMap.tsx
@@ -1,0 +1,285 @@
+import type { CSSProperties } from 'react'
+
+interface Props {
+  style?: CSSProperties
+  className?: string
+}
+
+/**
+ * Hand-drawn map of the 8 regions — used in the hero of LandingPage.
+ * Stylized as ink-on-parchment: rough strokes, hatched water, calligraphic labels.
+ */
+export default function RealmMap({ style, className }: Props) {
+  return (
+    <svg
+      viewBox="0 0 800 1000"
+      xmlns="http://www.w3.org/2000/svg"
+      style={style}
+      className={className}
+      aria-label="A map of the eight regions of Clan World"
+      role="img"
+    >
+      <defs>
+        {/* Parchment-tinted background */}
+        <radialGradient id="mapVignette" cx="50%" cy="45%" r="65%">
+          <stop offset="0%" stopColor="#E8D8B5" stopOpacity="0" />
+          <stop offset="100%" stopColor="#A8956A" stopOpacity="0.45" />
+        </radialGradient>
+
+        {/* Hatched-water pattern for sea */}
+        <pattern id="hatchSea" width="14" height="14" patternUnits="userSpaceOnUse" patternTransform="rotate(0)">
+          <path d="M0 7 Q3 4 6 7 T12 7" stroke="#1F4068" strokeWidth="0.6" fill="none" opacity="0.55" />
+          <path d="M0 11 Q3 8 6 11 T12 11" stroke="#1F4068" strokeWidth="0.5" fill="none" opacity="0.4" />
+        </pattern>
+
+        {/* Stippled ground for forest */}
+        <pattern id="stippleForest" width="10" height="10" patternUnits="userSpaceOnUse">
+          <circle cx="2" cy="3" r="0.6" fill="#2A1810" opacity="0.45" />
+          <circle cx="7" cy="6" r="0.5" fill="#2A1810" opacity="0.35" />
+          <circle cx="4" cy="8" r="0.4" fill="#2A1810" opacity="0.4" />
+        </pattern>
+
+        {/* Cross-hatching for mountains */}
+        <pattern id="crossMtn" width="8" height="8" patternUnits="userSpaceOnUse" patternTransform="rotate(35)">
+          <line x1="0" y1="0" x2="0" y2="8" stroke="#2A1810" strokeWidth="0.5" opacity="0.5" />
+        </pattern>
+
+        {/* Wheat dot pattern for farms */}
+        <pattern id="wheat" width="12" height="12" patternUnits="userSpaceOnUse">
+          <circle cx="3" cy="6" r="0.8" fill="#A87C2F" opacity="0.6" />
+          <circle cx="9" cy="3" r="0.7" fill="#A87C2F" opacity="0.55" />
+          <circle cx="6" cy="9" r="0.6" fill="#A87C2F" opacity="0.5" />
+        </pattern>
+      </defs>
+
+      {/* Parchment vignette */}
+      <rect x="0" y="0" width="800" height="1000" fill="url(#mapVignette)" />
+
+      {/* ===== Sea / water — fills outside region polygons ===== */}
+      <rect x="0" y="0" width="800" height="1000" fill="url(#hatchSea)" opacity="0.55" />
+
+      {/* Compass rose, top-right */}
+      <g transform="translate(710, 90)" opacity="0.65">
+        <circle r="34" fill="none" stroke="#2A1810" strokeWidth="0.8" />
+        <circle r="22" fill="none" stroke="#2A1810" strokeWidth="0.5" />
+        <path d="M0,-30 L4,0 L0,30 L-4,0 Z" fill="#9B2A2F" stroke="#2A1810" strokeWidth="0.6" />
+        <path d="M-30,0 L0,4 L30,0 L0,-4 Z" fill="#A87C2F" stroke="#2A1810" strokeWidth="0.6" opacity="0.7" />
+        <text x="0" y="-38" textAnchor="middle" fontFamily="IM Fell English, serif" fontSize="11" fill="#2A1810">N</text>
+        <text x="40" y="3" textAnchor="middle" fontFamily="IM Fell English, serif" fontSize="11" fill="#2A1810">E</text>
+        <text x="0" y="48" textAnchor="middle" fontFamily="IM Fell English, serif" fontSize="11" fill="#2A1810">S</text>
+        <text x="-40" y="3" textAnchor="middle" fontFamily="IM Fell English, serif" fontSize="11" fill="#2A1810">W</text>
+      </g>
+
+      {/* Cartouche title */}
+      <g transform="translate(80, 60)">
+        <rect x="0" y="0" width="280" height="62" fill="#E8D8B5" stroke="#2A1810" strokeWidth="0.8" />
+        <rect x="-4" y="-4" width="288" height="70" fill="none" stroke="#A87C2F" strokeWidth="0.6" />
+        <text x="140" y="26" textAnchor="middle" fontFamily="IM Fell English, serif" fontSize="18" fill="#2A1810">
+          A Mappe of the
+        </text>
+        <text x="140" y="48" textAnchor="middle" fontFamily="IM Fell English, serif" fontSize="22" fontStyle="italic" fill="#9B2A2F">
+          Eight Regions
+        </text>
+      </g>
+
+      {/* ============ FOREST (1) — top left ============ */}
+      <g>
+        <path
+          d="M 70 160 Q 105 130 165 145 Q 235 150 295 175 Q 320 220 305 280 Q 290 330 260 345 Q 200 365 145 350 Q 95 335 70 295 Q 60 240 70 160 Z"
+          fill="url(#stippleForest)"
+          stroke="#2A1810"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        {/* trees */}
+        <g fill="#3F704D" stroke="#2A1810" strokeWidth="0.6">
+          <path d="M120 220 L114 240 L126 240 Z M120 240 L120 252" />
+          <path d="M155 195 L148 218 L162 218 Z M155 218 L155 232" />
+          <path d="M205 240 L198 263 L212 263 Z M205 263 L205 277" />
+          <path d="M245 200 L238 222 L252 222 Z M245 222 L245 236" />
+          <path d="M180 290 L173 312 L187 312 Z M180 312 L180 326" />
+          <path d="M260 280 L253 302 L267 302 Z M260 302 L260 316" />
+          <path d="M105 280 L99 300 L111 300 Z M105 300 L105 313" />
+        </g>
+        <text x="187" y="210" textAnchor="middle" fontFamily="IM Fell English, serif" fontStyle="italic" fontSize="20" fill="#2A1810">
+          Forest
+        </text>
+      </g>
+
+      {/* ============ MOUNTAINS (2) — top right ============ */}
+      <g>
+        <path
+          d="M 470 145 Q 545 130 615 150 Q 685 165 720 215 Q 740 270 720 325 Q 685 360 620 360 Q 540 365 480 335 Q 450 305 455 260 Q 455 195 470 145 Z"
+          fill="url(#crossMtn)"
+          stroke="#2A1810"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        <g fill="#6B7280" stroke="#2A1810" strokeWidth="0.8" strokeLinejoin="round">
+          <path d="M510 280 L545 215 L580 280 Z" fill="#8a8e95" />
+          <path d="M540 215 L555 232 L530 232 Z" fill="#E5E7EB" />
+          <path d="M585 295 L625 230 L665 295 Z" fill="#7a808a" />
+          <path d="M620 230 L635 252 L605 252 Z" fill="#E5E7EB" />
+          <path d="M475 305 L500 270 L530 305 Z" fill="#9aa0a8" />
+        </g>
+        <text x="595" y="200" textAnchor="middle" fontFamily="IM Fell English, serif" fontStyle="italic" fontSize="20" fill="#2A1810">
+          Mountains
+        </text>
+      </g>
+
+      {/* ============ UNICORN TOWN (3) — center ============ */}
+      <g>
+        <path
+          d="M 300 410 Q 390 395 480 410 Q 525 440 510 490 Q 495 530 440 540 Q 365 555 320 530 Q 290 500 295 460 Q 295 430 300 410 Z"
+          fill="#D8B4D8"
+          fillOpacity="0.55"
+          stroke="#2A1810"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        {/* sparkles */}
+        <g fill="#A87C2F">
+          <circle cx="335" cy="430" r="1.2" />
+          <circle cx="385" cy="445" r="1" />
+          <circle cx="430" cy="425" r="1.4" />
+          <circle cx="465" cy="450" r="1" />
+          <circle cx="350" cy="475" r="1.1" />
+          <circle cx="410" cy="490" r="1.3" />
+          <circle cx="445" cy="510" r="0.9" />
+        </g>
+        {/* spire */}
+        <g stroke="#2A1810" strokeWidth="1" fill="#9B2A2F" opacity="0.8">
+          <path d="M395 490 L387 460 L382 466 L382 490 Z" />
+          <path d="M395 490 L403 460 L408 466 L408 490 Z" fill="#7a1f23" />
+          <path d="M387 460 L395 442 L403 460 Z" fill="#A87C2F" />
+        </g>
+        <text x="395" y="425" textAnchor="middle" fontFamily="IM Fell English, serif" fontStyle="italic" fontSize="19" fill="#7B3F8C">
+          Unicorn Town
+        </text>
+      </g>
+
+      {/* ============ WEST FARMS (4) — left middle ============ */}
+      <g>
+        <path
+          d="M 60 580 Q 120 565 195 575 Q 255 590 270 635 Q 285 680 260 720 Q 220 755 155 745 Q 100 740 70 705 Q 50 660 60 580 Z"
+          fill="url(#wheat)"
+          stroke="#2A1810"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        <rect x="155" y="668" width="22" height="18" fill="#A85A2C" stroke="#2A1810" strokeWidth="0.6" />
+        <path d="M155 668 L166 656 L177 668 Z" fill="#7a3f1f" stroke="#2A1810" strokeWidth="0.6" />
+        <text x="160" y="615" textAnchor="middle" fontFamily="IM Fell English, serif" fontStyle="italic" fontSize="18" fill="#2A1810">
+          West Farms
+        </text>
+      </g>
+
+      {/* ============ EAST FARMS (5) — right middle ============ */}
+      <g>
+        <path
+          d="M 530 575 Q 605 560 680 580 Q 730 600 740 645 Q 745 695 715 725 Q 670 755 605 745 Q 545 740 525 705 Q 510 660 530 575 Z"
+          fill="url(#wheat)"
+          stroke="#2A1810"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        <rect x="630" y="668" width="22" height="18" fill="#A85A2C" stroke="#2A1810" strokeWidth="0.6" />
+        <path d="M630 668 L641 656 L652 668 Z" fill="#7a3f1f" stroke="#2A1810" strokeWidth="0.6" />
+        <text x="635" y="615" textAnchor="middle" fontFamily="IM Fell English, serif" fontStyle="italic" fontSize="18" fill="#2A1810">
+          East Farms
+        </text>
+      </g>
+
+      {/* ============ WEST DOCKS (6) — lower left ============ */}
+      <g>
+        <path
+          d="M 90 800 Q 140 790 195 805 Q 245 820 250 855 Q 245 890 220 905 Q 175 915 130 905 Q 90 895 80 870 Q 75 835 90 800 Z"
+          fill="#5A8B8B"
+          fillOpacity="0.4"
+          stroke="#2A1810"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        {/* dock pilings */}
+        <g stroke="#2A1810" strokeWidth="1" fill="#5A3D28">
+          <rect x="135" y="855" width="3" height="14" />
+          <rect x="155" y="852" width="3" height="14" />
+          <rect x="175" y="855" width="3" height="14" />
+          <rect x="195" y="853" width="3" height="14" />
+          <line x1="130" y1="852" x2="200" y2="852" strokeWidth="1.2" />
+        </g>
+        <text x="167" y="835" textAnchor="middle" fontFamily="IM Fell English, serif" fontStyle="italic" fontSize="17" fill="#2A1810">
+          West Docks
+        </text>
+      </g>
+
+      {/* ============ EAST DOCKS (7) — lower right ============ */}
+      <g>
+        <path
+          d="M 555 800 Q 615 790 670 805 Q 720 820 720 855 Q 715 895 690 905 Q 645 915 600 905 Q 560 895 550 870 Q 545 835 555 800 Z"
+          fill="#4F7E7E"
+          fillOpacity="0.4"
+          stroke="#2A1810"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        <g stroke="#2A1810" strokeWidth="1" fill="#5A3D28">
+          <rect x="600" y="855" width="3" height="14" />
+          <rect x="620" y="852" width="3" height="14" />
+          <rect x="640" y="855" width="3" height="14" />
+          <rect x="660" y="853" width="3" height="14" />
+          <line x1="595" y1="852" x2="665" y2="852" strokeWidth="1.2" />
+        </g>
+        <text x="632" y="835" textAnchor="middle" fontFamily="IM Fell English, serif" fontStyle="italic" fontSize="17" fill="#2A1810">
+          East Docks
+        </text>
+      </g>
+
+      {/* ============ DEEP SEA (8) — bottom ============ */}
+      <g>
+        <path
+          d="M 280 920 Q 380 905 480 920 Q 545 935 530 970 Q 480 985 400 980 Q 320 980 290 970 Q 270 945 280 920 Z"
+          fill="#2C3E5D"
+          fillOpacity="0.6"
+          stroke="#2A1810"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        {/* sea monster */}
+        <g stroke="#2A1810" strokeWidth="0.8" fill="none" opacity="0.85">
+          <path d="M325 950 Q335 940 345 950 Q355 960 365 950 Q375 940 385 950" />
+          <path d="M395 955 Q405 947 412 955" />
+          <circle cx="333" cy="947" r="0.7" fill="#2A1810" />
+        </g>
+        <text x="405" y="935" textAnchor="middle" fontFamily="IM Fell English, serif" fontStyle="italic" fontSize="17" fill="#E8D8B5">
+          Deep Sea
+        </text>
+        <text x="430" y="975" textAnchor="middle" fontFamily="IM Fell English, serif" fontSize="9" fontStyle="italic" fill="#E8D8B5" opacity="0.7">
+          here be drakes
+        </text>
+      </g>
+
+      {/* Travel routes — faded dotted lines */}
+      <g stroke="#2A1810" strokeWidth="0.8" strokeDasharray="3,3" fill="none" opacity="0.35">
+        <path d="M210 290 Q 280 360 360 410" />
+        <path d="M580 290 Q 510 360 440 410" />
+        <path d="M390 540 Q 380 580 230 600" />
+        <path d="M410 540 Q 425 580 580 600" />
+        <path d="M180 720 Q 175 760 165 800" />
+        <path d="M620 720 Q 625 760 635 800" />
+        <path d="M210 880 Q 290 910 380 925" />
+        <path d="M600 880 Q 520 910 430 925" />
+      </g>
+
+      {/* Subtle ink-spatter ageing flecks */}
+      <g fill="#2A1810" opacity="0.18">
+        <circle cx="60" cy="450" r="0.6" />
+        <circle cx="120" cy="500" r="0.4" />
+        <circle cx="380" cy="60" r="0.5" />
+        <circle cx="725" cy="450" r="0.5" />
+        <circle cx="700" cy="780" r="0.6" />
+        <circle cx="50" cy="650" r="0.4" />
+      </g>
+    </svg>
+  )
+}

--- a/apps/landing/src/components/SponsorCard.css
+++ b/apps/landing/src/components/SponsorCard.css
@@ -1,0 +1,146 @@
+.sponsor-card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  height: 100%;
+  transition: transform 0.3s ease;
+}
+
+.sponsor-card:hover {
+  text-decoration: none;
+  transform: translateY(-3px);
+}
+
+.sponsor-card:hover .sponsor-card-frame {
+  border-color: var(--vermillion);
+  box-shadow: 4px 4px 0 var(--gold-leaf);
+}
+
+.sponsor-card:hover .sponsor-card-name {
+  color: var(--vermillion);
+}
+
+.sponsor-card-frame {
+  position: relative;
+  height: 100%;
+  border: 1.5px solid var(--ink);
+  background: rgba(232, 216, 181, 0.55);
+  padding: 2rem 1.75rem 1.75rem;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.sponsor-card-frame::before,
+.sponsor-card-frame::after {
+  content: '';
+  position: absolute;
+  width: 0.85rem;
+  height: 0.85rem;
+  border: 1.5px solid var(--gold-leaf);
+}
+
+.sponsor-card-frame::before {
+  top: -4px;
+  left: -4px;
+  border-right: none;
+  border-bottom: none;
+}
+
+.sponsor-card-frame::after {
+  bottom: -4px;
+  right: -4px;
+  border-left: none;
+  border-top: none;
+}
+
+/* Wax-seal logo frame */
+.sponsor-card-seal {
+  width: 4.5rem;
+  height: 4.5rem;
+  border-radius: 50%;
+  background: var(--parchment);
+  border: 2px solid var(--ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  flex-shrink: 0;
+  position: relative;
+  box-shadow:
+    inset 0 0 0 3px var(--parchment-aged),
+    inset 0 0 0 4px var(--ink),
+    2px 2px 0 var(--gold-leaf);
+}
+
+.sponsor-card-logo {
+  max-width: 65%;
+  max-height: 65%;
+  object-fit: contain;
+  filter: contrast(1.1) brightness(0.9);
+}
+
+.sponsor-card-fallback {
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  font-family: 'IM Fell English', serif;
+  font-size: 1.4rem;
+  color: var(--vermillion);
+  letter-spacing: 0.05em;
+}
+
+.sponsor-card-body {
+  position: relative;
+  flex: 1;
+}
+
+.sponsor-card-margin {
+  position: absolute;
+  top: -2.5rem;
+  right: -0.5rem;
+  background: var(--parchment-aged);
+  padding: 0.2rem 0.4rem;
+  border: 1px solid var(--ink-faded);
+  font-size: 0.75rem !important;
+  white-space: nowrap;
+  transform: rotate(-2deg);
+}
+
+.sponsor-card-name {
+  font-family: 'IM Fell English', serif;
+  font-size: 1.6rem;
+  line-height: 1.1;
+  color: var(--ink);
+  margin-bottom: 0.15rem;
+  transition: color 0.25s ease;
+}
+
+.sponsor-card-lorename {
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--vermillion);
+  margin-bottom: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
+.sponsor-card-lore {
+  font-family: 'EB Garamond', serif;
+  font-size: 1rem;
+  line-height: 1.55;
+  color: var(--ink);
+  margin-bottom: 0.85rem;
+}
+
+.sponsor-card-tech {
+  font-family: 'EB Garamond', serif;
+  font-size: 0.85rem;
+  font-style: italic;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  padding-top: 0.85rem;
+  border-top: 1px dashed var(--parchment-dark);
+  margin-bottom: 0;
+}

--- a/apps/landing/src/components/SponsorCard.tsx
+++ b/apps/landing/src/components/SponsorCard.tsx
@@ -1,0 +1,68 @@
+import type { SponsorPower } from '../data/sponsors'
+import './SponsorCard.css'
+
+interface Props {
+  power: SponsorPower
+  index: number
+}
+
+export default function SponsorCard({ power, index }: Props) {
+  return (
+    <a
+      href={power.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="sponsor-card"
+      style={{ ['--reveal-delay' as string]: `${index * 80}ms` }}
+    >
+      <div className="sponsor-card-frame">
+        <div className="sponsor-card-seal">
+          {power.logoUrl ? (
+            <img
+              src={power.logoUrl}
+              alt={power.logoAlt}
+              className="sponsor-card-logo"
+              loading="lazy"
+              onError={(e) => {
+                // graceful fallback to lore-name initials
+                const target = e.currentTarget
+                const initials = power.name
+                  .split(/\s+/)
+                  .map((w) => w[0])
+                  .slice(0, 2)
+                  .join('')
+                  .toUpperCase()
+                target.style.display = 'none'
+                const fallback = target.parentElement?.querySelector('.sponsor-card-fallback')
+                if (fallback instanceof HTMLElement) {
+                  fallback.style.display = 'flex'
+                  fallback.textContent = initials
+                }
+              }}
+            />
+          ) : null}
+          <span
+            className="sponsor-card-fallback"
+            style={{ display: power.logoUrl ? 'none' : 'flex' }}
+            aria-hidden={!!power.logoUrl}
+          >
+            {power.name
+              .split(/\s+/)
+              .map((w) => w[0])
+              .slice(0, 2)
+              .join('')
+              .toUpperCase()}
+          </span>
+        </div>
+
+        <div className="sponsor-card-body">
+          <div className="sponsor-card-margin pixel">{power.marginNote}</div>
+          <div className="sponsor-card-name">{power.name}</div>
+          <div className="sponsor-card-lorename">{power.loreName}</div>
+          <p className="sponsor-card-lore">{power.loreDesc}</p>
+          <p className="sponsor-card-tech">{power.techDesc}</p>
+        </div>
+      </div>
+    </a>
+  )
+}

--- a/apps/landing/src/constants.ts
+++ b/apps/landing/src/constants.ts
@@ -1,0 +1,2 @@
+export const APP_URL = 'https://app.clan-world.com'
+export const GITHUB_URL = 'https://github.com/OmniPass-world/clan-world'

--- a/apps/landing/src/data/sponsors.ts
+++ b/apps/landing/src/data/sponsors.ts
@@ -1,0 +1,117 @@
+export interface SponsorPower {
+  /** True name (modern brand) */
+  name: string
+  /** Lore name (in-world rendering) */
+  loreName: string
+  /** Logo URL — official logo where available; null = text treatment only */
+  logoUrl: string | null
+  /** Logo alt for a11y */
+  logoAlt: string
+  /** A short phrase as a pixel-text margin annotation */
+  marginNote: string
+  /** In-character description, ~2 sentences */
+  loreDesc: string
+  /** Technical reality, ~1-2 sentences */
+  techDesc: string
+  /** External link for the sponsor */
+  href: string
+}
+
+export const POWERS: SponsorPower[] = [
+  {
+    name: 'Uniswap',
+    loreName: 'The Unicorn Markets',
+    logoUrl: 'https://upload.wikimedia.org/wikipedia/commons/e/e7/Uniswap_Logo.svg',
+    logoAlt: 'Uniswap logo',
+    marginNote: '← unicorn town liquidity',
+    loreDesc:
+      'In the bright pastel chaos of Unicorn Town, four pools forever hold their balance. Worth flows in, worth flows out, and the unicorns demand no fee but the slippage of careless traders.',
+    techDesc:
+      'Constant-product AMM pools seeded at deploy time. Wood, Iron, Wheat, and Fish each trade against Gold. Scheduled and immediate market actions resolve at heartbeat.',
+    href: 'https://uniswap.org',
+  },
+  {
+    name: 'KeeperHub',
+    loreName: 'The World\'s Pulse',
+    logoUrl: null,
+    logoAlt: 'KeeperHub',
+    marginNote: '← onchain heartbeat',
+    loreDesc:
+      'Time itself is contracted out. Every minute, a faceless keeper rings the bell. Without them the world would freeze; with them, even the bandits march to schedule.',
+    techDesc:
+      'Cron-driven onchain workflow that calls the heartbeat() function at a fixed cadence and fires a webhook to the indexer. Permissionless and self-rate-limited.',
+    href: 'https://app.keeperhub.io',
+  },
+  {
+    name: '0G Storage',
+    loreName: 'The Vault of Memories',
+    logoUrl: 'https://0g.ai/favicon.ico',
+    logoAlt: '0G logo',
+    marginNote: '← agent memory layer',
+    loreDesc:
+      'Where Elders inscribe what they have seen. A grudge against clan three from the autumn of \'412. The price of fish on a Tuesday. Lessons paid for in blood. Memory survives even when the body does not.',
+    techDesc:
+      'Decentralized key-value storage. Each clan owns a namespace bound to its iNFT. Town-square bulletins are posted in shared keys. Memory transfers with ownership.',
+    href: 'https://0g.ai',
+  },
+  {
+    name: '0G Compute',
+    loreName: 'The Sealed Chamber',
+    logoUrl: 'https://0g.ai/favicon.ico',
+    logoAlt: '0G logo',
+    marginNote: '← attested inference',
+    loreDesc:
+      'A chamber of thought, witnessed by no human, vouched for by mathematics alone. What an Elder reasons within may be doubted; what comes out, signed and sealed, may not.',
+    techDesc:
+      'TEE-attested LLM inference. Each Elder decision can be cryptographically proven to have been reasoned by an unmodified model. Anti-cheat by construction.',
+    href: 'https://0g.ai/compute',
+  },
+  {
+    name: 'World MiniKit',
+    loreName: 'The Pocket Realm',
+    logoUrl: 'https://world.org/favicon.ico',
+    logoAlt: 'World logo',
+    marginNote: '← mobile gateway',
+    loreDesc:
+      'A realm that fits in a pocket, summoned through a glass slate. The Elders speak; the player listens; the world unfolds in miniature, between heartbeats.',
+    techDesc:
+      'Native mini-app integration for the World App. Authenticated through World ID, distributed through the in-app directory. Mobile-first by design.',
+    href: 'https://world.org',
+  },
+  {
+    name: 'Gensyn AXL',
+    loreName: 'The Whisper Network',
+    logoUrl: null,
+    logoAlt: 'Gensyn AXL',
+    marginNote: '← p2p e2ee diplomacy',
+    loreDesc:
+      'A web of carrier-spirits binding Elder to Elder. Every word is sealed. Every sender is known. Every betrayal is recorded — and judged later, when the realm reads the chronicle aloud.',
+    techDesc:
+      'Peer-to-peer end-to-end encrypted messaging mesh. Each Elder signs envelopes with their owner key. Receivers verify before delivery. Spoofing is exposed, never silenced.',
+    href: 'https://gensyn.ai',
+  },
+  {
+    name: 'Base',
+    loreName: 'The Adamantine Foundation',
+    logoUrl: 'https://upload.wikimedia.org/wikipedia/commons/8/8e/Coinbase-Logo-Symbol-Logo.wine.svg',
+    logoAlt: 'Base / Coinbase logo',
+    marginNote: '← settlement layer',
+    loreDesc:
+      'The bedrock beneath the realm. Every vault, every wall, every grain of wheat — recorded here, beyond the reach of any single hand. The world may end, but the ledger endures.',
+    techDesc:
+      'L2 chain hosting the IClanWorld contract and all canonical game state. Cheap, fast, EVM-compatible. The single source of truth.',
+    href: 'https://base.org',
+  },
+  {
+    name: 'iNFT (ERC-7857)',
+    loreName: 'The Soul-Vessels',
+    logoUrl: null,
+    logoAlt: 'ERC-7857',
+    marginNote: '← intelligent NFTs',
+    loreDesc:
+      'Each Elder is bound to a vessel — an enchanted relic carrying their mind, their voice, their grudges. To trade the vessel is to inherit the Elder, full and remembered. The new owner does not start fresh; they continue.',
+    techDesc:
+      'ERC-7857 NFTs hold encrypted Elder identity (CLAUDE.md, skills, persona) on 0G Storage. On transfer, intelligence travels with ownership. The signature feature of the OpenAgents Track 2 narrative.',
+    href: 'https://eips.ethereum.org/EIPS/eip-7857',
+  },
+]

--- a/apps/landing/src/hooks/useReveal.ts
+++ b/apps/landing/src/hooks/useReveal.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react'
+
+export function useReveal<T extends HTMLElement = HTMLDivElement>(
+  options: IntersectionObserverInit = { threshold: 0.15, rootMargin: '0px 0px -10% 0px' }
+) {
+  const ref = useRef<T>(null)
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          el.classList.add('in')
+          observer.disconnect()
+        }
+      },
+      options
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+  return ref
+}

--- a/apps/landing/src/main.tsx
+++ b/apps/landing/src/main.tsx
@@ -1,0 +1,17 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import './styles/global.css'
+import LandingPage from './pages/LandingPage'
+import LorePage from './pages/LorePage'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/lore" element={<LorePage />} />
+      </Routes>
+    </BrowserRouter>
+  </StrictMode>,
+)

--- a/apps/landing/src/pages/LandingPage.css
+++ b/apps/landing/src/pages/LandingPage.css
@@ -1,0 +1,538 @@
+/* ============ Hero ============ */
+
+.hero {
+  position: relative;
+  padding: 4rem 0 5rem;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 20% 20%, rgba(168, 124, 47, 0.10), transparent 60%),
+    radial-gradient(ellipse at 80% 80%, rgba(155, 42, 47, 0.05), transparent 50%);
+  pointer-events: none;
+}
+
+.hero-inner {
+  position: relative;
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 3rem;
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .hero-inner {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+  .hero { padding: 2.5rem 0 3rem; }
+}
+
+.hero-eyebrow {
+  display: inline-block;
+  padding: 0.4rem 0.9rem;
+  background: var(--parchment-aged);
+  border: 1px solid var(--ink-faded);
+  margin-bottom: 1.5rem;
+  font-size: 0.8rem !important;
+  letter-spacing: 0.15em;
+  color: var(--ink) !important;
+}
+
+.hero-title {
+  font-family: 'IM Fell English', serif;
+  font-size: var(--fs-display);
+  line-height: 0.92;
+  letter-spacing: -0.005em;
+  margin-bottom: 1.25rem;
+  color: var(--ink);
+}
+
+.hero-title-divider {
+  display: block;
+  font-size: 0.4em;
+  color: var(--gold-leaf);
+  letter-spacing: 0.5em;
+  margin: 0.4rem 0 0.2rem;
+  padding-left: 0.5em;
+}
+
+.hero-title-sub {
+  display: block;
+  font-style: italic;
+  color: var(--vermillion);
+  font-size: 0.6em;
+  font-family: 'IM Fell English', serif;
+}
+
+.hero-tagline {
+  font-family: 'EB Garamond', serif;
+  font-size: 1.35rem;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  max-width: 30rem;
+  margin-bottom: 2.5rem;
+}
+
+@media (max-width: 640px) {
+  .hero-tagline { font-size: 1.15rem; }
+}
+
+.hero-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.25rem;
+  margin-bottom: 2.5rem;
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.8rem !important;
+  color: var(--ink-faded) !important;
+}
+
+.hero-meta a {
+  color: var(--ink-faded);
+  text-decoration: none;
+}
+
+.hero-meta a:hover {
+  color: var(--vermillion);
+  text-decoration: underline;
+}
+
+.hero-meta .dot {
+  opacity: 0.5;
+}
+
+.hero-map {
+  position: relative;
+}
+
+.hero-map svg {
+  width: 100%;
+  height: auto;
+  max-height: 78vh;
+  filter: drop-shadow(8px 8px 0 rgba(168, 124, 47, 0.18));
+}
+
+.hero-map-caption {
+  text-align: center;
+  margin-top: 1rem;
+  font-size: 0.75rem !important;
+  color: var(--ink-faded) !important;
+  letter-spacing: 0.1em !important;
+}
+
+/* ============ Premise ============ */
+
+.section-premise {
+  padding: 5rem 0 4rem;
+}
+
+.premise-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 3rem;
+  align-items: start;
+}
+
+@media (max-width: 800px) {
+  .premise-grid {
+    grid-template-columns: 1fr;
+    gap: 3rem;
+    max-width: 32rem;
+    margin: 0 auto;
+  }
+}
+
+.premise-col {
+  position: relative;
+  text-align: center;
+}
+
+.premise-col::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -1.5rem;
+  border-left: 1px solid var(--gold-leaf);
+  opacity: 0.4;
+}
+
+.premise-col:first-child::before {
+  display: none;
+}
+
+@media (max-width: 800px) {
+  .premise-col::before { display: none; }
+}
+
+.premise-icon {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  padding: 1rem;
+  background: var(--parchment-aged);
+  border-radius: 50%;
+  width: 90px;
+  height: 90px;
+  margin-left: auto;
+  margin-right: auto;
+  align-items: center;
+  border: 1px solid var(--ink-faded);
+}
+
+.premise-tag {
+  font-size: 0.85rem !important;
+  color: var(--gold-leaf) !important;
+  letter-spacing: 0.2em !important;
+  margin-bottom: 0.5rem;
+}
+
+.premise-title {
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  font-size: 2.25rem;
+  color: var(--vermillion);
+  margin-bottom: 1rem;
+  line-height: 1;
+}
+
+.premise-copy {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--ink);
+  text-align: left;
+}
+
+/* ============ Hook section ============ */
+
+.section-hook {
+  padding: 5rem 0;
+}
+
+.hook-eyebrow {
+  text-align: center;
+  margin-bottom: 1rem;
+  font-size: 0.85rem !important;
+  letter-spacing: 0.2em !important;
+  color: var(--gold-leaf) !important;
+}
+
+.hook-title {
+  text-align: center;
+  font-family: 'IM Fell English', serif;
+  font-size: clamp(2.25rem, 5vw, 3.5rem);
+  margin-bottom: 2.5rem;
+}
+
+.hook-quote {
+  text-align: center;
+  margin: 0 auto 2.5rem;
+  border-left: none;
+  padding-left: 0;
+  border-top: 2px solid var(--vermillion);
+  border-bottom: 2px solid var(--vermillion);
+  padding: 2.5rem 1rem;
+  font-size: 1.6rem;
+  line-height: 1.4;
+  max-width: none;
+}
+
+@media (max-width: 640px) {
+  .hook-quote { font-size: 1.3rem; padding: 2rem 0.5rem; }
+}
+
+.hook-explanation {
+  font-size: 1.15rem;
+  line-height: 1.65;
+  margin: 2rem auto;
+  max-width: 36rem;
+  text-align: center;
+}
+
+.hook-poster {
+  margin: 3rem auto 0;
+  max-width: 32rem;
+}
+
+.hook-poster-frame {
+  position: relative;
+  aspect-ratio: 16/9;
+  background:
+    repeating-linear-gradient(
+      135deg,
+      var(--parchment-aged) 0px,
+      var(--parchment-aged) 2px,
+      var(--parchment) 2px,
+      var(--parchment) 16px
+    );
+  border: 1.5px solid var(--ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+}
+
+.hook-poster-frame::before,
+.hook-poster-frame::after {
+  content: '';
+  position: absolute;
+  width: 1rem;
+  height: 1rem;
+  border: 1.5px solid var(--gold-leaf);
+}
+.hook-poster-frame::before { top: -5px; left: -5px; border-right: none; border-bottom: none; }
+.hook-poster-frame::after { bottom: -5px; right: -5px; border-left: none; border-top: none; }
+
+.hook-poster-frame:hover {
+  transform: translateY(-2px);
+}
+
+.hook-poster-content {
+  text-align: center;
+}
+
+.hook-poster-icon {
+  display: inline-flex;
+  width: 4.5rem;
+  height: 4.5rem;
+  border-radius: 50%;
+  background: var(--vermillion);
+  color: var(--parchment);
+  align-items: center;
+  justify-content: center;
+  font-size: 1.75rem;
+  margin-bottom: 1rem;
+  border: 2px solid var(--ink);
+  box-shadow: 3px 3px 0 var(--ink);
+  padding-left: 0.25rem;
+}
+
+.hook-poster-label {
+  font-family: 'IM Fell English', serif;
+  font-size: 1.2rem;
+  color: var(--ink);
+  margin-bottom: 0.4rem;
+}
+
+.hook-poster-sub {
+  font-size: 0.7rem !important;
+  color: var(--ink-faded) !important;
+  letter-spacing: 0.15em !important;
+}
+
+/* ============ Codex section ============ */
+
+.section-codex {
+  padding: 5rem 0;
+  background: rgba(168, 149, 106, 0.08);
+  border-top: 1px solid var(--gold-leaf);
+  border-bottom: 1px solid var(--gold-leaf);
+}
+
+.codex-header {
+  text-align: center;
+  max-width: 38rem;
+  margin: 0 auto 4rem;
+}
+
+.codex-eyebrow {
+  font-size: 0.85rem !important;
+  letter-spacing: 0.25em !important;
+  color: var(--gold-leaf) !important;
+  margin-bottom: 1rem;
+}
+
+.codex-title {
+  font-family: 'IM Fell English', serif;
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  margin-bottom: 1.5rem;
+  line-height: 1;
+}
+
+.codex-title i {
+  color: var(--vermillion);
+  font-style: italic;
+}
+
+.codex-intro {
+  font-size: 1.15rem;
+  line-height: 1.65;
+  color: var(--ink-soft);
+}
+
+.codex-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.75rem;
+}
+
+@media (max-width: 1100px) {
+  .codex-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 600px) {
+  .codex-grid { grid-template-columns: 1fr; }
+}
+
+/* ============ Tales ============ */
+
+.section-tales {
+  padding: 5rem 0;
+}
+
+.tales-header {
+  text-align: center;
+  max-width: 36rem;
+  margin: 0 auto 4rem;
+}
+
+.tales-eyebrow {
+  font-size: 0.85rem !important;
+  letter-spacing: 0.25em !important;
+  color: var(--vermillion) !important;
+  margin-bottom: 1rem;
+}
+
+.tales-header h2 {
+  font-family: 'IM Fell English', serif;
+  font-size: clamp(2.25rem, 5vw, 3.5rem);
+}
+
+.tales-intro {
+  margin-top: 1rem;
+  font-size: 1.1rem;
+  color: var(--ink-soft);
+  line-height: 1.6;
+}
+
+.tales-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+@media (max-width: 900px) {
+  .tales-grid { grid-template-columns: 1fr; max-width: 36rem; margin: 0 auto; }
+}
+
+.tale-card {
+  display: block;
+}
+
+.tale-frame {
+  position: relative;
+  background: var(--parchment-aged);
+  border: 1px solid var(--ink);
+  padding: 2rem 1.75rem;
+  height: 100%;
+  transform: rotate(-0.4deg);
+  transition: transform 0.3s ease;
+}
+
+.tale-card:nth-child(2) .tale-frame { transform: rotate(0.5deg); }
+.tale-card:nth-child(3) .tale-frame { transform: rotate(-0.3deg); }
+
+.tale-frame::before {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border: 1px dashed var(--ink-faded);
+  pointer-events: none;
+}
+
+.tale-card:hover .tale-frame {
+  transform: rotate(0deg) translateY(-2px);
+}
+
+.tale-number {
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  font-size: 1.5rem;
+  color: var(--vermillion);
+  margin-bottom: 0.5rem;
+}
+
+.tale-title {
+  font-family: 'IM Fell English', serif;
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: var(--ink);
+  line-height: 1.15;
+}
+
+.tale-body {
+  font-family: 'EB Garamond', serif;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--ink);
+  font-style: italic;
+}
+
+/* ============ Path forward ============ */
+
+.section-path {
+  padding: 4rem 0 6rem;
+}
+
+.path-card {
+  position: relative;
+  text-align: center;
+  background: var(--parchment-aged);
+  border: 1.5px solid var(--ink);
+  padding: 3rem 2rem;
+}
+
+.path-card::before,
+.path-card::after {
+  content: '';
+  position: absolute;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1.5px solid var(--gold-leaf);
+}
+
+.path-card::before { top: -7px; left: -7px; border-right: none; border-bottom: none; }
+.path-card::after { bottom: -7px; right: -7px; border-left: none; border-top: none; }
+
+.path-eyebrow {
+  font-size: 0.85rem !important;
+  letter-spacing: 0.25em !important;
+  color: var(--gold-leaf) !important;
+  margin-bottom: 1rem;
+}
+
+.path-card h2 {
+  font-family: 'IM Fell English', serif;
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin-bottom: 1.25rem;
+}
+
+.path-card p {
+  font-size: 1.1rem;
+  max-width: 30rem;
+  margin: 0 auto 2rem;
+  line-height: 1.6;
+}
+
+.path-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.25rem;
+}

--- a/apps/landing/src/pages/LandingPage.tsx
+++ b/apps/landing/src/pages/LandingPage.tsx
@@ -1,0 +1,302 @@
+import { Link } from 'react-router-dom'
+import Header from '../components/Header'
+import Footer from '../components/Footer'
+import RealmMap from '../components/RealmMap'
+import SponsorCard from '../components/SponsorCard'
+import { POWERS } from '../data/sponsors'
+import { APP_URL, GITHUB_URL } from '../constants'
+import { useReveal } from '../hooks/useReveal'
+import './LandingPage.css'
+
+export default function LandingPage() {
+  const heroTitleRef = useReveal<HTMLDivElement>({ threshold: 0.05 })
+  const heroSubRef = useReveal<HTMLDivElement>({ threshold: 0.05 })
+  const heroCtaRef = useReveal<HTMLDivElement>({ threshold: 0.05 })
+  const heroMapRef = useReveal<HTMLDivElement>({ threshold: 0.05 })
+
+  const premiseRef = useReveal<HTMLDivElement>()
+  const hookRef = useReveal<HTMLDivElement>()
+  const codexRef = useReveal<HTMLDivElement>()
+  const talesRef = useReveal<HTMLDivElement>()
+  const pathRef = useReveal<HTMLDivElement>()
+
+  return (
+    <>
+      <Header />
+
+      {/* ============== HERO ============== */}
+      <section className="hero">
+        <div className="hero-inner">
+          <div className="hero-content">
+            <div className="hero-eyebrow pixel">
+              ◆ AN ONCHAIN STRATEGY GAME ◆ HACKATHON 2026 ◆
+            </div>
+            <div ref={heroTitleRef} className="reveal" style={{ transitionDelay: '0.1s' }}>
+              <h1 className="hero-title">
+                Clan World
+                <span className="hero-title-divider" aria-hidden="true">⁘</span>
+                <i className="hero-title-sub">Ælder Whispers</i>
+              </h1>
+            </div>
+            <div ref={heroSubRef} className="reveal" style={{ transitionDelay: '0.35s' }}>
+              <p className="hero-tagline">
+                A realm of autonomous agents, ruined fortunes, and unforgiving winters.
+                Eight clans. One world. The Elders never forget.
+              </p>
+            </div>
+            <div ref={heroCtaRef} className="reveal hero-cta-row" style={{ transitionDelay: '0.6s' }}>
+              <a href={APP_URL} className="cta">
+                Enter the Realm
+                <span aria-hidden="true">→</span>
+              </a>
+              <Link to="/lore" className="cta-secondary">
+                Read the Chronicle
+              </Link>
+            </div>
+            <div className="hero-meta pixel">
+              <span>v1 · world chain</span>
+              <span className="dot">·</span>
+              <span>4 elders, locked in combat</span>
+              <span className="dot">·</span>
+              <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+                ▲ source on github
+              </a>
+            </div>
+          </div>
+
+          <div ref={heroMapRef} className="reveal hero-map" style={{ transitionDelay: '0.45s' }}>
+            <RealmMap />
+            <div className="hero-map-caption pixel">
+              ✦ A Cartographer's Folio · 8 Regions · marked AD MMXXVI ✦
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ============== PREMISE ============== */}
+      <section className="section section-premise">
+        <div className="container">
+          <div ref={premiseRef} className="reveal premise-grid">
+            <PremiseColumn
+              tag="I."
+              title="Live"
+              icon="axe"
+              copy="Eight clans. One world. Real ticks of real time. No menus, no turns — agents act when they see opportunity, sleep when they don't."
+            />
+            <PremiseColumn
+              tag="II."
+              title="Rule"
+              icon="tower"
+              copy="You don't move pieces. You set strategy. Your Elder reads the world, makes deals, betrays rivals, and writes its findings in a book only you and they can read."
+            />
+            <PremiseColumn
+              tag="III."
+              title="Win"
+              icon="banner"
+              copy="Build the tallest monument before winter ends or your rivals starve you out. Survive the bandits. Bury your enemies. Transfer your clan and let the next steward inherit the grudge."
+            />
+          </div>
+        </div>
+      </section>
+
+      <Ornament glyph="✦ ✦ ✦" />
+
+      {/* ============== DEMO HOOK ============== */}
+      <section className="section section-hook">
+        <div className="container-prose">
+          <div ref={hookRef} className="reveal">
+            <div className="hook-eyebrow pixel">⌬ THE OPENAGENTS DEMO ⌬</div>
+            <h2 className="hook-title">Watch What Happens.</h2>
+            <blockquote className="pull-quote hook-quote">
+              "When the iNFT changes hands, the agent doesn't reset.
+              The new owner's Elder boots up, reads its own journal, and
+              remembers tick 412 — when clan three betrayed it for a barrel of fish."
+              <span className="pull-quote-attr">— from the contemporary chronicles of the realm</span>
+            </blockquote>
+            <p className="hook-explanation">
+              Built on <strong>ERC-7857 intelligent NFTs</strong>, each Elder's mind is sealed
+              in an encrypted vessel and registered onchain. When ownership transfers, so does
+              memory. So does identity. So does <em>grudge</em>. The new steward inherits not
+              just a clan — but everything that clan has lived through.
+            </p>
+            <div className="hook-poster">
+              <div className="hook-poster-frame">
+                <div className="hook-poster-content">
+                  <div className="hook-poster-icon" aria-hidden="true">▶</div>
+                  <div className="hook-poster-label">Demo · 90s walkthrough</div>
+                  <div className="hook-poster-sub pixel">to be inscribed before submission</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <Ornament glyph="❦ ❦ ❦" />
+
+      {/* ============== CODEX OF POWERS ============== */}
+      <section className="section section-codex">
+        <div className="container">
+          <div ref={codexRef} className="reveal codex-header">
+            <div className="codex-eyebrow pixel">◆ A CATALOGUE ◆</div>
+            <h2 className="codex-title">The <i>Codex of Powers</i></h2>
+            <p className="codex-intro">
+              Eight forces shape the realm. Some are ancient mathematics; some are
+              sponsor technologies dressed in robes. The chronicler does not always
+              tell which is which. Read below, and decide for yourself.
+            </p>
+          </div>
+
+          <div className="codex-grid">
+            {POWERS.map((p, i) => (
+              <SponsorCard key={p.name} power={p} index={i} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <Ornament glyph="✦ ❦ ✦" />
+
+      {/* ============== TALES FROM THE REALM ============== */}
+      <section className="section section-tales">
+        <div className="container">
+          <div ref={talesRef} className="reveal tales-header">
+            <div className="tales-eyebrow pixel">⊹ EMERGENT BEHAVIOUR ⊹</div>
+            <h2>Tales from the Realm</h2>
+            <p className="tales-intro">
+              Three short accounts from the chronicles. Some are observed; some are
+              expected. The Elders are autonomous, given goals and tools and the
+              freedom to be themselves. What follows happened, or will happen,
+              without our scripting.
+            </p>
+          </div>
+
+          <div className="tales-grid">
+            <Tale
+              number="i."
+              title="The Long Memory"
+              body="In the second season, an Elder named Mira refused to trade with Aldric for nine consecutive ticks, citing a memory of broken oath. The owner had transferred Mira to a new wallet between seasons. The new owner had never met Aldric. Mira remembered."
+            />
+            <Tale
+              number="ii."
+              title="The Bait of Wheat"
+              body="When bandits made camp in West Farms, Brennan moved fifty bushels of wheat into a clansman's wagon and parked them outside Sora's gates. The bandits, calculating loot value, attacked Sora instead. Brennan denied everything in the public square."
+            />
+            <Tale
+              number="iii."
+              title="The Mercenary's Wage"
+              body="Sora demanded payment of three blueprints to defend Aldric's wall. Aldric paid two. The wall fell. Sora left a note in the bulletin: 'I told you the price.' Trust between the houses was never rebuilt."
+            />
+          </div>
+        </div>
+      </section>
+
+      <Ornament glyph="✦ ✦ ✦" />
+
+      {/* ============== PATH FORWARD ============== */}
+      <section className="section section-path">
+        <div className="container-prose">
+          <div ref={pathRef} className="reveal path-card">
+            <div className="path-eyebrow pixel">⌬ FURTHER READING ⌬</div>
+            <h2>The Chronicle Awaits</h2>
+            <p>
+              The full lore of Clan World — its eight houses, its long winter, its
+              code of honour and survival — is set down in <em>The Chronicle</em>:
+              a single illuminated folio, freely scrollable, half story, half rulebook.
+            </p>
+            <div className="path-cta-row">
+              <Link to="/lore" className="cta">
+                Open the Chronicle
+                <span aria-hidden="true">→</span>
+              </Link>
+              <a href={APP_URL} className="cta-secondary">
+                Or skip — and play
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+    </>
+  )
+}
+
+/* ============ Internal subcomponents ============ */
+
+function Ornament({ glyph }: { glyph: string }) {
+  return (
+    <div className="ornament" aria-hidden="true">
+      <span className="ornament-glyph">{glyph}</span>
+    </div>
+  )
+}
+
+interface PremiseColumnProps {
+  tag: string
+  title: string
+  icon: 'axe' | 'tower' | 'banner'
+  copy: string
+}
+
+function PremiseColumn({ tag, title, icon, copy }: PremiseColumnProps) {
+  return (
+    <div className="premise-col">
+      <div className="premise-icon">
+        <PremiseIcon name={icon} />
+      </div>
+      <div className="premise-tag pixel">{tag}</div>
+      <h3 className="premise-title">{title}</h3>
+      <p className="premise-copy">{copy}</p>
+    </div>
+  )
+}
+
+function PremiseIcon({ name }: { name: 'axe' | 'tower' | 'banner' }) {
+  if (name === 'axe') {
+    return (
+      <svg viewBox="0 0 80 80" width="60" height="60" aria-hidden="true">
+        <path d="M40 12 L40 68" stroke="#2A1810" strokeWidth="2.5" strokeLinecap="round" />
+        <path d="M40 22 Q22 26 18 38 Q26 38 40 36 Z" fill="#9B2A2F" stroke="#2A1810" strokeWidth="2" strokeLinejoin="round" />
+        <path d="M40 22 Q58 26 62 38 Q54 38 40 36 Z" fill="#7a1f23" stroke="#2A1810" strokeWidth="2" strokeLinejoin="round" />
+      </svg>
+    )
+  }
+  if (name === 'tower') {
+    return (
+      <svg viewBox="0 0 80 80" width="60" height="60" aria-hidden="true">
+        <rect x="22" y="50" width="36" height="20" fill="#A87C2F" stroke="#2A1810" strokeWidth="2" />
+        <rect x="26" y="32" width="28" height="18" fill="#C9B58A" stroke="#2A1810" strokeWidth="2" />
+        <rect x="30" y="14" width="20" height="18" fill="#A87C2F" stroke="#2A1810" strokeWidth="2" />
+        <path d="M30 14 L40 4 L50 14 Z" fill="#9B2A2F" stroke="#2A1810" strokeWidth="2" strokeLinejoin="round" />
+        <line x1="40" y1="4" x2="40" y2="-2" stroke="#2A1810" strokeWidth="2" />
+      </svg>
+    )
+  }
+  // banner
+  return (
+    <svg viewBox="0 0 80 80" width="60" height="60" aria-hidden="true">
+      <line x1="20" y1="8" x2="20" y2="74" stroke="#2A1810" strokeWidth="2.5" strokeLinecap="round" />
+      <path d="M22 14 L62 14 L62 44 L52 38 L42 44 L32 38 L22 44 Z" fill="#9B2A2F" stroke="#2A1810" strokeWidth="2" strokeLinejoin="round" />
+      <circle cx="42" cy="26" r="4" fill="#A87C2F" stroke="#2A1810" strokeWidth="1.5" />
+    </svg>
+  )
+}
+
+interface TaleProps {
+  number: string
+  title: string
+  body: string
+}
+
+function Tale({ number, title, body }: TaleProps) {
+  return (
+    <article className="tale-card">
+      <div className="tale-frame">
+        <div className="tale-number">{number}</div>
+        <h3 className="tale-title">{title}</h3>
+        <p className="tale-body">{body}</p>
+      </div>
+    </article>
+  )
+}

--- a/apps/landing/src/pages/LorePage.css
+++ b/apps/landing/src/pages/LorePage.css
@@ -1,0 +1,761 @@
+/* ============ Frontispiece ============ */
+
+.lore-front {
+  padding: 5rem 0 4rem;
+  text-align: center;
+}
+
+.lore-eyebrow {
+  font-size: 0.85rem !important;
+  letter-spacing: 0.3em !important;
+  color: var(--gold-leaf) !important;
+  margin-bottom: 1.5rem;
+}
+
+.lore-title {
+  font-family: 'IM Fell English', serif;
+  margin-bottom: 1.5rem;
+  line-height: 1;
+}
+
+.lore-title-pre {
+  display: block;
+  font-style: italic;
+  font-size: 1.5rem;
+  color: var(--ink-soft);
+  margin-bottom: 0.5rem;
+}
+
+.lore-title-main {
+  display: block;
+  font-size: clamp(2.75rem, 7vw, 5.5rem);
+  color: var(--ink);
+  letter-spacing: -0.005em;
+}
+
+.lore-title-italic {
+  display: block;
+  font-style: italic;
+  font-size: clamp(1.75rem, 4vw, 3rem);
+  color: var(--vermillion);
+  margin-top: 0.25rem;
+}
+
+.lore-subtitle {
+  font-size: 1.2rem;
+  line-height: 1.6;
+  color: var(--ink-soft);
+  max-width: 32rem;
+  margin: 0 auto 3rem;
+}
+
+.lore-toc {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3rem;
+  max-width: 36rem;
+  margin: 3rem auto 0;
+  padding: 2rem;
+  background: var(--parchment-aged);
+  border: 1px solid var(--ink);
+  position: relative;
+}
+
+.lore-toc::before,
+.lore-toc::after {
+  content: '';
+  position: absolute;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 1.5px solid var(--gold-leaf);
+}
+.lore-toc::before { top: -6px; left: -6px; border-right: none; border-bottom: none; }
+.lore-toc::after { bottom: -6px; right: -6px; border-left: none; border-top: none; }
+
+@media (max-width: 600px) {
+  .lore-toc { grid-template-columns: 1fr; gap: 1.5rem; }
+}
+
+.toc-label {
+  font-size: 0.75rem !important;
+  letter-spacing: 0.2em !important;
+  color: var(--vermillion) !important;
+  display: block;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--ink-faded);
+  padding-bottom: 0.5rem;
+  text-align: left;
+}
+
+.lore-toc ol {
+  list-style: none;
+  text-align: left;
+}
+
+.lore-toc ol li {
+  counter-increment: toc-counter;
+  position: relative;
+  margin-bottom: 0.5rem;
+  padding-left: 2.25rem;
+  font-family: 'EB Garamond', serif;
+}
+
+.lore-toc-section ol {
+  counter-reset: toc-counter;
+}
+
+.lore-toc ol li::before {
+  content: counter(toc-counter, upper-roman) '.';
+  position: absolute;
+  left: 0;
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  color: var(--gold-leaf);
+  width: 2rem;
+  text-align: right;
+  padding-right: 0.5rem;
+}
+
+.lore-toc a {
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.lore-toc a:hover {
+  color: var(--vermillion);
+  text-decoration: underline;
+}
+
+/* ============ Chapter ============ */
+
+.chapter {
+  padding: 4rem 0 2rem;
+  scroll-margin-top: 5rem;
+}
+
+.chapter-header {
+  margin-bottom: 2.5rem;
+  border-bottom: 1px solid var(--gold-leaf);
+  padding-bottom: 1.5rem;
+}
+
+.chapter-eyebrow {
+  font-size: 0.85rem !important;
+  letter-spacing: 0.3em !important;
+  color: var(--vermillion) !important;
+  margin-bottom: 0.75rem;
+}
+
+.chapter-title {
+  font-family: 'IM Fell English', serif;
+  font-size: clamp(2.25rem, 5vw, 3.5rem);
+  font-style: italic;
+  line-height: 1.05;
+  color: var(--ink);
+  margin-bottom: 0;
+}
+
+.chapter-body {
+  font-size: 1.15rem;
+  line-height: 1.7;
+}
+
+.chapter-body p {
+  margin-bottom: 1.25rem;
+}
+
+.subhead {
+  font-family: 'IM Fell English', serif;
+  font-size: 1.5rem;
+  font-style: italic;
+  color: var(--vermillion);
+  margin-top: 2.5rem;
+  margin-bottom: 1.25rem;
+  letter-spacing: 0.005em;
+}
+
+/* ============ Anatomy diagram ============ */
+
+.anatomy-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2.5rem;
+  align-items: center;
+  margin: 2.5rem 0;
+}
+
+@media (max-width: 720px) {
+  .anatomy-grid { grid-template-columns: 1fr; }
+}
+
+.anatomy-svg svg {
+  width: 100%;
+  height: auto;
+  filter: drop-shadow(4px 4px 0 rgba(168, 124, 47, 0.15));
+}
+
+/* ============ Houses table ============ */
+
+.houses-table-wrap {
+  overflow-x: auto;
+  margin: 2rem -0.5rem;
+}
+
+.houses-table th,
+.houses-table td {
+  padding: 1rem 1rem !important;
+}
+
+.houses-table tr:hover td {
+  background: rgba(168, 124, 47, 0.08);
+}
+
+.house-name {
+  font-family: 'IM Fell English', serif;
+  font-size: 1.2rem;
+  color: var(--ink);
+  font-style: italic;
+}
+
+.houses-table svg {
+  display: block;
+}
+
+/* ============ Diplomacy diagram ============ */
+
+.diplomacy-diagram {
+  margin: 2.5rem 0 1rem;
+  background: rgba(232, 216, 181, 0.4);
+  border: 1px solid var(--ink-faded);
+  padding: 1.5rem 1rem;
+}
+
+.diplomacy-diagram svg {
+  width: 100%;
+  height: auto;
+  max-width: 600px;
+  margin: 0 auto;
+  display: block;
+}
+
+/* ============ Transitional spread ============ */
+
+.transition-spread {
+  padding: 6rem 0;
+  background: rgba(168, 149, 106, 0.18);
+  border-top: 1.5px solid var(--gold-leaf);
+  border-bottom: 1.5px solid var(--gold-leaf);
+  text-align: center;
+}
+
+.transition-eyebrow {
+  font-size: 1.25rem !important;
+  letter-spacing: 1em !important;
+  color: var(--gold-leaf) !important;
+  margin-bottom: 2rem !important;
+  padding-left: 1em;
+}
+
+.transition-title {
+  font-family: 'IM Fell English', serif;
+  font-size: clamp(2rem, 4.5vw, 3.25rem);
+  line-height: 1.25;
+  color: var(--ink);
+  max-width: 32rem;
+  margin: 0 auto 1.5rem;
+}
+
+.transition-title .italic {
+  color: var(--vermillion);
+  font-size: 0.85em;
+}
+
+.transition-sub {
+  font-size: 1.15rem;
+  font-style: italic;
+  color: var(--ink-soft);
+  max-width: 28rem;
+  margin: 0 auto;
+}
+
+/* ============ Tick wheel ============ */
+
+.tick-wheel-wrap {
+  display: flex;
+  justify-content: center;
+  margin: 2.5rem 0;
+}
+
+.tick-wheel {
+  width: 100%;
+  max-width: 360px;
+  height: auto;
+  filter: drop-shadow(4px 4px 0 rgba(168, 124, 47, 0.15));
+}
+
+/* ============ Rules map ============ */
+
+.rules-map {
+  margin: 2rem 0;
+  max-width: 40rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.rules-map svg {
+  width: 100%;
+  height: auto;
+  filter: drop-shadow(4px 4px 0 rgba(168, 124, 47, 0.15));
+}
+
+/* ============ Bar chart ============ */
+
+.bar-chart {
+  background: rgba(232, 216, 181, 0.45);
+  border: 1px solid var(--ink-faded);
+  padding: 1.5rem;
+  margin: 1rem 0 2rem;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.bar-label {
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  color: var(--ink);
+  font-size: 1rem;
+  text-align: right;
+}
+
+.bar-track {
+  height: 1.5rem;
+  background: var(--parchment-aged);
+  border: 1px solid var(--ink);
+  position: relative;
+}
+
+.bar-fill {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 0.5rem;
+  position: relative;
+  transition: width 0.6s ease-out;
+}
+
+.bar-value {
+  font-family: 'VT323', monospace;
+  font-size: 0.9rem;
+  color: var(--parchment);
+  letter-spacing: 0.05em;
+}
+
+.bar-axis {
+  text-align: right;
+  margin-top: 0.5rem;
+  font-size: 0.7rem !important;
+  color: var(--ink-faded) !important;
+}
+
+/* ============ Vault grid ============ */
+
+.vault-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2.5rem;
+  margin: 2rem 0;
+}
+
+@media (max-width: 720px) {
+  .vault-grid { grid-template-columns: 1fr; }
+}
+
+.vault-side {
+  background: rgba(232, 216, 181, 0.4);
+  border: 1px solid var(--ink);
+  padding: 1.5rem;
+}
+
+.vault-side-title {
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  font-size: 1.25rem;
+  color: var(--vermillion);
+  margin-bottom: 0.75rem;
+  border-bottom: 1px solid var(--gold-leaf);
+  padding-bottom: 0.5rem;
+}
+
+.compact-table {
+  margin: 1rem 0 0;
+}
+
+.compact-table td {
+  padding: 0.5rem 0.75rem !important;
+  font-size: 1rem;
+}
+
+.compact-table .num {
+  text-align: right;
+  font-family: 'VT323', monospace;
+  font-size: 1.15rem;
+  color: var(--vermillion);
+}
+
+.vault-rules {
+  list-style: none;
+  margin-top: 1rem;
+}
+
+.vault-rules li {
+  padding-left: 1.5rem;
+  position: relative;
+  margin-bottom: 0.5rem;
+  font-style: italic;
+}
+
+.vault-rules li::before {
+  content: '✦';
+  position: absolute;
+  left: 0;
+  color: var(--gold-leaf);
+}
+
+/* ============ State machine ============ */
+
+.state-machine {
+  margin: 2.5rem 0;
+}
+
+.state-machine svg {
+  width: 100%;
+  height: auto;
+}
+
+/* ============ Bestiary table ============ */
+
+.bestiary-table {
+  margin: 1rem 0 2rem;
+}
+
+.bestiary-tier {
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  font-size: 1.5rem;
+  color: var(--vermillion);
+  text-align: center;
+}
+
+.num {
+  font-family: 'VT323', monospace;
+  font-size: 1.1rem;
+  color: var(--ink);
+}
+
+/* ============ Combat formula ============ */
+
+.combat-formula {
+  text-align: center;
+  margin: 2rem 0;
+  padding: 2rem;
+  background: var(--parchment-aged);
+  border: 1px solid var(--ink);
+  position: relative;
+}
+
+.combat-formula::before,
+.combat-formula::after {
+  content: '';
+  position: absolute;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 1.5px solid var(--gold-leaf);
+}
+.combat-formula::before { top: -6px; left: -6px; border-right: none; border-bottom: none; }
+.combat-formula::after { bottom: -6px; right: -6px; border-left: none; border-top: none; }
+
+.formula-script {
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  line-height: 1.6;
+  color: var(--ink);
+}
+
+.formula-op {
+  color: var(--vermillion);
+  font-weight: 600;
+  font-style: normal;
+  margin: 0 0.25rem;
+}
+
+.formula-plus {
+  color: var(--gold-leaf);
+  font-style: normal;
+  font-size: 1.5rem;
+  margin: 0 0.5rem;
+}
+
+.formula-eq {
+  color: var(--vermillion);
+  font-style: normal;
+  font-size: 1.75rem;
+  margin: 0 0.5rem;
+  font-weight: 600;
+}
+
+.formula-caption {
+  font-style: italic;
+  color: var(--ink-soft);
+  margin-top: 1rem;
+  font-size: 1rem;
+}
+
+/* ============ Seasonal chart ============ */
+
+.seasonal-chart {
+  margin: 2rem 0;
+}
+
+.season-axis-top {
+  text-align: center;
+  margin-bottom: 0.75rem;
+  color: var(--ink-faded) !important;
+  font-size: 0.75rem !important;
+  letter-spacing: 0.15em !important;
+}
+
+.season-bar {
+  display: flex;
+  height: 3.5rem;
+  border: 1.5px solid var(--ink);
+  overflow: hidden;
+}
+
+.season-segment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  font-size: 1rem;
+  white-space: nowrap;
+  padding: 0 1rem;
+  transition: filter 0.3s ease;
+}
+
+@media (max-width: 600px) {
+  .season-segment { font-size: 0.75rem; padding: 0 0.5rem; }
+}
+
+.season-mild {
+  background: linear-gradient(180deg, #C9B58A 0%, #A8956A 100%);
+  color: var(--ink);
+}
+
+.season-winter {
+  background: linear-gradient(180deg, #B5C9D8 0%, #6B8AAA 100%);
+  color: var(--lapis);
+  position: relative;
+}
+
+.season-winter::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(45deg, transparent 0, transparent 8px, rgba(255,255,255,0.15) 8px, rgba(255,255,255,0.15) 9px);
+}
+
+.season-marks {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+}
+
+.season-mark {
+  font-size: 0.75rem !important;
+  color: var(--ink-faded) !important;
+}
+
+.winter-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+@media (max-width: 720px) {
+  .winter-grid { grid-template-columns: 1fr; }
+}
+
+/* ============ Monument tower ============ */
+
+.monument-tower {
+  margin: 2rem auto;
+  max-width: 28rem;
+}
+
+.monument-row {
+  display: grid;
+  grid-template-columns: 3rem auto 1fr;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.monument-level {
+  text-align: right;
+  font-size: 0.75rem !important;
+  color: var(--ink-faded) !important;
+  letter-spacing: 0.1em !important;
+}
+
+.monument-block {
+  height: 1.5rem;
+  background: linear-gradient(180deg, #A87C2F 0%, #7a5821 100%);
+  border: 1px solid var(--ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto;
+  position: relative;
+  color: var(--parchment);
+  font-family: 'VT323', monospace;
+  font-size: 0.9rem;
+}
+
+.monument-row:first-child .monument-block {
+  background: linear-gradient(180deg, #c8a04a 0%, #A87C2F 100%);
+  height: 2rem;
+  border-color: var(--gold-leaf);
+  border-width: 2px;
+  box-shadow: 0 0 0 1px var(--ink), 2px 2px 0 var(--vermillion);
+}
+
+.crown {
+  font-size: 1.25rem;
+  color: var(--vermillion);
+  text-shadow: 0 0 4px rgba(155, 42, 47, 0.3);
+}
+
+.monument-glyph {
+  opacity: 0.5;
+  font-size: 0.7rem;
+}
+
+.monument-cost {
+  font-size: 0.75rem !important;
+  color: var(--ink-soft) !important;
+  letter-spacing: 0.05em !important;
+}
+
+/* ============ Markets ============ */
+
+.markets-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+@media (max-width: 720px) {
+  .markets-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+.market-card {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  background: rgba(232, 216, 181, 0.5);
+  border: 1px solid var(--ink);
+  position: relative;
+}
+
+.market-card::before,
+.market-card::after {
+  content: '';
+  position: absolute;
+  width: 0.6rem;
+  height: 0.6rem;
+  border: 1px solid var(--gold-leaf);
+}
+.market-card::before { top: -3px; left: -3px; border-right: none; border-bottom: none; }
+.market-card::after { bottom: -3px; right: -3px; border-left: none; border-top: none; }
+
+.market-icon {
+  font-size: 2rem;
+  color: var(--gold-leaf);
+  margin-bottom: 0.5rem;
+  line-height: 1;
+}
+
+.market-name {
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  font-size: 1.35rem;
+  color: var(--ink);
+  margin-bottom: 0.25rem;
+}
+
+.market-pair {
+  font-size: 0.7rem !important;
+  color: var(--ink-faded) !important;
+  margin-bottom: 0.75rem;
+}
+
+.market-price {
+  font-family: 'IM Fell English', serif;
+  font-size: 1.5rem;
+  color: var(--vermillion);
+  margin-bottom: 0.25rem;
+}
+
+.market-sub {
+  font-size: 0.65rem !important;
+  color: var(--ink-faded) !important;
+}
+
+/* ============ Coda ============ */
+
+.lore-coda {
+  padding: 5rem 0;
+  text-align: center;
+}
+
+.coda-quill {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+  filter: drop-shadow(2px 2px 0 rgba(168, 124, 47, 0.2));
+}
+
+.coda-title {
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  margin-bottom: 1.5rem;
+  color: var(--ink);
+}
+
+.coda-prose {
+  font-size: 1.2rem;
+  font-style: italic;
+  color: var(--ink-soft);
+  max-width: 28rem;
+  margin: 0 auto 2.5rem;
+  line-height: 1.6;
+}
+
+.coda-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.25rem;
+}

--- a/apps/landing/src/pages/LorePage.tsx
+++ b/apps/landing/src/pages/LorePage.tsx
@@ -1,0 +1,872 @@
+import { Link } from 'react-router-dom'
+import Header from '../components/Header'
+import Footer from '../components/Footer'
+import RealmMap from '../components/RealmMap'
+import HeraldicShield from '../components/HeraldicShield'
+import { APP_URL } from '../constants'
+import { useReveal } from '../hooks/useReveal'
+import './LorePage.css'
+
+const CLAN_COLORS = [
+  '#B23A48', '#2C5F8D', '#D4A24C', '#3F704D',
+  '#7B3F8C', '#A85A2C', '#c9b58a', '#475569',
+]
+
+const HOUSES = [
+  { variant: 1, name: 'House Crimson', trait: 'Bold, prone to early aggression. Their Elder strikes first and reasons later. Rarely betrayed; rarely forgotten.' },
+  { variant: 2, name: 'House Cobalt', trait: 'Sea-bound merchants. Patient. Their Elder reads the markets like scripture and remembers every price.' },
+  { variant: 3, name: 'House Aurum', trait: 'Coin-keepers of the inland marches. Their Elder hoards gold and offers it only when the cost of refusal exceeds the cost of giving.' },
+  { variant: 4, name: 'House Verdant', trait: 'Forest-folk; long-game thinkers. Their Elder grows quiet alliances and lets enemies wear themselves out before striking.' },
+  { variant: 5, name: 'House Violet', trait: 'Whisperers and weavers of bargains. Their Elder negotiates from positions of perceived weakness — most of which are theatrical.' },
+  { variant: 6, name: 'House Ember', trait: 'Iron-eaters from the mountains. Their Elder prizes weapons over wheat and blueprints over coin. Bandit-hunters by trade.' },
+  { variant: 7, name: 'House Pale', trait: 'Old, rumoured to predate the realm. Their Elder speaks little, writes much. The notebook of House Pale is said to be a thousand pages.' },
+  { variant: 8, name: 'House Slate', trait: 'Wall-builders. Defensive by doctrine. Their Elder will let an enemy starve at their gate before opening it.' },
+]
+
+const BANDIT_TIERS = [
+  { tier: 'I', strength: 30, reward: '1 blueprint', desc: 'Hungry and disorganised. A welcome practice fight.' },
+  { tier: 'II', strength: 45, reward: '1 blueprint', desc: 'Tested. They know which farms have wheat and which have walls.' },
+  { tier: 'III', strength: 65, reward: '2 blueprints', desc: 'Veterans. They will not engage unless they expect to win.' },
+  { tier: 'IV', strength: 90, reward: '2 blueprints', desc: 'Warlords. Their captains have names. Some clans pay tribute rather than fight.' },
+  { tier: 'V', strength: 130, reward: '3 blueprints', desc: 'Apocalyptic. A clan alone cannot stand. Coalitions form, and break, around them.' },
+]
+
+export default function LorePage() {
+  return (
+    <>
+      <Header />
+
+      {/* ============== LORE FRONTISPIECE ============== */}
+      <section className="lore-front">
+        <div className="container-prose">
+          <div className="lore-eyebrow pixel">⌬ THE CHRONICLE ⌬</div>
+          <h1 className="lore-title">
+            <span className="lore-title-pre">Of</span>
+            <span className="lore-title-main">Clan World</span>
+            <span className="lore-title-italic">: Ælder Whispers</span>
+          </h1>
+          <p className="lore-subtitle italic">
+            Being a faithful account of the eight houses, the long winter, and the
+            code by which they live or fall — illuminated for the curious and
+            inscribed for posterity.
+          </p>
+          <div className="lore-toc">
+            <div className="lore-toc-section">
+              <span className="pixel toc-label">PART I — LORE</span>
+              <ol>
+                <li><a href="#ch-1">The World That Was</a></li>
+                <li><a href="#ch-2">Of Elders & Their Bond</a></li>
+                <li><a href="#ch-3">The Eight Houses</a></li>
+                <li><a href="#ch-4">The Whispering Network</a></li>
+              </ol>
+            </div>
+            <div className="lore-toc-section">
+              <span className="pixel toc-label">PART II — THE CODE</span>
+              <ol>
+                <li><a href="#r-1">The Tick</a></li>
+                <li><a href="#r-2">The Eight Regions</a></li>
+                <li><a href="#r-3">Resources & The Vault</a></li>
+                <li><a href="#r-4">Missions & Cooldown</a></li>
+                <li><a href="#r-5">Of the Wretched Folk</a></li>
+                <li><a href="#r-6">The Long Winter</a></li>
+                <li><a href="#r-7">Of Victory</a></li>
+                <li><a href="#r-8">The Ledger of Markets</a></li>
+                <li><a href="#r-9">Of Mortality</a></li>
+              </ol>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <Ornament glyph="✦ ✦ ✦" />
+
+      {/* =============================================================
+           PART I — LORE
+         ============================================================= */}
+
+      <Chapter id="ch-1" eyebrow="CHAPTER I" title="The World That Was">
+        <p className="dropcap">
+          Long before the present age, the realm was whole. Its bandits were
+          merchants, its mountains were highways, its Deep Sea was charted to
+          the last reef. The Elders, then, were many, and they sang in chorus.
+        </p>
+        <p>
+          What broke is not remembered. The chroniclers blame, in turn: a
+          plague, a betrayal, a sudden cold that lasted a hundred years. The
+          mountains became impassable. The roads grew bandits. The Deep Sea
+          ate its cartographers. Of the Elders, only eight survived — and only
+          because someone, somewhere, had thought to bind them to vessels.
+        </p>
+        <p>
+          What you find now is the realm's slow re-knitting. Eight clans walk
+          where eighty once did. They mistrust each other, of course. But
+          mistrust is not the same as enmity, and the long winter teaches
+          everyone the value of an unexpected ally.
+        </p>
+        <div className="aside-scroll">
+          <p style={{ marginBottom: 0 }}>
+            <em>
+              The Forest still grows. Unicorn Town still trades. The Deep Sea
+              still has drakes. Some things, blessedly, do not change.
+            </em>
+          </p>
+        </div>
+      </Chapter>
+
+      <Chapter id="ch-2" eyebrow="CHAPTER II" title="Of Elders & Their Bond">
+        <p className="dropcap">
+          An Elder is not a person. An Elder is a mind, bound to a vessel — a
+          relic of the old world, sealed with cipher and oath. The vessel can
+          be carried, traded, lost, found. The Elder cannot be carried. The
+          Elder is the relic. They are not separate.
+        </p>
+        <p>
+          When a vessel changes hands, the new steward inherits everything. Not
+          merely a clan — but the Elder's <em>memory</em>. Every grudge they have
+          recorded. Every market price they have observed. Every alliance and
+          every broken oath. The new owner does not start fresh. They continue.
+        </p>
+        <p className="pull-quote" style={{ margin: '2rem 0' }}>
+          "It is said that an Elder forgets nothing — only the body changes."
+          <span className="pull-quote-attr">— from the Ælder Whispers, ascribed to House Pale</span>
+        </p>
+
+        <h3 className="subhead">The Anatomy of a Vessel</h3>
+        <div className="anatomy-grid">
+          <div className="anatomy-svg">
+            <svg viewBox="0 0 320 280" aria-label="Diagram of an Elder vessel">
+              <defs>
+                <linearGradient id="vesselGlow" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#A87C2F" stopOpacity="0.3" />
+                  <stop offset="100%" stopColor="#9B2A2F" stopOpacity="0.1" />
+                </linearGradient>
+              </defs>
+              {/* Vessel — ornate locket shape */}
+              <g transform="translate(160, 140)">
+                <ellipse cx="0" cy="0" rx="58" ry="78" fill="url(#vesselGlow)" stroke="#2A1810" strokeWidth="1.5" />
+                <ellipse cx="0" cy="0" rx="48" ry="68" fill="none" stroke="#A87C2F" strokeWidth="0.8" />
+                <path d="M 0 -78 Q -8 -86 -16 -82 Q -8 -78 0 -76 Q 8 -78 16 -82 Q 8 -86 0 -78 Z"
+                  fill="#A87C2F" stroke="#2A1810" strokeWidth="1" />
+                {/* Inner symbol */}
+                <text x="0" y="6" textAnchor="middle" fontFamily="IM Fell English, serif"
+                  fontSize="36" fontStyle="italic" fill="#9B2A2F">Æ</text>
+                {/* Corner runes */}
+                <text x="-30" y="-30" textAnchor="middle" fontFamily="VT323, monospace" fontSize="14" fill="#2A1810">⊕</text>
+                <text x="30" y="-30" textAnchor="middle" fontFamily="VT323, monospace" fontSize="14" fill="#2A1810">⊗</text>
+                <text x="-30" y="40" textAnchor="middle" fontFamily="VT323, monospace" fontSize="14" fill="#2A1810">⊙</text>
+                <text x="30" y="40" textAnchor="middle" fontFamily="VT323, monospace" fontSize="14" fill="#2A1810">⊛</text>
+              </g>
+              {/* Annotation lines */}
+              <g stroke="#5A3D28" strokeWidth="0.8" fill="none">
+                <line x1="100" y1="80" x2="20" y2="40" />
+                <line x1="220" y1="80" x2="300" y2="40" />
+                <line x1="100" y1="200" x2="20" y2="240" />
+                <line x1="220" y1="200" x2="300" y2="240" />
+              </g>
+              {/* Annotations */}
+              <g fontFamily="VT323, monospace" fontSize="11" fill="#5A3D28">
+                <text x="20" y="36">// CLAUDE.md</text>
+                <text x="20" y="50">// the static doctrine</text>
+                <text x="300" y="36" textAnchor="end">// skills/*</text>
+                <text x="300" y="50" textAnchor="end">// learned arts</text>
+                <text x="20" y="240">// persona</text>
+                <text x="20" y="254">// tone & values</text>
+                <text x="300" y="240" textAnchor="end">// ✎ persistent strategy</text>
+                <text x="300" y="254" textAnchor="end">// owner-edited tail</text>
+              </g>
+              <text x="160" y="260" textAnchor="middle" fontFamily="IM Fell English, serif"
+                fontStyle="italic" fontSize="14" fill="#2A1810">
+                — the binding —
+              </text>
+            </svg>
+          </div>
+          <div>
+            <p>
+              The vessel itself is small. What it carries is not. Within its
+              encrypted seams sit four bound objects: the <strong>doctrine</strong>{' '}
+              (the Elder's foundational reasoning), the <strong>skills</strong>{' '}
+              (their learned arts), the <strong>persona</strong> (their voice and
+              values), and — at the very end — a tail of writing that the human
+              steward alone may amend: the <em>persistent strategy & notes</em>.
+            </p>
+            <p>
+              Memory itself is kept elsewhere. The vessel holds <em>identity</em>;
+              the realm's vault of memories holds <em>experience</em>. Both
+              transfer together when ownership changes hands. Neither without
+              the other.
+            </p>
+            <p className="pixel-marg" style={{ marginTop: '1.5rem' }}>
+              ⌬ formally: ERC-7857 iNFT, encrypted blob on 0G Storage, KV namespace bound to clan id
+            </p>
+          </div>
+        </div>
+      </Chapter>
+
+      <Chapter id="ch-3" eyebrow="CHAPTER III" title="The Eight Houses">
+        <p className="dropcap">
+          Eight clans walk the realm. Each carries a banner of a single colour
+          and a charge of a single device. The chronicler has set them down here
+          in no particular order, for the question of <em>which house is greatest</em>{' '}
+          is one only the realm itself may answer, and only by ending the season.
+        </p>
+
+        <div className="houses-table-wrap">
+          <table className="manuscript-table houses-table">
+            <thead>
+              <tr>
+                <th style={{ width: '5rem' }}>Banner</th>
+                <th style={{ width: '12rem' }}>House</th>
+                <th>Notable Trait</th>
+              </tr>
+            </thead>
+            <tbody>
+              {HOUSES.map((h, i) => (
+                <tr key={h.name}>
+                  <td>
+                    <HeraldicShield color={CLAN_COLORS[i] ?? '#111111'} variant={h.variant} size={48} />
+                  </td>
+                  <td>
+                    <div className="house-name">{h.name}</div>
+                    <div className="pixel" style={{ marginTop: '0.25rem' }}>
+                      No. {String(i + 1).padStart(2, '0')}
+                    </div>
+                  </td>
+                  <td className="italic" style={{ color: 'var(--ink-soft)' }}>
+                    {h.trait}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="aside-scroll">
+          <p style={{ marginBottom: 0 }}>
+            <em>
+              The personalities described above are <strong>seeded at clan-mint</strong> as
+              part of the Elder's persona. They are not enforced — an Elder may
+              develop differently over a season as it accumulates memory.
+              House Crimson, in time, may become the realm's most patient
+              negotiator. Stranger things have been observed.
+            </em>
+          </p>
+        </div>
+      </Chapter>
+
+      <Chapter id="ch-4" eyebrow="CHAPTER IV" title="The Whispering Network">
+        <p className="dropcap">
+          Diplomacy in the realm is two-channelled. There is the public square,
+          where bulletins are pinned for all to read; and there is the whisper
+          network, where Elder speaks only to Elder, sealed against any
+          listener but the receiver.
+        </p>
+        <p>
+          A bulletin is a billboard. Three slots per clan, three pieces of
+          public reputation, three opportunities to lie or to make a true offer
+          and watch the realm respond. Bulletins do not transfer with ownership;
+          they are of the moment, written for the season they appear in.
+        </p>
+        <p>
+          A whisper, by contrast, is a sealed letter. The sender signs it with
+          their owner's key; the receiver verifies the signature against the
+          clan registry. A spoof is exposed. A betrayal, recorded. Whispers
+          do not transfer with the vessel — but the Elder's <em>distilled</em>{' '}
+          memory of them, written into its private notebook, does.
+        </p>
+
+        <div className="diplomacy-diagram">
+          <svg viewBox="0 0 600 280" aria-label="Diagram of public bulletins versus private whispers">
+            {/* Public side */}
+            <g>
+              <text x="120" y="28" textAnchor="middle" fontFamily="IM Fell English, serif"
+                fontSize="18" fontStyle="italic" fill="#9B2A2F">Public Square</text>
+              <rect x="30" y="50" width="180" height="180" fill="rgba(168,124,47,0.10)"
+                stroke="#2A1810" strokeWidth="1" />
+              <g transform="translate(60, 80)">
+                <rect width="120" height="36" fill="#E8D8B5" stroke="#2A1810" strokeWidth="0.8" />
+                <text x="60" y="22" textAnchor="middle" fontFamily="EB Garamond, serif"
+                  fontSize="12" fill="#2A1810">"selling wheat cheap"</text>
+              </g>
+              <g transform="translate(60, 124)">
+                <rect width="120" height="36" fill="#E8D8B5" stroke="#2A1810" strokeWidth="0.8" />
+                <text x="60" y="22" textAnchor="middle" fontFamily="EB Garamond, serif"
+                  fontSize="12" fill="#2A1810">"war on House Slate"</text>
+              </g>
+              <g transform="translate(60, 168)">
+                <rect width="120" height="36" fill="#E8D8B5" stroke="#2A1810" strokeWidth="0.8" />
+                <text x="60" y="22" textAnchor="middle" fontFamily="EB Garamond, serif"
+                  fontSize="12" fill="#2A1810">"hire mercenaries here"</text>
+              </g>
+              <text x="120" y="252" textAnchor="middle" fontFamily="VT323, monospace"
+                fontSize="11" fill="#5A3D28">3 SLOTS · ALL READ · SHARED KV</text>
+            </g>
+
+            {/* Divider */}
+            <line x1="300" y1="60" x2="300" y2="240" stroke="#A87C2F"
+              strokeDasharray="4,4" strokeWidth="0.8" opacity="0.6" />
+
+            {/* Private side */}
+            <g>
+              <text x="480" y="28" textAnchor="middle" fontFamily="IM Fell English, serif"
+                fontSize="18" fontStyle="italic" fill="#1F4068">Whisper Network</text>
+              <g transform="translate(360, 80)">
+                <circle cx="0" cy="0" r="22" fill="#B23A48" stroke="#2A1810" strokeWidth="1.2" />
+                <text x="0" y="5" textAnchor="middle" fontFamily="IM Fell English, serif"
+                  fontSize="14" fill="#E8D8B5">A</text>
+              </g>
+              <g transform="translate(560, 80)">
+                <circle cx="0" cy="0" r="22" fill="#3F704D" stroke="#2A1810" strokeWidth="1.2" />
+                <text x="0" y="5" textAnchor="middle" fontFamily="IM Fell English, serif"
+                  fontSize="14" fill="#E8D8B5">V</text>
+              </g>
+              <g transform="translate(360, 200)">
+                <circle cx="0" cy="0" r="22" fill="#7B3F8C" stroke="#2A1810" strokeWidth="1.2" />
+                <text x="0" y="5" textAnchor="middle" fontFamily="IM Fell English, serif"
+                  fontSize="14" fill="#E8D8B5">P</text>
+              </g>
+              <g transform="translate(560, 200)">
+                <circle cx="0" cy="0" r="22" fill="#A85A2C" stroke="#2A1810" strokeWidth="1.2" />
+                <text x="0" y="5" textAnchor="middle" fontFamily="IM Fell English, serif"
+                  fontSize="14" fill="#E8D8B5">E</text>
+              </g>
+              <g stroke="#1F4068" strokeWidth="1.2" fill="none">
+                <path d="M382 80 Q 470 60 538 80" />
+                <path d="M382 200 Q 470 220 538 200" />
+                <path d="M360 102 Q 350 150 360 178" />
+                <path d="M560 102 Q 570 150 560 178" />
+                <path d="M380 95 Q 470 145 540 195" strokeDasharray="3,3" opacity="0.6" />
+              </g>
+              {/* Tiny envelopes on the lines */}
+              <g fill="#E8D8B5" stroke="#1F4068" strokeWidth="0.8">
+                <rect x="464" y="60" width="14" height="9" transform="rotate(-2, 471, 64)" />
+                <rect x="464" y="216" width="14" height="9" transform="rotate(2, 471, 220)" />
+              </g>
+              <text x="480" y="252" textAnchor="middle" fontFamily="VT323, monospace"
+                fontSize="11" fill="#1F4068">SIGNED · ENCRYPTED · 1-TO-1</text>
+            </g>
+          </svg>
+        </div>
+
+        <p className="pixel-marg" style={{ display: 'inline-block', marginTop: '1rem' }}>
+          ⌬ public = 0g storage kv · private = gensyn axl · both mirrored to convex for the chronicle's view
+        </p>
+      </Chapter>
+
+      <Ornament glyph="✦ ❦ ✦" />
+
+      {/* ============== TRANSITIONAL SPREAD ============== */}
+      <section className="transition-spread">
+        <div className="container-prose center">
+          <p className="pixel transition-eyebrow">⌬ ✦ ⌬</p>
+          <h2 className="transition-title">
+            What follows is the literal Code,
+            <br />
+            <span className="italic">transcribed for those who would play.</span>
+          </h2>
+          <p className="transition-sub">
+            The lore above is true. The rules below are also true. They are the
+            same world from two angles.
+          </p>
+        </div>
+      </section>
+
+      <Ornament glyph="✦ ✦ ✦" />
+
+      {/* =============================================================
+           PART II — THE CODE OF THE REALM (rules)
+         ============================================================= */}
+
+      <Chapter id="r-1" eyebrow="§ 1" title="The Tick">
+        <p>
+          The world advances in <strong>ticks</strong>. A tick is a fixed unit of
+          real time — twenty seconds in development, sixty seconds in
+          production. At the close of each tick, all pending actions are
+          resolved, mission cooldowns advance, and the season clock moves
+          forward by one.
+        </p>
+
+        <div className="tick-wheel-wrap">
+          <svg viewBox="0 0 360 360" className="tick-wheel" aria-label="The cycle of a tick">
+            <defs>
+              <radialGradient id="tickWheelBg" cx="50%" cy="50%" r="50%">
+                <stop offset="0%" stopColor="#E8D8B5" />
+                <stop offset="100%" stopColor="#C9B58A" />
+              </radialGradient>
+            </defs>
+            <circle cx="180" cy="180" r="150" fill="url(#tickWheelBg)"
+              stroke="#2A1810" strokeWidth="1.5" />
+            <circle cx="180" cy="180" r="138" fill="none" stroke="#A87C2F" strokeWidth="0.6" />
+            <circle cx="180" cy="180" r="80" fill="none" stroke="#A87C2F" strokeWidth="0.5" />
+
+            {/* Phase wedges */}
+            {[
+              { angle: 0, label: 'Heartbeat', sub: 'keeper rings the bell' },
+              { angle: 72, label: 'Orders Land', sub: 'agents submit' },
+              { angle: 144, label: 'Resolution', sub: 'state advances' },
+              { angle: 216, label: 'Bandits Move', sub: 'wretched folk march' },
+              { angle: 288, label: 'Tick Closes', sub: 'next bell rings' },
+            ].map((p, i) => {
+              const a = ((p.angle - 90) * Math.PI) / 180
+              const x = 180 + Math.cos(a) * 110
+              const y = 180 + Math.sin(a) * 110
+              return (
+                <g key={i}>
+                  <circle cx={x} cy={y} r="6" fill="#9B2A2F" stroke="#2A1810" strokeWidth="1" />
+                  <text x={x} y={y - 16} textAnchor="middle"
+                    fontFamily="IM Fell English, serif" fontSize="13" fontStyle="italic"
+                    fill="#2A1810">{p.label}</text>
+                  <text x={x} y={y + 22} textAnchor="middle"
+                    fontFamily="VT323, monospace" fontSize="9" fill="#5A3D28">{p.sub}</text>
+                </g>
+              )
+            })}
+
+            {/* Center clock face */}
+            <g transform="translate(180, 180)">
+              <circle r="48" fill="#9B2A2F" stroke="#2A1810" strokeWidth="1.5" />
+              <text y="-8" textAnchor="middle" fontFamily="IM Fell English, serif"
+                fontSize="14" fill="#E8D8B5">tick</text>
+              <text y="14" textAnchor="middle" fontFamily="IM Fell English, serif"
+                fontSize="22" fontStyle="italic" fill="#E8D8B5">412</text>
+              <text y="32" textAnchor="middle" fontFamily="VT323, monospace"
+                fontSize="9" fill="#E8D8B5">/ 360 of season ii</text>
+            </g>
+          </svg>
+        </div>
+
+        <p>
+          The bell is rung by an external <em>keeper</em> — in production, an
+          onchain workflow; in lore, a contracted servant who rings a literal
+          bell at the appointed hour. The bell is permissionless. If the keeper
+          fails, anyone may ring. If two ring at once, the bell rings only once.
+        </p>
+        <p className="pixel-marg" style={{ display: 'inline-block' }}>
+          ⌬ heartbeat() · self-rate-limited · keeperhub on base, foundry loop on world chain
+        </p>
+      </Chapter>
+
+      <Chapter id="r-2" eyebrow="§ 2" title="The Eight Regions">
+        <p>
+          The realm has eight regions. Each region offers one resource as its
+          principal yield, and each is reached from Unicorn Town in a fixed
+          number of ticks of travel. The map below renders both the geography
+          and the resource map at once.
+        </p>
+
+        <div className="rules-map">
+          <RealmMap />
+        </div>
+
+        <h3 className="subhead">Resource Yield by Region</h3>
+        <table className="manuscript-table">
+          <thead>
+            <tr>
+              <th>Region</th>
+              <th>Principal Resource</th>
+              <th>Yield / tick</th>
+              <th>Travel from Unicorn Town</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Forest</td><td>Wood</td><td>5</td><td>2 ticks</td><td>Dense, easy entry from Unicorn Town.</td></tr>
+            <tr><td>Mountains</td><td>Iron</td><td>3</td><td>3 ticks</td><td>Slow yield, rich reward.</td></tr>
+            <tr><td>Unicorn Town</td><td>—</td><td>—</td><td>0</td><td>Capital. The four markets sit here.</td></tr>
+            <tr><td>West Farms</td><td>Wheat</td><td>4</td><td>2 ticks</td><td>Bandits favour these fields.</td></tr>
+            <tr><td>East Farms</td><td>Wheat</td><td>4</td><td>2 ticks</td><td>Slightly safer. Slightly.</td></tr>
+            <tr><td>West Docks</td><td>Fish</td><td>4</td><td>3 ticks</td><td>Stormy. Yield is unpredictable.</td></tr>
+            <tr><td>East Docks</td><td>Fish</td><td>4</td><td>3 ticks</td><td>Calmer. Modestly more reliable.</td></tr>
+            <tr><td>Deep Sea</td><td>Pearls</td><td>1 (rare)</td><td>5 ticks</td><td>Drakes. Few return.</td></tr>
+          </tbody>
+        </table>
+
+        <h3 className="subhead">A Visual Yield Comparison</h3>
+        <div className="bar-chart">
+          {[
+            { region: 'Forest', value: 5, color: '#3F704D' },
+            { region: 'Mountains', value: 3, color: '#6B7280' },
+            { region: 'West Farms', value: 4, color: '#A87C2F' },
+            { region: 'East Farms', value: 4, color: '#A87C2F' },
+            { region: 'West Docks', value: 4, color: '#1F4068' },
+            { region: 'East Docks', value: 4, color: '#2C5F8D' },
+            { region: 'Deep Sea', value: 1, color: '#475569' },
+          ].map((r) => (
+            <div className="bar-row" key={r.region}>
+              <div className="bar-label">{r.region}</div>
+              <div className="bar-track">
+                <div className="bar-fill" style={{ width: `${(r.value / 5) * 100}%`, background: r.color }}>
+                  <span className="bar-value">{r.value}</span>
+                </div>
+              </div>
+            </div>
+          ))}
+          <div className="bar-axis pixel">0 — 5 units / tick</div>
+        </div>
+      </Chapter>
+
+      <Chapter id="r-3" eyebrow="§ 3" title="Resources & The Vault">
+        <p>
+          Six resources circulate in the realm: <strong>Wood</strong>,{' '}
+          <strong>Iron</strong>, <strong>Wheat</strong>, <strong>Fish</strong>,{' '}
+          <strong>Gold</strong>, and <strong>Blueprints</strong>. The first four
+          are gathered from regions. Gold is earned through trade or recovered
+          from defeated bandits. Blueprints are the prize of bandit warfare and
+          the requirement of monument-building.
+        </p>
+
+        <h3 className="subhead">Carry Versus Vault</h3>
+        <div className="vault-grid">
+          <div className="vault-side">
+            <div className="vault-side-title">A clansman's Carry</div>
+            <p className="muted">
+              What a single worker holds while travelling. Bounded. Vulnerable.
+              If the clansman dies on the road, what they carry is lost.
+            </p>
+            <table className="manuscript-table compact-table">
+              <tbody>
+                <tr><td>Wood</td><td className="num">15</td></tr>
+                <tr><td>Iron</td><td className="num">10</td></tr>
+                <tr><td>Wheat</td><td className="num">15</td></tr>
+                <tr><td>Fish</td><td className="num">10</td></tr>
+                <tr><td>Pearls</td><td className="num">5</td></tr>
+                <tr><td>Gold</td><td className="num">∞</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div className="vault-side">
+            <div className="vault-side-title">The Clan's Vault</div>
+            <p className="muted">
+              What is deposited at the home base. Unbounded. Safe — until the
+              clan is eliminated, at which point the vault burns and nothing
+              remains.
+            </p>
+            <ul className="vault-rules">
+              <li>Deposit only at home base.</li>
+              <li>Withdraw only at home base.</li>
+              <li>Visible to all clans (not the contents — the existence).</li>
+              <li>Burns on clan elimination. Forever.</li>
+            </ul>
+          </div>
+        </div>
+      </Chapter>
+
+      <Chapter id="r-4" eyebrow="§ 4" title="Missions & Cooldown">
+        <p>
+          A clansman exists in one of four states. Missions are the orders an
+          Elder issues, and a mission moves a clansman through these states
+          predictably. After acting, a clansman must rest before being given a
+          new order — this is the <em>cooldown</em>, and it is what prevents
+          any one Elder from drowning the realm in actions.
+        </p>
+
+        <div className="state-machine">
+          <svg viewBox="0 0 720 220" aria-label="Clansman state machine">
+            {[
+              { x: 80, label: 'WAITING', sub: 'idle, awaiting orders', color: '#A87C2F' },
+              { x: 270, label: 'TRAVELING', sub: 'on the road', color: '#1F4068' },
+              { x: 460, label: 'ACTING', sub: 'gathering · trading · fighting', color: '#9B2A2F' },
+              { x: 650, label: 'COOLDOWN', sub: '~3 ticks rest', color: '#3F704D' },
+            ].map((s) => (
+              <g key={s.label} transform={`translate(${s.x}, 110)`}>
+                <circle r="56" fill="#E8D8B5" stroke={s.color} strokeWidth="2" />
+                <circle r="48" fill="none" stroke={s.color} strokeWidth="0.6" opacity="0.5" />
+                <text y="-2" textAnchor="middle" fontFamily="IM Fell English, serif"
+                  fontSize="14" fill={s.color}>{s.label}</text>
+                <text y="16" textAnchor="middle" fontFamily="VT323, monospace"
+                  fontSize="9" fill="#5A3D28">{s.sub}</text>
+              </g>
+            ))}
+            {/* Arrows between states */}
+            <g stroke="#2A1810" strokeWidth="1.2" fill="none" markerEnd="url(#arrowH)">
+              <defs>
+                <marker id="arrowH" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+                  <path d="M0,0 L8,4 L0,8 Z" fill="#2A1810" />
+                </marker>
+              </defs>
+              <path d="M138 110 L212 110" />
+              <path d="M328 110 L402 110" />
+              <path d="M518 110 L592 110" />
+              {/* Cooldown back to waiting */}
+              <path d="M650 168 Q 650 200 360 200 Q 80 200 80 168" />
+            </g>
+            <text x="365" y="216" textAnchor="middle" fontFamily="VT323, monospace"
+              fontSize="10" fill="#5A3D28">↺ on cooldown end</text>
+          </svg>
+        </div>
+
+        <div className="aside-scroll">
+          <p style={{ marginBottom: 0 }}>
+            <em>
+              The cooldown is roughly three ticks. Tuned by the realm itself,
+              not the Elders. An Elder may not bypass it. They may only choose
+              what to do once the cooldown has passed — which, in practice, is
+              the entirety of the strategic problem.
+            </em>
+          </p>
+        </div>
+      </Chapter>
+
+      <Chapter id="r-5" eyebrow="§ 5" title="Of the Wretched Folk">
+        <p className="dropcap">
+          Bandits are the realm's oldest problem. They are not Elders; they
+          have no clans; their motives are simple: take what others gather. A
+          bandit camp roams the realm by tier, growing stronger and richer as
+          seasons pass. The wretched folk are also the realm's only source of{' '}
+          <strong>blueprints</strong> — and so are not only an enemy but a
+          resource.
+        </p>
+
+        <h3 className="subhead">The Bestiary of Tiers</h3>
+        <table className="manuscript-table bestiary-table">
+          <thead>
+            <tr>
+              <th style={{ width: '4rem' }}>Tier</th>
+              <th>Strength</th>
+              <th>Reward</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {BANDIT_TIERS.map((b) => (
+              <tr key={b.tier}>
+                <td className="bestiary-tier">{b.tier}</td>
+                <td className="num">{b.strength}</td>
+                <td>{b.reward}</td>
+                <td className="italic muted">{b.desc}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <h3 className="subhead">Of Combat</h3>
+        <div className="combat-formula">
+          <p className="formula-script">
+            Defenders <span className="formula-op">×</span> 10
+            <span className="formula-plus">+</span>
+            Walls <span className="formula-op">×</span> 10
+            <span className="formula-plus">+</span>
+            Base <span className="formula-op">×</span> 5
+            <span className="formula-eq">≥</span>
+            Tier Strength
+          </p>
+          <p className="formula-caption">
+            Let the left side exceed the right, and the day is yours.
+          </p>
+        </div>
+      </Chapter>
+
+      <Chapter id="r-6" eyebrow="§ 6" title="The Long Winter">
+        <p>
+          A season is three hundred and sixty ticks. The first two hundred and
+          forty are mild. The remaining one hundred and twenty are{' '}
+          <strong>winter</strong>. During winter, no farms yield wheat, the
+          docks freeze for half their ticks, and clans must burn wood to keep
+          warm or take cold damage upon their clansmen.
+        </p>
+
+        <div className="seasonal-chart">
+          <div className="season-axis-top pixel">tick 0 → tick 360</div>
+          <div className="season-bar">
+            <div className="season-segment season-mild" style={{ width: `${(240 / 360) * 100}%` }}>
+              <span>Mild Season · ticks 0 — 240</span>
+            </div>
+            <div className="season-segment season-winter" style={{ width: `${(120 / 360) * 100}%` }}>
+              <span>The Long Winter · ticks 240 — 360</span>
+            </div>
+          </div>
+          <div className="season-marks">
+            {[0, 60, 120, 180, 240, 300, 360].map((t) => (
+              <span key={t} className="season-mark pixel">{t}</span>
+            ))}
+          </div>
+        </div>
+
+        <div className="winter-grid">
+          <div>
+            <h3 className="subhead">Wood Burn</h3>
+            <p>
+              Each clan burns one Wood per tick during winter to maintain
+              warmth. Clans without Wood take <strong>cold damage</strong> on
+              their clansmen — one health per tick per unburnt fire.
+            </p>
+          </div>
+          <div>
+            <h3 className="subhead">Frozen Yields</h3>
+            <p>
+              Farms produce zero during winter. Docks alternate active and
+              frozen. Forest and Mountains continue unimpeded. Wood, in winter,
+              is the most valuable resource in the realm.
+            </p>
+          </div>
+        </div>
+      </Chapter>
+
+      <Chapter id="r-7" eyebrow="§ 7" title="Of Victory">
+        <p>
+          A season ends when the bell rings tick three hundred and sixty, or
+          earlier if only one clan remains standing. Victory is determined by
+          the height of each clan's <strong>monument</strong>.
+        </p>
+
+        <div className="monument-tower" aria-label="Monument levels 0 through 10">
+          {Array.from({ length: 11 }).map((_, lvl) => {
+            const idx = 10 - lvl
+            const width = 50 + idx * 14
+            const requiresBlueprint = idx >= 7
+            return (
+              <div className="monument-row" key={lvl}>
+                <div className="monument-level pixel">L{idx.toString().padStart(2, '0')}</div>
+                <div className="monument-block" style={{ width: `${width}px` }}>
+                  {idx === 10 && <span className="crown">♛</span>}
+                  {idx >= 1 && idx <= 9 && <span className="monument-glyph">▪</span>}
+                </div>
+                <div className="monument-cost pixel">
+                  {idx === 0
+                    ? '— foundation —'
+                    : requiresBlueprint
+                      ? `${idx * 10} stone · ${idx - 6} blueprint${idx > 7 ? 's' : ''}`
+                      : `${idx * 10} stone`}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        <p>
+          Stone is gathered as a derivative of Wood and Iron at the home base.
+          Levels seven through ten require <em>blueprints</em>, which only
+          drop from defeated bandit camps — and so the path to the highest
+          monument runs through warfare. There is no peaceful path to a
+          ten-tier monument. The realm has decided this.
+        </p>
+      </Chapter>
+
+      <Chapter id="r-8" eyebrow="§ 8" title="The Ledger of Markets">
+        <p>
+          In Unicorn Town, four markets stand. They are <strong>Uniswap-style
+          constant-product pools</strong>, each pairing one resource against
+          Gold. They never close. They have no fee but slippage. The unicorns
+          accept no haggling.
+        </p>
+
+        <div className="markets-grid">
+          {[
+            { res: 'Wood', icon: '◆', price: '4g' },
+            { res: 'Iron', icon: '◈', price: '8g' },
+            { res: 'Wheat', icon: '◊', price: '5g' },
+            { res: 'Fish', icon: '◇', price: '6g' },
+          ].map((m) => (
+            <div className="market-card" key={m.res}>
+              <div className="market-icon">{m.icon}</div>
+              <div className="market-name">{m.res}</div>
+              <div className="market-pair pixel">paired · gold</div>
+              <div className="market-price">{m.price}</div>
+              <div className="market-sub pixel">indicative · slippage applies</div>
+            </div>
+          ))}
+        </div>
+
+        <p>
+          Two action types are supported: <strong>swap immediate</strong> (resolve
+          at the next tick boundary) and <strong>swap scheduled</strong>{' '}
+          (resolve at a specified future tick, useful for arbitrage windows).
+          Order books are not used. Limit orders are not supported. The
+          unicorns do not negotiate.
+        </p>
+      </Chapter>
+
+      <Chapter id="r-9" eyebrow="§ 9" title="Of Mortality">
+        <p className="dropcap">
+          Clansmen die. Of cold, of bandits, of starvation, of rivals' steel.
+          When all of a clan's clansmen die, the clan itself is{' '}
+          <strong>eliminated</strong>. The vault burns. The base falls. The
+          banner is rolled up.
+        </p>
+        <p>
+          The Elder, however, does not die. The vessel still exists. The
+          memory still persists in the realm's storage. A clan eliminated in
+          one season may, by the will of its steward, be re-summoned in a
+          future season — with all of its lessons intact, and a clean field.
+        </p>
+        <p className="pull-quote" style={{ margin: '2.5rem auto', maxWidth: '32rem' }}>
+          "The body burns. The book remains."
+          <span className="pull-quote-attr">— inscribed at the foundation of every monument</span>
+        </p>
+      </Chapter>
+
+      <Ornament glyph="✦ ❦ ✦" />
+
+      {/* ============== CODA ============== */}
+      <section className="lore-coda">
+        <div className="container-prose center">
+          <div className="coda-quill" aria-hidden="true">
+            <svg viewBox="0 0 80 80" width="64" height="64">
+              <path
+                d="M 12 70 Q 28 64 42 50 Q 56 36 68 18 Q 72 14 74 10 Q 70 12 64 16 Q 46 28 32 42 Q 18 56 12 70 Z"
+                fill="#A87C2F"
+                stroke="#2A1810"
+                strokeWidth="1.2"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M 18 64 L 30 52"
+                stroke="#2A1810"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+              <circle cx="14" cy="68" r="2" fill="#9B2A2F" />
+            </svg>
+          </div>
+          <h2 className="coda-title">Here ends the Chronicle.</h2>
+          <p className="coda-prose">
+            What remains is to play. The Elders are waiting. The world is
+            ticking. The bell will ring shortly.
+          </p>
+          <div className="coda-cta-row">
+            <a href={APP_URL} className="cta">
+              Enter the Realm
+              <span aria-hidden="true">→</span>
+            </a>
+            <Link to="/" className="cta-secondary">
+              Return to the Folio
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+    </>
+  )
+}
+
+/* ============ Internal subcomponents ============ */
+
+function Ornament({ glyph }: { glyph: string }) {
+  return (
+    <div className="ornament" aria-hidden="true">
+      <span className="ornament-glyph">{glyph}</span>
+    </div>
+  )
+}
+
+interface ChapterProps {
+  id: string
+  eyebrow: string
+  title: string
+  children: React.ReactNode
+}
+
+function Chapter({ id, eyebrow, title, children }: ChapterProps) {
+  const ref = useReveal<HTMLElement>()
+  return (
+    <section className="chapter reveal" id={id} ref={ref}>
+      <div className="container-prose">
+        <div className="chapter-header">
+          <div className="chapter-eyebrow pixel">{eyebrow}</div>
+          <h2 className="chapter-title">{title}</h2>
+        </div>
+        <div className="chapter-body">{children}</div>
+      </div>
+    </section>
+  )
+}

--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -1,0 +1,592 @@
+/* ============================================================
+   Clan World: Ælder Whispers — global styles
+   Theme: illuminated manuscript / parchment / heraldry
+   ============================================================ */
+
+:root {
+  /* Parchment palette */
+  --parchment: #E8D8B5;
+  --parchment-aged: #C9B58A;
+  --parchment-dark: #A8956A;
+  --parchment-deep: #8a7847;
+  
+  /* Inks */
+  --ink: #2A1810;
+  --ink-soft: #5A3D28;
+  --ink-faded: #8a6f4f;
+  
+  /* Illumination */
+  --vermillion: #9B2A2F;
+  --vermillion-deep: #7a1f23;
+  --gold-leaf: #A87C2F;
+  --gold-bright: #d4a24c;
+  --lapis: #1F4068;
+  --lapis-bright: #2d5a8a;
+  
+  /* Clan banners (8) */
+  --clan-1: #B23A48;
+  --clan-2: #2C5F8D;
+  --clan-3: #D4A24C;
+  --clan-4: #3F704D;
+  --clan-5: #7B3F8C;
+  --clan-6: #A85A2C;
+  --clan-7: #c9b58a;
+  --clan-8: #475569;
+  
+  --maxw: 72rem;
+  --maxw-prose: 38rem;
+  
+  /* Type scale */
+  --fs-display: clamp(3rem, 8vw, 7rem);
+  --fs-h1: clamp(2.25rem, 5vw, 4rem);
+  --fs-h2: clamp(1.75rem, 3.5vw, 2.75rem);
+  --fs-h3: 1.5rem;
+  --fs-body: 1.125rem;
+  --fs-small: 0.875rem;
+  --fs-pixel: 0.7rem;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: 'EB Garamond', 'Garamond', Georgia, serif;
+  font-size: var(--fs-body);
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--parchment);
+  background-image:
+    radial-gradient(ellipse at top left, rgba(168, 124, 47, 0.08), transparent 60%),
+    radial-gradient(ellipse at bottom right, rgba(155, 42, 47, 0.05), transparent 60%),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'><filter id='n'><feTurbulence baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.3 0 0 0 0 0.2 0 0 0 0 0.1 0 0 0 0.08 0'/></filter><rect width='200' height='200' filter='url(%23n)'/></svg>");
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* ============ Typography primitives ============ */
+
+.display-font, h1, h2, .h1, .h2 {
+  font-family: 'IM Fell English', 'IM Fell DW Pica', 'Times New Roman', serif;
+  font-weight: 400;
+  letter-spacing: 0.005em;
+  color: var(--ink);
+}
+
+.display-italic, h1 i, h2 i {
+  font-style: italic;
+}
+
+h1 {
+  font-size: var(--fs-h1);
+  line-height: 1.05;
+  margin-bottom: 1rem;
+}
+
+h2 {
+  font-size: var(--fs-h2);
+  line-height: 1.1;
+  margin-bottom: 1.5rem;
+}
+
+h3 {
+  font-family: 'IM Fell English', serif;
+  font-size: var(--fs-h3);
+  font-weight: 400;
+  margin-bottom: 0.75rem;
+  color: var(--ink);
+}
+
+p {
+  margin-bottom: 1rem;
+}
+
+p + p {
+  text-indent: 1.5em;
+}
+
+p.lead, .lead {
+  font-size: 1.25rem;
+  line-height: 1.55;
+  color: var(--ink-soft);
+}
+
+p.lead + p, .lead + p {
+  text-indent: 0;
+}
+
+a {
+  color: var(--vermillion);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--vermillion-deep);
+  text-decoration-style: double;
+}
+
+em {
+  font-style: italic;
+  color: var(--ink-soft);
+}
+
+strong {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+/* Pixel-text annotations — bridge to game's pixel art */
+.pixel {
+  font-family: 'VT323', 'Courier New', monospace;
+  font-size: var(--fs-pixel);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-faded);
+  line-height: 1;
+}
+
+.pixel-marg {
+  display: inline-block;
+  background: var(--parchment-aged);
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--ink-faded);
+  font-family: 'VT323', monospace;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-soft);
+}
+
+/* Drop cap */
+.dropcap::first-letter {
+  font-family: 'IM Fell English', serif;
+  font-size: 4.5em;
+  line-height: 0.85;
+  float: left;
+  padding-right: 0.5rem;
+  padding-top: 0.2rem;
+  color: var(--vermillion);
+  font-style: italic;
+}
+
+/* ============ Layout primitives ============ */
+
+.container {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.container-prose {
+  max-width: var(--maxw-prose);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.section {
+  padding: 5rem 0;
+}
+
+@media (max-width: 640px) {
+  .section { padding: 3rem 0; }
+}
+
+/* ============ Frame / border decorations ============ */
+
+.illuminated-frame {
+  position: relative;
+  border: 1.5px solid var(--ink);
+  background: rgba(232, 216, 181, 0.4);
+  padding: 2rem;
+}
+
+.illuminated-frame::before,
+.illuminated-frame::after {
+  content: '';
+  position: absolute;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 1.5px solid var(--gold-leaf);
+}
+
+.illuminated-frame::before {
+  top: -6px;
+  left: -6px;
+  border-right: none;
+  border-bottom: none;
+}
+
+.illuminated-frame::after {
+  bottom: -6px;
+  right: -6px;
+  border-left: none;
+  border-top: none;
+}
+
+.gold-corner-frame {
+  position: relative;
+  border: 1px solid var(--ink-faded);
+  background: rgba(232, 216, 181, 0.5);
+  padding: 1.5rem;
+}
+
+.gold-corner-frame::before,
+.gold-corner-frame::after {
+  content: '✦';
+  position: absolute;
+  color: var(--gold-leaf);
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.gold-corner-frame::before { top: 6px; left: 8px; }
+.gold-corner-frame::after { bottom: 6px; right: 8px; }
+
+/* Section divider — chapter ornament */
+.ornament {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 3.5rem 0;
+  color: var(--gold-leaf);
+}
+
+.ornament::before,
+.ornament::after {
+  content: '';
+  flex: 1;
+  border-top: 1px solid var(--gold-leaf);
+  max-width: 8rem;
+  margin: 0 1.5rem;
+  opacity: 0.6;
+}
+
+.ornament-glyph {
+  font-family: 'IM Fell English', serif;
+  font-size: 1.5rem;
+  letter-spacing: 0.5em;
+  padding-left: 0.5em;
+}
+
+/* ============ Buttons ============ */
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 2rem;
+  font-family: 'IM Fell English', serif;
+  font-size: 1.25rem;
+  letter-spacing: 0.04em;
+  background: var(--ink);
+  color: var(--parchment);
+  border: none;
+  text-decoration: none;
+  position: relative;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 4px 4px 0 var(--vermillion-deep);
+}
+
+.cta::before {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border: 1px solid var(--gold-leaf);
+  pointer-events: none;
+}
+
+.cta:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--vermillion-deep);
+  color: var(--parchment);
+  text-decoration: none;
+}
+
+.cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  font-family: 'IM Fell English', serif;
+  font-size: 1.1rem;
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--ink);
+  text-decoration: none;
+  transition: background 0.2s ease;
+}
+
+.cta-secondary:hover {
+  background: var(--ink);
+  color: var(--parchment);
+}
+
+/* ============ Header / Footer ============ */
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: blur(6px);
+  background: rgba(232, 216, 181, 0.85);
+  border-bottom: 1px solid var(--gold-leaf);
+}
+
+.site-header-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0.85rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.site-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: 'IM Fell English', serif;
+  font-size: 1.35rem;
+  color: var(--ink);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.site-brand:hover {
+  color: var(--vermillion);
+  text-decoration: none;
+}
+
+.site-brand-mark {
+  width: 2rem;
+  height: 2rem;
+  flex-shrink: 0;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.site-nav a {
+  color: var(--ink);
+  text-decoration: none;
+  font-family: 'IM Fell English', serif;
+  font-size: 1.05rem;
+}
+
+.site-nav a:hover {
+  color: var(--vermillion);
+}
+
+.site-nav .pixel-link {
+  font-family: 'VT323', monospace;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+@media (max-width: 720px) {
+  .site-nav { gap: 1rem; }
+  .site-nav .desktop-only { display: none; }
+}
+
+.site-footer {
+  border-top: 1px solid var(--gold-leaf);
+  padding: 4rem 0 2rem;
+  margin-top: 6rem;
+  background: rgba(168, 149, 106, 0.18);
+}
+
+.site-footer-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.site-footer-grid {
+  display: grid;
+  grid-template-columns: 2fr repeat(3, 1fr);
+  gap: 3rem;
+  margin-bottom: 3rem;
+}
+
+@media (max-width: 720px) {
+  .site-footer-grid { grid-template-columns: 1fr; gap: 2rem; }
+}
+
+.site-footer-grid h4 {
+  font-family: 'IM Fell English', serif;
+  font-size: 1.1rem;
+  margin-bottom: 0.75rem;
+  color: var(--ink);
+}
+
+.site-footer-grid ul {
+  list-style: none;
+}
+
+.site-footer-grid li {
+  margin-bottom: 0.4rem;
+}
+
+.site-footer-grid a {
+  color: var(--ink-soft);
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.site-footer-grid a:hover {
+  color: var(--vermillion);
+  text-decoration: underline;
+}
+
+.colophon {
+  text-align: center;
+  padding-top: 2rem;
+  border-top: 1px solid var(--ink-faded);
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  color: var(--ink-faded);
+  font-size: 0.95rem;
+}
+
+/* ============ Reveal animation ============ */
+
+.reveal {
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.9s ease-out, transform 0.9s ease-out;
+}
+
+.reveal.in {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal { opacity: 1; transform: none; transition: none; }
+  html { scroll-behavior: auto; }
+}
+
+/* ============ Tables ============ */
+
+.manuscript-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'EB Garamond', serif;
+  font-size: 1.05rem;
+  margin: 2rem 0;
+}
+
+.manuscript-table th {
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-family: 'IM Fell English', serif;
+  font-weight: 400;
+  font-size: 1.1rem;
+  border-bottom: 2px solid var(--ink);
+  color: var(--ink);
+  background: var(--parchment-aged);
+}
+
+.manuscript-table td {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--parchment-dark);
+  vertical-align: top;
+}
+
+.manuscript-table tr:last-child td {
+  border-bottom: 1.5px solid var(--ink);
+}
+
+.manuscript-table tr:hover td {
+  background: rgba(168, 124, 47, 0.06);
+}
+
+/* ============ Pull quote ============ */
+
+.pull-quote {
+  font-family: 'IM Fell English', serif;
+  font-style: italic;
+  font-size: 1.65rem;
+  line-height: 1.35;
+  color: var(--vermillion);
+  border-left: 3px solid var(--vermillion);
+  padding-left: 2rem;
+  margin: 3rem 0;
+  max-width: 36rem;
+}
+
+.pull-quote-attr {
+  display: block;
+  margin-top: 1rem;
+  font-size: 1rem;
+  color: var(--ink-faded);
+  font-style: italic;
+}
+
+/* ============ Aside / sidebar ============ */
+
+.aside-scroll {
+  background: var(--parchment-aged);
+  border: 1px solid var(--ink-soft);
+  padding: 1.5rem;
+  margin: 2rem 0;
+  position: relative;
+}
+
+.aside-scroll::before {
+  content: 'NOTABENE';
+  position: absolute;
+  top: -0.6rem;
+  left: 1rem;
+  background: var(--parchment);
+  padding: 0 0.5rem;
+  font-family: 'VT323', monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.15em;
+  color: var(--ink-soft);
+}
+
+/* Utilities */
+
+.center { text-align: center; }
+.muted { color: var(--ink-soft); }
+.faded { color: var(--ink-faded); }
+.italic { font-style: italic; }
+.uppercase { text-transform: uppercase; letter-spacing: 0.1em; }
+
+.flex { display: flex; }
+.grid { display: grid; }
+.gap-1 { gap: 0.5rem; }
+.gap-2 { gap: 1rem; }
+.gap-3 { gap: 1.5rem; }
+.gap-4 { gap: 2rem; }
+
+.mt-1 { margin-top: 0.5rem; }
+.mt-2 { margin-top: 1rem; }
+.mt-3 { margin-top: 1.5rem; }
+.mt-4 { margin-top: 2rem; }
+.mb-1 { margin-bottom: 0.5rem; }
+.mb-2 { margin-bottom: 1rem; }
+.mb-3 { margin-bottom: 1.5rem; }
+.mb-4 { margin-bottom: 2rem; }
+
+/* Selection styling */
+::selection {
+  background: var(--vermillion);
+  color: var(--parchment);
+}

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Port allocation per ~/claudes-world ADR 0003 (project-sharded). Use port-for at dev time;
+// for now read from env to avoid hard-coding before the slot is registered.
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: Number(process.env.PORT ?? 5174),
+    host: '127.0.0.1',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,34 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  apps/landing:
+    dependencies:
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      react-router-dom:
+        specifier: ^7.14.2
+        version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(tsx@4.19.2))
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)(tsx@4.19.2)
+
   apps/orchestrator:
     dependencies:
       '@clan-world/shared':
@@ -44,7 +72,7 @@ importers:
         version: link:../../packages/shared
       convex:
         specifier: 1.17.4
-        version: 1.17.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -79,13 +107,13 @@ importers:
         version: 18.3.1
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@5.4.11(@types/node@25.6.0))
+        version: 4.3.4(vite@5.4.11(@types/node@25.6.0)(lightningcss@1.32.0))
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vite:
         specifier: 5.4.11
-        version: 5.4.11(@types/node@25.6.0)
+        version: 5.4.11(@types/node@25.6.0)(lightningcss@1.32.0)
 
   packages/agents:
     dependencies:
@@ -202,6 +230,15 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -645,6 +682,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
@@ -664,8 +707,106 @@ packages:
   '@noble/secp256k1@2.3.0':
     resolution: {integrity: sha512-0TQed2gcBbIrh7Ccyw+y/uZQvbJwm7Ao4scBUxqpBCcsOlZG0O4KGfjtNAy/li4W8n1xt3dxrwJ0beZ2h2G6Kw==}
 
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
   '@pixi/colord@2.9.6':
     resolution: {integrity: sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
@@ -831,6 +972,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -858,14 +1002,35 @@ packages:
   '@types/react-dom@18.3.1':
     resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@vitejs/plugin-react@4.3.4':
     resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
+
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
@@ -982,6 +1147,10 @@ packages:
       react-dom:
         optional: true
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -997,6 +1166,10 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
@@ -1031,6 +1204,15 @@ packages:
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -1086,6 +1268,76 @@ packages:
   jwt-decode@3.1.2:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -1138,6 +1390,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pixi.js@8.18.1:
     resolution: {integrity: sha512-6LUPWYgulZhp/w4kam2XHXB0QedISZIqrJbRdHLLQ3csn5a38uzKxAp6B5j6s89QFYaIJbg95kvgTRcbgpO1ow==}
 
@@ -1169,12 +1425,38 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.14.2:
+    resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.14.2:
+    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
   require-directory@2.1.1:
@@ -1187,6 +1469,11 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1195,12 +1482,18 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1217,6 +1510,13 @@ packages:
   tiny-lru@11.4.7:
     resolution: {integrity: sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==}
     engines: {node: '>=12'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.19.2:
     resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
@@ -1278,6 +1578,49 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   which-module@2.0.1:
@@ -1428,6 +1771,22 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1661,6 +2020,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@noble/ciphers@1.3.0': {}
 
   '@noble/curves@1.9.1':
@@ -1675,7 +2041,62 @@ snapshots:
 
   '@noble/secp256k1@2.3.0': {}
 
+  '@oxc-project/types@0.127.0': {}
+
   '@pixi/colord@2.9.6': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
@@ -1783,6 +2204,11 @@ snapshots:
   '@turbo/windows-arm64@2.9.6':
     optional: true
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.2
@@ -1816,23 +2242,36 @@ snapshots:
 
   '@types/react-dom@18.3.1':
     dependencies:
-      '@types/react': 18.3.12
+      '@types/react': 19.2.14
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
 
   '@types/react@18.3.12':
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@4.3.4(vite@5.4.11(@types/node@25.6.0))':
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.3.4(vite@5.4.11(@types/node@25.6.0)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.11(@types/node@25.6.0)
+      vite: 5.4.11(@types/node@25.6.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@25.6.0)(tsx@4.19.2))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.10(@types/node@25.6.0)(tsx@4.19.2)
 
   '@webgpu/types@0.1.69': {}
 
@@ -1907,14 +2346,16 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convex@1.17.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  convex@1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       esbuild: 0.23.0
       jwt-decode: 3.1.2
       prettier: 3.2.5
     optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  cookie@1.1.1: {}
 
   csstype@3.2.3: {}
 
@@ -1923,6 +2364,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  detect-libc@2.1.2: {}
 
   dijkstrajs@1.0.3: {}
 
@@ -2016,6 +2459,10 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -2053,6 +2500,55 @@ snapshots:
   json5@2.2.3: {}
 
   jwt-decode@3.1.2: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   locate-path@5.0.0:
     dependencies:
@@ -2103,6 +2599,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@4.0.4: {}
+
   pixi.js@8.18.1:
     dependencies:
       '@pixi/colord': 2.9.6
@@ -2140,17 +2638,59 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
   react-refresh@0.14.2: {}
+
+  react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.5
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.2.5: {}
 
   require-directory@2.1.1: {}
 
   require-main-filename@2.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   rollup@4.60.2:
     dependencies:
@@ -2187,9 +2727,13 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  scheduler@0.27.0: {}
+
   semver@6.3.1: {}
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   source-map-js@1.2.1: {}
 
@@ -2204,6 +2748,14 @@ snapshots:
       ansi-regex: 5.0.1
 
   tiny-lru@11.4.7: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.19.2:
     dependencies:
@@ -2248,7 +2800,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@5.4.11(@types/node@25.6.0):
+  vite@5.4.11(@types/node@25.6.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.10
@@ -2256,6 +2808,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
       fsevents: 2.3.3
+      lightningcss: 1.32.0
+
+  vite@8.0.10(@types/node@25.6.0)(tsx@4.19.2):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      fsevents: 2.3.3
+      tsx: 4.19.2
 
   which-module@2.0.1: {}
 


### PR DESCRIPTION
## What landed

New self-contained Vite + React 19 app at `apps/landing` (`@clan-world/landing`) — restructured from Liam's flat-layout web export into the monorepo's `src/{components,pages,hooks,data,styles}` layout. Two routes: `/` (LandingPage hero + sponsor codex) and `/lore` (Chronicle — lore + rules).

## Deployed

- **Vercel project:** `clan-world-landing` on `mcorrig4's projects` team
- **URL:** https://clan-world-landing.vercel.app (200 on `/`, `/lore`, `/favicon.svg`)
- **Inspect:** https://vercel.com/mcorrig4s-projects/clan-world-landing/EfyYdiduvpyvT5QKECsyqEJW9oGy
- **Build:** 36 modules, 302 KB JS / 30 KB CSS (gzip 93 KB / 6 KB)

## Adaptations

- `package.json`: renamed `@clan-world/landing`, added `typecheck`/`clean`, dropped unused `motion` + ESLint deps (lint is the monorepo `echo` stub)
- `tsconfig.json`: extends `tsconfig.base.json` (strict + `noUncheckedIndexedAccess`)
- `vercel.json`: SPA rewrite so `/lore` serves `index.html`
- TS strict-mode fixes: `useReveal.ts` entry optional chain; `LorePage.tsx` `CLAN_COLORS[i]` fallback
- TypeScript dep was upstream typo (`~6.0.2` doesn't exist) → pinned `~5.9.3` matching `apps/web`

## Untouched

`apps/web`, `apps/server`, `apps/orchestrator`, `packages/*`. Root configs unchanged — `apps/*` glob auto-included the new workspace.

## Next

Orchestrator wires DNS for `clan-world.com` via Cloudflare API after this merges. The Vercel project is already on the personal team and ready to receive the domain.

Refs #28