### PR TITLE
fix(web): pinch-zoom — override Pixi v8 touchAction='none'

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -14,6 +14,10 @@
         margin: 0;
         padding: 0;
         overflow: hidden;
+        /* Defense-in-depth for pinch-zoom: ensure no ancestor of the Pixi
+           canvas ships touch-action:none. The Pixi canvas itself overrides
+           this to 'pinch-zoom' in WorldMap.tsx after app.init(). */
+        touch-action: pinch-zoom;
       }
       body {
         background: #0a0a0a;

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -285,6 +285,13 @@ export function WorldMap() {
         app.canvas.style.display = 'block';
         app.canvas.style.width = '100%';
         app.canvas.style.height = '100%';
+        // Allow native pinch-zoom on iOS/Telegram WebView. Pixi v8's EventSystem
+        // sets touchAction='none' on the canvas during init (see pixijs.com/8.x
+        // events guide + GH#2483), which blocks the browser's native pinch
+        // gesture regardless of <meta viewport user-scalable=yes>. Overriding
+        // back to 'pinch-zoom' restores two-finger zoom on the canvas while
+        // single-touch events still reach Pixi for hit testing.
+        app.canvas.style.touchAction = 'pinch-zoom';
 
         // 1. Background terrain map (PR #40) — fantasy strategy art generated to match REGIONS layout.
         // Loaded async; sprite is added to app.stage BEFORE buildScene so region circles render on top.


### PR DESCRIPTION
## Summary

Five prior attempts at fixing pinch-zoom only tweaked the viewport meta tag — the actual culprit was Pixi v8 itself.

**Root cause:** Pixi v8's `EventSystem` sets `canvas.style.touchAction = 'none'` during `app.init()` on any device that supports pointer events (confirmed in [Pixi v8 events guide](https://pixijs.com/8.x/guides/components/events) and [pixijs/pixijs#2483](https://github.com/pixijs/pixijs/issues/2483)). With `touch-action: none` on the canvas, iOS Safari/Telegram WebView refuses two-finger pinch regardless of `<meta viewport user-scalable=yes>`.

**Fix:**
- `WorldMap.tsx`: after `app.init()` resolves, set `app.canvas.style.touchAction = 'pinch-zoom'`.
- `index.html`: set `touch-action: pinch-zoom` on `html/body/#root` as defense-in-depth.

Diff is +11/-0 across two files. No event-handler or Pixi config changes — minimal conflict surface with in-flight visual rework on `WorldMap.tsx`.

## Test plan

- [ ] Manually pinch-zoom in app.clan-world.com on iOS Telegram WebView (post-deploy)
- [ ] Confirm Pixi canvas still receives clicks/taps (hit-testing intact)

Closes prior failed pinch-zoom attempts (#50 and earlier).