### PR TITLE
[demo] Bypass World App guard via env for demo recording

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -44,3 +44,6 @@ VITE_CLAN_WORLD_USE_STUB_LLM=true
 # World mini app client-facing IDs
 VITE_WORLD_APP_ID=
 VITE_WORLD_ACTION_ID=
+
+# Set to 'true' to bypass the "Open in World App" guard (for demo recording / judges testing in regular browser)
+VITE_DEMO_BYPASS_WORLD_GUARD=

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,9 +34,16 @@ const IDKIT_CONFIG: IDKitRequestHookConfig = {
   preset: { type: 'OrbLegacy' },
 };
 
+// Demo-mode escape hatch: when set to the string 'true' at build time, the
+// "Open in World App to play" guard below is skipped so the full canvas + UI
+// renders in any browser (for Loom recording / judges testing). The guard is
+// the production default — only the explicit env opt-in disables it.
+const DEMO_BYPASS_WORLD_GUARD =
+  import.meta.env.VITE_DEMO_BYPASS_WORLD_GUARD === 'true';
+
 export function App() {
   const [verified, setVerified] = useState(false);
-  const isInWorldApp = MiniKit.isInstalled();
+  const isInWorldApp = MiniKit.isInstalled() || DEMO_BYPASS_WORLD_GUARD;
 
   const { open: openIDKit, result, isSuccess } = useIDKitRequest(IDKIT_CONFIG);
 


### PR DESCRIPTION
## Summary

Adds an opt-in env flag so the full Pixi canvas + game UI renders in a regular browser, for Loom demo recording and judges testing in Chrome/Safari without the World App webview.

- `VITE_DEMO_BYPASS_WORLD_GUARD='true'` → `isInWorldApp` short-circuits to `true`, the "Open in World App to play" fallback is skipped, the rest of the app (MiniKit init, IDKit verify integration) is untouched and still works once a real World App webview loads.
- Default behavior unchanged: env unset/empty → guard remains in place. Production safety is the default.
- Vite dead-code elimination drops the guard branch entirely from the demo bundle when the env is `'true'` at build time (verified: live `index-CBKJhY7F.js` has zero "Open in World App" matches).

## Files

- `apps/web/src/App.tsx` — read `import.meta.env.VITE_DEMO_BYPASS_WORLD_GUARD === 'true'`, OR into existing `isInWorldApp` check.
- `.env.template` — document the new var.
- `.env.local` (gitignored) — orchestrator's local set to `true` so build picks it up. Not in this PR (gitignored).

**Note on brief deviation:** task description said edit `main.tsx`, but the guard actually lives in `App.tsx` (where `MiniKit.isInstalled()` is checked). Edited `App.tsx` as the surgical, correct location. `main.tsx` only contains MiniKit install + Convex provider setup, no guard.

## Verification

- Local build: `pnpm --filter @clan-world/web build` succeeded, bundle hash `index-CBKJhY7F.js` (568 kB).
- Deployed: `vercel deploy --prod --archive=tgz dist/` → `dpl_9eYqxfz5zkg9f7k7EUTfehZhV1Uh`, aliased to `app.clan-world.com`.
- Curl test: `curl -s https://app.clan-world.com/assets/index-CBKJhY7F.js | grep -c "Open in World App"` → `0` (guard text dead-code-eliminated). `grep -c "Claim Your Clan"` → `1` (main UI intact).

## Test plan

- [ ] Open `https://app.clan-world.com/` in regular Chrome — full canvas renders (no "Open in World App" message).
- [ ] Open in World App webview (production path) — MiniKit.install + IDKit verify still works as before.
- [ ] Liam records the Loom demo against the live URL.

DO NOT MERGE until the orchestrator confirms the live URL renders the full app.

Refs #28.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>