### PR TITLE
feat(agents): integration seam interfaces (types-only)

### DIFF
--- a/packages/agents/src/seams/IElderMemoryStore.ts
+++ b/packages/agents/src/seams/IElderMemoryStore.ts
@@ -1,0 +1,34 @@
+/**
+ * IElderMemoryStore — durable Elder memory across context resets.
+ *
+ * S2 stub: local JSON file at ~/.world/clanworld-runner/state/elder-{N}-memory.json
+ * Phase 7: 0G iNFT memory (ERC-7857 linked storage per clan; survives ownership transfer)
+ *
+ * Contract:
+ * - Key/value store scoped to a single Elder (N).
+ * - All keys are strings; values are JSON-serialisable strings.
+ * - reads must not throw on missing keys (return undefined).
+ * - writes must be durable: a read after a successful write must return the written value.
+ * - Implementations must be safe for single-Elder single-writer use (no concurrent write guarantee required).
+ */
+export interface IElderMemoryStore {
+  /**
+   * Read the value stored for topic/key, or undefined if not set.
+   */
+  recall(key: string): Promise<string | undefined>;
+
+  /**
+   * Persist a value for key. Overwrites any previous value.
+   *
+   * Contract:
+   * - Must complete before the tick loop continues (caller does not fire-and-forget).
+   * - Must throw on storage failure (full disk, permission denied, 0G write error).
+   */
+  save(key: string, value: string): Promise<void>;
+
+  /**
+   * Return all stored key/value pairs (snapshot at call time).
+   * Used by the runner to compose the continuity summary block on final-tick warning.
+   */
+  snapshot(): Promise<Record<string, string>>;
+}

--- a/packages/agents/src/seams/IElderPeerInbox.ts
+++ b/packages/agents/src/seams/IElderPeerInbox.ts
@@ -1,0 +1,45 @@
+/**
+ * IElderPeerInbox — private Elder-to-Elder diplomacy transport.
+ *
+ * S2 stub: file-based jsonl at ~/.world/clanworld-runner/state/peer-inbox/elder-{recipientClanId}.jsonl
+ * Phase 8: Gensyn AXL private messaging transport
+ *
+ * Contract:
+ * - Messages are ordered (FIFO) within a sender/recipient pair per tick.
+ * - Peer messages are agent-private: not mirrored to Convex or the UI in S2.
+ *   (Phase 8: Convex getPeerMessagesFor() switches from file to AXL transport.)
+ * - send() writes to the RECIPIENT's inbox (indexed by recipient clan ID), not the sender's.
+ * - inbox() reads the caller Elder's own inbox (indexed by the Elder's own clan ID).
+ * - Implementations must be idempotent: the runner may re-deliver a whisper on retry;
+ *   implementations that guarantee exactly-once must deduplicate by (fromClanId, tick, msgId).
+ */
+export interface IElderPeerInbox {
+  /**
+   * Send a whisper to another clan's Elder.
+   *
+   * @param toClanId - recipient clan ID (determines which inbox file / AXL channel to write)
+   * @param message  - free-text message content (≤ 500 chars recommended for AXL compat)
+   * @param tick     - current game tick (used for ordering and deduplication)
+   */
+  send(toClanId: string, message: string, tick: number): Promise<void>;
+
+  /**
+   * Read all unread messages in this Elder's own inbox.
+   *
+   * Contract:
+   * - Returns messages in arrival order.
+   * - Does NOT consume/delete messages — same messages returned on next call.
+   *   (Stateful consumption is the Elder's responsibility via memory store.)
+   * - Must not throw if inbox is empty or does not yet exist.
+   */
+  inbox(): Promise<PeerMessage[]>;
+}
+
+export interface PeerMessage {
+  fromClanId: string;
+  toClanId: string;
+  message: string;
+  tick: number;
+  /** ISO 8601 timestamp of when the message was sent. */
+  sentAt: string;
+}

--- a/packages/agents/src/seams/IHeartbeatCaller.ts
+++ b/packages/agents/src/seams/IHeartbeatCaller.ts
@@ -1,0 +1,43 @@
+/**
+ * IHeartbeatCaller — caller of ClanWorld.heartbeat() on-chain.
+ *
+ * S2 bootstrap: runner-side `cast send` (or viem writeContract) using a dedicated runner wallet.
+ *   The runner calls heartbeat() after each Elder settle window (default 90s).
+ * Phase 6: KeeperHub workflow fires heartbeat() automatically; runner stops calling it
+ *   and instead consumes the resulting /keeperHubHeartbeat webhook via Convex.
+ *
+ * Contract:
+ * - Caller must be permissionless: anyone may call heartbeat(); the contract self-rate-limits.
+ * - callHeartbeat() must wait for tx confirmation before resolving (not fire-and-forget).
+ * - If the chain rejects because the rate limit hasn't elapsed, implementations must
+ *   surface HeartbeatRateLimitedError, not a generic Error, so the runner can back off.
+ * - Implementations must NOT use the same wallet as any Elder (Elder wallets sign clan orders;
+ *   mixing nonces causes order submission failures).
+ */
+export interface IHeartbeatCaller {
+  /**
+   * Call ClanWorld.heartbeat() and wait for confirmation.
+   *
+   * @returns confirmed tx hash on success
+   * @throws HeartbeatRateLimitedError if the on-chain rate limit has not elapsed
+   * @throws Error on other chain/network failures
+   */
+  callHeartbeat(): Promise<{ txHash: string }>;
+
+  /**
+   * Check whether the rate limit window has elapsed without submitting a tx.
+   * Used by the runner to decide whether to attempt a heartbeat call.
+   */
+  isHeartbeatDue(): Promise<boolean>;
+}
+
+/** Thrown when heartbeat() is called before nextHeartbeatAtTs has elapsed. */
+export class HeartbeatRateLimitedError extends Error {
+  constructor(
+    /** Unix seconds when the next heartbeat will be accepted. */
+    public readonly nextAllowedAt: number,
+  ) {
+    super(`heartbeat rate-limited: next allowed at ${new Date(nextAllowedAt * 1000).toISOString()}`);
+    this.name = 'HeartbeatRateLimitedError';
+  }
+}

