### PR TITLE
fix(web): graceful render fallback (#28)

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,19 +6,69 @@ import { App } from './App';
 
 // MiniKit v2: install() must be called before rendering in the World App webview.
 // No MiniKitProvider component in v2 — install() is a static class call.
-MiniKit.install(import.meta.env.VITE_WORLD_APP_ID);
+// Guard against undefined APP_ID (e.g. env not baked into prod bundle): calling
+// install(undefined) in older builds shipped a literal `void 0` and broke the
+// page on first navigation. Skip install if missing — MiniKit.isInstalled()
+// will return false and App will render its "Open in World App" fallback.
+const worldAppId = import.meta.env.VITE_WORLD_APP_ID as string | undefined;
+if (worldAppId) {
+  try {
+    MiniKit.install(worldAppId as `app_${string}`);
+  } catch (err) {
+    console.error('MiniKit.install failed:', err);
+  }
+} else {
+  console.warn('VITE_WORLD_APP_ID not set — MiniKit not installed');
+}
 
-const convexUrl = import.meta.env.VITE_CONVEX_URL;
-if (!convexUrl) throw new Error('VITE_CONVEX_URL is not set');
-const convex = new ConvexReactClient(convexUrl);
+const convexUrl = import.meta.env.VITE_CONVEX_URL as string | undefined;
 
 // Cast required: convex's React.FC type conflicts with @types/react@18.3 ReactNode (bigint addition)
-const Provider = ConvexProvider as React.ComponentType<{ client: ConvexReactClient; children?: React.ReactNode }>;
+const Provider = ConvexProvider as React.ComponentType<{
+  client: ConvexReactClient;
+  children?: React.ReactNode;
+}>;
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <Provider client={convex}>
-      <App />
-    </Provider>
-  </React.StrictMode>,
-);
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+
+if (!convexUrl) {
+  // Fail soft instead of throwing — a thrown error here leaves a blank page,
+  // which is unacceptable for the hackathon submission. Render a visible
+  // message so the user sees something even if the build is misconfigured.
+  console.error('VITE_CONVEX_URL is not set — rendering degraded fallback');
+  root.render(
+    <main
+      style={{
+        background: '#0d1a0d',
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '24px',
+        textAlign: 'center',
+      }}
+    >
+      <div
+        style={{
+          color: 'white',
+          fontFamily: 'monospace',
+          maxWidth: '420px',
+        }}
+      >
+        <h1 style={{ margin: 0, fontSize: '20px' }}>ClanWorld</h1>
+        <p style={{ marginTop: '12px', opacity: 0.8 }}>
+          Backend not configured. Open in the World App or contact the team.
+        </p>
+      </div>
+    </main>,
+  );
+} else {
+  const convex = new ConvexReactClient(convexUrl);
+  root.render(
+    <React.StrictMode>
+      <Provider client={convex}>
+        <App />
+      </Provider>
+    </React.StrictMode>,
+  );
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,10 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'node:path';
 
 // Port allocation per ~/claudes-world ADR 0003 (project-sharded). Use port-for at dev time;
 // for now read from env to avoid hard-coding before the slot is registered.
+//
+// envDir: load .env.local from the monorepo root, not the web app folder.
+// .env.local lives at <repo-root>/.env.local and is shared with server/agents.
+// Without this, VITE_* values are undefined at build time and the prod bundle
+// has no Convex URL / World App ID baked in (white screen).
 export default defineConfig({
   plugins: [react()],
+  envDir: path.resolve(__dirname, '../..'),
   server: {
     port: Number(process.env.PORT ?? 5173),
     host: '127.0.0.1',


### PR DESCRIPTION
## Summary

The deployed mini app at https://app.clan-world.com was a white screen on mobile. Bundle inspection showed `Zh.install(void 0)` plus a synchronous module-top-level `throw new Error(\"VITE_CONVEX_URL is not set\")` — React never mounted.

## Root cause

`.env.local` lives at the monorepo root, but Vite reads env files from the project root passed to `vite build` (`apps/web/`). So every `VITE_*` was `undefined` at build time. The bundle had no Convex URL, no Worldcoin app id, and a synchronous fail-fast that crashed boot.

## Fix

- **`apps/web/vite.config.ts`** — set `envDir: ../..` so Vite loads `.env.local` from the monorepo root. This is the actual bug.
- **`apps/web/src/main.tsx`** — defense in depth:
  - Wrap `MiniKit.install()` in a guard + try/catch (no `void 0`, no thrown errors leaking to boot).
  - Replace the top-level `throw` for missing `VITE_CONVEX_URL` with a visible degraded-mode fallback. White screen is never acceptable.

## Verification

- New bundle (`index-BsDO3jJ-.js`) bakes in `app_9241a3…` and `oceanic-hound-951.convex.cloud`. Old bundle (`index-BR1tJw8Y.js`, broken) had neither.
- Deployed to Vercel prod, alias `app.clan-world.com` updated.
- Playwright headless (390x844 mobile viewport):
  - `#root` populated with expected "Open in World App to play" fallback (mobile chromium is not the World App webview, so this branch is correct).
  - Zero page errors, zero failed requests.
  - Only console message: expected `MiniKit is not installed` warning.
- Bundle no longer contains the `is not set` throw string (verified via grep).

Live URL: https://app.clan-world.com
Fresh deploy: `dpl_3NwXST8CMGwn6KqQusA5v4LhmA7K`

## Test plan

- [x] Build succeeds with env baked in (verified bundle contents)
- [x] Page renders without white screen (Playwright)
- [x] No console errors, no failed requests (Playwright)
- [ ] Open in World App webview on mobile and confirm Pixi canvas renders (Liam — physical device only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)