### PR TITLE
[style] Fullscreen viewport + title subtitle + landing fonts

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,10 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>ClanWorld</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <title>ClanWorld: Ælder Whispers</title>
     <style>
-      html, body, #root { height: 100%; margin: 0; }
-      body { background: #0d1a0d; overscroll-behavior: none; }
+      html, body, #root {
+        width: 100vw;
+        height: 100vh;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+      }
+      body {
+        background: #0a0a0a;
+        overscroll-behavior: none;
+        font-family: 'Inter', system-ui, sans-serif;
+      }
     </style>
   </head>
   <body>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -75,14 +75,15 @@ export function App() {
     return (
       <main
         style={{
-          background: '#0d1a0d',
-          minHeight: '100vh',
+          background: '#0a0a0a',
+          width: '100vw',
+          height: '100vh',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
         }}
       >
-        <p style={{ color: 'white', fontFamily: 'monospace' }}>
+        <p style={{ color: 'white', fontFamily: '"Cinzel", "Times New Roman", serif', letterSpacing: '0.08em' }}>
           Open in World App to play
         </p>
       </main>
@@ -92,25 +93,27 @@ export function App() {
   return (
     <main
       style={{
-        background: '#0d1a0d',
-        minHeight: '100dvh',
+        background: '#0a0a0a',
+        width: '100vw',
+        height: '100vh',
         display: 'flex',
         flexDirection: 'column',
+        overflow: 'hidden',
       }}
     >
       <h1
         style={{
           color: 'white',
           fontFamily: '"Cinzel", "Times New Roman", serif',
-          fontSize: 20,
-          letterSpacing: '0.12em',
+          fontSize: 18,
+          letterSpacing: '0.1em',
           margin: 0,
-          padding: '14px 12px 10px',
-          lineHeight: 1,
+          padding: '10px 12px 8px',
+          lineHeight: 1.1,
           flex: '0 0 auto',
         }}
       >
-        ClanWorld
+        ClanWorld<span style={{ opacity: 0.75, fontWeight: 400, fontStyle: 'italic', marginLeft: 6 }}>: Ælder Whispers</span>
       </h1>
       {!verified && (
         <button


### PR DESCRIPTION
Refs #28. Removes white border (100vh/vw root), adds 'Ælder Whispers' subtitle, applies Cinzel + Inter fonts from landing.

## Changes

- `apps/web/index.html`:
  - Inline CSS: `html, body, #root { width: 100vw; height: 100vh; overflow: hidden; }` + `body { margin:0; padding:0; background:#0a0a0a; }` — kills the mobile webview white border
  - Add Google Fonts `<link>` (Cinzel 500/700, Inter 400/500/600) — same families landing uses
  - `<title>` updated from `ClanWorld` to `ClanWorld: Ælder Whispers`
  - Default body `font-family: 'Inter', system-ui, sans-serif`
- `apps/web/src/App.tsx`:
  - Root `<main>` now `width: 100vw; height: 100vh; overflow: hidden` (was `minHeight: 100dvh`) — canvas fills viewport with no overflow space
  - On-canvas h1 includes italic, lower-opacity `: Ælder Whispers` subtitle next to existing 'ClanWorld' (Cinzel was already wired — now it actually loads)
  - "Open in World App to play" fallback also uses Cinzel + 100vw/vh

## Build

`pnpm --filter @clan-world/web build` — passes, dist/index.html renders the fonts + viewport CSS as expected.

## Out of scope (intentional)

- Did not touch `apps/web/public/sprites/` or `apps/web/public/portraits/` — concurrent sprite-archetype subagent owns those.
- `WorldMap.tsx` Pixi labels still use `monospace` for in-canvas data text (region labels, clan badges, log feed) — keeps tabular feel + matches user brief 'body text can stay monospace'.
