### PR TITLE
style(landing): font + polish pass

### DIFF
--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -9,7 +9,7 @@
     <meta property="og:description" content="A realm of autonomous agents, ruined fortunes, and unforgiving winters." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&family=IM+Fell+DW+Pica:ital@0;1&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=VT323&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;700&family=IM+Fell+English:ital@0;1&family=IM+Fell+DW+Pica:ital@0;1&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@400;500;600&family=VT323&display=swap" rel="stylesheet">
     <title>Clan World: Ælder Whispers</title>
   </head>
   <body>

--- a/apps/landing/src/components/SponsorCard.css
+++ b/apps/landing/src/components/SponsorCard.css
@@ -85,7 +85,7 @@
   height: 100%;
   align-items: center;
   justify-content: center;
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-size: 1.4rem;
   color: var(--vermillion);
   letter-spacing: 0.05em;
@@ -109,7 +109,7 @@
 }
 
 .sponsor-card-name {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-size: 1.6rem;
   line-height: 1.1;
   color: var(--ink);
@@ -118,7 +118,7 @@
 }
 
 .sponsor-card-lorename {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   font-size: 1rem;
   color: var(--vermillion);
@@ -127,7 +127,7 @@
 }
 
 .sponsor-card-lore {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--ff-prose);
   font-size: 1rem;
   line-height: 1.55;
   color: var(--ink);
@@ -135,7 +135,7 @@
 }
 
 .sponsor-card-tech {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--ff-prose);
   font-size: 0.85rem;
   font-style: italic;
   line-height: 1.5;

--- a/apps/landing/src/pages/LandingPage.css
+++ b/apps/landing/src/pages/LandingPage.css
@@ -47,10 +47,11 @@
 }
 
 .hero-title {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-display);
+  font-weight: 700;
   font-size: var(--fs-display);
   line-height: 0.92;
-  letter-spacing: -0.005em;
+  letter-spacing: 0.005em;
   margin-bottom: 1.25rem;
   color: var(--ink);
 }
@@ -60,7 +61,7 @@
   font-size: 0.4em;
   color: var(--gold-leaf);
   letter-spacing: 0.5em;
-  margin: 0.4rem 0 0.2rem;
+  margin: 0.5rem 0 0.3rem;
   padding-left: 0.5em;
 }
 
@@ -68,12 +69,14 @@
   display: block;
   font-style: italic;
   color: var(--vermillion);
-  font-size: 0.6em;
-  font-family: 'IM Fell English', serif;
+  font-size: 0.55em;
+  font-weight: 400;
+  font-family: var(--ff-manuscript);
+  letter-spacing: 0.005em;
 }
 
 .hero-tagline {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--ff-prose);
   font-size: 1.35rem;
   line-height: 1.5;
   color: var(--ink-soft);
@@ -203,7 +206,7 @@
 }
 
 .premise-title {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   font-size: 2.25rem;
   color: var(--vermillion);
@@ -234,8 +237,10 @@
 
 .hook-title {
   text-align: center;
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-display);
+  font-weight: 500;
   font-size: clamp(2.25rem, 5vw, 3.5rem);
+  letter-spacing: 0.01em;
   margin-bottom: 2.5rem;
 }
 
@@ -324,7 +329,7 @@
 }
 
 .hook-poster-label {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-size: 1.2rem;
   color: var(--ink);
   margin-bottom: 0.4rem;
@@ -359,13 +364,17 @@
 }
 
 .codex-title {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-display);
+  font-weight: 500;
   font-size: clamp(2.5rem, 6vw, 4rem);
+  letter-spacing: 0.01em;
   margin-bottom: 1.5rem;
   line-height: 1;
 }
 
 .codex-title i {
+  font-family: var(--ff-manuscript);
+  font-weight: 400;
   color: var(--vermillion);
   font-style: italic;
 }
@@ -410,8 +419,10 @@
 }
 
 .tales-header h2 {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-display);
