### PR TITLE
fix(web): pinch zoom — pixi-viewport (round 6, real fix)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
@@ -14,15 +14,20 @@
         margin: 0;
         padding: 0;
         overflow: hidden;
-        /* Defense-in-depth for pinch-zoom: ensure no ancestor of the Pixi
-           canvas ships touch-action:none. The Pixi canvas itself overrides
-           this to 'pinch-zoom' in WorldMap.tsx after app.init(). */
-        touch-action: pinch-zoom;
+        /* Round-6 pinch fix: pixi-viewport handles all gestures inside the
+           canvas. Browser-level zoom is locked via viewport meta above. */
+        touch-action: none;
       }
       body {
         background: #0a0a0a;
         overscroll-behavior: none;
         font-family: 'Inter', system-ui, sans-serif;
+      }
+      canvas {
+        touch-action: none;
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        user-select: none;
       }
     </style>
   </head>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@worldcoin/idkit": "4.1.2",
     "@worldcoin/minikit-js": "2.0.3",
     "convex": "1.17.4",
+    "pixi-viewport": "^6.0.3",
     "pixi.js": "^8.18.1",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -2,8 +2,15 @@ import { useEffect, useRef, useState } from 'react';
 import { useQuery } from 'convex/react';
 import { type FunctionReference, anyApi } from 'convex/server';
 import { Application, Assets, Container, Graphics, Sprite, Text } from 'pixi.js';
+import { Viewport } from 'pixi-viewport';
 import { useAgentLogs, type AgentLog } from './useAgentLogs';
 import worldMapBg from './assets/world-map.png';
