### PR TITLE
feat: Playwright e2e harness for apps/web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,8 @@ vite.config.ts.timestamp-*
 
 # Local planning extraction (V1.zip already committed; the unzipped tree is per-checkout)
 docs/planning/V1/
+
+# Playwright (anchor as glob so per-app dirs like apps/web/test-results/ also match)
+**/test-results/
+**/playwright-report/
+**/playwright/.cache/

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// TODO: replace 58840 with port-for-resolved value once the
+// `port-for --init <worktree>` slot for clan-world is registered. Until then
+// PLAYWRIGHT_BASE_URL env override is the canonical way to point tests at the
+// real dev server.
+const DEFAULT_PORT = 58840;
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${DEFAULT_PORT}`;
+
+// Derive the dev-server PORT from baseURL so that an external override of
+// PLAYWRIGHT_BASE_URL also relocates the spawned Vite server. If the URL has
+// no explicit port (e.g. http://staging.example.com), fall through to default.
+const webServerPort = (() => {
+  try {
+    const parsed = new URL(baseURL);
+    return parsed.port || String(DEFAULT_PORT);
+  } catch {
+    return String(DEFAULT_PORT);
+  }
+})();
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  outputDir: 'test-results',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'chromium-mobile',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+  webServer: {
+    command: `PORT=${webServerPort} pnpm --filter @clan-world/web dev`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/apps/web/tests/e2e/01-renders.spec.ts
+++ b/apps/web/tests/e2e/01-renders.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('app renders', () => {
+  test('loads index without error boundary', async ({ page }, testInfo) => {
+    await page.goto('/');
+
+    // Expect a document to be present (title may be empty in Wave 0).
+    const html = page.locator('html');
+    await expect(html).toBeVisible();
+
+    // Some page content must mount — body must not be empty.
+    const body = page.locator('body');
+    await expect(body).not.toBeEmpty();
+
+    // No error boundary should be rendered.
+    const errorBoundary = page.locator('[data-testid="error-boundary"]');
+    await expect(errorBoundary).toHaveCount(0);
+
+    // Visual debug aid — Playwright manages the per-test output dir.
+    await page.screenshot({
+      path: testInfo.outputPath('01-renders-home.png'),
+      fullPage: true,
+    });
+  });
+});

--- a/apps/web/tests/e2e/02-demo-mode.spec.ts
+++ b/apps/web/tests/e2e/02-demo-mode.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+// NOTE: Demo-mode wiring is Phase 4 work. Today the only demo-related env is
+// `VITE_DEMO_BYPASS_WORLD_GUARD` (apps/web/src/App.tsx) which bypasses the
+// "open in World App" guard but does NOT toggle a mock-clan dataset.
+//
+// `VITE_CLANWORLD_DEMO_MODE` referenced in the harness brief does not exist
+// yet. These tests are placeholders documenting the contract; once the demo
+// flag is wired they should be flipped from `test.skip` to live assertions.
+
+test.describe('demo mode wiring (Phase 4)', () => {
+  test.skip(
+    'demo-mode=true → mock clans visible (e.g. Storm Riders)',
+    async ({ page }) => {
+      // Future shape:
+      //   await page.goto('/');
+      //   const bubbles = page.locator('[data-testid="clan-bubble"]');
+      //   await expect(bubbles).toHaveCount(8);
+      //   await expect(page.getByText(/Storm Riders/)).toBeVisible();
+      void page;
+    },
+  );
+
+  test.skip(
+    'demo-mode=false → empty world map / "no chain data yet" placeholder',
+    async ({ page }) => {
+      // Future shape:
+      //   await page.goto('/');
+      //   const placeholder = page.getByText(/no chain data yet/i);
+      //   const emptyMap = page.locator('[data-testid="world-map-empty"]');
+      //   await expect(placeholder.or(emptyMap)).toBeVisible();
+      void page;
+    },
+  );
+});

--- a/apps/web/tests/e2e/03-message-bubbles.spec.ts
+++ b/apps/web/tests/e2e/03-message-bubbles.spec.ts
@@ -1,0 +1,24 @@
+import { test } from '@playwright/test';
+
+// Placeholder for message taxonomy v4.6 e2e coverage.
+// Spec: ~/claudes-world/tmp/20260426-message-taxonomy-response.md
+//
+// Five event classes that will eventually be tested as distinct visual
+// bubble styles in the world feed:
+//   1. world events       — parchment-style global ticks / chain heartbeat
+//   2. agent inputs       — what the Elder LLM saw in its <situation> block
+//   3. agent thoughts     — internal reasoning rendered for spectator UI
+//   4. agent directives   — orders the Elder issued (chain txs / mission queue)
+//   5. clansman comms     — clan-internal whispers + cross-clan diplomacy
+//
+// Each class needs: distinct `data-testid` (e.g. `bubble-world-event`,
+// `bubble-agent-input`, ...), distinct visual treatment, correct ordering in
+// the feed by tick + intra-tick sequence.
+//
+// Unskip + flesh out once the taxonomy is implemented in apps/web.
+
+test.describe('message bubble taxonomy v4.6 (Phase 4)', () => {
+  test.skip('renders all 5 event classes with distinct styling', async () => {
+    // TODO: implement when message taxonomy lands. See spec link above.
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,13 +8,16 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "test": "turbo run test",
+    "test:e2e": "playwright test --config apps/web/playwright.config.ts",
+    "test:e2e:ui": "playwright test --config apps/web/playwright.config.ts --ui",
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean && rm -rf node_modules .turbo"
   },
   "devDependencies": {
-    "turbo": "2.9.6",
-    "typescript": "5.9.3",
+    "@playwright/test": "^1.59.1",
     "@types/node": "25.6.0",
-    "prettier": "3.8.3"
+    "prettier": "3.8.3",
+    "turbo": "2.9.6",
+    "typescript": "5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -725,6 +728,11 @@ packages:
   '@pixi/colord@2.9.6':
     resolution: {integrity: sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1295,6 +1303,11 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1494,6 +1507,16 @@ packages:
 
   pixi.js@8.18.1:
     resolution: {integrity: sha512-6LUPWYgulZhp/w4kam2XHXB0QedISZIqrJbRdHLLQ3csn5a38uzKxAp6B5j6s89QFYaIJbg95kvgTRcbgpO1ow==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -2211,6 +2234,10 @@ snapshots:
 
   '@pixi/colord@2.9.6': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
@@ -2716,6 +2743,9 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2877,6 +2907,14 @@ snapshots:
       ismobilejs: 1.1.1
       parse-svg-path: 0.1.2
       tiny-lru: 11.4.7
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Stream C foundation work for hackathon Submission 2. Installs Playwright as a workspace dev dep and lays down a minimal e2e harness for `apps/web` so Phase 4 frontend gating (demo-mode wiring + message taxonomy v4.6) has a verification surface to plug into.

## What's in

- `@playwright/test` added as workspace-root devDep (one install, not per-app)
- `apps/web/playwright.config.ts`
  - chromium-desktop + chromium-mobile (Pixel 5) projects
  - `webServer.command` boots `pnpm --filter @clan-world/web dev`
  - `baseURL` defaults to `http://localhost:58840`, override via `PLAYWRIGHT_BASE_URL`
  - dev-server `PORT` is derived from `baseURL` so an external override relocates the spawned server, not just the wait URL
  - `retries: 2` on CI, `0` locally; `reuseExistingServer: !CI`; 120s timeout
  - HTML report + list reporter