+  font-weight: 500;
   font-size: clamp(2.25rem, 5vw, 3.5rem);
+  letter-spacing: 0.01em;
 }
 
 .tales-intro {
@@ -461,7 +472,7 @@
 }
 
 .tale-number {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   font-size: 1.5rem;
   color: var(--vermillion);
@@ -469,7 +480,7 @@
 }
 
 .tale-title {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-size: 1.5rem;
   margin-bottom: 1rem;
   color: var(--ink);
@@ -477,7 +488,7 @@
 }
 
 .tale-body {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--ff-prose);
   font-size: 1.05rem;
   line-height: 1.6;
   color: var(--ink);
@@ -518,8 +529,10 @@
 }
 
 .path-card h2 {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-display);
+  font-weight: 500;
   font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: 0.01em;
   margin-bottom: 1.25rem;
 }
 

--- a/apps/landing/src/pages/LorePage.css
+++ b/apps/landing/src/pages/LorePage.css
@@ -13,14 +13,16 @@
 }
 
 .lore-title {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-display);
   margin-bottom: 1.5rem;
   line-height: 1;
 }
 
 .lore-title-pre {
   display: block;
+  font-family: var(--ff-manuscript);
   font-style: italic;
+  font-weight: 400;
   font-size: 1.5rem;
   color: var(--ink-soft);
   margin-bottom: 0.5rem;
@@ -28,17 +30,22 @@
 
 .lore-title-main {
   display: block;
-  font-size: clamp(2.75rem, 7vw, 5.5rem);
+  font-family: var(--ff-display);
+  font-weight: 700;
+  font-size: clamp(2.75rem, 7vw, 5rem);
   color: var(--ink);
-  letter-spacing: -0.005em;
+  letter-spacing: 0.01em;
 }
 
 .lore-title-italic {
   display: block;
+  font-family: var(--ff-manuscript);
   font-style: italic;
+  font-weight: 400;
   font-size: clamp(1.75rem, 4vw, 3rem);
   color: var(--vermillion);
-  margin-top: 0.25rem;
+  margin-top: 0.5rem;
+  letter-spacing: 0.005em;
 }
 
 .lore-subtitle {
@@ -97,7 +104,7 @@
   position: relative;
   margin-bottom: 0.5rem;
   padding-left: 2.25rem;
-  font-family: 'EB Garamond', serif;
+  font-family: var(--ff-prose);
 }
 
 .lore-toc-section ol {
@@ -108,7 +115,7 @@
   content: counter(toc-counter, upper-roman) '.';
   position: absolute;
   left: 0;
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   color: var(--gold-leaf);
   width: 2rem;
@@ -147,9 +154,10 @@
 }
 
 .chapter-title {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-size: clamp(2.25rem, 5vw, 3.5rem);
   font-style: italic;
+  font-weight: 400;
   line-height: 1.05;
   color: var(--ink);
   margin-bottom: 0;
@@ -165,9 +173,10 @@
 }
 
 .subhead {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-size: 1.5rem;
   font-style: italic;
+  font-weight: 400;
   color: var(--vermillion);
   margin-top: 2.5rem;
   margin-bottom: 1.25rem;
@@ -211,7 +220,7 @@
 }
 
 .house-name {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-size: 1.2rem;
   color: var(--ink);
   font-style: italic;
@@ -257,8 +266,10 @@
 }
 
 .transition-title {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-display);
+  font-weight: 500;
   font-size: clamp(2rem, 4.5vw, 3.25rem);
+  letter-spacing: 0.01em;
   line-height: 1.25;
   color: var(--ink);
   max-width: 32rem;
@@ -266,8 +277,10 @@
 }
 
 .transition-title .italic {
+  font-family: var(--ff-manuscript);
+  font-weight: 400;
   color: var(--vermillion);
-  font-size: 0.85em;
+  font-size: 0.9em;
 }
 
 .transition-sub {
@@ -326,7 +339,7 @@
 }
 
 .bar-label {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   color: var(--ink);
   font-size: 1rem;
@@ -351,7 +364,7 @@
 }
 
 .bar-value {
-  font-family: 'VT323', monospace;
+  font-family: var(--ff-mono);
   font-size: 0.9rem;
   color: var(--parchment);
   letter-spacing: 0.05em;
@@ -384,7 +397,7 @@
 }
 
 .vault-side-title {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   font-size: 1.25rem;
   color: var(--vermillion);
@@ -404,7 +417,7 @@
 
 .compact-table .num {
   text-align: right;
-  font-family: 'VT323', monospace;
+  font-family: var(--ff-mono);
   font-size: 1.15rem;
   color: var(--vermillion);
 }
@@ -446,7 +459,7 @@
 }
 
 .bestiary-tier {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   font-size: 1.5rem;
   color: var(--vermillion);
@@ -454,7 +467,7 @@
 }
 
 .num {
-  font-family: 'VT323', monospace;
+  font-family: var(--ff-mono);
   font-size: 1.1rem;
   color: var(--ink);
 }
