### PR TITLE
feat(runner): ClanWorld runner daemon prototype (Stream B Step 2)

### DIFF
--- a/packages/runner/.env.example
+++ b/packages/runner/.env.example
@@ -1,0 +1,33 @@
+# ClanWorld runner daemon — environment template.
+# Copy to ~/.config/clanworld-runner/runner.env (chmod 600), fill in real values.
+# The daemon does NOT load this file at runtime; it reads only process.env.
+
+# REQUIRED — dedicated runner wallet (NEVER reuse an Elder wallet).
+# 64-hex-char private key, 0x prefix optional.
+RUNNER_PRIVATE_KEY=
+
+# REQUIRED — deployed ClanWorld contract address on World Chain Sepolia.
+CLAN_WORLD_CONTRACT_ADDRESS=0xC012275376b867944cd874FB2d600d6dA3B4A56e
+
+# REQUIRED for non-stub operation. If unset, the runner uses StubConvexClient
+# and the tick loop will idle (snapshot.tick = 0).
+CONVEX_URL=
+
+# Optional — defaults to https://worldchain-sepolia.g.alchemy.com/public
+CHAIN_RPC_URL=
+
+# Optional tunables (defaults shown).
+RUNNER_POLL_INTERVAL_MS=5000
+RUNNER_SETTLE_WINDOW_SEC=90
+RUNNER_DELIVERY_TIMEOUT_MS=10000
+RUNNER_ACK_TIMEOUT_MS=30000
+RUNNER_TMUX_SESSION_PREFIX=elder
+
+# Optional — Elder-to-clan-id mapping. Defaults to 1→"1" ... 4→"4".
+ELDER_1_CLAN_ID=1
+ELDER_2_CLAN_ID=2
+ELDER_3_CLAN_ID=3
+ELDER_4_CLAN_ID=4
+
+# Optional — override state dir. Defaults to ~/.world/clanworld-runner/state
+# CLAN_WORLD_RUNNER_STATE_DIR=

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -1,0 +1,104 @@
+# @clan-world/runner
+
+ClanWorld runner daemon — drives 4 Elder Claude Code sessions through the
+per-tick reasoning loop.
+
+## What it does
+
+```
+loop:
+  chainTick = pollChainTick(convex)
+  if chainTick > lastProcessedTick:
+    parallel for elder in 1..4:
+      block = composeSituationBlock(elder, chainTick, ...)
+      tmux send-keys -t elder-N -l "$block" + Enter
+    settle window (~90s) — Elders read, reason, submit orders
+    heartbeat() on-chain (rate-limit aware)
+    lastProcessedTick = chainTick
+  sleep pollInterval
+```
+
+The runner is the **only** writer of situation blocks into Elder sessions. It
+satisfies four seam interfaces from `@clan-world/agents/src/seams`:
+
+| Seam                  | Impl                       | Notes                                              |
+| --------------------- | -------------------------- | -------------------------------------------------- |
+| `IRunnerInbox`        | `TmuxRunnerInbox`          | `tmux send-keys -l` + paste block + Enter         |
+| `IElderMemoryStore`   | `FileMemoryStore`          | `~/.world/clanworld-runner/state/elder-N-memory.json` |
+| `IElderPeerInbox`     | `FilePeerInbox`            | JSONL per recipient clan                          |
+| `IHeartbeatCaller`    | `RunnerCastHeartbeat`      | viem `writeContract`, dedicated runner wallet     |
+
+## Run it
+
+```bash
+# 1. Provision a fresh runner wallet (NEVER reuse an Elder key) and fund it
+#    with World Chain Sepolia ETH.
+export RUNNER_PRIVATE_KEY=0x...
+export CLAN_WORLD_CONTRACT_ADDRESS=0xC012275376b867944cd874FB2d600d6dA3B4A56e
+export CONVEX_URL=https://...convex.cloud   # optional; runner idles without it
+
+# 2. Make sure 4 tmux sessions exist with Elder Claude Code already attached:
+#    elder-1, elder-2, elder-3, elder-4
+
+# 3. Start the daemon:
+pnpm --filter @clan-world/runner start
+```
+
+## Env vars
+
+See [`.env.example`](./.env.example). All vars are read from `process.env`
+at startup — the daemon does **not** auto-load any `.env` file.
+
+## State directory
+
+Default: `~/.world/clanworld-runner/state/`. Layout:
+
+```
+elder-1-memory.json          ← FileMemoryStore
+elder-2-memory.json
+elder-3-memory.json
+elder-4-memory.json
+
+elder-1-last-tick.txt        ← TmuxRunnerInbox idempotency marker
+elder-2-last-tick.txt
+…
+
+elder-1-ack.flag             ← Set by `elder ack-clear` from Elder side
+…
+
+peer-inbox/
+  elder-1.jsonl              ← FilePeerInbox; one file per recipient clan
+  elder-2.jsonl
+  …
+```
+
+## Stub mode
+
+- If `CONVEX_URL` is unset, `createConvexClient()` hands back a stub returning
+  `{ tick: 0, ... }`. The tick loop interprets this as "no real chain state"
+  and idles (logs a warning at boot).
+- If `RUNNER_PRIVATE_KEY` is missing, the daemon refuses to start.
+
+## systemd
+
+Template unit file: [`clanworld-runner.service`](./clanworld-runner.service).
+Install with:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp packages/runner/clanworld-runner.service ~/.config/systemd/user/
+mkdir -p ~/.config/clanworld-runner
+cp packages/runner/.env.example ~/.config/clanworld-runner/runner.env
+chmod 600 ~/.config/clanworld-runner/runner.env
+# edit runner.env, then:
+systemctl --user daemon-reload
+systemctl --user enable --now clanworld-runner.service
+```
+
+## Known TODOs
+
+- `pollChainTick` reads the full snapshot — switch to a dedicated
+  `getCurrentTick` Convex query once it exists.
+- Heartbeat rate-limit detection re-reads `getWorldState()` after a revert.
+  When a typed `HeartbeatTooSoon` custom error lands in the contract ABI,
+  upgrade `RunnerCastHeartbeat.callHeartbeat` to decode it directly.

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -19,7 +19,7 @@ loop:
 ```
 
 The runner is the **only** writer of situation blocks into Elder sessions. It
-satisfies four seam interfaces from `@clan-world/agents/src/seams`:
+satisfies four seam interfaces from `@clan-world/agents/seams`:
 
 | Seam                  | Impl                       | Notes                                              |
 | --------------------- | -------------------------- | -------------------------------------------------- |

--- a/packages/runner/clanworld-runner.service
+++ b/packages/runner/clanworld-runner.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=ClanWorld Runner Daemon (per-tick Elder orchestrator)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Adjust these paths to the deployed checkout location.
+WorkingDirectory=%h/code/clan-world
+ExecStart=/usr/bin/env pnpm --filter @clan-world/runner start
+Restart=on-failure
+RestartSec=10s
+# Read env vars from this file (chmod 600). Required:
+#   RUNNER_PRIVATE_KEY
+#   CLAN_WORLD_CONTRACT_ADDRESS
+#   CONVEX_URL
+# Optional:
+#   CHAIN_RPC_URL, RUNNER_POLL_INTERVAL_MS, RUNNER_SETTLE_WINDOW_SEC,
+#   RUNNER_TMUX_SESSION_PREFIX, ELDER_<N>_CLAN_ID
+EnvironmentFile=%h/.config/clanworld-runner/runner.env
+
+# Soft journal output — keep stdout/stderr in journal, no file rotation needed.
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/packages/runner/clanworld-runner.service
+++ b/packages/runner/clanworld-runner.service
@@ -10,11 +10,12 @@ WorkingDirectory=%h/code/clan-world
 ExecStart=/usr/bin/env pnpm --filter @clan-world/runner start
 Restart=on-failure
 RestartSec=10s
-# Read env vars from this file (chmod 600). Required:
+# Read env vars from this file (chmod 600).
+# Required:
 #   RUNNER_PRIVATE_KEY
 #   CLAN_WORLD_CONTRACT_ADDRESS
-#   CONVEX_URL
 # Optional:
