### PR TITLE
feat(agents,orchestrator): elder clan submit-orders + real tx via RealChainClient (#9)

### DIFF
--- a/apps/orchestrator/src/main.ts
+++ b/apps/orchestrator/src/main.ts
@@ -21,10 +21,11 @@ async function main(): Promise<void> {
   const { txHash } = await chain.submitOrders('0', orders);
   console.error(`[orchestrator] tx submitted: ${txHash}`);
 
-  await convex.postLog(
-    'info',
-    `Elder Aldric (clan-0): ChopWood mission submitted — txHash=${txHash} tick=${tick}`,
-  );
+  try {
+    await convex.postLog('info', `Elder Aldric (clan-0): ChopWood submitted — txHash=${txHash} tick=${tick}`);
+  } catch (err) {
+    console.error('[orchestrator] convex log failed (non-fatal):', err);
+  }
 
   // Print final JSON summary to stdout
   process.stdout.write(

--- a/apps/orchestrator/src/main.ts
+++ b/apps/orchestrator/src/main.ts
@@ -1,12 +1,38 @@
-// Wave 0 stub. The real orchestrator will spawn 4 long-running Claude Code Elder
-// sessions and pump <situation> blocks into stdin per tick. See
-// docs/guides/stream-agents.md and docs/planning/V1/02 Frontend Spec/clanworld_agent_runner_spec.md
-// (note: §7-§11 of agent runner spec is deprecated — Submission 1 uses the simpler
-// `elder` CLI from packages/agents).
+import type { ClanOrder } from '@clan-world/shared';
+import { createChainClient, createConvexClient } from '@clan-world/shared/adapters';
 
-function main(): void {
-  // eslint-disable-next-line no-console
-  console.log('orchestrator starting (stub)');
+async function main(): Promise<void> {
+  const chain = createChainClient();
+  const convex = createConvexClient();
+
+  // Get current tick
+  const tick = await chain.getCurrentTick();
+  console.error(`[orchestrator] tick=${tick}`);
+
+  // Hardcoded mission for clan-0: clansman 1 chops wood in Forest
+  const orders: ClanOrder[] = [
+    {
+      kind: 'mission',
+      payload: { clansmanId: 1, gotoRegion: 0, action: 1 }, // action=1 is ChopWood
+    },
+  ];
+
+  console.error('[orchestrator] submitting orders for clan-0...');
+  const { txHash } = await chain.submitOrders('0', orders);
+  console.error(`[orchestrator] tx submitted: ${txHash}`);
+
+  await convex.postLog(
+    'info',
+    `Elder Aldric (clan-0): ChopWood mission submitted — txHash=${txHash} tick=${tick}`,
+  );
+
+  // Print final JSON summary to stdout
+  process.stdout.write(
+    JSON.stringify({ tick, txHash, clan: '0', mission: 'ChopWood-Forest' }, null, 2) + '\n',
+  );
 }
 
-main();
+main().catch(err => {
+  console.error('[orchestrator] fatal:', err);
+  process.exit(1);
+});

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
+import fs from 'node:fs';
 import type { WorldSnapshot } from '@clan-world/shared';
+import type { ClanOrder } from '@clan-world/shared';
+import { createChainClient } from '@clan-world/shared/adapters';
 
 // elder CLI — toolbelt invoked by Elder Claude Code sessions per tick.
 // Wave 0 stub: only `elder world snapshot` is implemented and returns mock JSON.
@@ -14,18 +17,50 @@ function snapshot(): WorldSnapshot {
   };
 }
 
-function main(argv: string[]): void {
-  const [, , ns, cmd] = argv;
+async function main(argv: string[]): Promise<void> {
+  const [, , ns, cmd, ...rest] = argv;
+
   if (ns === 'world' && cmd === 'snapshot') {
     process.stdout.write(JSON.stringify(snapshot(), null, 2) + '\n');
     return;
   }
+
+  if (ns === 'clan' && cmd === 'submit-orders') {
+    const [clanId, ordersFile] = rest;
+    if (!clanId || !ordersFile) {
+      process.stderr.write('usage: elder clan submit-orders <clanId> <ordersJsonFile>\n');
+      process.exit(1);
+    }
+    const raw = fs.readFileSync(ordersFile, 'utf8');
+    const orders = JSON.parse(raw) as ClanOrder[];
+    const client = createChainClient();
+    const result = await client.submitOrders(clanId, orders);
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return;
+  }
+
+  if (ns === 'clan' && cmd === 'view') {
+    const [clanId] = rest;
+    if (!clanId) {
+      process.stderr.write('usage: elder clan view <clanId>\n');
+      process.exit(1);
+    }
+    const client = createChainClient();
+    const result = await client.getClanFullView(clanId);
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return;
+  }
+
   process.stderr.write(
     'usage: elder world snapshot\n' +
-      '       elder clan submit-orders <clanId> <ordersJson>   (TBD)\n' +
+      '       elder clan submit-orders <clanId> <ordersJsonFile>\n' +
+      '       elder clan view <clanId>\n' +
       '       elder whisper send <fromClan> <toClan> <text>    (TBD)\n',
   );
   process.exit(1);
 }
 
-main(process.argv);
+main(process.argv).catch(err => {
+  process.stderr.write(`elder: fatal: ${String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -1,4 +1,5 @@
-import { createPublicClient, http, fallback, defineChain } from 'viem';
+import { createPublicClient, createWalletClient, http, fallback, defineChain } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 import type { ClanFullView, ClanOrder, Tick } from '../types';
 import { readEnv } from './_env';
 
@@ -200,6 +201,39 @@ const CLAN_WORLD_ABI = [
     ],
     stateMutability: 'view',
   },
+  {
+    name: 'submitClanOrders',
+    type: 'function',
+    inputs: [
+      { name: 'clanId', type: 'uint32' },
+      {
+        name: 'orders',
+        type: 'tuple[]',
+        components: [
+          { name: 'clansmanId', type: 'uint32' },
+          { name: 'gotoRegion', type: 'uint8' },
+          { name: 'action', type: 'uint8' },
+          { name: 'targetClanId', type: 'uint32' },
+          { name: 'marketToken', type: 'address' },
+          { name: 'marketAmount', type: 'uint256' },
+          { name: 'maxGoldIn', type: 'uint256' },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: 'results',
+        type: 'tuple[]',
+        components: [
+          { name: 'clansmanId', type: 'uint32' },
+          { name: 'status', type: 'uint8' },
+          { name: 'cooldownEndsAtTs', type: 'uint64' },
+          { name: 'missionNonce', type: 'uint64' },
+        ],
+      },
+    ],
+    stateMutability: 'nonpayable',
+  },
 ] as const;
 
 class StubChainClient implements IChainClient {
@@ -222,12 +256,13 @@ class StubChainClient implements IChainClient {
 class RealChainClient implements IChainClient {
   private readonly client: ReturnType<typeof createPublicClient>;
   private readonly contractAddress: `0x${string}`;
+  private readonly transport: ReturnType<typeof http> | ReturnType<typeof fallback>;
 
   constructor() {
     const primaryRpc = readEnv('RPC_URL_PRIMARY');
     const fallbackRpc = readEnv('RPC_URL_FALLBACK');
 
-    const transport =
+    this.transport =
       primaryRpc && fallbackRpc
         ? fallback([http(primaryRpc), http(fallbackRpc)])
         : http(primaryRpc ?? fallbackRpc);
@@ -237,7 +272,7 @@ class RealChainClient implements IChainClient {
 
     this.client = createPublicClient({
       chain: worldChainSepolia,
-      transport,
+      transport: this.transport,
     });
   }
 
@@ -250,10 +285,37 @@ class RealChainClient implements IChainClient {
     return Number(snapshot.currentTick); // safe: tick values are small enough to fit Number precisely in Wave 0
   }
 
-  async submitOrders(_clanId: string, _orders: ClanOrder[]): Promise<{ txHash: string }> {
-    throw new Error(
-      'RealChainClient: submitOrders not supported — use agents package for tx signing',
-    );
+  async submitOrders(clanId: string, orders: ClanOrder[]): Promise<{ txHash: string }> {
+    const pk = readEnv('DEPLOYER_PRIVATE_KEY');
+    if (!pk) throw new Error('DEPLOYER_PRIVATE_KEY not set');
+
+    const account = privateKeyToAccount(pk as `0x${string}`);
+    const walletClient = createWalletClient({
+      account,
+      chain: worldChainSepolia,
+      transport: this.transport,
+    });
+
+    const contractOrders = orders
+      .filter(o => o.kind === 'mission')
+      .map(o => ({
+        clansmanId: Number(o.payload.clansmanId ?? 0),
+        gotoRegion: Number(o.payload.gotoRegion ?? 0),
+        action: Number(o.payload.action ?? 1),
+        targetClanId: 0,
+        marketToken: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+        marketAmount: 0n,
+        maxGoldIn: 0n,
+      }));
+
+    const hash = await walletClient.writeContract({
+      address: this.contractAddress,
+      abi: CLAN_WORLD_ABI,
+      functionName: 'submitClanOrders',
+      args: [parseInt(clanId, 10), contractOrders],
+    });
+
+    return { txHash: hash };
   }
 
   async getClanFullView(clanId: string): Promise<ClanFullView> {

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -286,6 +286,26 @@ class RealChainClient implements IChainClient {
   }
 
   async submitOrders(clanId: string, orders: ClanOrder[]): Promise<{ txHash: string }> {
+    // Wave 0: single-Elder only — concurrent nonce coordination deferred to Wave 1
+    const parsedClanId = parseInt(clanId, 10);
+    if (isNaN(parsedClanId) || String(parsedClanId) !== clanId.trim()) {
+      throw new Error(`submitOrders: clanId must be a decimal integer, got '${clanId}'`);
+    }
+
+    for (const order of orders) {
+      if (order.kind === 'mission') {
+        const { clansmanId, gotoRegion, action } = order.payload;
+        if (clansmanId === undefined || gotoRegion === undefined || action === undefined) {
+          throw new Error(`submitOrders: mission order missing required payload fields (clansmanId, gotoRegion, action)`);
+        }
+      }
+    }
+
+    const nonMissionOrders = orders.filter(o => o.kind !== 'mission');
+    if (nonMissionOrders.length > 0) {
+      console.warn(`[RealChainClient] submitOrders: ${nonMissionOrders.length} non-mission order(s) skipped (Wave 0 only supports 'mission' kind)`);
+    }
+
     const pk = readEnv('DEPLOYER_PRIVATE_KEY');
     if (!pk) throw new Error('DEPLOYER_PRIVATE_KEY not set');
 
@@ -299,9 +319,9 @@ class RealChainClient implements IChainClient {
     const contractOrders = orders
       .filter(o => o.kind === 'mission')
       .map(o => ({
-        clansmanId: Number(o.payload.clansmanId ?? 0),
-        gotoRegion: Number(o.payload.gotoRegion ?? 0),
-        action: Number(o.payload.action ?? 1),
+        clansmanId: Number(o.payload.clansmanId),
+        gotoRegion: Number(o.payload.gotoRegion),
+        action: Number(o.payload.action),
         targetClanId: 0,
         marketToken: '0x0000000000000000000000000000000000000000' as `0x${string}`,
         marketAmount: 0n,
@@ -312,7 +332,7 @@ class RealChainClient implements IChainClient {
       address: this.contractAddress,
       abi: CLAN_WORLD_ABI,
       functionName: 'submitClanOrders',
-      args: [parseInt(clanId, 10), contractOrders],
+      args: [parsedClanId, contractOrders],
     });
 
     return { txHash: hash };

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -306,16 +306,6 @@ class RealChainClient implements IChainClient {
       console.warn(`[RealChainClient] submitOrders: ${nonMissionOrders.length} non-mission order(s) skipped (Wave 0 only supports 'mission' kind)`);
     }
 
-    const pk = readEnv('DEPLOYER_PRIVATE_KEY');
-    if (!pk) throw new Error('DEPLOYER_PRIVATE_KEY not set');
-
-    const account = privateKeyToAccount(pk as `0x${string}`);
-    const walletClient = createWalletClient({
-      account,
-      chain: worldChainSepolia,
-      transport: this.transport,
-    });
-
     const contractOrders = orders
       .filter(o => o.kind === 'mission')
       .map(o => ({
@@ -327,6 +317,20 @@ class RealChainClient implements IChainClient {
         marketAmount: 0n,
         maxGoldIn: 0n,
       }));
+
+    if (contractOrders.length === 0) {
+      throw new Error('submitOrders: no valid mission orders to submit');
+    }
+
+    const pk = readEnv('DEPLOYER_PRIVATE_KEY');
+    if (!pk) throw new Error('DEPLOYER_PRIVATE_KEY not set');
+
+    const account = privateKeyToAccount(pk as `0x${string}`);
+    const walletClient = createWalletClient({
+      account,
+      chain: worldChainSepolia,
+      transport: this.transport,
+    });
 
     const hash = await walletClient.writeContract({
       address: this.contractAddress,


### PR DESCRIPTION
## Summary

- `packages/shared/src/adapters/IChainClient.ts` — `RealChainClient.submitOrders` fully implemented:
  - Wallet client via `createWalletClient` + `privateKeyToAccount(DEPLOYER_PRIVATE_KEY)`
  - `submitClanOrders` ABI entry added (full tuple struct)
  - `clanId` decimal-integer validation (rejects junk strings)
  - Mission payload field presence validation (clansmanId, gotoRegion, action must be defined)
  - Empty contractOrders guard before `writeContract`
  - Non-mission orders warn + skip (Wave 0 mission-only)
  - Wave 0 single-Elder nonce note

- `packages/agents/src/cli.ts` — added `elder clan submit-orders <clanId> <ordersFile>` + `elder clan view <clanId>` commands; async main migration

- `apps/orchestrator/src/main.ts` — replaced stub: fetches tick, submits hardcoded ChopWood mission for clan-0 (clansman 1, Forest), logs to Convex (non-fatal catch), prints JSON summary

## Notes
- `RealConvexClient.postLog` is still Wave 1+; orchestrator wraps it in try/catch — tx submission is not blocked by Convex logging failure
- Nonce coordination between concurrent processes deferred to Wave 1 (Wave 0: single Elder only)

## Review status
- Codex: CLEAN (post-fix)
- Claude: CLEAN (post micro-fix)

Closes #9