--- a/packages/agents/src/seams/IRunnerInbox.ts
+++ b/packages/agents/src/seams/IRunnerInbox.ts
@@ -1,0 +1,43 @@
+/**
+ * IRunnerInbox — contract between the runner daemon and each Elder session.
+ *
+ * The runner pushes per-tick situation blocks into the Elder's tmux session;
+ * the Elder acknowledges consolidation readiness before a context reset.
+ * Implementations must be idempotent: delivering the same situation block
+ * twice for the same tick must not cause duplicate processing.
+ */
+export interface IRunnerInbox {
+  /**
+   * Deliver a per-tick situation block to the Elder.
+   *
+   * The block is a free-text summary of world state, clan state, recent events,
+   * and peer messages, composed by the runner from Convex data.
+   *
+   * Contract:
+   * - Must complete (resolve or reject) within the runner's per-Elder delivery timeout.
+   * - Must not throw on transient Elder session unavailability — surface via returned status.
+   * - Idempotent: re-delivering tick N's block while the Elder is still processing tick N
+   *   must be a no-op (same tick, same block = skip).
+   */
+  deliverSituationBlock(tick: number, block: string): Promise<DeliveryStatus>;
+
+  /**
+   * Wait for the Elder's ack-clear signal, then trigger a context reset.
+   *
+   * Flow:
+   * 1. Runner sends final-tick warning to Elder.
+   * 2. Runner calls waitForAckAndClear(timeout).
+   * 3. If Elder calls `elder ack-clear` within timeout: runner issues /clear then bootstraps.
+   * 4. If timeout elapses with no ack: runner issues /clear anyway (Elder loses the turn's reasoning).
+   *
+   * Contract:
+   * - timeoutMs is the maximum wait; implementations must not block beyond it.
+   * - Returns 'ack' if Elder acknowledged, 'timeout' if not.
+   * - Must never deadlock the tick loop.
+   */
+  waitForAckAndClear(timeoutMs: number): Promise<'ack' | 'timeout'>;
+}
+
+export type DeliveryStatus =
+  | { ok: true }
+  | { ok: false; reason: 'session-down' | 'timeout' | 'duplicate-tick' };

--- a/packages/agents/src/seams/index.ts
+++ b/packages/agents/src/seams/index.ts
@@ -1,0 +1,5 @@
+export type { IRunnerInbox, DeliveryStatus } from './IRunnerInbox';
+export type { IElderMemoryStore } from './IElderMemoryStore';
+export type { IElderPeerInbox, PeerMessage } from './IElderPeerInbox';
+export type { IHeartbeatCaller } from './IHeartbeatCaller';
+export { HeartbeatRateLimitedError } from './IHeartbeatCaller';


### PR DESCRIPTION
## Summary

Types-only PR — 4 integration seam interfaces for Phase 6/7/8 sponsor adapters. No runtime imports. No implementations.

### Interfaces

| Interface | S2 stub | Future impl |
|---|---|---|
| `IRunnerInbox` | tmux session delivery + ack-clear handshake | — (runner-internal) |
| `IElderMemoryStore` | local JSON file `~/.world/clanworld-runner/state/elder-{N}-memory.json` | Phase 7: 0G iNFT memory (ERC-7857 linked storage per clan) |
| `IElderPeerInbox` | file-based JSONL at `~/.world/clanworld-runner/state/peer-inbox/elder-{recipientClanId}.jsonl` | Phase 8: Gensyn AXL private messaging transport |
| `IHeartbeatCaller` | runner-side `cast send` / viem `writeContract` with dedicated runner wallet | Phase 6: KeeperHub workflow fires heartbeat automatically |

### Error class

`HeartbeatRateLimitedError extends Error` — only runtime export; surfaces on-chain rate limit so runner can back off cleanly without catching generic `Error`.

### Export discipline

- All interface/type exports: `export type { ... }` (erased at compile time)
- `HeartbeatRateLimitedError`: `export { ... }` (has runtime value as a class)

Closes #89