+#   CONVEX_URL (omit to run in stub/idle mode)
 #   CHAIN_RPC_URL, RUNNER_POLL_INTERVAL_MS, RUNNER_SETTLE_WINDOW_SEC,
 #   RUNNER_TMUX_SESSION_PREFIX, ELDER_<N>_CLAN_ID
 EnvironmentFile=%h/.config/clanworld-runner/runner.env

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,16 +1,12 @@
 {
-  "name": "@clan-world/agents",
+  "name": "@clan-world/runner",
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "exports": {
-    "./seams": "./src/seams/index.ts"
-  },
-  "bin": {
-    "elder": "./bin/elder"
-  },
+  "main": "./src/main.ts",
   "scripts": {
-    "dev": "tsx watch src/cli.ts",
+    "dev": "tsx watch src/main.ts",
+    "start": "tsx src/main.ts",
     "build": "echo 'uses tsx at runtime; no emit build needed'",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
@@ -18,8 +14,10 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@clan-world/agents": "workspace:*",
     "@clan-world/shared": "workspace:*",
-    "tsx": "4.19.2"
+    "tsx": "4.19.2",
+    "viem": "^2.48.4"
   },
   "devDependencies": {
     "@types/node": "25.6.0",

--- a/packages/runner/src/composeSituationBlock.ts
+++ b/packages/runner/src/composeSituationBlock.ts
@@ -1,0 +1,124 @@
+import type { IConvexClient } from '@clan-world/shared/adapters';
+import type { IElderMemoryStore, IElderPeerInbox } from '@clan-world/agents/seams';
+import type { ElderId } from './types';
+
+export interface ComposeDeps {
+  convex: IConvexClient;
+  memory: IElderMemoryStore;
+  peerInbox: IElderPeerInbox;
+}
+
+export interface ComposeArgs {
+  elder: ElderId;
+  clanId: string;
+  tick: number;
+}
+
+/**
+ * Compose the per-tick situation block for a single Elder.
+ *
+ * Block sections (in order — Elder prompts depend on this ordering):
+ *
+ *   1. Identity reminder      — "You are Elder N of Clan X"
+ *   2. Tick state             — current tick + tick-epoch info
+ *   3. World snapshot summary — leaderboard-relevant slice
+ *   4. Clan view              — clan's own resources, regions, pending orders
+ *   5. Peer messages          — whispers in this Elder's inbox
+ *   6. Memory continuity      — keys saved last reasoning cycle
+ *
+ * Format is plain text (Markdown headings) so it pastes legibly into a Claude
+ * Code session. We deliberately do NOT include Convex internal IDs or other
+ * implementation noise — only fields the Elder needs to reason.
+ */
+export async function composeSituationBlock(
+  args: ComposeArgs,
+  deps: ComposeDeps,
+): Promise<string> {
+  const [snap, view, peers, memory] = await Promise.all([
+    deps.convex.getSnapshot(),
+    deps.convex.getClanFullView(args.clanId),
+    deps.peerInbox.inbox(),
+    deps.memory.snapshot(),
+  ]);
+
+  const lines: string[] = [];
+  lines.push(`# Tick ${args.tick} — Elder ${args.elder} (Clan ${args.clanId})`);
+  lines.push('');
+
+  lines.push('## Identity');
+  lines.push(
+    `You are Elder ${args.elder}, ruling Clan ${args.clanId}. You reason once per tick and ` +
+      `submit clan orders via the \`elder clan submit-orders\` CLI before the tick closes.`,
+  );
+  lines.push('');
+
+  lines.push('## Tick state');
+  lines.push(`- current tick: ${args.tick}`);
+  lines.push(`- tick started at (unix s): ${snap.tickEpoch.startedAt}`);
+  lines.push(`- tick duration: ${snap.tickEpoch.durationMs}ms`);
+  lines.push('');
+
+  lines.push('## World snapshot');
+  if (snap.regions.length === 0 && snap.clans.length === 0) {
+    lines.push('- (no world data yet — Convex stub or pre-genesis)');
+  } else {
+    lines.push(`- regions: ${snap.regions.length}`);
+    lines.push(`- clans: ${snap.clans.length}`);
+    for (const clan of snap.clans) {
+      lines.push(`  - ${clan.id} (${clan.name}) — treasury: ${clan.treasury}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Your clan');
+  lines.push(`- id: ${view.clan.id}`);
+  lines.push(`- name: ${view.clan.name}`);
+  lines.push(`- treasury: ${view.clan.treasury}`);
+  lines.push(`- controlled regions: ${view.controlledRegions.length}`);
+  for (const r of view.controlledRegions) {
+    lines.push(`  - ${r.id} (${r.name})`);
+  }
+  lines.push(`- pending orders for next tick: ${view.pendingOrders.length}`);
+  for (const o of view.pendingOrders) {
+    lines.push(`  - ${o.kind}: ${JSON.stringify(o.payload)}`);
+  }
+  lines.push('');
+
+  lines.push('## Peer messages (whispers)');
+  if (peers.length === 0) {
+    lines.push('- (none)');
+  } else {
+    for (const p of peers) {
+      lines.push(`- [${p.sentAt}] from clan ${p.fromClanId} (tick ${p.tick}): ${p.message}`);
+    }
+  }
+  // Whispers visible via the convex-side feed (public/region-broadcast variant).
+  if (view.whispers.length > 0) {
+    lines.push('');
+    lines.push('## Public whispers (region/world feed)');
+    for (const w of view.whispers) {
+      lines.push(`- tick ${w.tick} from clan ${w.fromClanId} → ${w.toClanId}: ${w.text}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Memory (continuity)');
+  const memKeys = Object.keys(memory).sort();
+  if (memKeys.length === 0) {
+    lines.push('- (empty — first tick, or post-clear bootstrap)');
+  } else {
+    for (const k of memKeys) {
+      lines.push(`- ${k}: ${memory[k]}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Action');
+  lines.push(
+    'Reason about your clan\'s next move. Use `elder peer whisper`, `elder memory save`, and ' +
+      '`elder clan submit-orders` to act. The runner will heartbeat the chain after the settle ' +
+      'window — get your orders in before then.',
+  );
+
+  return lines.join('\n');
+}

--- a/packages/runner/src/fileMemoryStore.ts
+++ b/packages/runner/src/fileMemoryStore.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { IElderMemoryStore } from '@clan-world/agents/seams';
+import type { ElderId } from './types';
+
+/**
+ * S2 stub of `IElderMemoryStore` backed by a per-Elder JSON file.
+ *
+ * File: `${stateDir}/elder-{N}-memory.json`
+ *
+ * Single-writer assumption: only ONE process should hold a `FileMemoryStore`
+ * for a given Elder at a time. The runner satisfies this naturally — there is
+ * a single daemon. The Elder CLI (`elder memory save/recall`) reads + writes
+ * the same file but is invoked synchronously from inside the Elder's tmux
+ * session, so writes do not race the runner's writes.
+ */
+export class FileMemoryStore implements IElderMemoryStore {
+  private readonly file: string;
+
+  constructor(elder: ElderId, stateDir: string) {
+    this.file = path.join(stateDir, `elder-${elder}-memory.json`);
+  }
+
+  async recall(key: string): Promise<string | undefined> {
+    const data = this.read();
+    return data[key];
+  }
+
+  async save(key: string, value: string): Promise<void> {
+    const data = this.read();
+    data[key] = value;
+    this.write(data);
+  }
+
+  async snapshot(): Promise<Record<string, string>> {
+    return this.read();
+  }
+
+  private read(): Record<string, string> {
+    if (!fs.existsSync(this.file)) return {};
+    try {
+      const raw = fs.readFileSync(this.file, 'utf8');
+      return JSON.parse(raw) as Record<string, string>;
+    } catch {
+      // Corrupt file: treat as empty so the Elder can recover. We deliberately
+      // swallow the parse error here — a corrupt memory file should not crash
+      // the tick loop. The next `save()` will overwrite with a valid JSON doc.
+      return {};
+    }
+  }
+
+  private write(data: Record<string, string>): void {
+    fs.mkdirSync(path.dirname(this.file), { recursive: true });
+    // Write to a temp file then rename for atomic durability.
+    const tmp = `${this.file}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', 'utf8');
+    fs.renameSync(tmp, this.file);
+  }
+}

--- a/packages/runner/src/filePeerInbox.ts
+++ b/packages/runner/src/filePeerInbox.ts
@@ -1,12 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { IElderPeerInbox, PeerMessage } from '@clan-world/agents/seams';
-import type { ElderId } from './types';
+import { ELDER_IDS, type ElderId } from './types';
 
 /**
  * S2 stub of `IElderPeerInbox` backed by per-recipient JSONL files.
  *
- * File layout: `${stateDir}/peer-inbox/elder-{recipientClanId}.jsonl`
+ * File layout: `${stateDir}/peer-inbox/elder-{recipient}.jsonl`
  *
  * Each line is a JSON-encoded `PeerMessage`. Append-only; consumption is the
  * Elder's responsibility (it tracks last-read offset in its own memory store).
@@ -23,26 +23,24 @@ import type { ElderId } from './types';
  * This S2 stub does NOT dedup — `send()` always appends. Callers that need
  * exactly-once must dedup at the consumer side, or wrap this in a dedup layer.
  *
- * Routing note: writes go to `peer-inbox/elder-${recipientClanId}.jsonl`,
- * keyed by clan id. This matches the Elder CLI's `peer whisper` writer
- * (`recipientInboxFile(clanId)`). The CLI's `peer inbox` READER, however,
- * keys by ELDER_N (1..4) via `inboxFile(n)` — so for the on-disk layout to
- * round-trip cleanly, clanId must equal `String(elderId)` for each Elder.
- * The default `ELDER_N_CLAN_ID` env mapping satisfies this; custom mappings
- * will desync the runner writer from the CLI reader. See PR #90 follow-up.
+ * Routing note: reads use `ELDER_N`, matching the CLI's `peer inbox` reader
+ * (`inboxFile(n)`). Writes resolve recipient clan ids through `ELDER_{N}_CLAN_ID`
+ * env mappings when present, so non-default mappings still land on the same
+ * elder-N inbox key.
  */
 export class FilePeerInbox implements IElderPeerInbox {
   private readonly inboxDir: string;
   private readonly ownClanId: string;
+  private readonly elderN: string;
 
   constructor(elder: ElderId, ownClanId: string, stateDir: string) {
-    void elder;
     this.inboxDir = path.join(stateDir, 'peer-inbox');
     this.ownClanId = ownClanId;
+    this.elderN = process.env['ELDER_N'] ?? String(elder);
   }
 
   async send(toClanId: string, message: string, tick: number): Promise<void> {
-    const file = path.join(this.inboxDir, `elder-${toClanId}.jsonl`);
+    const file = path.join(this.inboxDir, `elder-${inboxKeyForClanId(toClanId)}.jsonl`);
     fs.mkdirSync(path.dirname(file), { recursive: true });
     // CLI uses `from: <Elder N>` (number); the seam uses `fromClanId: string`.
     // We write BOTH so either reader can parse — see `read()` below.
@@ -63,7 +61,7 @@ export class FilePeerInbox implements IElderPeerInbox {
   }
 
   async inbox(): Promise<PeerMessage[]> {
-    const file = path.join(this.inboxDir, `elder-${this.ownClanId}.jsonl`);
+    const file = path.join(this.inboxDir, `elder-${this.elderN}.jsonl`);
     if (!fs.existsSync(file)) return [];
     const lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
     const out: PeerMessage[] = [];
@@ -73,6 +71,14 @@ export class FilePeerInbox implements IElderPeerInbox {
     }
     return out;
   }
+}
+
+function inboxKeyForClanId(clanId: string, env: NodeJS.ProcessEnv = process.env): string {
+  for (const elder of ELDER_IDS) {
+    const mappedClanId = env[`ELDER_${elder}_CLAN_ID`] ?? String(elder);
+    if (mappedClanId === clanId) return String(elder);
+  }
+  return clanId;
 }
 
 interface CliShape {

--- a/packages/runner/src/filePeerInbox.ts
+++ b/packages/runner/src/filePeerInbox.ts
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { IElderPeerInbox, PeerMessage } from '@clan-world/agents/seams';
+import type { ElderId } from './types';
+
+/**
+ * S2 stub of `IElderPeerInbox` backed by per-recipient JSONL files.
+ *
+ * File layout: `${stateDir}/peer-inbox/elder-{recipientClanId}.jsonl`
+ *
+ * Each line is a JSON-encoded `PeerMessage`. Append-only; consumption is the
+ * Elder's responsibility (it tracks last-read offset in its own memory store).
+ *
+ * Wire format on disk MATCHES the format the Elder CLI's `peer whisper`
+ * command writes (see `packages/agents/src/cli.ts`):
+ *   {from: number, to: string, msg: string, ts: string}
+ * We translate to/from the seam's `PeerMessage` shape inside `parseLine()`
+ * (called from `inbox()`), so the runner-side and Elder-side writers stay
+ * file-compatible.
+ *
+ * Idempotency note: per the seam contract, dedup is OPTIONAL ("implementations
+ * that guarantee exactly-once must deduplicate by (fromClanId, tick, msgId)").
+ * This S2 stub does NOT dedup — `send()` always appends. Callers that need
+ * exactly-once must dedup at the consumer side, or wrap this in a dedup layer.
+ *
+ * Routing note: writes go to `peer-inbox/elder-${recipientClanId}.jsonl`,
+ * keyed by clan id. This matches the Elder CLI's `peer whisper` writer
+ * (`recipientInboxFile(clanId)`). The CLI's `peer inbox` READER, however,
+ * keys by ELDER_N (1..4) via `inboxFile(n)` — so for the on-disk layout to
+ * round-trip cleanly, clanId must equal `String(elderId)` for each Elder.
+ * The default `ELDER_N_CLAN_ID` env mapping satisfies this; custom mappings
+ * will desync the runner writer from the CLI reader. See PR #90 follow-up.
+ */
+export class FilePeerInbox implements IElderPeerInbox {
+  private readonly inboxDir: string;
+  private readonly ownClanId: string;
+
+  constructor(elder: ElderId, ownClanId: string, stateDir: string) {
+    void elder;
+    this.inboxDir = path.join(stateDir, 'peer-inbox');
+    this.ownClanId = ownClanId;
+  }
+
+  async send(toClanId: string, message: string, tick: number): Promise<void> {
+    const file = path.join(this.inboxDir, `elder-${toClanId}.jsonl`);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    // CLI uses `from: <Elder N>` (number); the seam uses `fromClanId: string`.
+    // We write BOTH so either reader can parse — see `read()` below.
+    const sentAt = new Date().toISOString();
+    const entry = {
+      fromClanId: this.ownClanId,
+      toClanId,
+      message,
+      tick,
+      sentAt,
+      // Back-compat with the Elder CLI inbox-list formatter:
+      from: this.ownClanId,
+      to: toClanId,
+      msg: message,
+      ts: sentAt,
+    };
+    fs.appendFileSync(file, JSON.stringify(entry) + '\n', 'utf8');
+  }
+
+  async inbox(): Promise<PeerMessage[]> {
+    const file = path.join(this.inboxDir, `elder-${this.ownClanId}.jsonl`);
+    if (!fs.existsSync(file)) return [];
+    const lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+    const out: PeerMessage[] = [];
+    for (const line of lines) {
+      const parsed = parseLine(line, this.ownClanId);
+      if (parsed) out.push(parsed);
+    }
+    return out;
+  }
+}
+
+interface CliShape {
+  from?: number | string;
+  to?: string;
+  msg?: string;
+  ts?: string;
+}
+interface SeamShape {
+  fromClanId?: string;
+  toClanId?: string;
+  message?: string;
+  tick?: number;
+  sentAt?: string;
+}
+
+function parseLine(line: string, ownClanId: string): PeerMessage | undefined {
+  let raw: CliShape & SeamShape;
+  try {
+    raw = JSON.parse(line) as CliShape & SeamShape;
+  } catch {
+    return undefined;
+  }
+  const fromClanId = raw.fromClanId ?? (raw.from !== undefined ? String(raw.from) : undefined);
+  const toClanId = raw.toClanId ?? raw.to ?? ownClanId;
+  const message = raw.message ?? raw.msg;
+  const sentAt = raw.sentAt ?? raw.ts;
+  if (!fromClanId || !message || !sentAt) return undefined;
+  return {
+    fromClanId,
+    toClanId,
+    message,
+    tick: raw.tick ?? 0,
+    sentAt,
+  };
+}

--- a/packages/runner/src/main.ts
+++ b/packages/runner/src/main.ts
@@ -1,0 +1,137 @@
+import os from 'node:os';
+import path from 'node:path';
+import { createConvexClient } from '@clan-world/shared/adapters';
+import { FileMemoryStore } from './fileMemoryStore';
+import { FilePeerInbox } from './filePeerInbox';
+import { configFromEnv, RunnerCastHeartbeat } from './runnerCastHeartbeat';
+import { tickLoop, type PerElderDeps } from './tickLoop';
+import { TmuxRunnerInbox } from './tmuxRunnerInbox';
+import { ELDER_IDS, type ElderId, type RunnerConfig } from './types';
+
+/**
+ * Default state directory. Matches the layout the Elder CLI reads/writes
+ * (`packages/agents/src/cli.ts::stateDir`).
+ */
+function defaultStateDir(): string {
+  return path.join(os.homedir(), '.world', 'clanworld-runner', 'state');
+}
+
+/**
+ * Bootstrap block sent immediately after `/clear` so the freshly reset Elder
+ * session knows who it is. The runner sends a full situation block on the
+ * next tick — this is just the "you are Elder N, clan X, await tick" preamble.
+ */
+function bootstrapBlock(elder: ElderId, clanId: string): string {
+  return [
+    `# Bootstrap — Elder ${elder} (Clan ${clanId})`,
+    '',
+    `You are Elder ${elder} of Clan ${clanId} in ClanWorld. Your context was just reset.`,
+    'A full situation block will arrive on the next tick. Until then, you can use the `elder` CLI to:',
+    '- `elder world snapshot`             — read current world state',
+    `- \`elder clan view ${clanId}\`     — read your clan's state`,
+    '- `elder memory recall <key>`        — restore continuity from prior cycles',
+    '- `elder peer inbox`                  — read whispers',
+    '',
+    'Wait for the next tick.',
+  ].join('\n');
+}
+
+function loadConfig(env: NodeJS.ProcessEnv = process.env): RunnerConfig {
+  const stateDir = env['CLAN_WORLD_RUNNER_STATE_DIR'] ?? defaultStateDir();
+  const pollIntervalMs = parseIntEnv(env, 'RUNNER_POLL_INTERVAL_MS', 5_000);
+  const settleWindowSec = parseIntEnv(env, 'RUNNER_SETTLE_WINDOW_SEC', 90);
+  const deliveryTimeoutMs = parseIntEnv(env, 'RUNNER_DELIVERY_TIMEOUT_MS', 10_000);
+  const ackTimeoutMs = parseIntEnv(env, 'RUNNER_ACK_TIMEOUT_MS', 30_000);
+  const tmuxSessionPrefix = env['RUNNER_TMUX_SESSION_PREFIX'] ?? 'elder';
+  const elderToClanId: Record<ElderId, string> = {
+    1: env['ELDER_1_CLAN_ID'] ?? '1',
+    2: env['ELDER_2_CLAN_ID'] ?? '2',
+    3: env['ELDER_3_CLAN_ID'] ?? '3',
+    4: env['ELDER_4_CLAN_ID'] ?? '4',
+  };
+  return {
+    pollIntervalMs,
+    settleWindowSec,
+    deliveryTimeoutMs,
+    ackTimeoutMs,
+    stateDir,
+    tmuxSessionPrefix,
+    elderToClanId,
+  };
+}
+
+function parseIntEnv(env: NodeJS.ProcessEnv, key: string, fallback: number): number {
+  const v = env[key];
+  if (!v) return fallback;
+  const n = parseInt(v, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`${key} must be a positive integer; got '${v}'`);
+  }
+  return n;
+}
+
+async function main(): Promise<void> {
+  console.log(`[runner] starting ClanWorld runner daemon at ${new Date().toISOString()}`);
+
+  const config = loadConfig();
+  console.log('[runner] config:', {
+    stateDir: config.stateDir,
+    pollIntervalMs: config.pollIntervalMs,
+    settleWindowSec: config.settleWindowSec,
+    tmuxSessionPrefix: config.tmuxSessionPrefix,
+    elderToClanId: config.elderToClanId,
+  });
+
+  if (!process.env['CONVEX_URL']) {
+    console.warn(
+      '[runner] CONVEX_URL is not set — using stub Convex client; tick poll will return 0 and the loop will idle. ' +
+        'Set CONVEX_URL once Convex is deployed to advance.',
+    );
+  }
+
+  const convex = createConvexClient();
+  const heartbeatCaller = new RunnerCastHeartbeat(configFromEnv());
+
+  const perElder = {} as Record<ElderId, PerElderDeps>;
+  for (const elder of ELDER_IDS) {
+    const clanId = config.elderToClanId[elder];
+    perElder[elder] = {
+      inbox: new TmuxRunnerInbox({
+        elder,
+        sessionPrefix: config.tmuxSessionPrefix,
+        stateDir: config.stateDir,
+        bootstrapBlock: bootstrapBlock(elder, clanId),
+      }),
+      memory: new FileMemoryStore(elder, config.stateDir),
+      peerInbox: new FilePeerInbox(elder, clanId, config.stateDir),
+    };
+  }
+
+  const abort = new AbortController();
+  let shuttingDown = false;
+  const onSignal = (sig: string): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`[runner] ${sig} received — shutting down cleanly`);
+    abort.abort();
+  };
+  process.on('SIGTERM', () => onSignal('SIGTERM'));
+  process.on('SIGINT', () => onSignal('SIGINT'));
+
+  try {
+    await tickLoop({
+      convex,
+      heartbeatCaller,
+      perElder,
+      config,
+      signal: abort.signal,
+    });
+  } finally {
+    console.log('[runner] tick loop exited');
+  }
+}
+
+main().catch(err => {
+  console.error('[runner] fatal:', err);
+  process.exit(1);
+});

--- a/packages/runner/src/main.ts
+++ b/packages/runner/src/main.ts
@@ -82,13 +82,6 @@ async function main(): Promise<void> {
     elderToClanId: config.elderToClanId,
   });
 
-  if (!process.env['CONVEX_URL']) {
-    console.warn(
-      '[runner] CONVEX_URL is not set — using stub Convex client; tick poll will return 0 and the loop will idle. ' +
-        'Set CONVEX_URL once Convex is deployed to advance.',
-    );
-  }
-
   const convex = createConvexClient();
   const heartbeatCaller = new RunnerCastHeartbeat(configFromEnv());
 

--- a/packages/runner/src/pollChainTick.ts
+++ b/packages/runner/src/pollChainTick.ts
@@ -1,0 +1,19 @@
+import type { IConvexClient } from '@clan-world/shared/adapters';
+
+/**
+ * Read the current tick from Convex.
+ *
+ * S2 stub behaviour: if Convex is unreachable / not deployed yet, the
+ * `IConvexClient` factory hands us a `StubConvexClient` that returns
+ * `{ tick: 0, ... }`. The tick loop interprets `0` as "no real chain state
+ * yet — keep polling". We log a one-shot warning at boot in `main.ts` when
+ * `CONVEX_URL` is missing so this state is observable.
+ *
+ * TODO(stream-B-step-3): once Convex is deployed and exposing
+ * `getCurrentTick`, wire this to a dedicated query rather than reading the
+ * full snapshot — cheaper on the public Convex tier.
+ */
+export async function pollChainTick(convex: IConvexClient): Promise<number> {
+  const snap = await convex.getSnapshot();
+  return snap.tick;
+}

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -1,4 +1,5 @@
 import {
+  ContractFunctionRevertedError,
   createPublicClient,
   createWalletClient,
   defineChain,
@@ -143,10 +144,9 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     } catch (err) {
       // Already a rate-limit error — rethrow immediately; no second RPC read.
       if (err instanceof HeartbeatRateLimitedError) throw err;
-      // Attempt to upgrade a simulation-level revert to HeartbeatRateLimitedError.
-      // TODO(phase-2): narrow this to ContractFunctionRevertedError only so
-      // pre-flight errors (insufficient funds, bad nonce, RPC failures) are not
-      // silently classified as rate-limit back-offs.
+      // Attempt to upgrade only simulation-level contract reverts to
+      // HeartbeatRateLimitedError; pre-flight/RPC errors must surface unchanged.
+      if (!(err instanceof ContractFunctionRevertedError)) throw err;
       const next = await this.readNextHeartbeatAt().catch(() => undefined);
       if (next !== undefined && next > Math.floor(Date.now() / 1000)) {
         throw new HeartbeatRateLimitedError(next);

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -141,7 +141,12 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
       }
       return { txHash: hash };
     } catch (err) {
-      // Try to upgrade a generic revert to HeartbeatRateLimitedError.
+      // Already a rate-limit error — rethrow immediately; no second RPC read.
+      if (err instanceof HeartbeatRateLimitedError) throw err;
+      // Attempt to upgrade a simulation-level revert to HeartbeatRateLimitedError.
+      // TODO(phase-2): narrow this to ContractFunctionRevertedError only so
+      // pre-flight errors (insufficient funds, bad nonce, RPC failures) are not
+      // silently classified as rate-limit back-offs.
       const next = await this.readNextHeartbeatAt().catch(() => undefined);
       if (next !== undefined && next > Math.floor(Date.now() / 1000)) {
         throw new HeartbeatRateLimitedError(next);

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -1,0 +1,179 @@
+import {
+  createPublicClient,
+  createWalletClient,
+  defineChain,
+  http,
+  type Account,
+  type PublicClient,
+  type WalletClient,
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import {
+  HeartbeatRateLimitedError,
+  type IHeartbeatCaller,
+} from '@clan-world/agents/seams';
+
+/**
+ * Minimal ABI: only the `heartbeat()` write and the `nextHeartbeatAtTs` field
+ * we read out of `getWorldState()`. We avoid pulling in the full IClanWorld
+ * ABI here so the runner stays decoupled from contract-package versioning.
+ */
+const HEARTBEAT_ABI = [
+  {
+    type: 'function',
+    name: 'heartbeat',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'getWorldState',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        components: [
+          { name: 'currentTick', type: 'uint64' },
+          { name: 'seasonStartTick', type: 'uint64' },
+          { name: 'seasonEndTick', type: 'uint64' },
+          { name: 'seasonFinalized', type: 'bool' },
+          { name: 'nextHeartbeatAtTs', type: 'uint64' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+] as const;
+
+const worldChainSepolia = defineChain({
+  id: 4801,
+  name: 'World Chain Sepolia',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: { default: { http: ['https://worldchain-sepolia.g.alchemy.com/public'] } },
+});
+
+export interface RunnerHeartbeatConfig {
+  /** Hex-encoded 64-char private key, optionally 0x-prefixed. */
+  privateKey: string;
+  /** Override RPC URL; defaults to the World Chain Sepolia public endpoint. */
+  rpcUrl?: string;
+  /** ClanWorld contract address. */
+  contractAddress: `0x${string}`;
+}
+
+/**
+ * Reads `RUNNER_PRIVATE_KEY`, `CHAIN_RPC_URL`, `CLAN_WORLD_CONTRACT_ADDRESS`
+ * from env. Throws if `RUNNER_PRIVATE_KEY` is missing — the runner intentionally
+ * does not generate or store its own wallet; provisioning is operator-side.
+ */
+export function configFromEnv(env: NodeJS.ProcessEnv = process.env): RunnerHeartbeatConfig {
+  const pk = env['RUNNER_PRIVATE_KEY'];
+  if (!pk) {
+    throw new Error(
+      'RUNNER_PRIVATE_KEY is not set — the runner needs a dedicated wallet (NEVER reuse an Elder wallet). ' +
+        'Provision a fresh key, fund it with testnet ETH, and export RUNNER_PRIVATE_KEY before starting the daemon.',
+    );
+  }
+  const contractAddress = env['CLAN_WORLD_CONTRACT_ADDRESS'];
+  if (!contractAddress || !/^0x[0-9a-fA-F]{40}$/.test(contractAddress)) {
+    throw new Error(
+      `CLAN_WORLD_CONTRACT_ADDRESS missing or invalid; expected 0x-prefixed 40-hex-char address, got ${String(contractAddress)}`,
+    );
+  }
+  return {
+    privateKey: pk,
+    rpcUrl: env['CHAIN_RPC_URL'],
+    contractAddress: contractAddress as `0x${string}`,
+  };
+}
+
+/**
+ * Viem-backed `IHeartbeatCaller`. Wallet account is the dedicated runner key.
+ *
+ * Rate-limit detection: ClanWorld.heartbeat() reverts when called before
+ * `nextHeartbeatAtTs`. We don't have a typed custom error in the ABI, so on
+ * any revert we re-read `getWorldState().nextHeartbeatAtTs` and, if it is
+ * still in the future, throw `HeartbeatRateLimitedError(nextAllowedAt)`.
+ * Other reverts surface as the original error.
+ */
+export class RunnerCastHeartbeat implements IHeartbeatCaller {
+  private readonly publicClient: PublicClient;
+  private readonly walletClient: WalletClient;
+  private readonly account: Account;
+  private readonly contractAddress: `0x${string}`;
+
+  constructor(cfg: RunnerHeartbeatConfig) {
+    const pk = normalizePk(cfg.privateKey);
+    this.account = privateKeyToAccount(pk);
+    const transport = cfg.rpcUrl ? http(cfg.rpcUrl) : http();
+    this.publicClient = createPublicClient({ chain: worldChainSepolia, transport });
+    this.walletClient = createWalletClient({
+      account: this.account,
+      chain: worldChainSepolia,
+      transport,
+    });
+    this.contractAddress = cfg.contractAddress;
+  }
+
+  async callHeartbeat(): Promise<{ txHash: string }> {
+    try {
+      const hash = await this.walletClient.writeContract({
+        account: this.account,
+        chain: worldChainSepolia,
+        address: this.contractAddress,
+        abi: HEARTBEAT_ABI,
+        functionName: 'heartbeat',
+        args: [],
+      });
+      // Wait for confirmation per the seam contract ("not fire-and-forget").
+      const receipt = await this.publicClient.waitForTransactionReceipt({ hash });
+      if (receipt.status !== 'success') {
+        // Mined-but-reverted. Most common cause is the rate-limit window
+        // hadn't elapsed yet (when simulation succeeded but execution didn't).
+        // Re-read state to upgrade to HeartbeatRateLimitedError when applicable.
+        const next = await this.readNextHeartbeatAt().catch(() => undefined);
+        if (next !== undefined && next > Math.floor(Date.now() / 1000)) {
+          throw new HeartbeatRateLimitedError(next);
+        }
+        throw new Error(`heartbeat tx ${hash} reverted on-chain`);
+      }
+      return { txHash: hash };
+    } catch (err) {
+      // Try to upgrade a generic revert to HeartbeatRateLimitedError.
+      const next = await this.readNextHeartbeatAt().catch(() => undefined);
+      if (next !== undefined && next > Math.floor(Date.now() / 1000)) {
+        throw new HeartbeatRateLimitedError(next);
+      }
+      throw err;
+    }
+  }
+
+  async isHeartbeatDue(): Promise<boolean> {
+    const next = await this.readNextHeartbeatAt();
+    return next <= Math.floor(Date.now() / 1000);
+  }
+
+  private async readNextHeartbeatAt(): Promise<number> {
+    const state = await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: HEARTBEAT_ABI,
+      functionName: 'getWorldState',
+      args: [],
+    });
+    // viem decodes the named tuple into an object with the same field names.
+    return Number((state as { nextHeartbeatAtTs: bigint }).nextHeartbeatAtTs);
+  }
+}
+
+function normalizePk(pk: string): `0x${string}` {
+  const trimmed = pk.trim();
+  const withPrefix = trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`;
+  if (!/^0x[0-9a-fA-F]{64}$/.test(withPrefix)) {
+    throw new Error(
+      'RUNNER_PRIVATE_KEY is not a valid 64-hex-char private key (0x-prefixed optional)',
+    );
+  }
+  return withPrefix as `0x${string}`;
+}

--- a/packages/runner/src/settleWindow.ts
+++ b/packages/runner/src/settleWindow.ts
@@ -1,0 +1,32 @@
+/**
+ * Wait `ms` milliseconds before resolving — gives the Elders time to read
+ * the situation block, reason, and submit on-chain orders before the runner
+ * advances the chain via heartbeat().
+ *
+ * Default in `RunnerConfig` is 90s. Tests pass a small value via the same
+ * function so this is intentionally minimal — no shortcuts, no jitter.
+ *
+ * Returns early if `signal` is aborted; the tick loop uses this to react to
+ * SIGTERM mid-window without waiting the full settle period.
+ */
+export function settleWindow(ms: number, signal?: AbortSignal): Promise<'settled' | 'aborted'> {
+  return new Promise(resolve => {
+    if (signal?.aborted) {
+      resolve('aborted');
+      return;
+    }
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve('settled');
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      cleanup();
+      resolve('aborted');
+    };
+    signal?.addEventListener('abort', onAbort);
+    function cleanup(): void {
+      signal?.removeEventListener('abort', onAbort);
+    }
+  });
+}

--- a/packages/runner/src/tickLoop.ts
+++ b/packages/runner/src/tickLoop.ts
@@ -1,0 +1,190 @@
+import {
+  HeartbeatRateLimitedError,
+  type IElderMemoryStore,
+  type IElderPeerInbox,
+  type IHeartbeatCaller,
+  type IRunnerInbox,
+} from '@clan-world/agents/seams';
+import type { IConvexClient } from '@clan-world/shared/adapters';
+import { composeSituationBlock } from './composeSituationBlock';
+import { pollChainTick } from './pollChainTick';
+import { settleWindow } from './settleWindow';
+import { ELDER_IDS, type ElderId, type RunnerConfig } from './types';
+
+export interface PerElderDeps {
+  inbox: IRunnerInbox;
+  memory: IElderMemoryStore;
+  peerInbox: IElderPeerInbox;
+}
+
+export interface TickLoopDeps {
+  convex: IConvexClient;
+  heartbeatCaller: IHeartbeatCaller;
+  perElder: Record<ElderId, PerElderDeps>;
+  config: RunnerConfig;
+  /** AbortSignal for clean shutdown. */
+  signal: AbortSignal;
+  /** Logger — defaults to console. Tests pass a recorder. */
+  log?: Logger;
+}
+
+export interface Logger {
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+const consoleLogger: Logger = {
+  info: (...a) => console.log('[runner]', ...a),
+  warn: (...a) => console.warn('[runner]', ...a),
+  error: (...a) => console.error('[runner]', ...a),
+};
+
+/**
+ * Per-tick orchestration:
+ *
+ *   while !shuttingDown:
+ *     chainTick = pollChainTick(convex)
+ *     if chainTick > lastProcessedTick:
+ *       for each elder in parallel:
+ *         block  = composeSituationBlock(...)
+ *         status = inbox.deliverSituationBlock(chainTick, block)
+ *       wait settleWindow
+ *       try heartbeat() (inline rate-limit retry)
+ *       on success: lastProcessedTick = chainTick
+ *     sleep pollIntervalMs
+ *
+ * Returns when `signal` is aborted.
+ *
+ * Design notes:
+ *
+ * - `lastProcessedTick` is process-local. On runner restart we lose it and
+ *   may re-attempt a heartbeat for a tick that was already advanced. The
+ *   on-chain `nextHeartbeatAtTs` rate limit is the safety: a redundant
+ *   heartbeat reverts and surfaces as `HeartbeatRateLimitedError`, which we
+ *   back off on. Persisting `lastProcessedTick` to disk is a Phase-2 follow-up.
+ *
+ * - We heartbeat unconditionally after the settle window, even if all 4
+ *   Elder deliveries failed. This is intentional: the runner's job is to
+ *   advance the chain. Per the IRunnerInbox contract, an Elder that misses
+ *   delivery "loses the turn's reasoning" — the chain still advances.
+ *
+ * - On non-rate-limit heartbeat failure we break out of the inner retry and
+ *   fall through to the outer `pollIntervalMs` sleep. The next outer
+ *   iteration will see `chainTick > lastProcessedTick` again and retry
+ *   delivery + heartbeat. The `TmuxRunnerInbox` idempotency check makes the
+ *   re-deliver a no-op (returns 'duplicate-tick'); the cost is one extra
+ *   settle-window of latency before retry. Acceptable for prototype.
+ */
+export async function tickLoop(deps: TickLoopDeps): Promise<void> {
+  const log = deps.log ?? consoleLogger;
+  let lastProcessedTick = -1;
+
+  while (!deps.signal.aborted) {
+    let chainTick: number;
+    try {
+      chainTick = await pollChainTick(deps.convex);
+    } catch (err) {
+      log.error('pollChainTick failed:', err);
+      await sleepWithSignal(deps.config.pollIntervalMs, deps.signal);
+      continue;
+    }
+
+    if (chainTick > lastProcessedTick && chainTick > 0) {
+      log.info(`tick ${chainTick} observed (last processed: ${lastProcessedTick})`);
+
+      // Compose + deliver to all 4 Elders in parallel. Per-Elder errors are
+      // contained — one Elder being down must not block the others or the
+      // heartbeat that follows.
+      await Promise.all(
+        ELDER_IDS.map(async elder => {
+          const per = deps.perElder[elder];
+          try {
+            const block = await composeSituationBlock(
+              { elder, clanId: deps.config.elderToClanId[elder], tick: chainTick },
+              { convex: deps.convex, memory: per.memory, peerInbox: per.peerInbox },
+            );
+            const status = await withTimeout(
+              per.inbox.deliverSituationBlock(chainTick, block),
+              deps.config.deliveryTimeoutMs,
+              `deliverSituationBlock(elder=${elder}, tick=${chainTick})`,
+            );
+            if (!status.ok) {
+              log.warn(`elder ${elder}: delivery returned not-ok: ${status.reason}`);
+            }
+          } catch (err) {
+            log.error(`elder ${elder}: deliver/compose failed:`, err);
+          }
+        }),
+      );
+
+      // Settle: give Elders time to read + submit orders.
+      const settleResult = await settleWindow(deps.config.settleWindowSec * 1000, deps.signal);
+      if (settleResult === 'aborted') {
+        log.info('settle window aborted by shutdown signal');
+        break;
+      }
+
+      // Heartbeat the chain. Retry inline on rate-limit so we don't re-run
+      // the (90s) settle window or re-paste situation blocks just to hit the
+      // same rate-limit window again.
+      let heartbeatDone = false;
+      while (!heartbeatDone && !deps.signal.aborted) {
+        try {
+          const { txHash } = await deps.heartbeatCaller.callHeartbeat();
+          log.info(`heartbeat tx confirmed: ${txHash}`);
+          lastProcessedTick = chainTick;
+          heartbeatDone = true;
+        } catch (err) {
+          if (err instanceof HeartbeatRateLimitedError) {
+            const waitMs = Math.max(0, err.nextAllowedAt * 1000 - Date.now());
+            log.warn(
+              `heartbeat rate-limited; backing off ${Math.ceil(waitMs / 1000)}s until ${new Date(
+                err.nextAllowedAt * 1000,
+              ).toISOString()}`,
+            );
+            await sleepWithSignal(waitMs, deps.signal);
+            continue; // retry callHeartbeat
+          }
+          log.error('heartbeat failed (non-rate-limit):', err);
+          // Bail out of this tick; the next poll loop will pick it up again.
+          break;
+        }
+      }
+    }
+
+    await sleepWithSignal(deps.config.pollIntervalMs, deps.signal);
+  }
+}
+
+async function sleepWithSignal(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise<void>(resolve => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    };
+    signal.addEventListener('abort', onAbort);
+  });
+}
+
+async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timeout after ${ms}ms: ${label}`)), ms);
+  });
+  try {
+    return await Promise.race([p, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/runner/src/tmuxRunnerInbox.ts
+++ b/packages/runner/src/tmuxRunnerInbox.ts
@@ -1,0 +1,144 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { IRunnerInbox, DeliveryStatus } from '@clan-world/agents/seams';
+import type { ElderId } from './types';
+
+/**
+ * `IRunnerInbox` impl that pushes situation blocks into a tmux session via
+ * `tmux send-keys`.
+ *
+ * Idempotency contract (from `IRunnerInbox`):
+ *   Re-delivering tick N's block to the same Elder while tick N is still
+ *   in-flight must be a no-op. We persist the last-delivered tick to a small
+ *   per-Elder marker file so idempotency survives a runner restart mid-tick.
+ *
+ * Multi-line paste contract:
+ *   `tmux send-keys -l "$block"` sends the literal string (no key-name parsing)
+ *   so newlines, dollar signs, and quotes inside the block are preserved.
+ *   We then send a separate `Enter` keystroke to submit. This matches the
+ *   send-keys-paste-block pattern used by `~/bin/cc-send`.
+ */
+export class TmuxRunnerInbox implements IRunnerInbox {
+  private readonly target: string;
+  private readonly markerFile: string;
+  private readonly ackFlagFile: string;
+  private readonly bootstrapBlock: string;
+  private readonly runner: TmuxRunner;
+
+  constructor(opts: {
+    elder: ElderId;
+    sessionPrefix: string;
+    stateDir: string;
+    bootstrapBlock: string;
+    /** Override for tests — defaults to spawning real `tmux`. */
+    runner?: TmuxRunner;
+  }) {
+    this.target = `${opts.sessionPrefix}-${opts.elder}`;
+    this.markerFile = path.join(opts.stateDir, `elder-${opts.elder}-last-tick.txt`);
+    // The Elder CLI writes ack to `elder-{N}-ack.flag` (see packages/agents/src/cli.ts).
+    this.ackFlagFile = path.join(opts.stateDir, `elder-${opts.elder}-ack.flag`);
+    this.bootstrapBlock = opts.bootstrapBlock;
+    this.runner = opts.runner ?? defaultTmuxRunner;
+  }
+
+  async deliverSituationBlock(tick: number, block: string): Promise<DeliveryStatus> {
+    const last = readLastTick(this.markerFile);
+    if (last !== undefined && last >= tick) {
+      return { ok: false, reason: 'duplicate-tick' };
+    }
+    try {
+      await sendBlock(this.runner, this.target, block);
+      writeLastTick(this.markerFile, tick);
+      return { ok: true };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // tmux exits non-zero when the target session does not exist
+      // ("can't find session") — surface as session-down per the seam.
+      if (/can't find session|no server running|session not found/i.test(msg)) {
+        return { ok: false, reason: 'session-down' };
+      }
+      return { ok: false, reason: 'timeout' };
+    }
+  }
+
+  async waitForAckAndClear(timeoutMs: number): Promise<'ack' | 'timeout'> {
+    const result = await waitForFile(this.ackFlagFile, timeoutMs);
+    // Regardless of ack/timeout, perform /clear + bootstrap. The seam contract
+    // says "if timeout: runner issues /clear anyway (Elder loses the turn's
+    // reasoning)", so we always do the reset.
+    try {
+      await this.runner.send(this.target, ['/clear'], { literal: false });
+      // Send a small delay between /clear and the bootstrap by issuing them
+      // as two separate send-keys invocations — tmux processes them in order.
+      await sendBlock(this.runner, this.target, this.bootstrapBlock);
+    } catch {
+      // /clear failures are non-fatal — the next tick will try again.
+    }
+    if (result === 'found') {
+      // Consume the ack flag so the next final-tick warning starts fresh.
+      try {
+        fs.unlinkSync(this.ackFlagFile);
+      } catch {
+        /* already gone — fine */
+      }
+      return 'ack';
+    }
+    return 'timeout';
+  }
+}
+
+/**
+ * Tmux process abstraction so tests can swap in a recorder.
+ */
+export interface TmuxRunner {
+  send(target: string, keys: string[], opts: { literal: boolean }): Promise<void>;
+}
+
+export const defaultTmuxRunner: TmuxRunner = {
+  send(target, keys, opts) {
+    return new Promise((resolve, reject) => {
+      const args = ['send-keys', '-t', target];
+      if (opts.literal) args.push('-l');
+      args.push(...keys);
+      const child = spawn('tmux', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      let stderr = '';
+      child.stderr.on('data', chunk => {
+        stderr += String(chunk);
+      });
+      child.on('error', reject);
+      child.on('close', code => {
+        if (code === 0) resolve();
+        else reject(new Error(`tmux ${args.join(' ')} exited ${code}: ${stderr.trim()}`));
+      });
+    });
+  },
+};
+
+async function sendBlock(runner: TmuxRunner, target: string, block: string): Promise<void> {
+  // Two-step paste: literal block, then Enter to submit.
+  await runner.send(target, [block], { literal: true });
+  await runner.send(target, ['Enter'], { literal: false });
+}
+
+function readLastTick(file: string): number | undefined {
+  if (!fs.existsSync(file)) return undefined;
+  const raw = fs.readFileSync(file, 'utf8').trim();
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function writeLastTick(file: string, tick: number): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${tick}\n`, 'utf8');
+}
+
+async function waitForFile(file: string, timeoutMs: number): Promise<'found' | 'timeout'> {
+  const start = Date.now();
+  const intervalMs = 250;
+  while (Date.now() - start < timeoutMs) {
+    if (fs.existsSync(file)) return 'found';
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+  return fs.existsSync(file) ? 'found' : 'timeout';
+}

--- a/packages/runner/src/types.ts
+++ b/packages/runner/src/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Local types for the ClanWorld runner daemon.
+ *
+ * The runner drives 4 Elder Claude Code sessions (`elder-1` ... `elder-4`)
+ * through a per-tick reasoning loop:
+ *
+ *   1. Poll Convex for the latest tick.
+ *   2. For each Elder: compose situation block, deliver via tmux.
+ *   3. Wait a settle window (~90s) for Elders to act + their txs to confirm.
+ *   4. Call ClanWorld.heartbeat() to advance the chain.
+ */
+
+export type ElderId = 1 | 2 | 3 | 4;
+
+export const ELDER_IDS: readonly ElderId[] = [1, 2, 3, 4] as const;
+
+/**
+ * Validated Elder id 1..4. Throws on anything else.
+ */
+export function asElderId(n: number): ElderId {
+  if (n === 1 || n === 2 || n === 3 || n === 4) return n;
+  throw new Error(`invalid ElderId: ${n} (must be 1..4)`);
+}
+
+export interface RunnerConfig {
+  /** Milliseconds between Convex tick polls when no new tick is observed. */
+  pollIntervalMs: number;
+  /** Seconds to wait after delivering situation blocks before calling heartbeat. */
+  settleWindowSec: number;
+  /** Per-Elder timeout for `deliverSituationBlock` (ms). */
+  deliveryTimeoutMs: number;
+  /** Timeout when waiting for an `elder ack-clear` flag (ms). */
+  ackTimeoutMs: number;
+  /** State directory root (typically `~/.world/clanworld-runner/state`). */
+  stateDir: string;
+  /** tmux session name prefix. Each Elder lives in `${prefix}-${n}`. */
+  tmuxSessionPrefix: string;
+  /** Map of Elder id → clan id used for situation-block context + peer routing. */
+  elderToClanId: Record<ElderId, string>;
+}

--- a/packages/runner/test/composeSituationBlock.test.ts
+++ b/packages/runner/test/composeSituationBlock.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import type { IConvexClient } from '@clan-world/shared/adapters';
+import type {
+  IElderMemoryStore,
+  IElderPeerInbox,
+  PeerMessage,
+} from '@clan-world/agents/seams';
+import { composeSituationBlock } from '../src/composeSituationBlock';
+
+function fakeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
+  return {
+    async getSnapshot() {
+      return {
+        tick: 12,
+        tickEpoch: { startedAt: 1700000000, durationMs: 60000 },
+        regions: [{ id: 'r1', name: 'North', ownerClanId: '1' }],
+        clans: [{ id: '1', name: 'Wolfclan', treasury: '1000' }],
+      };
+    },
+    async getClanFullView(clanId: string) {
+      return {
+        clan: { id: clanId, name: 'Wolfclan', treasury: '1000' },
+        controlledRegions: [{ id: 'r1', name: 'North', ownerClanId: clanId }],
+        pendingOrders: [],
+        whispers: [],
+      };
+    },
+    async postLog() {},
+    subscribeWhispers() {
+      return () => {};
+    },
+    ...overrides,
+  };
+}
+
+function fakeMemory(map: Record<string, string>): IElderMemoryStore {
+  return {
+    async recall(k: string) {
+      return map[k];
+    },
+    async save(k: string, v: string) {
+      map[k] = v;
+    },
+    async snapshot() {
+      return { ...map };
+    },
+  };
+}
+
+function fakePeerInbox(messages: PeerMessage[]): IElderPeerInbox {
+  return {
+    async send() {},
+    async inbox() {
+      return messages;
+    },
+  };
+}
+
+describe('composeSituationBlock', () => {
+  it('produces a block with all required sections in order', async () => {
+    const block = await composeSituationBlock(
+      { elder: 1, clanId: '1', tick: 12 },
+      {
+        convex: fakeConvex(),
+        memory: fakeMemory({ strategy: 'expand-north', last_tick_handled: '11' }),
+        peerInbox: fakePeerInbox([
+          {
+            fromClanId: '2',
+            toClanId: '1',
+            message: 'truce until tick 20?',
+            tick: 11,
+            sentAt: '2024-01-01T00:00:00Z',
+          },
+        ]),
+      },
+    );
+
+    // Section order: Identity, Tick state, World snapshot, Your clan, Peer messages, Memory, Action.
+    const sections = [
+      '## Identity',
+      '## Tick state',
+      '## World snapshot',
+      '## Your clan',
+      '## Peer messages',
+      '## Memory',
+      '## Action',
+    ];
+    let lastIdx = -1;
+    for (const s of sections) {
+      const idx = block.indexOf(s);
+      expect(idx, `section ${s} missing`).toBeGreaterThanOrEqual(0);
+      expect(idx, `section ${s} out of order`).toBeGreaterThan(lastIdx);
+      lastIdx = idx;
+    }
+
+    expect(block).toContain('Tick 12 — Elder 1 (Clan 1)');
+    expect(block).toContain('You are Elder 1, ruling Clan 1');
+    expect(block).toContain('treasury: 1000');
+    expect(block).toContain('truce until tick 20?');
+    expect(block).toContain('strategy: expand-north');
+  });
+
+  it('handles empty peer inbox + empty memory gracefully', async () => {
+    const block = await composeSituationBlock(
+      { elder: 3, clanId: '3', tick: 1 },
+      {
+        convex: fakeConvex({
+          async getSnapshot() {
+            return {
+              tick: 1,
+              tickEpoch: { startedAt: 0, durationMs: 20000 },
+              regions: [],
+              clans: [],
+            };
+          },
+          async getClanFullView() {
+            return {
+              clan: { id: '3', name: 'Stub', treasury: '0' },
+              controlledRegions: [],
+              pendingOrders: [],
+              whispers: [],
+            };
+          },
+        }),
+        memory: fakeMemory({}),
+        peerInbox: fakePeerInbox([]),
+      },
+    );
+    expect(block).toContain('## Peer messages');
+    expect(block).toContain('- (none)');
+    expect(block).toContain('## Memory');
+    expect(block).toContain('first tick, or post-clear bootstrap');
+  });
+
+  it('renders pending orders with their kind + payload', async () => {
+    const block = await composeSituationBlock(
+      { elder: 2, clanId: '2', tick: 5 },
+      {
+        convex: fakeConvex({
+          async getClanFullView(clanId: string) {
+            return {
+              clan: { id: clanId, name: 'Bearclan', treasury: '500' },
+              controlledRegions: [],
+              pendingOrders: [
+                { kind: 'mission', payload: { target: 'r2', squad: ['c1'] } },
+                { kind: 'transfer', payload: { to: '3', amount: '100' } },
+              ],
+              whispers: [],
+            };
+          },
+        }),
+        memory: fakeMemory({}),
+        peerInbox: fakePeerInbox([]),
+      },
+    );
+    expect(block).toMatch(/mission: \{"target":"r2"/);
+    expect(block).toMatch(/transfer: \{"to":"3"/);
+  });
+});

--- a/packages/runner/test/filePeerInbox.test.ts
+++ b/packages/runner/test/filePeerInbox.test.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { FilePeerInbox } from '../src/filePeerInbox';
+
+describe('FilePeerInbox', () => {
+  const originalElderN = process.env['ELDER_N'];
+  const originalElder3ClanId = process.env['ELDER_3_CLAN_ID'];
+
+  afterEach(() => {
+    if (originalElderN === undefined) {
+      delete process.env['ELDER_N'];
+    } else {
+      process.env['ELDER_N'] = originalElderN;
+    }
+    if (originalElder3ClanId === undefined) {
+      delete process.env['ELDER_3_CLAN_ID'];
+    } else {
+      process.env['ELDER_3_CLAN_ID'] = originalElder3ClanId;
+    }
+  });
+
+  it('reads the CLI elder-N inbox even when clan id mapping differs', async () => {
+    process.env['ELDER_N'] = '3';
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clanworld-peer-inbox-'));
+    const inboxDir = path.join(stateDir, 'peer-inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(inboxDir, 'elder-3.jsonl'),
+      JSON.stringify({
+        from: 1,
+        to: 'clan-7',
+        msg: 'hold the ford',
+        ts: '2026-04-28T12:00:00.000Z',
+      }) + '\n',
+      'utf8',
+    );
+    fs.writeFileSync(
+      path.join(inboxDir, 'elder-clan-7.jsonl'),
+      JSON.stringify({
+        from: 2,
+        to: 'clan-7',
+        msg: 'stale mapping path',
+        ts: '2026-04-28T12:01:00.000Z',
+      }) + '\n',
+      'utf8',
+    );
+
+    const inbox = new FilePeerInbox(3, 'clan-7', stateDir);
+
+    await expect(inbox.inbox()).resolves.toEqual([
+      {
+        fromClanId: '1',
+        toClanId: 'clan-7',
+        message: 'hold the ford',
+        tick: 0,
+        sentAt: '2026-04-28T12:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('writes to the mapped elder-N inbox for a non-default recipient clan id', async () => {
+    process.env['ELDER_3_CLAN_ID'] = 'clan-7';
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clanworld-peer-inbox-'));
+    const inbox = new FilePeerInbox(1, 'clan-1', stateDir);
+
+    await inbox.send('clan-7', 'hold the ford', 42);
+
+    const mappedFile = path.join(stateDir, 'peer-inbox', 'elder-3.jsonl');
+    const oldClanFile = path.join(stateDir, 'peer-inbox', 'elder-clan-7.jsonl');
+    expect(fs.existsSync(mappedFile)).toBe(true);
+    expect(fs.existsSync(oldClanFile)).toBe(false);
+    expect(fs.readFileSync(mappedFile, 'utf8')).toContain('"toClanId":"clan-7"');
+  });
+});

--- a/packages/runner/test/settleWindow.test.ts
+++ b/packages/runner/test/settleWindow.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { settleWindow } from '../src/settleWindow';
+
+describe('settleWindow', () => {
+  it('resolves with "settled" after the timeout elapses', async () => {
+    const start = Date.now();
+    const result = await settleWindow(80);
+    const elapsed = Date.now() - start;
+    expect(result).toBe('settled');
+    // Allow a generous lower bound to account for timer drift on shared CI.
+    expect(elapsed).toBeGreaterThanOrEqual(70);
+  });
+
+  it('resolves immediately with "aborted" if signal is already aborted', async () => {
+    const ctl = new AbortController();
+    ctl.abort();
+    const start = Date.now();
+    const result = await settleWindow(10_000, ctl.signal);
+    expect(result).toBe('aborted');
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it('resolves with "aborted" if signal aborts during the wait', async () => {
+    const ctl = new AbortController();
+    setTimeout(() => ctl.abort(), 30);
+    const start = Date.now();
+    const result = await settleWindow(10_000, ctl.signal);
+    const elapsed = Date.now() - start;
+    expect(result).toBe('aborted');
+    expect(elapsed).toBeLessThan(500);
+  });
+});

--- a/packages/runner/test/tmuxRunnerInbox.test.ts
+++ b/packages/runner/test/tmuxRunnerInbox.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TmuxRunnerInbox, type TmuxRunner } from '../src/tmuxRunnerInbox';
+
+interface RecordedCall {
+  target: string;
+  keys: string[];
+  literal: boolean;
+}
+
+class RecordingTmux implements TmuxRunner {
+  calls: RecordedCall[] = [];
+  shouldFail: false | { message: string } = false;
+
+  async send(target: string, keys: string[], opts: { literal: boolean }): Promise<void> {
+    this.calls.push({ target, keys, literal: opts.literal });
+    if (this.shouldFail) {
+      throw new Error(this.shouldFail.message);
+    }
+  }
+}
+
+let tmpDir: string;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runner-tmux-test-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('TmuxRunnerInbox.deliverSituationBlock', () => {
+  it('sends literal block then Enter to elder-N target', async () => {
+    const tmux = new RecordingTmux();
+    const inbox = new TmuxRunnerInbox({
+      elder: 1,
+      sessionPrefix: 'elder',
+      stateDir: tmpDir,
+      bootstrapBlock: 'bootstrap',
+      runner: tmux,
+    });
+    const status = await inbox.deliverSituationBlock(5, 'hello\nworld');
+    expect(status).toEqual({ ok: true });
+    expect(tmux.calls).toHaveLength(2);
+    expect(tmux.calls[0]).toEqual({
+      target: 'elder-1',
+      keys: ['hello\nworld'],
+      literal: true,
+    });
+    expect(tmux.calls[1]).toEqual({
+      target: 'elder-1',
+      keys: ['Enter'],
+      literal: false,
+    });
+  });
+
+  it('returns duplicate-tick when re-delivering the same tick', async () => {
+    const tmux = new RecordingTmux();
+    const inbox = new TmuxRunnerInbox({
+      elder: 2,
+      sessionPrefix: 'elder',
+      stateDir: tmpDir,
+      bootstrapBlock: 'b',
+      runner: tmux,
+    });
+    await inbox.deliverSituationBlock(7, 'block-A');
+    const second = await inbox.deliverSituationBlock(7, 'block-A-retry');
+    expect(second).toEqual({ ok: false, reason: 'duplicate-tick' });
+    // First delivery sends 2 calls (literal + Enter); second short-circuits.
+    expect(tmux.calls).toHaveLength(2);
+  });
+
+  it('also rejects an older tick after a newer one was delivered', async () => {
+    const tmux = new RecordingTmux();
+    const inbox = new TmuxRunnerInbox({
+      elder: 3,
+      sessionPrefix: 'elder',
+      stateDir: tmpDir,
+      bootstrapBlock: 'b',
+      runner: tmux,
+    });
+    await inbox.deliverSituationBlock(10, 'newer');
+    const older = await inbox.deliverSituationBlock(9, 'older');
+    expect(older).toEqual({ ok: false, reason: 'duplicate-tick' });
+  });
+
+  it('surfaces session-down when tmux says the session is missing', async () => {
+    const tmux = new RecordingTmux();
+    tmux.shouldFail = { message: "tmux send-keys -t elder-4 exited 1: can't find session: elder-4" };
+    const inbox = new TmuxRunnerInbox({
+      elder: 4,
+      sessionPrefix: 'elder',
+      stateDir: tmpDir,
+      bootstrapBlock: 'b',
+      runner: tmux,
+    });
+    const status = await inbox.deliverSituationBlock(1, 'block');
+    expect(status).toEqual({ ok: false, reason: 'session-down' });
+  });
+
+  it('persists the last-tick marker so idempotency survives restart', async () => {
+    const tmux1 = new RecordingTmux();
+    const inbox1 = new TmuxRunnerInbox({
+      elder: 1,
+      sessionPrefix: 'elder',
+      stateDir: tmpDir,
+      bootstrapBlock: 'b',
+      runner: tmux1,
+    });
+    await inbox1.deliverSituationBlock(42, 'first-impl');
+
+    const marker = path.join(tmpDir, 'elder-1-last-tick.txt');
+    expect(fs.readFileSync(marker, 'utf8').trim()).toBe('42');
+
+    // Simulate restart: new instance, same stateDir.
+    const tmux2 = new RecordingTmux();
+    const inbox2 = new TmuxRunnerInbox({
+      elder: 1,
+      sessionPrefix: 'elder',
+      stateDir: tmpDir,
+      bootstrapBlock: 'b',
+      runner: tmux2,
+    });
+    const replay = await inbox2.deliverSituationBlock(42, 'replayed');
+    expect(replay).toEqual({ ok: false, reason: 'duplicate-tick' });
+    expect(tmux2.calls).toHaveLength(0);
+  });
+});
+
+describe('TmuxRunnerInbox.waitForAckAndClear', () => {
+  it('returns timeout and still issues /clear + bootstrap when no flag appears', async () => {
+    const tmux = new RecordingTmux();
+    const inbox = new TmuxRunnerInbox({
+      elder: 1,
+      sessionPrefix: 'elder',
+      stateDir: tmpDir,
+      bootstrapBlock: 'BOOT',
+      runner: tmux,
+    });
+    const result = await inbox.waitForAckAndClear(500);
+    expect(result).toBe('timeout');
+    // /clear (non-literal) + bootstrap (literal) + Enter (non-literal) = 3 calls.
+    expect(tmux.calls).toHaveLength(3);
+    expect(tmux.calls[0]).toEqual({ target: 'elder-1', keys: ['/clear'], literal: false });
+    expect(tmux.calls[1]).toEqual({ target: 'elder-1', keys: ['BOOT'], literal: true });
+    expect(tmux.calls[2]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
+  });
+
+  it('returns ack and consumes the flag file when it exists', async () => {
+    const tmux = new RecordingTmux();
+    const flagFile = path.join(tmpDir, 'elder-2-ack.flag');
+    fs.writeFileSync(flagFile, new Date().toISOString() + '\n', 'utf8');
+    const inbox = new TmuxRunnerInbox({
+      elder: 2,
+      sessionPrefix: 'elder',
+      stateDir: tmpDir,
+      bootstrapBlock: 'BOOT',
+      runner: tmux,
+    });
+    const result = await inbox.waitForAckAndClear(500);
+    expect(result).toBe('ack');
+    expect(fs.existsSync(flagFile)).toBe(false);
+  });
+});

--- a/packages/runner/tsconfig.json
+++ b/packages/runner/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,31 @@ importers:
 
   packages/contracts: {}
 
+  packages/runner:
+    dependencies:
+      '@clan-world/agents':
+        specifier: workspace:*
+        version: link:../agents
+      '@clan-world/shared':
+        specifier: workspace:*
+        version: link:../shared
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      viem:
+        specifier: ^2.48.4
+        version: 2.48.4(typescript@5.9.3)
+    devDependencies:
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.4(@types/node@25.6.0)(lightningcss@1.32.0)
+
   packages/shared:
     dependencies:
       convex:


### PR DESCRIPTION
## Summary

New package `@clan-world/runner` — TypeScript Node daemon that drives 4 Elder Claude Code sessions through the per-tick reasoning loop. **Stream B Step 2**, stacked on the seams branch from PR #89.

## What's in the box

```
packages/runner/
├── package.json                       # @clan-world/runner, type=module, deps: tsx, viem, workspace pkgs
├── tsconfig.json                      # extends repo base; strict + NodeNext + bundler resolution
├── README.md                          # run instructions + state dir layout + systemd notes
├── .env.example                       # required + optional env vars documented
├── clanworld-runner.service           # systemd template (NOT installed — Liam runs it manually)
├── src/
│   ├── main.ts                        # entry: load config, build per-Elder seam impls, start tickLoop, signal handling
│   ├── tickLoop.ts                    # poll → parallel-deliver → settle → heartbeat (rate-limit aware retry)
│   ├── pollChainTick.ts               # stub-aware Convex tick read (idles when CONVEX_URL unset)
│   ├── composeSituationBlock.ts       # 7-section block format (identity/tick/world/clan/peers/memory/action)
│   ├── tmuxRunnerInbox.ts             # IRunnerInbox: send-keys -l + Enter; last-tick.txt idempotency marker
│   ├── fileMemoryStore.ts             # IElderMemoryStore: atomic temp-file rename JSON writes
│   ├── filePeerInbox.ts               # IElderPeerInbox: JSONL per recipient clan; CLI-format compatible
│   ├── runnerCastHeartbeat.ts         # IHeartbeatCaller: viem writeContract + receipt-status check + rate-limit detect
│   ├── settleWindow.ts                # signal-aware sleep
│   └── types.ts                       # ElderId, RunnerConfig, ELDER_IDS
└── test/                              # 13 vitest specs (idempotency, block format, abort behavior)
```

Also adds `\"exports\": { \"./seams\": \"./src/seams/index.ts\" }` to `@clan-world/agents/package.json` so the runner can import seam types via the documented subpath. Pure packaging metadata — **no contract change** to the seams.

## Seam impls

| Seam | Impl | Notes |
| --- | --- | --- |
| `IRunnerInbox` | `TmuxRunnerInbox` | `tmux send-keys -l \$block` + `Enter`; idempotency persisted in `elder-N-last-tick.txt` |
| `IElderMemoryStore` | `FileMemoryStore` | Atomic temp-file rename for durability |
| `IElderPeerInbox` | `FilePeerInbox` | JSONL appended to `peer-inbox/elder-\${recipientClanId}.jsonl`; reads tolerate both seam shape + Elder-CLI shape |
| `IHeartbeatCaller` | `RunnerCastHeartbeat` | viem on World Chain Sepolia; checks `receipt.status`; detects rate-limit via `getWorldState().nextHeartbeatAtTs` |

## Constraints honored

- No new runtime deps (only viem, tsx, workspace packages)
- `pollChainTick` is stub-aware — falls back to `StubConvexClient` if `CONVEX_URL` unset and idles
- systemd unit shipped as a template, **not installed**
- `RUNNER_PRIVATE_KEY` hard-required at boot — refuses to start without it; no key generation
- All paths via `os.homedir() + path.join`, never hardcoded
- `.env.example` provided but daemon reads only from `process.env` at startup

## Verification

```
pnpm install                                # 0 new deps; lockfile updated for new workspace pkg
pnpm --filter @clan-world/runner typecheck  # CLEAN
pnpm --filter @clan-world/runner test       # 13/13 passing
pnpm --filter @clan-world/agents typecheck  # CLEAN (exports field doesn't break agents)
pnpm --filter @clan-world/agents test       # 16/16 passing (pre-existing tests still pass)
```

Pre-existing `@clan-world/server` typecheck failures (`convex/heartbeat.ts`, `convex/verify.ts`) are baseline on the seams branch — unrelated to this PR.

## Local swarm review

Ran codex (3-tier) against the diff. Findings triaged:

**Fixed in this PR:**
- `runnerCastHeartbeat.ts` — now checks `receipt.status === 'success'` and re-checks `nextHeartbeatAtTs` on revert to surface rate-limit errors that slip past simulation
- `runnerCastHeartbeat.ts` — typed `Account` field instead of non-null-assertion on `walletClient.account!`
- `tickLoop.ts` — inline rate-limit retry inside the heartbeat block (avoids re-running the 90s settle window when only the rate-limit window is the blocker)
- `fileMemoryStore.ts` + `filePeerInbox.ts` — corrected stale comments

**Acknowledged + documented (deferred for prototype scope):**
- `lastProcessedTick` is process-local; on restart we may re-attempt a heartbeat. The on-chain rate limit catches it. Persistence is Phase-2 follow-up — comment added in `tickLoop.ts`.
- Heartbeat fires unconditionally after settle window even if all Elder deliveries failed. Per `IRunnerInbox` contract, a missing Elder \"loses the turn\" — chain still advances. Comment added.
- `FilePeerInbox.send()` always appends; per seam contract dedup is OPTIONAL. Comment added; consumer-side dedup is the explicit policy.
- `peer-inbox/elder-\${id}.jsonl` keying is consistent with the Elder CLI's `peer whisper` writer but the CLI's `peer inbox` READER keys by ELDER_N — works only when `clanId === String(elderId)`. The default env mapping satisfies this; documented as a seam follow-up to surface on PR #89.

## TODOs deferred

- `pollChainTick` reads full snapshot — switch to a dedicated `getCurrentTick` Convex query when one exists.
- Heartbeat rate-limit detection re-reads `getWorldState()` on revert; upgrade to a typed custom error decode if/when the contract gets one.
- systemd installation (template provided in repo).

## Test plan

- [ ] CI typecheck passes for the runner package
- [ ] CI vitest passes (13 specs)
- [ ] Manually: `pnpm --filter @clan-world/runner start` with `CONVEX_URL` unset logs the stub warning and idles cleanly
- [ ] Manually: with stub Convex returning a non-zero tick, runner pastes a situation block into a real `elder-1` tmux session
- [ ] Manually: SIGTERM exits the daemon within `pollIntervalMs`, settle window aborts on signal