+
+// World dimensions used by pixi-viewport for pan/clamp/center math.
+// Matches REF_W/REF_H so all existing layout coords (offsetX + nx*REF_W*scaleX)
+// continue to work unchanged inside the viewport.
+const WORLD_WIDTH = 800;
+const WORLD_HEIGHT = 600;
 
 interface RegionDef {
   id: string;
@@ -211,6 +218,10 @@ export function WorldMap() {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasWrapRef = useRef<HTMLDivElement>(null);
   const appRef = useRef<Application | null>(null);
+  // pixi-viewport instance — wraps all map layers so multi-touch pinch / drag /
+  // wheel are handled at the application layer (works in iOS WebKit + World App
+  // WebView where browser-level pinch is unreliable).
+  const viewportRef = useRef<Viewport | null>(null);
   const layoutRef = useRef<{ scale: number; scaleX: number; scaleY: number; offsetX: number; offsetY: number }>({
     scale: 1,
     scaleX: 1,
@@ -300,16 +311,39 @@ export function WorldMap() {
         app.canvas.style.display = 'block';
         app.canvas.style.width = '100%';
         app.canvas.style.height = '100%';
-        // Allow native pinch-zoom on iOS/Telegram WebView. Pixi v8's EventSystem
-        // sets touchAction='none' on the canvas during init (see pixijs.com/8.x
-        // events guide + GH#2483), which blocks the browser's native pinch
-        // gesture regardless of <meta viewport user-scalable=yes>. Overriding
-        // back to 'pinch-zoom' restores two-finger zoom on the canvas while
-        // single-touch events still reach Pixi for hit testing.
-        app.canvas.style.touchAction = 'pinch-zoom';
+        // Round-6 pinch fix: pixi-viewport handles multi-touch internally, so
+        // canvas touch-action is 'none' (we own all gestures inside the canvas).
+        // Browser-level pinch is locked via index.html viewport meta.
+        app.canvas.style.touchAction = 'none';
+        // Defensive — block iOS WebKit's 300ms double-tap delay + ensure no
+        // stray multi-touch escapes to the page-level zoom.
+        app.canvas.addEventListener('touchstart', (e) => {
+          if (e.touches.length > 1) e.preventDefault();
+        }, { passive: false });
+
+        // pixi-viewport: wraps all map layers (bg, regions, sigils, bases,
+        // bubbles, travel dots) so .pinch() / .drag() / .wheel() handle
+        // multi-touch math at the application layer. Round 5's
+        // canvas.style.touchAction='pinch-zoom' approach failed in World App
+        // WebView; this is the canonical fix per Pixi docs.
+        const viewport = new Viewport({
+          screenWidth: initialW,
+          screenHeight: initialH,
+          worldWidth: WORLD_WIDTH,
+          worldHeight: WORLD_HEIGHT,
+          events: app.renderer.events,
+        });
+        app.stage.addChild(viewport); // viewport is the only direct child of stage
+        viewport
+          .drag()
+          .pinch()
+          .wheel()
+          .decelerate()
+          .clampZoom({ minScale: 0.5, maxScale: 4 });
+        viewportRef.current = viewport;
 
         // 1. Background terrain map (PR #40) — fantasy strategy art generated to match REGIONS layout.
-        // Loaded async; sprite is added to app.stage BEFORE buildScene so region circles render on top.
+        // Loaded async; sprite is added to viewport BEFORE buildScene so region circles render on top.
         try {
           const tex = await Assets.load(worldMapBg);
           if (!mounted) return;
@@ -318,7 +352,7 @@ export function WorldMap() {
           bg.height = initialH;
           bg.x = 0;
           bg.y = 0;
-          app.stage.addChild(bg);
+          viewport.addChild(bg);
           drawnRef.current.bgSprite = bg;
         } catch (err) {
           // Non-fatal — fall through to flat background color set in app.init
@@ -326,11 +360,12 @@ export function WorldMap() {
         }
 
         // 2. Build scene (regions, sigil sprites, bandit indicator) — PR #41 + PR #42 logic
-        buildScene(app);
+        // Layers are added to `viewport` (not app.stage) so pinch/drag affect them.
+        buildScene(app, viewport);
 
         // 3. Speech bubble layer + ticker (PR #43) — added last so bubbles render above everything.
         const bubbleLayer = new Container();
-        app.stage.addChild(bubbleLayer);
+        viewport.addChild(bubbleLayer);
         bubbleLayerRef.current = bubbleLayer;
 
         const cb = (ticker: { deltaMS: number }) => {
@@ -383,7 +418,7 @@ export function WorldMap() {
         // Added after bubble layer so dots can render under bubbles (less visual noise).
         const travelLayer = new Container();
         // Insert below bubble layer so bubbles always appear on top of moving dots.
-        app.stage.addChildAt(travelLayer, app.stage.getChildIndex(bubbleLayer));
+        viewport.addChildAt(travelLayer, viewport.getChildIndex(bubbleLayer));
         travelLayerRef.current = travelLayer;
 
         const travelCb = (_ticker: { deltaMS: number }) => {
@@ -499,6 +534,7 @@ export function WorldMap() {
         banditCountdown: null,
         bgSprite: null,
       };
+      viewportRef.current = null;
       appRef.current = null;
       a?.destroy(true);
     };
@@ -517,6 +553,10 @@ export function WorldMap() {
       const h = wrap.clientHeight;
       if (w <= 0 || h <= 0) return;
       app.renderer.resize(w, h);
+      // Update pixi-viewport's screen dimensions so pinch/drag math tracks
+      // the new canvas size. World dims stay fixed at WORLD_WIDTH/HEIGHT.
+      const vp = viewportRef.current;
+      if (vp) vp.resize(w, h, WORLD_WIDTH, WORLD_HEIGHT);
       relayout(w, h);
       setSize({ w, h });
     };
@@ -531,20 +571,22 @@ export function WorldMap() {
   }, [pixiReady]);
 
   // ---- One-time: create Pixi display objects (refs hold them for relayout) -
-  function buildScene(app: Application) {
+  // All layers attach to `viewport` (not app.stage) so pixi-viewport's pinch /
+  // drag transforms apply to the whole map atomically.
+  function buildScene(app: Application, viewport: Viewport) {
     const drawn = drawnRef.current;
 
     // Clan zones (big translucent breathing halos) — drawn FIRST so everything else
     // sits on top. Visual sense of "this clan controls this zone."
     for (const clan of MOCK_CLANS) {
       const zoneGfx = new Graphics();
-      app.stage.addChild(zoneGfx);
+      viewport.addChild(zoneGfx);
       drawn.clanZones.push({ gfx: zoneGfx, clan });
     }
 
     for (const region of REGIONS) {
       const g = new Graphics();
-      app.stage.addChild(g);
+      viewport.addChild(g);
       drawn.regions.push(g);
 
       const label = new Text({
@@ -552,33 +594,33 @@ export function WorldMap() {
         style: { fill: 0xdddddd, fontSize: 11, fontFamily: 'monospace' },
       });
       label.anchor.set(0.5, 0);
-      app.stage.addChild(label);
+      viewport.addChild(label);
       drawn.regionLabels.push(label);
     }
 
     // Wall rings — drawn first so they sit above region circles but under sigils.
     for (const clan of MOCK_CLANS) {
       const wallGfx = new Graphics();
-      app.stage.addChild(wallGfx);
+      viewport.addChild(wallGfx);
       drawn.walls.push({ gfx: wallGfx, clan });
     }
 
     // Monument towers — drawn before flags so sigil layers cleanly on top.
     for (const clan of MOCK_CLANS) {
       const monGfx = new Graphics();
-      app.stage.addChild(monGfx);
+      viewport.addChild(monGfx);
       drawn.monuments.push({ gfx: monGfx, clan });
     }
 
     for (const clan of MOCK_CLANS) {
       const flag = new Graphics();
-      app.stage.addChild(flag);
+      viewport.addChild(flag);
       const label = new Text({
         text: clan.name,
         style: { fill: clan.color, fontSize: 10, fontFamily: 'monospace', fontWeight: 'bold' },
       });
       label.anchor.set(0, 1);
-      app.stage.addChild(label);
+      viewport.addChild(label);
       const entry: { gfx: Graphics; sprite: Sprite | null; label: Text; clan: ClanDef } = {
         gfx: flag,
         sprite: null,
@@ -593,7 +635,7 @@ export function WorldMap() {
         .then((texture) => {
           const sprite = new Sprite(texture);
           sprite.alpha = 0; // hidden until first relayout positions it
-          app.stage.addChild(sprite);
+          viewport.addChild(sprite);
           entry.sprite = sprite;
           // Trigger a relayout so sprite gets positioned and shown.
           const wrap = canvasWrapRef.current;
@@ -611,13 +653,13 @@ export function WorldMap() {
     // visible during the load and as a safety net if the asset 404s. The countdown text
     // anchors next to whichever marker is currently rendered.
     const banditIcon = new Graphics();
-    app.stage.addChild(banditIcon);
+    viewport.addChild(banditIcon);
     const countdown = new Text({
       text: '',
       style: { fill: 0xffe9b8, fontSize: 11, fontFamily: 'monospace', fontWeight: 'bold' },
     });
     countdown.anchor.set(0, 0.5);
-    app.stage.addChild(countdown);
+    viewport.addChild(countdown);
     drawn.banditIcon = banditIcon;
     drawn.banditCountdown = countdown;
 
@@ -628,7 +670,7 @@ export function WorldMap() {
         const sprite = new Sprite(texture);
         sprite.anchor.set(0.5, 0.5);
         sprite.alpha = 0; // hidden until first redrawBandit positions it
-        app.stage.addChild(sprite);
+        viewport.addChild(sprite);
         drawn.banditSprite = sprite;
         redrawBandit();
       })
@@ -640,7 +682,7 @@ export function WorldMap() {
     // Visible on top of region circles + sigil flags. Falls back to a simple colored rect.
     for (const clan of MOCK_CLANS) {
       const fallback = new Graphics();
-      app.stage.addChild(fallback);
+      viewport.addChild(fallback);
       const entry: { sprite: Sprite | null; fallback: Graphics; clan: ClanDef } = {
         sprite: null,
         fallback,
@@ -653,7 +695,7 @@ export function WorldMap() {
           const sprite = new Sprite(texture);
           sprite.anchor.set(0.5, 1); // anchored at bottom-center so it "stands" on the region
           sprite.alpha = 0;
-          app.stage.addChild(sprite);
+          viewport.addChild(sprite);
           entry.sprite = sprite;
           const wrap = canvasWrapRef.current;
           if (wrap && appRef.current) {
@@ -668,7 +710,7 @@ export function WorldMap() {
     // Floating "Lv N" badges — drawn last so they overlay everything.
     for (const clan of MOCK_CLANS) {
       const bg = new Graphics();
-      app.stage.addChild(bg);
+      viewport.addChild(bg);
       const label = new Text({
         text: 'Lv 1',
         style: {
@@ -679,7 +721,7 @@ export function WorldMap() {
         },
       });
       label.anchor.set(0.5, 0.5);
-      app.stage.addChild(label);
+      viewport.addChild(label);
       drawn.levelBadges.push({ bg, label, clan });
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       convex:
         specifier: 1.17.4
         version: 1.17.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      pixi-viewport:
+        specifier: ^6.0.3
+        version: 6.0.3(pixi.js@8.18.1)
       pixi.js:
         specifier: ^8.18.1
         version: 8.18.1
@@ -1397,6 +1400,11 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pixi-viewport@6.0.3:
+    resolution: {integrity: sha512-2+qPJ0/n+8hQYhWvY+795+x9y3MiUrCOWacK0DY53whowWaGdx9iDocy7z1pBwjkZhC52YvrJQuZKK0sdVLtBw==}
+    peerDependencies:
+      pixi.js: '>=8'
+
   pixi.js@8.18.1:
     resolution: {integrity: sha512-6LUPWYgulZhp/w4kam2XHXB0QedISZIqrJbRdHLLQ3csn5a38uzKxAp6B5j6s89QFYaIJbg95kvgTRcbgpO1ow==}
 
@@ -2612,6 +2620,10 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pixi-viewport@6.0.3(pixi.js@8.18.1):
+    dependencies:
+      pixi.js: 8.18.1
 
   pixi.js@8.18.1:
     dependencies:


### PR DESCRIPTION
## Summary

Round 6 pinch-zoom fix. Liam's own ChatGPT research confirmed the canonical solution: **install `pixi-viewport`** to handle multi-touch math at the application layer.

Round 5's `canvas.style.touchAction = 'pinch-zoom'` approach failed in World App WebView because Pixi v8's EventSystem (or the WebView wrapper) still consumed the touches.

## Changes

- Install `pixi-viewport@^6.0.3` (Pixi v8 compatible)
- Wrap all map layers (bg, regions, sigils, bases, levelBadges, walls, monuments, bubbles, travel dots) inside a `Viewport` instance
- Enable `.drag().pinch().wheel().decelerate().clampZoom({minScale:0.5,maxScale:4})`
- Lock browser-level zoom: viewport meta `maximum-scale=1.0, user-scalable=no` so only pixi-viewport's internal pinch is active
- Defensive `touchstart preventDefault` on multi-touch (covers iOS WebKit 300ms delay)
- `canvas { touch-action: none }` so canvas owns all gestures

## Test plan

- [ ] iOS Safari: two-finger pinch zooms the map, single-finger pans
- [ ] World App WebView: same gestures work
- [ ] Desktop: mouse wheel zooms, click+drag pans
- [ ] Bubbles, travel dots, sigils, level labels still render on top
- [ ] Resize/orientation change keeps viewport in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)