@@ -482,7 +495,7 @@
 .combat-formula::after { bottom: -6px; right: -6px; border-left: none; border-top: none; }
 
 .formula-script {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   font-size: clamp(1.25rem, 3vw, 1.75rem);
   line-height: 1.6;
@@ -543,7 +556,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   font-size: 1rem;
   white-space: nowrap;
@@ -628,7 +641,7 @@
   margin: 0 auto;
   position: relative;
   color: var(--parchment);
-  font-family: 'VT323', monospace;
+  font-family: var(--ff-mono);
   font-size: 0.9rem;
 }
 
@@ -697,7 +710,7 @@
 }
 
 .market-name {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   font-size: 1.35rem;
   color: var(--ink);
@@ -711,7 +724,7 @@
 }
 
 .market-price {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-size: 1.5rem;
   color: var(--vermillion);
   margin-bottom: 0.25rem;
@@ -737,7 +750,7 @@
 }
 
 .coda-title {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   font-size: clamp(2rem, 5vw, 3.25rem);
   margin-bottom: 1.5rem;

--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -9,12 +9,12 @@
   --parchment-aged: #C9B58A;
   --parchment-dark: #A8956A;
   --parchment-deep: #8a7847;
-  
+
   /* Inks */
   --ink: #2A1810;
   --ink-soft: #5A3D28;
   --ink-faded: #8a6f4f;
-  
+
   /* Illumination */
   --vermillion: #9B2A2F;
   --vermillion-deep: #7a1f23;
@@ -22,7 +22,7 @@
   --gold-bright: #d4a24c;
   --lapis: #1F4068;
   --lapis-bright: #2d5a8a;
-  
+
   /* Clan banners (8) */
   --clan-1: #B23A48;
   --clan-2: #2C5F8D;
@@ -32,18 +32,40 @@
   --clan-6: #A85A2C;
   --clan-7: #c9b58a;
   --clan-8: #475569;
-  
+
   --maxw: 72rem;
   --maxw-prose: 38rem;
-  
+
   /* Type scale */
-  --fs-display: clamp(3rem, 8vw, 7rem);
+  --fs-display: clamp(3rem, 8vw, 6.5rem);
   --fs-h1: clamp(2.25rem, 5vw, 4rem);
   --fs-h2: clamp(1.75rem, 3.5vw, 2.75rem);
   --fs-h3: 1.5rem;
   --fs-body: 1.125rem;
   --fs-small: 0.875rem;
   --fs-pixel: 0.7rem;
+
+  /* Font families — semantic tokens
+     - Display: Cinzel — carved-stone Roman caps, strong hierarchy for hero + section titles
+     - Manuscript: IM Fell English — hand-printed feel for chapter/tale/intimate headings
+     - Prose: EB Garamond — chronicle body voice
+     - UI: Inter — crisp legibility for nav, eyebrow tags, meta chrome
+     - Mono: VT323 — pixel/8-bit accents, bridges to game art */
+  --ff-display: 'Cinzel', 'IM Fell English', 'Times New Roman', serif;
+  --ff-manuscript: 'IM Fell English', 'IM Fell DW Pica', 'Times New Roman', serif;
+  --ff-prose: 'EB Garamond', 'Garamond', Georgia, serif;
+  --ff-ui: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --ff-mono: 'VT323', 'Courier New', monospace;
+
+  /* Spacing scale (consistent vertical rhythm) */
+  --space-1: 0.5rem;
+  --space-2: 1rem;
+  --space-3: 1.5rem;
+  --space-4: 2rem;
+  --space-5: 3rem;
+  --space-6: 4rem;
+  --space-7: 5rem;
+  --space-8: 6rem;
 }
 
 * {
@@ -57,7 +79,7 @@ html {
 }
 
 body {
-  font-family: 'EB Garamond', 'Garamond', Georgia, serif;
+  font-family: var(--ff-prose);
   font-size: var(--fs-body);
   line-height: 1.65;
   color: var(--ink);
@@ -74,30 +96,34 @@ body {
 /* ============ Typography primitives ============ */
 
 .display-font, h1, h2, .h1, .h2 {
-  font-family: 'IM Fell English', 'IM Fell DW Pica', 'Times New Roman', serif;
-  font-weight: 400;
-  letter-spacing: 0.005em;
+  font-family: var(--ff-display);
+  font-weight: 500;
+  letter-spacing: 0.01em;
   color: var(--ink);
 }
 
-.display-italic, h1 i, h2 i {
+/* Italic variants drop to manuscript family — Cinzel has no italic cut */
+.display-italic, h1 i, h2 i, h1 em, h2 em {
+  font-family: var(--ff-manuscript);
   font-style: italic;
+  font-weight: 400;
+  letter-spacing: 0.005em;
 }
 
 h1 {
   font-size: var(--fs-h1);
   line-height: 1.05;
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-2);
 }
 
 h2 {
   font-size: var(--fs-h2);
   line-height: 1.1;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-3);
 }
 
 h3 {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-size: var(--fs-h3);
   font-weight: 400;
   margin-bottom: 0.75rem;
@@ -127,11 +153,17 @@ a {
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
+  transition: color 0.2s ease;
 }
 
 a:hover {
   color: var(--vermillion-deep);
   text-decoration-style: double;
+}
+
+a:focus-visible {
+  outline: 2px solid var(--gold-leaf);
+  outline-offset: 2px;
 }
 
 em {
@@ -146,7 +178,7 @@ strong {
 
 /* Pixel-text annotations — bridge to game's pixel art */
 .pixel {
-  font-family: 'VT323', 'Courier New', monospace;
+  font-family: var(--ff-mono);
   font-size: var(--fs-pixel);
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -159,7 +191,7 @@ strong {
   background: var(--parchment-aged);
   padding: 0.25rem 0.5rem;
   border: 1px solid var(--ink-faded);
-  font-family: 'VT323', monospace;
+  font-family: var(--ff-mono);
   font-size: 0.85rem;
   letter-spacing: 0.04em;
   color: var(--ink-soft);
@@ -167,7 +199,7 @@ strong {
 
 /* Drop cap */
 .dropcap::first-letter {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-size: 4.5em;
   line-height: 0.85;
   float: left;
@@ -192,11 +224,11 @@ strong {
 }
 
 .section {
-  padding: 5rem 0;
+  padding: var(--space-7) 0;
 }
 
 @media (max-width: 640px) {
-  .section { padding: 3rem 0; }
+  .section { padding: var(--space-5) 0; }
 }
 
 /* ============ Frame / border decorations ============ */
@@ -255,7 +287,7 @@ strong {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 3.5rem 0;
+  margin: var(--space-5) 0;
   color: var(--gold-leaf);
 }
 
@@ -270,7 +302,7 @@ strong {
 }
 
 .ornament-glyph {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-size: 1.5rem;
   letter-spacing: 0.5em;
   padding-left: 0.5em;
@@ -282,17 +314,19 @@ strong {
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 1rem 2rem;
-  font-family: 'IM Fell English', serif;
-  font-size: 1.25rem;
-  letter-spacing: 0.04em;
+  padding: 0.95rem 2rem;
+  font-family: var(--ff-display);
+  font-weight: 500;
+  font-size: 1.05rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
   background: var(--ink);
   color: var(--parchment);
   border: none;
   text-decoration: none;
   position: relative;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
   box-shadow: 4px 4px 0 var(--vermillion-deep);
 }
 
@@ -302,13 +336,24 @@ strong {
   inset: -4px;
   border: 1px solid var(--gold-leaf);
   pointer-events: none;
+  transition: border-color 0.2s ease;
 }
 
 .cta:hover {
   transform: translate(-2px, -2px);
   box-shadow: 6px 6px 0 var(--vermillion-deep);
+  background: var(--vermillion-deep);
   color: var(--parchment);
   text-decoration: none;
+}
+
+.cta:hover::before {
+  border-color: var(--gold-bright);
+}
+
+.cta:focus-visible {
+  outline: 2px solid var(--gold-bright);
+  outline-offset: 6px;
 }
 
 .cta-secondary {
@@ -316,18 +361,38 @@ strong {
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.5rem;
-  font-family: 'IM Fell English', serif;
-  font-size: 1.1rem;
+  font-family: var(--ff-display);
+  font-weight: 500;
+  font-size: 0.95rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
   background: transparent;
   color: var(--ink);
   border: 1px solid var(--ink);
   text-decoration: none;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .cta-secondary:hover {
   background: var(--ink);
   color: var(--parchment);
+  text-decoration: none;
+  border-color: var(--ink);
+}
+
+.cta-secondary:focus-visible {
+  outline: 2px solid var(--vermillion);
+  outline-offset: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cta, .cta-secondary, a {
+    transition: background-color 0.15s ease, color 0.15s ease;
+  }
+  .cta:hover {
+    transform: none;
+    box-shadow: 4px 4px 0 var(--vermillion-deep);
+  }
 }
 
 /* ============ Header / Footer ============ */
@@ -355,11 +420,14 @@ strong {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  font-family: 'IM Fell English', serif;
-  font-size: 1.35rem;
+  font-family: var(--ff-display);
+  font-weight: 500;
+  font-size: 1.15rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--ink);
   text-decoration: none;
-  letter-spacing: 0.02em;
+  transition: color 0.2s ease;
 }
 
 .site-brand:hover {
@@ -376,14 +444,17 @@ strong {
 .site-nav {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .site-nav a {
   color: var(--ink);
   text-decoration: none;
-  font-family: 'IM Fell English', serif;
-  font-size: 1.05rem;
+  font-family: var(--ff-ui);
+  font-weight: 500;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  transition: color 0.2s ease;
 }
 
 .site-nav a:hover {
@@ -391,7 +462,7 @@ strong {
 }
 
 .site-nav .pixel-link {
-  font-family: 'VT323', monospace;
+  font-family: var(--ff-mono);
   font-size: 0.95rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -405,8 +476,8 @@ strong {
 
 .site-footer {
   border-top: 1px solid var(--gold-leaf);
-  padding: 4rem 0 2rem;
-  margin-top: 6rem;
+  padding: var(--space-6) 0 var(--space-4);
+  margin-top: var(--space-8);
   background: rgba(168, 149, 106, 0.18);
 }
 
@@ -419,18 +490,21 @@ strong {
 .site-footer-grid {
   display: grid;
   grid-template-columns: 2fr repeat(3, 1fr);
-  gap: 3rem;
-  margin-bottom: 3rem;
+  gap: var(--space-5);
+  margin-bottom: var(--space-5);
 }
 
 @media (max-width: 720px) {
-  .site-footer-grid { grid-template-columns: 1fr; gap: 2rem; }
+  .site-footer-grid { grid-template-columns: 1fr; gap: var(--space-4); }
 }
 
 .site-footer-grid h4 {
-  font-family: 'IM Fell English', serif;
-  font-size: 1.1rem;
-  margin-bottom: 0.75rem;
+  font-family: var(--ff-display);
+  font-weight: 500;
+  font-size: 0.9rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 0.85rem;
   color: var(--ink);
 }
 
@@ -445,7 +519,9 @@ strong {
 .site-footer-grid a {
   color: var(--ink-soft);
   text-decoration: none;
-  font-size: 0.95rem;
+  font-family: var(--ff-ui);
+  font-size: 0.9rem;
+  transition: color 0.2s ease;
 }
 
 .site-footer-grid a:hover {
@@ -455,9 +531,9 @@ strong {
 
 .colophon {
   text-align: center;
-  padding-top: 2rem;
+  padding-top: var(--space-4);
   border-top: 1px solid var(--ink-faded);
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   color: var(--ink-faded);
   font-size: 0.95rem;
@@ -486,7 +562,7 @@ strong {
 .manuscript-table {
   width: 100%;
   border-collapse: collapse;
-  font-family: 'EB Garamond', serif;
+  font-family: var(--ff-prose);
   font-size: 1.05rem;
   margin: 2rem 0;
 }
@@ -494,9 +570,11 @@ strong {
 .manuscript-table th {
   text-align: left;
   padding: 0.85rem 1rem;
-  font-family: 'IM Fell English', serif;
-  font-weight: 400;
-  font-size: 1.1rem;
+  font-family: var(--ff-display);
+  font-weight: 500;
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
   border-bottom: 2px solid var(--ink);
   color: var(--ink);
   background: var(--parchment-aged);
@@ -519,7 +597,7 @@ strong {
 /* ============ Pull quote ============ */
 
 .pull-quote {
-  font-family: 'IM Fell English', serif;
+  font-family: var(--ff-manuscript);
   font-style: italic;
   font-size: 1.65rem;
   line-height: 1.35;
@@ -555,7 +633,7 @@ strong {
   left: 1rem;
   background: var(--parchment);
   padding: 0 0.5rem;
-  font-family: 'VT323', monospace;
+  font-family: var(--ff-mono);
   font-size: 0.8rem;
   letter-spacing: 0.15em;
   color: var(--ink-soft);


### PR DESCRIPTION
## Summary

Typography hierarchy + design polish, **CSS-only**. No copy or component changes (separate `fix/landing-copy` branch handles text).

Closes part of #28 (landing polish).

## Applied changes

### Fonts
Added two Google Fonts families alongside existing IM Fell + EB Garamond + VT323:

- **Cinzel (display)** — carved-stone Roman caps. Weights 500/700. Used for:
  - Hero title (`Clan World`)
  - Section h2s (Hook, Codex, Tales, Path, Lore main, Transition)
  - CTAs (caps + tracked)
  - Header brand mark
  - Footer column headings
  - Manuscript table headers
- **Inter (UI chrome)** — crisp legibility. Weights 400/500/600. Used for:
  - Site nav links
  - Footer links
  - Other small UI labels

Kept existing roles intentionally:
- **IM Fell English (manuscript)** — chapter titles, tale titles, premise italics, drop cap, ornament glyph, italic descendants of h1/h2 (Cinzel has no italic cut so they cascade)
- **EB Garamond (prose)** — body chronicle voice, tale bodies, lore TOC list items, tagline
- **VT323 (mono)** — pixel/8-bit accents (eyebrows, .pixel labels, monument text, num cells)

### Polish (CSS-only)

- **Semantic font tokens** — `--ff-display`, `--ff-manuscript`, `--ff-prose`, `--ff-ui`, `--ff-mono` replace ~25 hardcoded font-family strings across 4 CSS files. Future font swaps = one-line change.
- **Spacing scale tokens** — `--space-1..8` (0.5rem to 6rem) standardize section padding, ornament margins, footer rhythm.
- **Section padding** — consistent `var(--space-7)` desktop / `var(--space-5)` mobile.
- **CTA buttons** — caps + tracked Cinzel; vermillion-deep hover background; gold-bright frame highlight on hover; `:focus-visible` outline ring; `prefers-reduced-motion` override.
- **Hover states** — smooth 0.2s color transitions on links, nav, footer, brand. No more abrupt color flips.
- **Hero clamp** — max font-size dropped 7rem → 6.5rem (7rem caused awkward wrap at ~1100px viewport with Cinzel).
- **Italic cascade** — `h1 i`, `h1 em`, `h2 i`, `h2 em` automatically use IM Fell italic so existing `<i>` tags inside Cinzel headings don't fall back to system serif.

### Build

`pnpm --filter @clan-world/landing build` → green. CSS bundle 32KB (gzip 6.6KB).

## Mobile / accessibility

- Verified responsive breakpoints (640px, 720px, 800px, 900px, 1100px) preserved.
- All hover states have parallel `:focus-visible` outlines.
- `prefers-reduced-motion` disables CTA transform.
- Mobile section padding shrinks via spacing tokens.

## Reported — NOT applied (structural suggestions for follow-up)

These exceed the CSS-only brief; flagging for future work:

1. **Section reordering** — current flow is Hero → Premise → Hook → Codex → Tales → Path. The Hook section ("Watch What Happens") arrives before the Codex of Powers, but it relies on understanding ERC-7857 + iNFTs which the Codex explains. Consider Hero → Premise → **Codex** → Hook → Tales → Path. Would let the demo quote land with prior context.

2. **Hero illustration** — `RealmMap` SVG is excellent but the hero feels text-heavy on desktop wide. Consider:
   - A faint sigil/shield watermark behind the hero title (low-opacity SVG, similar to the heraldic shield component already in the codebase)
   - Or a pixel-art Elder portrait inset between title and tagline
3. **Demo poster placeholder** — the 90s-walkthrough placeholder is currently a tiled-parchment pattern with a play button. Once the actual demo video exists, this becomes the highest-impact image on the page. Until then consider replacing the placeholder with a still frame from `apps/web` gameplay (even a screenshot would be more compelling than the pattern).
4. **Tale card variation** — three cards are visually identical aside from rotation angle. Could use clan-colored corner ornaments or subtle banner accents (drawing on the existing `--clan-1..8` palette tokens) to differentiate.
5. **Animation polish** — the existing reveal animation (`.reveal` class, opacity + translateY) is clean. A tasteful additional touch: stagger reveal of premise icons (axe → tower → banner) with `transition-delay` chained off scroll-trigger. Currently they all reveal simultaneously.
6. **Sponsor card differentiation** — wax-seal frames are a great touch but the 4-up grid reads as uniform tiles. Could vary seal color tint per tier (gold for headline, ink for sponsor, vermillion for blockchain partners).

## Test plan

- [ ] Visual review on `clan-world.com` after Vercel preview deploys
- [ ] Mobile sanity at 390×844 (iPhone 14)
- [ ] Verify Google Fonts loads in Chrome + Safari + Firefox (`@font-face` fallback chain handles offline/blocked-fonts case via system serifs)
- [ ] Lighthouse pass — should improve LCP slightly from tighter clamp
- [ ] Cross-check no visual regressions on Lore page (heaviest typography surface)