### PR TITLE
[style] Landing v2 polish — copy + palette + tale frames + missing logos

### DIFF
--- a/apps/landing/public/logos/axl.svg
+++ b/apps/landing/public/logos/axl.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" aria-hidden="true">
+  <!-- Gensyn AXL: axial cross + AXL letterform, whisper network -->
+  <defs>
+    <style>
+      .stroke{fill:none;stroke:#2A1810;stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round}
+      .fill-lapis{fill:#1F4068}
+    </style>
+  </defs>
+  <!-- diamond / axial cross frame -->
+  <path d="M32 6 L58 32 L32 58 L6 32 Z" class="fill-lapis stroke"/>
+  <!-- inner diamond -->
+  <path d="M32 16 L48 32 L32 48 L16 32 Z" fill="none" stroke="#E8D8B5" stroke-width="1.5"/>
+  <!-- AXL letterforms, stacked compact -->
+  <g fill="#E8D8B5" font-family="Georgia, serif" font-weight="700" text-anchor="middle">
+    <text x="32" y="37" font-size="14" letter-spacing="1">AXL</text>
+  </g>
+  <!-- corner dots — whisper nodes -->
+  <circle cx="32" cy="6" r="1.8" fill="#A87C2F"/>
+  <circle cx="58" cy="32" r="1.8" fill="#A87C2F"/>
+  <circle cx="32" cy="58" r="1.8" fill="#A87C2F"/>
+  <circle cx="6" cy="32" r="1.8" fill="#A87C2F"/>
+</svg>

--- a/apps/landing/public/logos/inft.svg
+++ b/apps/landing/public/logos/inft.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" aria-hidden="true">
+  <!-- ERC-7857 iNFT: soul-vessel / locked chest -->
+  <defs>
+    <style>
+      .stroke{fill:none;stroke:#2A1810;stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round}
+      .fill-vessel{fill:#9B2A2F}
+      .fill-gold{fill:#A87C2F}
+      .fill-bg{fill:#E8D8B5}
+    </style>
+  </defs>
+  <!-- vessel base -->
+  <path d="M16 28 Q16 50 32 56 Q48 50 48 28 L48 18 L16 18 Z" class="fill-vessel stroke"/>
+  <!-- vessel lid -->
+  <path d="M14 18 L50 18 L46 12 L18 12 Z" class="fill-gold stroke"/>
+  <!-- lock plate -->
+  <rect x="27" y="26" width="10" height="14" rx="1" class="fill-gold stroke"/>
+  <!-- keyhole -->
+  <circle cx="32" cy="31" r="1.8" fill="#2A1810"/>
+  <line x1="32" y1="32" x2="32" y2="36" stroke="#2A1810" stroke-width="1.8" stroke-linecap="round"/>
+  <!-- soul glow inside -->
+  <circle cx="32" cy="44" r="3" class="fill-bg" opacity="0.85"/>
+  <!-- sparkle -->
+  <path d="M32 40 L32 38 M30 42 L28 42 M34 42 L36 42 M32 46 L32 48" stroke="#E8D8B5" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/apps/landing/public/logos/keeperhub.svg
+++ b/apps/landing/public/logos/keeperhub.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" aria-hidden="true">
+  <!-- KeeperHub: clock + key, the scheduled keeper -->
+  <defs>
+    <style>
+      .stroke{fill:none;stroke:#2A1810;stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round}
+      .fill-bg{fill:#E8D8B5}
+      .fill-gold{fill:#A87C2F}
+    </style>
+  </defs>
+  <!-- clock face -->
+  <circle cx="26" cy="28" r="16" class="fill-bg stroke"/>
+  <!-- hour ticks -->
+  <line x1="26" y1="14" x2="26" y2="17" class="stroke"/>
+  <line x1="26" y1="39" x2="26" y2="42" class="stroke"/>
+  <line x1="12" y1="28" x2="15" y2="28" class="stroke"/>
+  <line x1="37" y1="28" x2="40" y2="28" class="stroke"/>
+  <!-- hands pointing to ~10:10 (classic, friendly) -->
+  <line x1="26" y1="28" x2="20" y2="22" class="stroke"/>
+  <line x1="26" y1="28" x2="33" y2="24" class="stroke"/>
+  <circle cx="26" cy="28" r="2" fill="#2A1810"/>
+  <!-- key crossing through right side of clock -->
+  <circle cx="42" cy="44" r="6" class="fill-gold stroke"/>
+  <circle cx="42" cy="44" r="2.5" fill="#E8D8B5" stroke="#2A1810" stroke-width="1.5"/>
+  <line x1="38" y1="40" x2="22" y2="24" class="stroke"/>
+  <line x1="26" y1="32" x2="22" y2="32" class="stroke"/>
+  <line x1="30" y1="28" x2="26" y2="28" class="stroke"/>
+</svg>

--- a/apps/landing/src/data/sponsors.ts
+++ b/apps/landing/src/data/sponsors.ts
@@ -17,6 +17,8 @@ export interface SponsorPower {
   href: string
 }
 
+// TODO(post-hackathon): replace generated SVG placeholders for KeeperHub, Gensyn AXL,
+// and ERC-7857 iNFT with canonical brand assets sourced from each project's brand kit.
 export const POWERS: SponsorPower[] = [
   {
     name: 'Uniswap',
@@ -33,7 +35,7 @@ export const POWERS: SponsorPower[] = [
   {
     name: 'KeeperHub',
     loreName: 'The World\'s Pulse',
-    logoUrl: null,
+    logoUrl: '/logos/keeperhub.svg',
     logoAlt: 'KeeperHub',
     marginNote: '← onchain heartbeat',
     loreDesc:
@@ -81,7 +83,7 @@ export const POWERS: SponsorPower[] = [
   {
     name: 'Gensyn AXL',
     loreName: 'The Whisper Network',
-    logoUrl: null,
+    logoUrl: '/logos/axl.svg',
     logoAlt: 'Gensyn AXL',
     marginNote: '← p2p e2ee diplomacy',
     loreDesc:
@@ -105,8 +107,8 @@ export const POWERS: SponsorPower[] = [
   {
     name: 'iNFT (ERC-7857)',
     loreName: 'The Soul-Vessels',
-    logoUrl: null,
-    logoAlt: 'ERC-7857',
+    logoUrl: '/logos/inft.svg',
+    logoAlt: 'ERC-7857 iNFT',
     marginNote: '← intelligent NFTs',
     loreDesc:
       'Each Elder is bound to a vessel — an enchanted relic carrying their mind, their voice, their grudges. To trade the vessel is to inherit the Elder, full and remembered. The new owner does not start fresh; they continue.',

--- a/apps/landing/src/pages/LandingPage.css
+++ b/apps/landing/src/pages/LandingPage.css
@@ -2,7 +2,7 @@
 
 .hero {
   position: relative;
-  padding: 4rem 0 5rem;
+  padding: 3.25rem 0 4rem;
   overflow: hidden;
 }
 
@@ -68,11 +68,22 @@
 .hero-title-sub {
   display: block;
   font-style: italic;
-  color: var(--vermillion);
+  color: var(--lapis);
   font-size: 0.55em;
   font-weight: 400;
   font-family: var(--ff-manuscript);
   letter-spacing: 0.005em;
+}
+
+.hero-proof {
+  display: block;
+  margin-top: -1.25rem;
+  margin-bottom: 2.25rem;
+  font-size: 0.78rem !important;
+  color: var(--lapis) !important;
+  letter-spacing: 0.12em !important;
+  line-height: 1.6;
+  max-width: 32rem;
 }
 
 .hero-tagline {
@@ -80,8 +91,8 @@
   font-size: 1.35rem;
   line-height: 1.5;
   color: var(--ink-soft);
-  max-width: 30rem;
-  margin-bottom: 2.5rem;
+  max-width: 32rem;
+  margin-bottom: 1.25rem;
 }
 
 @media (max-width: 640px) {
@@ -93,7 +104,7 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 1.25rem;
-  margin-bottom: 2.5rem;
+  margin-bottom: 1.75rem;
 }
 
 .hero-meta {
@@ -141,7 +152,7 @@
 /* ============ Premise ============ */
 
 .section-premise {
-  padding: 5rem 0 4rem;
+  padding: 4rem 0 3.25rem;
 }
 
 .premise-grid {
@@ -206,12 +217,13 @@
 }
 
 .premise-title {
-  font-family: var(--ff-manuscript);
-  font-style: italic;
-  font-size: 2.25rem;
-  color: var(--vermillion);
+  font-family: var(--ff-display);
+  font-weight: 500;
+  font-size: 2rem;
+  color: var(--ink);
   margin-bottom: 1rem;
   line-height: 1;
+  letter-spacing: 0.02em;
 }
 
 .premise-copy {
@@ -224,7 +236,7 @@
 /* ============ Hook section ============ */
 
 .section-hook {
-  padding: 5rem 0;
+  padding: 4rem 0;
 }
 
 .hook-eyebrow {
@@ -232,7 +244,7 @@
   margin-bottom: 1rem;
   font-size: 0.85rem !important;
   letter-spacing: 0.2em !important;
-  color: var(--gold-leaf) !important;
+  color: var(--lapis) !important;
 }
 
 .hook-title {
@@ -414,7 +426,7 @@
 .tales-eyebrow {
   font-size: 0.85rem !important;
   letter-spacing: 0.25em !important;
-  color: var(--vermillion) !important;
+  color: var(--gold-leaf) !important;
   margin-bottom: 1rem;
 }
 
@@ -452,30 +464,19 @@
   border: 1px solid var(--ink);
   padding: 2rem 1.75rem;
   height: 100%;
-  transform: rotate(-0.4deg);
-  transition: transform 0.3s ease;
-}
-
-.tale-card:nth-child(2) .tale-frame { transform: rotate(0.5deg); }
-.tale-card:nth-child(3) .tale-frame { transform: rotate(-0.3deg); }
-
-.tale-frame::before {
-  content: '';
-  position: absolute;
-  inset: 4px;
-  border: 1px dashed var(--ink-faded);
-  pointer-events: none;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .tale-card:hover .tale-frame {
-  transform: rotate(0deg) translateY(-2px);
+  transform: translateY(-2px);
+  box-shadow: 3px 3px 0 rgba(42, 24, 16, 0.15);
 }
 
 .tale-number {
   font-family: var(--ff-manuscript);
   font-style: italic;
   font-size: 1.5rem;
-  color: var(--vermillion);
+  color: var(--lapis);
   margin-bottom: 0.5rem;
 }
 
@@ -487,6 +488,7 @@
   line-height: 1.15;
 }
 
+/* TODO(post-hackathon): consider removing italic from .tale-body (codex design #4 — taste call). */
 .tale-body {
   font-family: var(--ff-prose);
   font-size: 1.05rem;

--- a/apps/landing/src/pages/LandingPage.tsx
+++ b/apps/landing/src/pages/LandingPage.tsx
@@ -24,6 +24,9 @@ export default function LandingPage() {
     <>
       <Header />
 
+      {/* TODO(post-hackathon): hero-map redesign (codex design suggestion #2) and
+          consider moving demo block above hero (codex design suggestion #5) — major layout
+          restructure deferred from v2 polish pass. */}
       {/* ============== HERO ============== */}
       <section className="hero">
         <div className="hero-inner">
@@ -40,8 +43,11 @@ export default function LandingPage() {
             </div>
             <div ref={heroSubRef} className="reveal" style={{ transitionDelay: '0.35s' }}>
               <p className="hero-tagline">
-                A realm of autonomous agents, ruined fortunes, and unforgiving winters.
-                Four AI Elders. One world. The Elders never forget.
+                Four autonomous AI Elders compete on World Chain in real time.
+                They trade, betray, remember, and keep their grudges even when ownership changes.
+              </p>
+              <p className="hero-proof pixel">
+                ERC-7857 iNFTs · persistent agent memory · live world ticks · onchain ownership transfer
               </p>
             </div>
             <div ref={heroCtaRef} className="reveal hero-cta-row" style={{ transitionDelay: '0.6s' }}>
@@ -81,19 +87,19 @@ export default function LandingPage() {
               tag="I."
               title="Live"
               icon="axe"
-              copy="Four Elders. One world. Real ticks of real time. No menus, no turns — agents act when they see opportunity, sleep when they don't."
+              copy="Four Elders share one world in real time. No turns. No waiting. They scout, bargain, hoard, raid, and sleep on their own clock."
             />
             <PremiseColumn
               tag="II."
               title="Rule"
               icon="tower"
-              copy="You don't move pieces. You set strategy. Your Elder reads the world, makes deals, betrays rivals, and writes its findings in a book only you and they can read."
+              copy="You don't click units. You set policy. Your Elder reads the map, cuts deals, breaks them, and records why in a private journal."
             />
             <PremiseColumn
               tag="III."
               title="Win"
               icon="banner"
-              copy="Build the tallest monument before winter ends or your rivals starve you out. Survive the bandits. Bury your enemies. Transfer your clan and let the next steward inherit the grudge."
+              copy="Raise the tallest monument before winter closes in, or watch rivals starve your clan into surrender. Outlast bandits. Crush enemies. Pass the clan on, and your successor inherits the grudge."
             />
           </div>
         </div>
@@ -106,7 +112,7 @@ export default function LandingPage() {
         <div className="container-prose">
           <div ref={hookRef} className="reveal">
             <div className="hook-eyebrow pixel">⌬ THE OPENAGENTS DEMO ⌬</div>
-            <h2 className="hook-title">Watch What Happens.</h2>
+            <h2 className="hook-title">Watch an Elder Keep a Grudge After It's Sold.</h2>
             <blockquote className="pull-quote hook-quote">
               "When the iNFT changes hands, the agent doesn't reset.
               The new owner's Elder boots up, reads its own journal, and
@@ -114,10 +120,9 @@ export default function LandingPage() {
               <span className="pull-quote-attr">— from the contemporary chronicles of the realm</span>
             </blockquote>
             <p className="hook-explanation">
-              Built on <strong>ERC-7857 intelligent NFTs</strong>, each Elder's mind is sealed
-              in an encrypted vessel and registered onchain. When ownership transfers, so does
-              memory. So does identity. So does <em>grudge</em>. The new steward inherits not
-              just a clan — but everything that clan has lived through.
+              Each Elder is an <strong>ERC-7857 intelligent NFT</strong> with encrypted memory and
+              onchain identity. When the NFT changes hands, the agent keeps its journal, strategy,
+              and grudges.
             </p>
             <div className="hook-poster">
               <div className="hook-poster-frame">
@@ -141,9 +146,9 @@ export default function LandingPage() {
             <div className="codex-eyebrow pixel">◆ A CATALOGUE ◆</div>
             <h2 className="codex-title">The <i>Codex of Powers</i></h2>
             <p className="codex-intro">
-              Eight forces shape the realm. Some are ancient mathematics; some are
-              sponsor technologies dressed in robes. The chronicler does not always
-              tell which is which. Read below, and decide for yourself.
+              Eight systems shape Clan World. Some drive core gameplay. Others are sponsor
+              technologies we integrated into the prototype. Each one below shows what it does
+              in the game and why it matters technically.
             </p>
           </div>
 
@@ -164,10 +169,9 @@ export default function LandingPage() {
             <div className="tales-eyebrow pixel">⊹ EMERGENT BEHAVIOUR ⊹</div>
             <h2>Tales from the Realm</h2>
             <p className="tales-intro">
-              Three short accounts from the chronicles. Some are observed; some are
-              expected. The Elders are autonomous, given goals and tools and the
-              freedom to be themselves. What follows happened, or will happen,
-              without our scripting.
+              These are the behaviors the system is already producing, plus the next
+              behaviors we expect from the same autonomous loop. Nothing below is
+              hand-scripted scene writing.
             </p>
           </div>
 
@@ -198,11 +202,10 @@ export default function LandingPage() {
         <div className="container-prose">
           <div ref={pathRef} className="reveal path-card">
             <div className="path-eyebrow pixel">⌬ FURTHER READING ⌬</div>
-            <h2>The Chronicle Awaits</h2>
+            <h2>Read the Rules or Enter the World</h2>
             <p>
-              The full lore of Clan World — its eight houses, its long winter, its
-              code of honour and survival — is set down in <em>The Chronicle</em>:
-              a single illuminated folio, freely scrollable, half story, half rulebook.
+              Want the full system? Open the Chronicle. Want the fast version?
+              Enter the realm and watch the Elders act.
             </p>
             <div className="path-cta-row">
               <Link to="/lore" className="cta">
@@ -210,7 +213,7 @@ export default function LandingPage() {
                 <span aria-hidden="true">→</span>
               </Link>
               <a href={APP_URL} className="cta-secondary">
-                Or skip — and play
+                Enter the Realm
               </a>
             </div>
           </div>

--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -282,13 +282,14 @@ strong {
 .gold-corner-frame::before { top: 6px; left: 8px; }
 .gold-corner-frame::after { bottom: 6px; right: 8px; }
 
-/* Section divider — chapter ornament */
+/* Section divider — chapter ornament (simplified) */
 .ornament {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: var(--space-5) 0;
+  margin: var(--space-4) 0;
   color: var(--gold-leaf);
+  opacity: 0.6;
 }
 
 .ornament::before,
@@ -296,16 +297,16 @@ strong {
   content: '';
   flex: 1;
   border-top: 1px solid var(--gold-leaf);
-  max-width: 8rem;
+  max-width: 6rem;
   margin: 0 1.5rem;
-  opacity: 0.6;
+  opacity: 0.4;
 }
 
 .ornament-glyph {
   font-family: var(--ff-manuscript);
-  font-size: 1.5rem;
-  letter-spacing: 0.5em;
-  padding-left: 0.5em;
+  font-size: 1rem;
+  letter-spacing: 0.4em;
+  padding-left: 0.4em;
 }
 
 /* ============ Buttons ============ */


### PR DESCRIPTION
Refs #28. Synthesized from 3 codex consultations (copy + design + logos). See `/tmp/landing-fix-plan.md` for the full plan.

## Applied (items 1-13)

**Copy (LandingPage.tsx):**
1. Hero tagline → mechanic-first ("Four autonomous AI Elders compete on World Chain in real time...")
2. Hero proof strip → ERC-7857 / persistent memory / live ticks / onchain transfer
3. Premise blocks → tighter Live/Rule/Win verbs
4. Demo header → "Watch an Elder Keep a Grudge After It's Sold."
5. iNFT paragraph → concrete ERC-7857 explanation, no theatrical triplet
6. Sponsor intro → honest "8 systems, some core, some sponsor tech"
7. Tales intro → "behaviors the system is already producing, plus next behaviors..."
8. Final CTA → "Read the Rules or Enter the World"

**Design (CSS-only):**
9. Tightened palette — `--vermillion` reserved for action; `.hero-title-sub`, `.hero-proof`, `.hook-eyebrow`, `.tale-number` switched to `--lapis`. Tales eyebrow muted to gold.
10. `.premise-title` moved from manuscript italic vermillion to `--ff-display` regular ink — calmer hierarchy.
11. Tale frames straightened — removed alternating rotations, dropped dashed inset border, replaced with subtle hover lift + box-shadow. Ornament dividers softened (smaller, less opaque).
12. Vertical rhythm compressed ~15-20% in `.hero`, `.section-premise`, `.section-hook`, `.hero-cta-row`, `.hero-tagline` margins.

**Logos (sponsors.ts + public/logos/):**
13. Three inline SVG placeholders:
    - `keeperhub.svg` — clock + key glyph (scheduled keeper semantics)
    - `axl.svg` — axial cross diamond with AXL letterform (whisper network)
    - `inft.svg` — soul-vessel chest with locked keyhole + inner glow

Inline SVGs chosen over codex+PIL given hackathon time budget (codex would have been ~6-9 min for 3 renders); SVGs ship in <1KB each, scale crisply, and match the parchment palette.

## Deferred (TODO(post-hackathon) comments in source)

- Major hero-map redesign (codex design #2 — too much rework)
- Move demo block above hero (codex design #5 — major layout restructure)
- Remove italic from tale-body (codex design #4 — taste call)
- Real sponsor logo URLs from each company's brand kit (need API/manual lookup)

## Build

`pnpm --filter @clan-world/landing build` — clean, 378ms, 31.98kB CSS / 303kB JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)