- `apps/web/tests/e2e/01-renders.spec.ts` — live render smoke test (loads `/`, asserts no `[data-testid="error-boundary"]`, takes a debug screenshot via `testInfo.outputPath`)
- `apps/web/tests/e2e/02-demo-mode.spec.ts` — two `test.skip` placeholders for `VITE_CLANWORLD_DEMO_MODE` (Phase 4 — flag isn't wired yet; today's only demo env is `VITE_DEMO_BYPASS_WORLD_GUARD`)
- `apps/web/tests/e2e/03-message-bubbles.spec.ts` — `test.skip` placeholder for the 5 message-taxonomy-v4.6 event classes
- Root `package.json`: `test:e2e` + `test:e2e:ui` scripts
- `.gitignore`: `**/test-results/`, `**/playwright-report/`, `**/playwright/.cache/`

## Verification

Only `chromium` was installed (`pnpm exec playwright install chromium`) per the disk-thrift constraint.

`pnpm test:e2e --list` output (8 instances = 3 files × 2 projects):

```
  [chromium-desktop] › 01-renders.spec.ts:4:3 › app renders › loads index without error boundary
  [chromium-desktop] › 02-demo-mode.spec.ts:12:8 › demo mode wiring (Phase 4) › demo-mode=true → mock clans visible (e.g. Storm Riders)
  [chromium-desktop] › 02-demo-mode.spec.ts:24:8 › demo mode wiring (Phase 4) › demo-mode=false → empty world map / "no chain data yet" placeholder
  [chromium-desktop] › 03-message-bubbles.spec.ts:21:8 › message bubble taxonomy v4.6 (Phase 4) › renders all 5 event classes with distinct styling
  [chromium-mobile]  › (same 4 tests)
Total: 8 tests in 3 files
```

Did NOT run the full e2e suite — Vite boot + browser launch is heavy and Liam should UAT first.

## Stubbed / deferred to Phase 4

- `VITE_CLANWORLD_DEMO_MODE` env flag does not exist yet; only `VITE_DEMO_BYPASS_WORLD_GUARD` is wired. Demo-mode tests are `test.skip` placeholders documenting the contract.
- Message taxonomy v4.6 bubble rendering not implemented yet; spec file lists the 5 event classes and references `~/claudes-world/tmp/20260426-message-taxonomy-response.md`.
- Port allocation: `port-for --init` slot for clan-world is not registered yet; default `58840` is hardcoded with a TODO referencing the lockfile.
- CI workflow intentionally not added — follow-up PR.

## Local 3-tier swarm review

- **Codex** caught: `PLAYWRIGHT_BASE_URL` overrides `baseURL` but `webServer.command` still pinned `PORT=58840`, leading to a port-mismatch timeout. Fixed by deriving `PORT` from the parsed `baseURL`.
- **Gemini flash** caught: hardcoded screenshot path would crash if dir absent (now uses `testInfo.outputPath`); `.gitignore` was anchored to repo root and would not catch `apps/web/test-results/` (now uses `**/` globs).
- **Claude tier 1** = this turn (verification round, list output proven). Local clean.

## Test plan

- [ ] Liam: `pnpm install && pnpm test:e2e --list` → expect 8 tests in 3 files
- [ ] Liam: `pnpm test:e2e --project=chromium-desktop` → 01-renders should pass, 6 others should report skipped
- [ ] When Phase 4 demo-mode env lands, flip `test.skip` → live assertions in `02-demo-mode.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)