### PR TITLE
fix(web): demo bypass also skips IDKit verified gate (#28)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -42,7 +42,10 @@ const DEMO_BYPASS_WORLD_GUARD =
   import.meta.env.VITE_DEMO_BYPASS_WORLD_GUARD === 'true';
 
 export function App() {
-  const [verified, setVerified] = useState(false);
+  // When the demo bypass env is set, start verified=true so the WorldMap canvas
+  // renders immediately without an IDKit verify round-trip (which can't complete
+  // outside World App). Production default (env unset) keeps the full gate.
+  const [verified, setVerified] = useState(DEMO_BYPASS_WORLD_GUARD);
   const isInWorldApp = MiniKit.isInstalled() || DEMO_BYPASS_WORLD_GUARD;
 
   const { open: openIDKit, result, isSuccess } = useIDKitRequest(IDKIT_CONFIG);


### PR DESCRIPTION
## Summary

PR #37 added `VITE_DEMO_BYPASS_WORLD_GUARD` to skip the "Open in World App" guard but the second gate — `verified` flag set only after `IDKit.verify` completes — still blocked the canvas. In a regular browser, IDKit can't complete (needs World App QR scan), so users only ever saw the "Claim Your Clan Identity" button doing nothing.

This patch initializes `verified` state to `DEMO_BYPASS_WORLD_GUARD` so when the env var is set, the WorldMap canvas renders immediately on page load. Production default (env unset) is unchanged — full IDKit gate stays in place.

## Change

```diff
-  const [verified, setVerified] = useState(false);
+  const [verified, setVerified] = useState(DEMO_BYPASS_WORLD_GUARD);
```

One-line behavioral change. IDKit logic, MiniKit init, verify endpoint flow — all untouched.

## Verification

- Build: clean, `index-4mvBMZqo.js` (568 KB)
- Deployed to prod alias `app.clan-world.com`
- `curl https://app.clan-world.com/` serves new bundle hash
- "Open in World App" text absent (already gone from #37)
- Bundle contains `agentLogs` (Convex live subscription) + `WorldMap` code path

## Test plan

- [ ] Load `https://app.clan-world.com/` in regular browser — Pixi canvas + 8 regions + 4 clans render immediately
- [ ] Speech bubbles populate from live Convex `agentLogs` subscription
- [ ] Production behavior unchanged when `VITE_DEMO_BYPASS_WORLD_GUARD` is unset

Closes #28 (demo recording unblock).