### PR TITLE
[fix] Landing page factual corrections

### DIFF
--- a/apps/landing/src/pages/LandingPage.tsx
+++ b/apps/landing/src/pages/LandingPage.tsx
@@ -41,7 +41,7 @@ export default function LandingPage() {
             <div ref={heroSubRef} className="reveal" style={{ transitionDelay: '0.35s' }}>
               <p className="hero-tagline">
                 A realm of autonomous agents, ruined fortunes, and unforgiving winters.
-                Eight clans. One world. The Elders never forget.
+                Four AI Elders. One world. The Elders never forget.
               </p>
             </div>
             <div ref={heroCtaRef} className="reveal hero-cta-row" style={{ transitionDelay: '0.6s' }}>
@@ -81,7 +81,7 @@ export default function LandingPage() {
               tag="I."
               title="Live"
               icon="axe"
-              copy="Eight clans. One world. Real ticks of real time. No menus, no turns — agents act when they see opportunity, sleep when they don't."
+              copy="Four Elders. One world. Real ticks of real time. No menus, no turns — agents act when they see opportunity, sleep when they don't."
             />
             <PremiseColumn
               tag="II."

--- a/apps/landing/src/pages/LorePage.tsx
+++ b/apps/landing/src/pages/LorePage.tsx
@@ -657,25 +657,46 @@ export default function LorePage() {
 
       <Chapter id="r-6" eyebrow="§ 6" title="The Long Winter">
         <p>
-          A season is three hundred and sixty ticks. The first two hundred and
-          forty are mild. The remaining one hundred and twenty are{' '}
-          <strong>winter</strong>. During winter, no farms yield wheat, the
-          docks freeze for half their ticks, and clans must burn wood to keep
-          warm or take cold damage upon their clansmen.
+          A season is three hundred and sixty ticks long. Winter falls upon the
+          realm <strong>every hundred and ten ticks</strong>, and each winter
+          lasts <strong>ten ticks</strong> — three winters in all, before the
+          season closes. During winter, farms yield no wheat, plots wither and
+          must regrow, and every clan must burn wood to keep warm or take cold
+          damage upon their walls and clansmen.
         </p>
 
         <div className="seasonal-chart">
-          <div className="season-axis-top pixel">tick 0 → tick 360</div>
-          <div className="season-bar">
-            <div className="season-segment season-mild" style={{ width: `${(240 / 360) * 100}%` }}>
-              <span>Mild Season · ticks 0 — 240</span>
-            </div>
-            <div className="season-segment season-winter" style={{ width: `${(120 / 360) * 100}%` }}>
-              <span>The Long Winter · ticks 240 — 360</span>
-            </div>
+          <div className="season-axis-top pixel">tick 0 → tick 360 · winter every 110 ticks · lasts 10 ticks</div>
+          <div className="season-bar season-bar-cycles">
+            {(() => {
+              const total = 360
+              const cycle = 110
+              const winterLen = 10
+              const segments: { label: string; width: number; kind: 'mild' | 'winter' }[] = []
+              let cursor = 0
+              // build winter starts at 110, 220, 330
+              for (let start = cycle; start <= total; start += cycle) {
+                const mildSpan = start - cursor
+                if (mildSpan > 0) segments.push({ label: `mild ${cursor}–${start}`, width: mildSpan, kind: 'mild' })
+                const winterEnd = Math.min(start + winterLen, total)
+                segments.push({ label: `winter ${start}–${winterEnd}`, width: winterEnd - start, kind: 'winter' })
+                cursor = winterEnd
+              }
+              if (cursor < total) segments.push({ label: `mild ${cursor}–${total}`, width: total - cursor, kind: 'mild' })
+              return segments.map((seg, i) => (
+                <div
+                  key={i}
+                  className={`season-segment season-${seg.kind}`}
+                  style={{ width: `${(seg.width / total) * 100}%` }}
+                  title={seg.label}
+                >
+                  {seg.width >= 30 ? <span>{seg.label}</span> : null}
+                </div>
+              ))
+            })()}
           </div>
           <div className="season-marks">
-            {[0, 60, 120, 180, 240, 300, 360].map((t) => (
+            {[0, 60, 110, 180, 220, 300, 330, 360].map((t) => (
               <span key={t} className="season-mark pixel">{t}</span>
             ))}
           </div>
@@ -693,9 +714,10 @@ export default function LorePage() {
           <div>
             <h3 className="subhead">Frozen Yields</h3>
             <p>
-              Farms produce zero during winter. Docks alternate active and
-              frozen. Forest and Mountains continue unimpeded. Wood, in winter,
-              is the most valuable resource in the realm.
+              Farms produce zero during winter — plots clear and only restart
+              regrowing once warmth returns. Logging, mining, and fishing
+              continue unimpeded. Wood, in winter, is the most valuable
+              resource in the realm.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Fixes two factual errors Liam called out on clan-world.com plus one related spec drift discovered during cross-check. Text-content only — does **not** touch CSS, fonts, layout, or component structure (parallel `fix/landing-design` subagent owns visual polish).

Closes #28 (if that's the tracking issue — adjust if needed)

## Factual fixes applied

### 1. Clan count: "Eight clans" → "Four AI Elders"
Per `docs/planning/V1/01 Blockchain Game Spec/clanworld_v1_implementation_profile.md` §2: **"4 active clans ideal, up to ~8 clans comfortable, ~12 clans possible upper bound."** The demo runs 4 (Aldric/Mira/Brennan/Sora archetypes per `07 clanworld_v4_5_alignment_addendum.md` §8.2).

- `apps/landing/src/pages/LandingPage.tsx:43-44` — hero tagline: `Eight clans. One world. The Elders never forget.` → `Four AI Elders. One world. The Elders never forget.`
- `apps/landing/src/pages/LandingPage.tsx:84` — premise column I "Live": `Eight clans. One world.` → `Four Elders. One world.`

Other "eight" references intentionally **kept**: `8 Regions` (correct per spec §2), `Eight forces shape the realm` (8 sponsor powers in `POWERS` array — correct), and the LorePage's in-fiction "Eight Houses" (the realm-lore has 8 houses; demo runs 4 — kept as worldbuilding flavor).

### 2. Winter cadence rewrite
Per `clanworld_v4_spec.md` §7.1, §7.2, §9.6: winter recurs **every 110 ticks**, **lasts 10 ticks**, season is 360 ticks total = **~3 winters per season**. Old copy described a single-winter "first 240 mild then 120 winter" model that doesn't match spec.

- `apps/landing/src/pages/LorePage.tsx:658-682` — Chapter §6 prose rewritten + seasonal bar chart now renders three winter segments (at ticks 110–120, 220–230, 330–340) with mild seasons in between.

### 3. Bonus spec drift caught: docks in winter
Old copy: "Docks alternate active and frozen." Spec §7.5 explicitly states **fishing is allowed during winter** — only farms freeze.

- `apps/landing/src/pages/LorePage.tsx:694-700` — "Frozen Yields" copy corrected: only farms zero out; logging/mining/fishing continue.

## Build status

`pnpm --filter @clan-world/landing build` exits 0. Bundle size unchanged within rounding.

## Reorganization / storytelling suggestions — NOT applied (Liam to decide)

Liam: I held off on these since they're judgment calls. Sharing for review:

### Hook strength (opening grab)
The hero eyebrow `◆ AN ONCHAIN STRATEGY GAME ◆ HACKATHON 2026 ◆` reads like meta-text for hackathon judges, not a hook. The tagline is good ("ruined fortunes, unforgiving winters"), but the eyebrow above it is throwaway. **Suggestion:** replace eyebrow with something that pulls the judge in — e.g. `◆ THE ELDERS REMEMBER EVERYTHING ◆` or `◆ A REALM RUN BY AGENTS, FOR AGENTS ◆`. Move "hackathon 2026" framing to a smaller bottom-corner badge if needed.

### "Why World" prominence is buried
World ID / MiniKit / World Chain integration is the entire "why this gets into the World mini app" story, but it appears only in the Codex of Powers list (5th of 8), with prose framing it as "The Pocket Realm" lore. For Submission 1 (World mini app challenge), this should be near the top — **suggestion:** add a thin "Built for World" callout between hero and premise, with the World logo + a one-sentence "verified humans, signed-in via World ID, distributed in World App" claim. Footer line `⌬ Built on Base · 0G · World Chain` is also true but quiet.

### Section ordering — demo arc vs Track 2 narrative bifurcation
Current order: Hero → Premise (live/rule/win) → Demo Hook (ERC-7857 iNFT memory) → Codex of Powers → Tales → Path. The **Demo Hook** section pitches Track 2 (OpenAgents, ERC-7857 memory transfer) hard, but Submission 1 is the **World mini app** challenge — different audience. **Suggestion:** consider whether one landing should pitch both, or whether Submission 1 lands a tighter "play it now in World App" page and Submission 2 gets the lore-heavy version. If keeping unified: lead with the World mini app story, treat ERC-7857 memory as the "and also: deeper ambition" beat.

### Tales section — emergent behaviour framing
The three Tales are **fictional** ("happened, or will happen, without our scripting"). Submission judges may read this as overclaim. **Suggestion:** either show one *real* tale from a recorded demo run (with a tick-number citation) plus two stylized examples clearly marked as illustrative; or reframe the section header to "Three things we expect to see" rather than "Three short accounts from the chronicles."

### Premise column copy density
Three-column "Live / Rule / Win" is dense and reads like a manual. Each column is 35–45 words. **Suggestion:** cut each to ~20 words, lead with a verb. Mobile reads especially suffer — three blocks of ~40 words stacked is a wall.

### Hero map caption "8 Regions" is a missed hook
Caption is just a label. **Suggestion:** make it diegetic — "✦ A Cartographer's Folio · 8 regions of the realm · marked AD MMXXVI ✦" already does this somewhat, but could be sharper: tease one region by name ("the Deep Sea — drakes still hunt there").

### Compliance note (no action needed)
Reviewed for World App Guidelines NFT pre-sale ban. **Clean.** No "buy / purchase / sale / pre-sale" language anywhere in the landing copy. The single `"selling wheat cheap"` text appears inside the public-bulletins SVG diagram and refers to in-game commerce, not iNFT sales. Sponsor card for ERC-7857 says "trade the vessel" / "intelligence travels with ownership" — appropriate framing.

### The tick-wheel diagram on LorePage shows "tick 412 / 360 of season ii"
412 > 360 makes no sense within a season. Probably intentional flavor (showing season-overflow), but a judge skim-reading might flag it. **Suggestion:** either change to e.g. `tick 87 / 360 of season ii` or annotate `(season ii has rolled past first winter)`.

## Test plan
- [ ] Visual check at https://clan-world.com after deploy — hero tagline reads "Four AI Elders"
- [ ] LorePage §6 chart shows 3 winter bands, not 1
- [ ] Build still exits 0 in CI
- [ ] No regressions in design-subagent's parallel `fix/landing-design` PR (text changes are minimal and shouldn't conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)