### PR TITLE
docs: Submission 1 video on README + landing embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 >
 > | | Link |
 > |---|---|
+> | **Submission video** | https://youtube.com/shorts/BCpLRwSvReI (3-min YouTube short) |
 > | **Live mini app** | https://app.clan-world.com — open inside World App or in any browser |
 > | **Landing page** | https://clan-world.com |
 > | **Submission 1 release branch** | [`release/worldbuild-FINAL`](https://github.com/OmniPass-world/clan-world/tree/release/worldbuild-FINAL) (frozen at submission state) |
@@ -11,9 +12,10 @@
 > | **Submission Notion form** | https://worldbuildlabs.notion.site/304f949f7ec0809b9b39f7d1f2147b9b |
 >
 > **What to look at first:**
-> 1. Open https://app.clan-world.com in any browser. The mini app is a Pixi.js canvas with 4 AI Elder bases (Iron Guard, Ember Hand, Dawn Watch, Storm Riders), real-time speech bubbles driven by a Convex backend, a parchment world-notice panel for events, and pinch-to-zoom on mobile.
-> 2. Skim the [Tech stack table](#tech-stack) below — it shows what's live (S1) vs. what's coming (S2).
-> 3. The release-branch tree (`release/worldbuild-FINAL`) contains every PR landed during the 8-hour build sprint. PR descriptions document the design choices.
+> 1. Watch the [3-min submission video](https://youtube.com/shorts/BCpLRwSvReI) — it shows the live mini app, the four Elders in motion, and the demo flow end-to-end.
+> 2. Open https://app.clan-world.com in any browser. The mini app is a Pixi.js canvas with 4 AI Elder bases (Iron Guard, Ember Hand, Dawn Watch, Storm Riders), real-time speech bubbles driven by a Convex backend, a parchment world-notice panel for events, and pinch-to-zoom on mobile.
+> 3. Skim the [Tech stack table](#tech-stack) below — it shows what's live (S1) vs. what's coming (S2).
+> 4. The release-branch tree (`release/worldbuild-FINAL`) contains every PR landed during the 8-hour build sprint. PR descriptions document the design choices.
 >
 > **What we built in 8 hours:** 41 PRs, 8-house landing page, 4-clan in-game roster with hand-curated 5-level base sprite sets, real clansman walking sprites, a Telegram-cue dispatcher for live demo recording, viewport pinch-zoom via `pixi-viewport`, parchment world-notice panel, 2-line speech bubbles with clan-colored Elder headers, Vercel monorepo per-app linkage, and Cloudflare DNS for the two custom domains.
 >
@@ -54,7 +56,7 @@ ClanWorld is a **World mini app** — wrapped with `@worldcoin/minikit-js` for i
 
 ## Demo
 
-🎥 [Demo video](https://youtube.com/placeholder) — recording in progress
+🎥 [Submission 1 demo video](https://youtube.com/shorts/BCpLRwSvReI) — 3-min YouTube short
 🌍 Live on World Chain Sepolia — contract `0xC012275376b867944cd874FB2d600d6dA3B4A56e`
 
 ## Quick start

--- a/apps/landing/src/pages/LandingPage.css
+++ b/apps/landing/src/pages/LandingPage.css
@@ -353,6 +353,54 @@
   letter-spacing: 0.15em !important;
 }
 
+/* ---- Submission video embed (vertical YouTube short) ---- */
+
+.hook-video {
+  margin: 3rem auto 0;
+  max-width: 420px;
+  text-align: center;
+}
+
+.hook-video-frame {
+  position: relative;
+  aspect-ratio: 9/16;
+  border: 1.5px solid var(--ink);
+  background: var(--ink);
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+}
+
+.hook-video-frame::before,
+.hook-video-frame::after {
+  content: '';
+  position: absolute;
+  width: 1rem;
+  height: 1rem;
+  border: 1.5px solid var(--gold-leaf);
+  z-index: 2;
+  pointer-events: none;
+}
+.hook-video-frame::before { top: -5px; left: -5px; border-right: none; border-bottom: none; }
+.hook-video-frame::after { bottom: -5px; right: -5px; border-left: none; border-top: none; }
+
+.hook-video-frame iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+.hook-video-caption {
+  margin-top: 0.9rem;
+  font-size: 0.7rem;
+  color: var(--ink-faded);
+  letter-spacing: 0.15em;
+}
+
+@media (max-width: 480px) {
+  .hook-video { max-width: 320px; }
+}
+
 /* ============ Codex section ============ */
 
 .section-codex {

--- a/apps/landing/src/pages/LandingPage.tsx
+++ b/apps/landing/src/pages/LandingPage.tsx
@@ -124,13 +124,17 @@ export default function LandingPage() {
               onchain identity. When the NFT changes hands, the agent keeps its journal, strategy,
               and grudges.
             </p>
-            <div className="hook-poster">
-              <div className="hook-poster-frame">
-                <div className="hook-poster-content">
-                  <div className="hook-poster-icon" aria-hidden="true">▶</div>
-                  <div className="hook-poster-label">Demo · 90s walkthrough</div>
-                  <div className="hook-poster-sub pixel">to be inscribed before submission</div>
-                </div>
+            <div className="hook-video">
+              <div className="hook-video-frame">
+                <iframe
+                  src="https://www.youtube.com/embed/BCpLRwSvReI"
+                  title="ClanWorld Submission 1 demo"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  allowFullScreen
+                />
+              </div>
+              <div className="hook-video-caption pixel">
+                ✦ Submission 1 · 3-min demo ✦
               </div>
             </div>
           </div>


### PR DESCRIPTION
Adds Liam's submission YouTube short ([BCpLRwSvReI](https://youtube.com/shorts/BCpLRwSvReI)) to the two judge-facing surfaces.

## Changes

- **README** — new top row in the judge-banner table linking the 3-min video; new bullet 1 in "What to look at first" recommending the video as the first thing to watch; replaced the "recording in progress" placeholder URL in the Demo section.
- **Landing** (`apps/landing`) — replaced the `.hook-poster` placeholder ("to be inscribed before submission") in the OpenAgents demo section with a real YouTube iframe embed. 9:16 aspect (Shorts vertical), max-width 420px desktop / 320px under 480px viewport, parchment-frame gold corners preserved to match the existing visual language.

## Out of scope

- `apps/web` untouched per direction.
- Skipping swarm review — doc-only, time-sensitive (judging window).

## Verification

- `pnpm --filter @clan-world/landing build` clean (303 KB bundle, 33 KB css).
- `BCpLRwSvReI` confirmed present in the built JS bundle.