### PR TITLE
feat: cockpit Phase A — 3-col 2-row layout shell with placeholder tabs

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { MiniKit } from '@worldcoin/minikit-js';
 import { useIDKitRequest } from '@worldcoin/idkit';
 import type { IDKitRequestHookConfig } from '@worldcoin/idkit';
 import { WorldMap } from './WorldMap';
+import { Cockpit } from './pages/Cockpit';
 
 // Convex HTTP actions are served at <deployment>.convex.site (not .convex.cloud)
 const CONVEX_SITE_URL =
@@ -41,7 +42,32 @@ const IDKIT_CONFIG: IDKitRequestHookConfig = {
 const DEMO_BYPASS_WORLD_GUARD =
   import.meta.env.VITE_DEMO_BYPASS_WORLD_GUARD === 'true';
 
+/**
+ * Top-level route decision. Lightweight path-based routing avoids a router
+ * dep for a single side route. Reading window.location once at render is
+ * fine here — the cockpit is a standalone judge view, not a SPA tab inside
+ * the main app, so we never need to navigate between them client-side.
+ */
+function isCockpitRoute(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.location.pathname.startsWith('/cockpit')
+  );
+}
+
 export function App() {
+  // /cockpit route — standalone judge view, bypasses World App / verify gate.
+  // Pure read-only frontend for now (Phase B will wire live data).
+  // Routed BEFORE any hooks so the cockpit branch never instantiates the
+  // World-App / IDKit hooks (which would warn about missing config in a
+  // plain browser).
+  if (isCockpitRoute()) {
+    return <Cockpit />;
+  }
+  return <MainApp />;
+}
+
+function MainApp() {
   // When the demo bypass env is set, start verified=true so the WorldMap canvas
   // renders immediately without an IDKit verify round-trip (which can't complete
   // outside World App). Production default (env unset) keeps the full gate.

--- a/apps/web/src/components/cockpit/MiniCockpit.tsx
+++ b/apps/web/src/components/cockpit/MiniCockpit.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { tokens, type ElderDef } from '../../styles/cockpit-tokens';
+import { CockpitTabBar, type TabId } from './shared/CockpitTabBar';
+import { TerminalTab } from './tabs/TerminalTab';
+import { VaultTab } from './tabs/VaultTab';
+import { ClansmanTab } from './tabs/ClansmanTab';
+import { ZeroGTab } from './tabs/ZeroGTab';
+import { CommsTab } from './tabs/CommsTab';
+
+interface Props {
+  elder: ElderDef;
+  /** Stub tick counter — Phase B will source this from the engine. */
+  tick?: number;
+  tickMax?: number;
+}
+
+/**
+ * One corner panel — tab bar on top, content below. Default tab is Terminal
+ * per Liam's spec ("First tab is terminal").
+ */
+export function MiniCockpit({ elder, tick = 4, tickMax = 10 }: Props) {
+  const [active, setActive] = useState<TabId>('terminal');
+  const testIdPrefix = `mini-cockpit-${elder.clanId}`;
+
+  return (
+    <section
+      data-testid={testIdPrefix}
+      data-clan-id={elder.clanId}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        background: tokens.bg.iron,
+        border: `1px solid ${tokens.border.iron}`,
+        borderTop: `2px solid ${elder.accent}`,
+        boxShadow: tokens.shadow.panel,
+        borderRadius: tokens.radius.md,
+        overflow: 'hidden',
+        minWidth: 0,
+        minHeight: 0,
+      }}
+      aria-label={`Mini cockpit for ${elder.name}`}
+    >
+      <CockpitTabBar
+        active={active}
+        onSelect={setActive}
+        tick={tick}
+        tickMax={tickMax}
+        clanName={elder.name}
+        clanAccent={elder.accent}
+        clanGlyph={elder.glyph}
+        testIdPrefix={testIdPrefix}
+      />
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+          overflow: 'hidden',
+        }}
+      >
+        {active === 'terminal' && <TerminalTab elder={elder} testIdPrefix={testIdPrefix} />}
+        {active === 'vault'    && <VaultTab    elder={elder} testIdPrefix={testIdPrefix} />}
+        {active === 'clansman' && <ClansmanTab elder={elder} testIdPrefix={testIdPrefix} />}
+        {active === '0g'       && <ZeroGTab    elder={elder} testIdPrefix={testIdPrefix} />}
+        {active === 'comms'    && <CommsTab    elder={elder} testIdPrefix={testIdPrefix} />}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/cockpit/shared/CockpitTabBar.tsx
+++ b/apps/web/src/components/cockpit/shared/CockpitTabBar.tsx
@@ -1,0 +1,175 @@
+import { tokens } from '../../../styles/cockpit-tokens';
+
+export type TabId = 'terminal' | 'vault' | 'clansman' | '0g' | 'comms';
+
+export interface TabDef {
+  id: TabId;
+  /** Single-glyph icon — kept tiny so the tab strip stays narrow. */
+  icon: string;
+  /** Tiny label rendered under the icon (Liam: "icons stacked on tiny text tabs"). */
+  label: string;
+}
+
+export const TABS: ReadonlyArray<TabDef> = [
+  { id: 'terminal', icon: '▣', label: 'TERM' },
+  { id: 'vault',    icon: '◈', label: 'VAULT' },
+  { id: 'clansman', icon: '☗', label: 'CLAN' },
+  { id: '0g',       icon: '◉', label: '0G' },
+  { id: 'comms',    icon: '✉', label: 'COMMS' },
+];
+
+interface Props {
+  active: TabId;
+  onSelect: (id: TabId) => void;
+  /** Current engine tick for this Elder. Rendered as `T/10` on the right side. */
+  tick: number;
+  tickMax: number;
+  /** Clan name / accent — colors the active-tab underline. */
+  clanName: string;
+  clanAccent: string;
+  clanGlyph: string;
+  /** data-testid prefix to scope test selectors to this mini-cockpit. */
+  testIdPrefix: string;
+}
+
+/**
+ * Compact tab bar — icon-stacked-on-text on the left, clan badge in the center,
+ * X/10 tick counter on the right. Matches Liam's spec verbatim.
+ *
+ * Layout chosen so the bar is dense at small panel widths (corner cells in a
+ * 3-col grid get ~340px on a 1440 desktop). Each tab is fixed ~44px wide.
+ */
+export function CockpitTabBar({
+  active,
+  onSelect,
+  tick,
+  tickMax,
+  clanName,
+  clanAccent,
+  clanGlyph,
+  testIdPrefix,
+}: Props) {
+  return (
+    <div
+      data-testid={`${testIdPrefix}-tabbar`}
+      style={{
+        display: 'flex',
+        alignItems: 'stretch',
+        background: tokens.bg.ironDeep,
+        borderBottom: `1px solid ${tokens.border.iron}`,
+        height: '46px',
+        flexShrink: 0,
+      }}
+    >
+      {/* Left: icon-stacked tabs */}
+      <div style={{ display: 'flex' }}>
+        {TABS.map((t) => {
+          const isActive = t.id === active;
+          return (
+            <button
+              key={t.id}
+              data-testid={`${testIdPrefix}-tab-${t.id}`}
+              data-active={isActive}
+              onClick={() => onSelect(t.id)}
+              style={{
+                width: '44px',
+                background: isActive ? tokens.bg.ink : 'transparent',
+                color: isActive ? tokens.text.accent : tokens.text.onIronDim,
+                border: 'none',
+                borderRight: `1px solid ${tokens.border.iron}`,
+                cursor: 'pointer',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '2px 0',
+                fontFamily: tokens.font.body,
+                boxShadow: isActive ? tokens.shadow.tabActive : 'none',
+                transition: 'background 120ms ease, color 120ms ease',
+              }}
+              aria-pressed={isActive}
+              aria-label={t.label}
+              type="button"
+            >
+              <span
+                style={{
+                  fontSize: '18px',
+                  lineHeight: 1,
+                  marginBottom: '2px',
+                }}
+                aria-hidden
+              >
+                {t.icon}
+              </span>
+              <span
+                style={{
+                  fontSize: '8px',
+                  letterSpacing: '0.12em',
+                  fontWeight: 600,
+                }}
+              >
+                {t.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Center: clan badge — pushes spacer between tabs and tick counter */}
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: `0 ${tokens.space.sm}`,
+          color: tokens.text.onIron,
+          fontFamily: tokens.font.display,
+          fontSize: '12px',
+          letterSpacing: '0.16em',
+          textTransform: 'uppercase',
+          minWidth: 0,
+        }}
+        title={clanName}
+      >
+        <span style={{ color: clanAccent, marginRight: '6px', fontSize: '14px' }}>
+          {clanGlyph}
+        </span>
+        <span
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {clanName}
+        </span>
+      </div>
+
+      {/* Right: tick counter */}
+      <div
+        data-testid={`${testIdPrefix}-tick`}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+          padding: `0 ${tokens.space.md}`,
+          borderLeft: `1px solid ${tokens.border.iron}`,
+          fontFamily: tokens.font.mono,
+          fontSize: '11px',
+          color: tokens.text.accent,
+          fontWeight: 600,
+          letterSpacing: '0.08em',
+          minWidth: '52px',
+          justifyContent: 'flex-end',
+        }}
+        title="Engine tick"
+      >
+        <span style={{ opacity: 0.6 }}>T</span>
+        <span>{tick}</span>
+        <span style={{ opacity: 0.4 }}>/</span>
+        <span style={{ opacity: 0.6 }}>{tickMax}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/cockpit/shared/WorldMapBoundary.tsx
+++ b/apps/web/src/components/cockpit/shared/WorldMapBoundary.tsx
@@ -1,0 +1,81 @@
+import { Component, type ReactNode } from 'react';
+import { tokens } from '../../../styles/cockpit-tokens';
+
+interface State {
+  hasError: boolean;
+}
+
+/**
+ * Tiny error boundary scoped to the cockpit's center cell. The WorldMap
+ * pixi canvas can throw during init when Convex is unreachable / the
+ * standalone judge route loads without a backend. In that case we want the
+ * 4 mini-cockpits to keep rendering — only the map cell should degrade.
+ *
+ * Phase B will replace this with a richer "no chain data yet" placeholder
+ * once the demo-mode toggle and seeded mock dataset land.
+ */
+export class WorldMapBoundary extends Component<
+  { children: ReactNode },
+  State
+> {
+  override state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  override componentDidCatch(error: unknown) {
+    console.warn('[cockpit] WorldMap failed to mount, rendering fallback:', error);
+  }
+
+  override render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          data-testid="cockpit-worldmap-fallback"
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background:
+              'radial-gradient(ellipse at center, #1a1612 0%, #050505 80%)',
+            color: tokens.text.onIron,
+            fontFamily: tokens.font.display,
+            letterSpacing: '0.2em',
+            fontSize: '12px',
+            textAlign: 'center',
+            padding: tokens.space.xl,
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontSize: '32px',
+                marginBottom: tokens.space.md,
+                opacity: 0.6,
+              }}
+              aria-hidden
+            >
+              ◈
+            </div>
+            <div style={{ textTransform: 'uppercase' }}>World Map Offline</div>
+            <div
+              style={{
+                fontFamily: tokens.font.mono,
+                fontSize: '10px',
+                marginTop: tokens.space.sm,
+                color: tokens.text.muted,
+                letterSpacing: '0.05em',
+              }}
+            >
+              Standalone view — backend not reachable
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/apps/web/src/components/cockpit/tabs/ClansmanTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/ClansmanTab.tsx
@@ -1,0 +1,158 @@
+import { tokens } from '../../../styles/cockpit-tokens';
+import type { ElderDef } from '../../../styles/cockpit-tokens';
+
+interface Props {
+  elder: ElderDef;
+  testIdPrefix: string;
+}
+
+interface ClansmanRow {
+  id: string;
+  mission: string;
+  location: string;
+  /** Ticks until mission completes — null = idle. */
+  eta: number | null;
+  /** Ticks of cooldown remaining after mission ends — 0 = ready. */
+  cooldown: number;
+  /** Hunger fraction 0-1; >0.7 = visual starvation warning. */
+  hunger: number;
+}
+
+const STUB_CLANSMEN: ClansmanRow[] = [
+  { id: 'C1', mission: 'Raid',   location: 'Forest',     eta: 2, cooldown: 0, hunger: 0.4 },
+  { id: 'C2', mission: 'Mill',   location: 'East Farms', eta: 1, cooldown: 0, hunger: 0.2 },
+  { id: 'C3', mission: 'Idle',   location: 'Home',       eta: null, cooldown: 3, hunger: 0.78 },
+  { id: 'C4', mission: 'Quarry', location: 'Mountains',  eta: 4, cooldown: 0, hunger: 0.55 },
+];
+
+export function ClansmanTab({ elder, testIdPrefix }: Props) {
+  return (
+    <div
+      data-testid={`${testIdPrefix}-content-clansman`}
+      style={{
+        flex: 1,
+        background: tokens.bg.parchment,
+        color: tokens.text.onParchment,
+        padding: tokens.space.md,
+        overflowY: 'auto',
+        fontFamily: tokens.font.body,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: tokens.space.sm,
+      }}
+    >
+      <h3
+        style={{
+          margin: 0,
+          fontFamily: tokens.font.display,
+          fontSize: '11px',
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+          color: tokens.text.onParchmentDim,
+          borderBottom: `1px solid ${tokens.border.parchmentEdge}`,
+          paddingBottom: '4px',
+        }}
+      >
+        Clansmen — Clan {elder.clanId}
+      </h3>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        {STUB_CLANSMEN.map((c) => {
+          const starving = c.hunger > 0.7;
+          return (
+            <div
+              key={c.id}
+              data-testid={`${testIdPrefix}-clansman-${c.id}`}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '28px 1fr 60px 36px',
+                gap: tokens.space.sm,
+                alignItems: 'center',
+                padding: '6px 8px',
+                background: 'rgba(255,255,255,0.22)',
+                border: `1px solid ${
+                  starving ? tokens.text.danger : tokens.border.parchmentEdge
+                }`,
+                borderRadius: tokens.radius.sm,
+                fontFamily: tokens.font.mono,
+                fontSize: '11px',
+              }}
+            >
+              <span
+                style={{
+                  fontWeight: 700,
+                  color: elder.accent,
+                  fontSize: '12px',
+                }}
+              >
+                {c.id}
+              </span>
+              <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+                <span
+                  style={{
+                    fontWeight: 600,
+                    color: tokens.text.onParchment,
+                  }}
+                >
+                  {c.mission}
+                </span>
+                <span
+                  style={{
+                    color: tokens.text.onParchmentDim,
+                    fontSize: '10px',
+                  }}
+                >
+                  {c.location}
+                </span>
+              </div>
+              <div
+                style={{
+                  fontSize: '10px',
+                  color: tokens.text.onParchmentDim,
+                  textAlign: 'right',
+                }}
+              >
+                {c.eta !== null ? (
+                  <span>ETA {c.eta}t</span>
+                ) : c.cooldown > 0 ? (
+                  <span>CD {c.cooldown}t</span>
+                ) : (
+                  <span style={{ color: '#3a7a3a' }}>ready</span>
+                )}
+              </div>
+              <HungerBar hunger={c.hunger} starving={starving} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function HungerBar({ hunger, starving }: { hunger: number; starving: boolean }) {
+  const pct = Math.round(hunger * 100);
+  const fill = starving ? tokens.text.danger : '#b8862e';
+  return (
+    <div
+      title={`Hunger ${pct}%`}
+      style={{
+        position: 'relative',
+        height: '8px',
+        background: 'rgba(0,0,0,0.18)',
+        borderRadius: '1px',
+        overflow: 'hidden',
+        border: `1px solid ${tokens.border.parchmentEdge}`,
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          width: `${pct}%`,
+          background: fill,
+          transition: 'width 240ms ease',
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/cockpit/tabs/CommsTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/CommsTab.tsx
@@ -1,0 +1,144 @@
+import { tokens } from '../../../styles/cockpit-tokens';
+import type { ElderDef } from '../../../styles/cockpit-tokens';
+
+interface Props {
+  elder: ElderDef;
+  testIdPrefix: string;
+}
+
+type CommsKind = 'whisper' | 'human' | 'orch';
+
+interface CommsLine {
+  tick: number;
+  kind: CommsKind;
+  speaker: string;
+  body: string;
+}
+
+/**
+ * Communication log — three input classes:
+ *   - whisper : AXL chain whisper between Elders
+ *   - human   : human prompt routed to this Elder
+ *   - orch    : orchestrator-injected directive
+ *
+ * Each kind gets a distinct visual treatment per Liam's bubble-taxonomy spec.
+ */
+const STUB_LINES: CommsLine[] = [
+  { tick: 4, kind: 'orch',    speaker: 'orchestrator', body: 'Tick T04 begun. Yield <directives>.' },
+  { tick: 4, kind: 'whisper', speaker: 'clan-3',       body: 'AXL: "trade ore for wood, 2:1?"' },
+  { tick: 3, kind: 'human',   speaker: 'liam',         body: 'Slow your raids — diplomacy first.' },
+  { tick: 3, kind: 'whisper', speaker: 'clan-2',       body: 'AXL: declined; counter offered 3:1.' },
+  { tick: 2, kind: 'orch',    speaker: 'orchestrator', body: 'Bandit camp surfaced at forest.' },
+];
+
+const KIND_STYLES: Record<
+  CommsKind,
+  { label: string; bg: string; border: string; fg: string }
+> = {
+  whisper: {
+    label: 'WHISPER',
+    bg: 'rgba(90,138,168,0.12)',
+    border: '#5a8aa8',
+    fg: '#3a5a78',
+  },
+  human: {
+    label: 'HUMAN',
+    bg: 'rgba(212,165,68,0.14)',
+    border: '#b8862e',
+    fg: '#7a4e10',
+  },
+  orch: {
+    label: 'ORCH',
+    bg: 'rgba(106,168,136,0.12)',
+    border: '#6aa888',
+    fg: '#3a6a4a',
+  },
+};
+
+export function CommsTab({ elder, testIdPrefix }: Props) {
+  return (
+    <div
+      data-testid={`${testIdPrefix}-content-comms`}
+      style={{
+        flex: 1,
+        background: tokens.bg.parchment,
+        color: tokens.text.onParchment,
+        padding: tokens.space.md,
+        overflowY: 'auto',
+        fontFamily: tokens.font.body,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: tokens.space.sm,
+      }}
+    >
+      <h3
+        style={{
+          margin: 0,
+          fontFamily: tokens.font.display,
+          fontSize: '11px',
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+          color: tokens.text.onParchmentDim,
+          borderBottom: `1px solid ${tokens.border.parchmentEdge}`,
+          paddingBottom: '4px',
+        }}
+      >
+        Comms — Elder {elder.clanId}
+      </h3>
+
+      <ul
+        style={{
+          listStyle: 'none',
+          margin: 0,
+          padding: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '6px',
+        }}
+      >
+        {STUB_LINES.map((l, i) => {
+          const s = KIND_STYLES[l.kind];
+          return (
+            <li
+              key={i}
+              data-testid={`${testIdPrefix}-comms-${l.kind}-${i}`}
+              style={{
+                background: s.bg,
+                borderLeft: `3px solid ${s.border}`,
+                padding: '6px 8px',
+                fontSize: '11px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '2px',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  fontFamily: tokens.font.mono,
+                  fontSize: '9px',
+                  letterSpacing: '0.12em',
+                }}
+              >
+                <span style={{ color: s.fg, fontWeight: 700 }}>
+                  [{s.label}] {l.speaker}
+                </span>
+                <span style={{ color: tokens.text.muted }}>T{l.tick}</span>
+              </div>
+              <div
+                style={{
+                  color: tokens.text.onParchment,
+                  fontStyle: l.kind === 'human' ? 'italic' : 'normal',
+                }}
+              >
+                {l.body}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/cockpit/tabs/TerminalTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/TerminalTab.tsx
@@ -1,0 +1,92 @@
+import { tokens } from '../../../styles/cockpit-tokens';
+import type { ElderDef } from '../../../styles/cockpit-tokens';
+
+interface Props {
+  elder: ElderDef;
+  testIdPrefix: string;
+}
+
+/**
+ * Terminal tab — placeholder for the future tmux read-only mirror.
+ *
+ * Phase A: renders a faux terminal with a few lines of stubbed output so the
+ * panel "looks alive". Phase B will wire a real tmux capture-pane → WebSocket
+ * stream (similar to CPC's terminal pane).
+ */
+export function TerminalTab({ elder, testIdPrefix }: Props) {
+  // Hardcoded sample lines — make them feel like Elder LLM thinking-out-loud.
+  const lines = [
+    `$ elder-${elder.clanId} stream --tail`,
+    `[T03] situation-block ingested (12.4kb)`,
+    `[T03] thinking — wood low; mill before raid`,
+    `[T03] directive: queue clansman-2 → forest`,
+    `[T04] tick boundary; awaiting orchestrator`,
+  ];
+
+  return (
+    <div
+      data-testid={`${testIdPrefix}-content-terminal`}
+      style={{
+        flex: 1,
+        background: '#0d0d0d',
+        color: '#9ec792',
+        fontFamily: tokens.font.mono,
+        fontSize: '11px',
+        lineHeight: 1.6,
+        padding: tokens.space.md,
+        overflowY: 'auto',
+        position: 'relative',
+        boxShadow: 'inset 0 0 24px rgba(0,0,0,0.6)',
+      }}
+    >
+      {/* CRT scanline effect — subtle, parchment aesthetic still dominant */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          background:
+            'repeating-linear-gradient(0deg, rgba(0,0,0,0.06) 0 1px, transparent 1px 3px)',
+        }}
+      />
+      <div
+        style={{
+          color: tokens.text.onIronDim,
+          fontSize: '9px',
+          letterSpacing: '0.15em',
+          marginBottom: '8px',
+          textTransform: 'uppercase',
+        }}
+      >
+        ── Elder-{elder.clanId} tmux mirror (read-only) ──
+      </div>
+      {lines.map((l, i) => (
+        <div key={i} style={{ position: 'relative', zIndex: 1 }}>
+          {l}
+        </div>
+      ))}
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 1,
+          marginTop: '4px',
+          color: '#d4a544',
+        }}
+      >
+        ▊
+      </div>
+      <div
+        style={{
+          position: 'absolute',
+          bottom: tokens.space.sm,
+          right: tokens.space.sm,
+          fontSize: '9px',
+          color: tokens.text.muted,
+          fontFamily: tokens.font.mono,
+        }}
+      >
+        Phase B: live tmux stream
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/cockpit/tabs/VaultTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/VaultTab.tsx
@@ -1,0 +1,171 @@
+import { tokens } from '../../../styles/cockpit-tokens';
+import type { ElderDef } from '../../../styles/cockpit-tokens';
+
+interface Props {
+  elder: ElderDef;
+  testIdPrefix: string;
+}
+
+/** Resource line in the stub vault — Phase B will source these from Convex. */
+const STUB_RESOURCES = [
+  { glyph: '◈', label: 'Gold',  value: 1240, delta: '+45'  },
+  { glyph: '⌬', label: 'Wood',  value: 320,  delta: '-12'  },
+  { glyph: '◆', label: 'Ore',   value: 88,   delta: '+0'   },
+  { glyph: '◇', label: 'Stone', value: 156,  delta: '+8'   },
+];
+
+/** Asset movement event for the log strip. */
+const STUB_MOVEMENTS = [
+  { tick: 4, type: 'gain',  amount: '+45 gold',  source: 'raid · forest' },
+  { tick: 3, type: 'spend', amount: '-12 wood',  source: 'mill upkeep'   },
+  { tick: 2, type: 'gain',  amount: '+8 stone',  source: 'quarry'        },
+  { tick: 1, type: 'gain',  amount: '+24 gold',  source: 'tribute'       },
+];
+
+export function VaultTab({ elder, testIdPrefix }: Props) {
+  return (
+    <div
+      data-testid={`${testIdPrefix}-content-vault`}
+      style={{
+        flex: 1,
+        background: tokens.bg.parchment,
+        color: tokens.text.onParchment,
+        padding: tokens.space.md,
+        overflowY: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: tokens.space.md,
+        fontFamily: tokens.font.body,
+      }}
+    >
+      {/* Resource grid */}
+      <section>
+        <SectionHeader>Vault — Clan {elder.clanId}</SectionHeader>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: tokens.space.sm,
+            marginTop: tokens.space.sm,
+          }}
+        >
+          {STUB_RESOURCES.map((r) => (
+            <div
+              key={r.label}
+              style={{
+                background: 'rgba(255,255,255,0.35)',
+                border: `1px solid ${tokens.border.parchmentEdge}`,
+                borderRadius: tokens.radius.sm,
+                padding: tokens.space.sm,
+                display: 'flex',
+                alignItems: 'center',
+                gap: tokens.space.sm,
+              }}
+            >
+              <span style={{ fontSize: '20px', color: elder.accent }}>{r.glyph}</span>
+              <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0 }}>
+                <span
+                  style={{
+                    fontSize: '9px',
+                    letterSpacing: '0.14em',
+                    textTransform: 'uppercase',
+                    color: tokens.text.onParchmentDim,
+                  }}
+                >
+                  {r.label}
+                </span>
+                <span
+                  style={{
+                    fontFamily: tokens.font.mono,
+                    fontSize: '16px',
+                    fontWeight: 600,
+                    color: tokens.text.onParchment,
+                  }}
+                >
+                  {r.value.toLocaleString()}
+                </span>
+              </div>
+              <span
+                style={{
+                  fontFamily: tokens.font.mono,
+                  fontSize: '10px',
+                  color: r.delta.startsWith('-') ? tokens.text.danger : '#3a7a3a',
+                }}
+              >
+                {r.delta}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Movement log */}
+      <section style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+        <SectionHeader>Asset movements</SectionHeader>
+        <ul
+          style={{
+            listStyle: 'none',
+            margin: `${tokens.space.sm} 0 0`,
+            padding: 0,
+            overflowY: 'auto',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }}
+        >
+          {STUB_MOVEMENTS.map((m, i) => (
+            <li
+              key={i}
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                gap: tokens.space.sm,
+                fontSize: '11px',
+                fontFamily: tokens.font.mono,
+                padding: '4px 6px',
+                borderLeft: `2px solid ${
+                  m.type === 'gain' ? '#3a7a3a' : tokens.text.danger
+                }`,
+                background: 'rgba(255,255,255,0.18)',
+              }}
+            >
+              <span style={{ color: tokens.text.muted, width: '32px' }}>T{m.tick}</span>
+              <span
+                style={{
+                  fontWeight: 600,
+                  color:
+                    m.type === 'gain' ? '#3a7a3a' : tokens.text.danger,
+                  width: '76px',
+                }}
+              >
+                {m.amount}
+              </span>
+              <span style={{ color: tokens.text.onParchmentDim, flex: 1 }}>
+                {m.source}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h3
+      style={{
+        margin: 0,
+        fontFamily: tokens.font.display,
+        fontSize: '11px',
+        letterSpacing: '0.18em',
+        textTransform: 'uppercase',
+        color: tokens.text.onParchmentDim,
+        borderBottom: `1px solid ${tokens.border.parchmentEdge}`,
+        paddingBottom: '4px',
+      }}
+    >
+      {children}
+    </h3>
+  );
+}

--- a/apps/web/src/components/cockpit/tabs/ZeroGTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/ZeroGTab.tsx
@@ -1,0 +1,216 @@
+import { tokens } from '../../../styles/cockpit-tokens';
+import type { ElderDef } from '../../../styles/cockpit-tokens';
+
+interface Props {
+  elder: ElderDef;
+  testIdPrefix: string;
+}
+
+const STUB_KV = [
+  { key: 'last_grudge',     value: 'clan-3'             },
+  { key: 'wood_threshold',  value: '80'                 },
+  { key: 'pref_target',     value: 'forest'             },
+  { key: 'mood',            value: 'cautious'           },
+];
+
+const STUB_CRUD = [
+  { tick: 4, op: 'WRITE', key: 'mood',         note: 'cautious → wary'   },
+  { tick: 3, op: 'READ',  key: 'last_grudge',  note: 'planning retort'   },
+  { tick: 2, op: 'WRITE', key: 'wood_threshold', note: 'raise to 80'     },
+  { tick: 1, op: 'READ',  key: 'pref_target',  note: 'mission seeding'   },
+];
+
+const STUB_BULLETINS = [
+  { age: '2t', body: '"Wood scarce — millers prioritize."' },
+  { age: '5t', body: '"Crimson moves — watch the river."'  },
+];
+
+export function ZeroGTab({ elder, testIdPrefix }: Props) {
+  return (
+    <div
+      data-testid={`${testIdPrefix}-content-0g`}
+      style={{
+        flex: 1,
+        background: tokens.bg.parchment,
+        color: tokens.text.onParchment,
+        padding: tokens.space.md,
+        overflowY: 'auto',
+        fontFamily: tokens.font.body,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: tokens.space.md,
+      }}
+    >
+      {/* iNFT metadata */}
+      <section>
+        <SectionHeader>iNFT — Elder #{elder.clanId}</SectionHeader>
+        <div
+          style={{
+            marginTop: tokens.space.sm,
+            display: 'grid',
+            gridTemplateColumns: 'auto 1fr',
+            gap: '4px 12px',
+            fontFamily: tokens.font.mono,
+            fontSize: '10px',
+          }}
+        >
+          <Field k="token_id"     v={`0x${(0xe1de7000 + elder.clanId).toString(16)}`} />
+          <Field k="archetype"    v={elder.archetype} />
+          <Field k="state_root"   v="0xa1b2…f7e9" />
+          <Field k="encrypted"    v="◉ tee-attested" />
+          <Field k="version"      v="v0.4.6" />
+        </div>
+      </section>
+
+      {/* KV state + memory CRUD side-by-side on wide, stacked on narrow */}
+      <section style={{ display: 'flex', flexDirection: 'column', gap: tokens.space.md }}>
+        <div>
+          <SectionHeader>kv state</SectionHeader>
+          <div
+            style={{
+              marginTop: tokens.space.sm,
+              fontFamily: tokens.font.mono,
+              fontSize: '10px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '2px',
+            }}
+          >
+            {STUB_KV.map((kv) => (
+              <div
+                key={kv.key}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  padding: '3px 6px',
+                  background: 'rgba(255,255,255,0.18)',
+                }}
+              >
+                <span style={{ color: tokens.text.onParchmentDim }}>{kv.key}</span>
+                <span style={{ color: elder.accent, fontWeight: 600 }}>{kv.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <SectionHeader>memory CRUD</SectionHeader>
+          <ul
+            style={{
+              listStyle: 'none',
+              margin: `${tokens.space.sm} 0 0`,
+              padding: 0,
+              fontFamily: tokens.font.mono,
+              fontSize: '10px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '2px',
+            }}
+          >
+            {STUB_CRUD.map((c, i) => (
+              <li
+                key={i}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '28px 52px 1fr',
+                  gap: '6px',
+                  padding: '3px 6px',
+                  background: 'rgba(255,255,255,0.18)',
+                  alignItems: 'center',
+                }}
+              >
+                <span style={{ color: tokens.text.muted }}>T{c.tick}</span>
+                <span
+                  style={{
+                    fontWeight: 700,
+                    color: c.op === 'WRITE' ? '#7a3a1a' : tokens.text.muted,
+                  }}
+                >
+                  {c.op}
+                </span>
+                <span>
+                  <span style={{ color: tokens.text.onParchmentDim }}>{c.key}</span>
+                  <span style={{ color: tokens.text.onParchment, marginLeft: '6px' }}>
+                    — {c.note}
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <SectionHeader>bulletins</SectionHeader>
+          <ul
+            style={{
+              listStyle: 'none',
+              margin: `${tokens.space.sm} 0 0`,
+              padding: 0,
+              fontFamily: tokens.font.body,
+              fontSize: '11px',
+              fontStyle: 'italic',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '4px',
+            }}
+          >
+            {STUB_BULLETINS.map((b, i) => (
+              <li
+                key={i}
+                style={{
+                  padding: '6px 8px',
+                  background: 'rgba(212,165,68,0.1)',
+                  borderLeft: `2px solid ${tokens.text.accent}`,
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: tokens.space.sm,
+                }}
+              >
+                <span>{b.body}</span>
+                <span
+                  style={{
+                    color: tokens.text.muted,
+                    fontFamily: tokens.font.mono,
+                    fontStyle: 'normal',
+                    fontSize: '9px',
+                    flexShrink: 0,
+                  }}
+                >
+                  {b.age}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function Field({ k, v }: { k: string; v: string }) {
+  return (
+    <>
+      <span style={{ color: tokens.text.onParchmentDim }}>{k}</span>
+      <span style={{ color: tokens.text.onParchment, fontWeight: 600 }}>{v}</span>
+    </>
+  );
+}
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h3
+      style={{
+        margin: 0,
+        fontFamily: tokens.font.display,
+        fontSize: '11px',
+        letterSpacing: '0.18em',
+        textTransform: 'uppercase',
+        color: tokens.text.onParchmentDim,
+        borderBottom: `1px solid ${tokens.border.parchmentEdge}`,
+        paddingBottom: '4px',
+      }}
+    >
+      {children}
+    </h3>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -57,7 +57,15 @@ const Provider = ConvexProvider as React.ComponentType<{
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 
-if (!convexUrl) {
+// `/cockpit` is a standalone judge view — always render it, even if Convex
+// env is missing. The Phase-A panels are pure placeholders; the embedded
+// WorldMap consumes Convex via useQuery which returns undefined when no
+// data is available, so a stub client is enough to satisfy the provider.
+const isCockpitPath =
+  typeof window !== 'undefined' &&
+  window.location.pathname.startsWith('/cockpit');
+
+if (!convexUrl && !isCockpitPath) {
   // Fail soft instead of throwing — a thrown error here leaves a blank page,
   // which is unacceptable for the hackathon submission. Render a visible
   // message so the user sees something even if the build is misconfigured.
@@ -89,7 +97,12 @@ if (!convexUrl) {
     </main>,
   );
 } else {
-  const convex = new ConvexReactClient(convexUrl);
+  // Use an RFC 5737 documentation IP when env is missing on the cockpit
+  // route. The Convex client requires a URL at construction time; pointing
+  // it at an unroutable address is harmless for the read-only stub view —
+  // useQuery will simply return undefined forever, which the cockpit's
+  // placeholder content already handles gracefully.
+  const convex = new ConvexReactClient(convexUrl ?? 'https://203.0.113.1');
   root.render(
     <React.StrictMode>
       <Provider client={convex}>

--- a/apps/web/src/pages/Cockpit.tsx
+++ b/apps/web/src/pages/Cockpit.tsx
@@ -1,0 +1,170 @@
+import { tokens, ELDERS } from '../styles/cockpit-tokens';
+import { MiniCockpit } from '../components/cockpit/MiniCockpit';
+import { WorldMap } from '../WorldMap';
+import { WorldMapBoundary } from '../components/cockpit/shared/WorldMapBoundary';
+
+/**
+ * Cockpit Phase A — 3-column 2-row layout shell.
+ *
+ *   1  |    | 2
+ *   -- | 5  | --
+ *   3  |    | 4
+ *
+ * Panels 1-4 are mini-cockpits (one per Elder, hardcoded clans 1-4).
+ * Panel 5 is the existing WorldMap pixi canvas, spanning both rows.
+ *
+ * Desktop-first; corners stack vertically below md (≤960px) so phones still
+ * see the world map + each agent panel.
+ *
+ * Phase B (separate PR) wires real Convex data + tmux mirror + tick counter.
+ */
+export function Cockpit() {
+  // Elder slot mapping — physical grid position → clanId.
+  // Row 1: clan 1 left, clan 2 right.
+  // Row 2: clan 3 left, clan 4 right.
+  // Lookup by clanId so TS keeps strict-mode happy without non-null assertions
+  // on a tuple-from-array destructure.
+  const findElder = (clanId: number) => {
+    const e = ELDERS.find((x) => x.clanId === clanId);
+    if (!e) {
+      throw new Error(`ELDERS roster missing clanId ${clanId} — check cockpit-tokens.ts`);
+    }
+    return e;
+  };
+  const el1 = findElder(1);
+  const el2 = findElder(2);
+  const el3 = findElder(3);
+  const el4 = findElder(4);
+
+  return (
+    <main
+      data-testid="cockpit-root"
+      style={{
+        background: tokens.bg.void,
+        width: '100vw',
+        height: '100vh',
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <CockpitChrome />
+
+      {/* Responsive grid:
+          - desktop (≥960px): 3 cols × 2 rows, center spans both rows
+          - mobile  (<960px): single column, world map first then 4 panels
+          Implemented via inline media-query CSS in <style> below since
+          React inline styles can't express @media. */}
+      <style>{`
+        .cockpit-grid {
+          flex: 1;
+          display: grid;
+          gap: 8px;
+          padding: 8px;
+          min-height: 0;
+          grid-template-columns: 1fr 1.6fr 1fr;
+          grid-template-rows: 1fr 1fr;
+          grid-template-areas:
+            "p1 p5 p2"
+            "p3 p5 p4";
+        }
+        .cockpit-cell-1 { grid-area: p1; min-width: 0; min-height: 0; }
+        .cockpit-cell-2 { grid-area: p2; min-width: 0; min-height: 0; }
+        .cockpit-cell-3 { grid-area: p3; min-width: 0; min-height: 0; }
+        .cockpit-cell-4 { grid-area: p4; min-width: 0; min-height: 0; }
+        .cockpit-cell-5 { grid-area: p5; min-width: 0; min-height: 0; position: relative; }
+
+        @media (max-width: 960px) {
+          .cockpit-grid {
+            grid-template-columns: 1fr;
+            grid-template-rows: 320px repeat(4, 1fr);
+            grid-template-areas:
+              "p5"
+              "p1"
+              "p2"
+              "p3"
+              "p4";
+          }
+        }
+      `}</style>
+
+      <div className="cockpit-grid" data-testid="cockpit-grid">
+        <div className="cockpit-cell-1">
+          <MiniCockpit elder={el1} />
+        </div>
+        <div className="cockpit-cell-2">
+          <MiniCockpit elder={el2} />
+        </div>
+        <div className="cockpit-cell-3">
+          <MiniCockpit elder={el3} />
+        </div>
+        <div className="cockpit-cell-4">
+          <MiniCockpit elder={el4} />
+        </div>
+        <div
+          className="cockpit-cell-5"
+          data-testid="cockpit-worldmap"
+          style={{
+            border: `1px solid ${tokens.border.iron}`,
+            borderRadius: tokens.radius.md,
+            overflow: 'hidden',
+            background: '#000',
+          }}
+        >
+          {/* WorldMap is full-bleed; sits inside the center cell.
+              The component handles its own pixi canvas sizing via ResizeObserver.
+              Wrapped in a boundary so a backend-less load (judge route in plain
+              browser) renders a degraded placeholder instead of unmounting the
+              whole cockpit tree. */}
+          <WorldMapBoundary>
+            <WorldMap />
+          </WorldMapBoundary>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+/**
+ * Cockpit chrome — thin top bar with title + global tick / status placeholder.
+ * Kept slim so the panels dominate vertical space.
+ */
+function CockpitChrome() {
+  return (
+    <header
+      data-testid="cockpit-chrome"
+      style={{
+        height: '32px',
+        background: tokens.bg.ironDeep,
+        borderBottom: `1px solid ${tokens.border.iron}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: `0 ${tokens.space.md}`,
+        flexShrink: 0,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: tokens.font.display,
+          fontSize: '11px',
+          letterSpacing: '0.24em',
+          color: tokens.text.onIron,
+          textTransform: 'uppercase',
+        }}
+      >
+        ClanWorld · Elder Cockpit
+      </div>
+      <div
+        style={{
+          fontFamily: tokens.font.mono,
+          fontSize: '10px',
+          color: tokens.text.onIronDim,
+          letterSpacing: '0.08em',
+        }}
+      >
+        Phase A · layout shell
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/styles/cockpit-tokens.ts
+++ b/apps/web/src/styles/cockpit-tokens.ts
@@ -1,0 +1,84 @@
+/**
+ * Cockpit design tokens — parchment-on-cosmic-dark aesthetic to match the
+ * existing WorldMap canvas. Token-only file (no React); imported by every
+ * cockpit component to keep the visual language consistent.
+ *
+ * Palette philosophy:
+ *   - Background = void (deep cosmic black) so the world-map canvas reads as
+ *     a "window" into the realm.
+ *   - Panels = parchment-on-iron — warm aged paper face on a cold iron frame.
+ *   - Tabs = inkwell — desaturated brown with a single warm gold accent for
+ *     the active state. Avoids the "generic dashboard primary blue" look.
+ *   - Tick counter = vellum gold, monospace, evokes scribe tally marks.
+ */
+
+export const tokens = {
+  // Foundation
+  bg: {
+    void: '#0a0a0a',          // page background (matches existing main)
+    parchment: '#e8dec7',     // panel face — aged paper
+    parchmentDim: '#cdbfa0',  // hover / inactive parchment
+    iron: '#2a2620',          // panel border / chrome
+    ironDeep: '#16140f',      // tab strip background
+    ink: '#1a1612',           // tab strip darker accent
+  },
+  // Text
+  text: {
+    onParchment: '#2a1f10',   // primary on parchment (rich brown ink)
+    onParchmentDim: '#5a4628',// secondary on parchment
+    onIron: '#c9b88a',        // primary on iron chrome (warm gold)
+    onIronDim: '#7a6b4a',     // secondary on iron
+    accent: '#d4a544',        // active tab / tick counter glow
+    danger: '#b03a2e',        // starvation / error
+    muted: '#6b5e44',
+  },
+  // Borders
+  border: {
+    iron: '#3a3528',
+    ironLight: '#4a4232',
+    parchmentEdge: '#a89b78',
+  },
+  // Typography
+  font: {
+    display: '"Cinzel", "Times New Roman", serif',
+    body: '"Inter", system-ui, sans-serif',
+    mono: '"JetBrains Mono", "SF Mono", Consolas, monospace',
+  },
+  // Spacing scale (4px base)
+  space: {
+    xs: '4px',
+    sm: '8px',
+    md: '12px',
+    lg: '16px',
+    xl: '24px',
+  },
+  // Radii — small, parchment edges should feel hand-cut not pillowy
+  radius: {
+    sm: '2px',
+    md: '4px',
+  },
+  // Shadows — subtle, warm
+  shadow: {
+    panel: '0 2px 8px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,220,160,0.08)',
+    tab: 'inset 0 -2px 0 rgba(0,0,0,0.4)',
+    tabActive: 'inset 0 -2px 0 #d4a544, 0 0 12px rgba(212,165,68,0.25)',
+  },
+} as const;
+
+/** Hardcoded clan roster for Phase A — mirrors ~/agents/elders/elder-N/. */
+export interface ElderDef {
+  clanId: number;        // 1-4, matches elder-N folder
+  name: string;
+  archetype: string;
+  /** Single-character glyph used in lieu of a sprite for the panel header. */
+  glyph: string;
+  /** Accent hue for this clan's panel chrome (subtle — keeps parchment dominant). */
+  accent: string;
+}
+
+export const ELDERS: ReadonlyArray<ElderDef> = [
+  { clanId: 1, name: 'Storm Riders',     archetype: 'Aggressive Raider',     glyph: '⚡', accent: '#5a8aa8' },
+  { clanId: 2, name: 'Iron Guard',       archetype: 'Cautious Accumulator',  glyph: '⛨', accent: '#7a8a6a' },
+  { clanId: 3, name: 'Crimson',          archetype: 'Volatile Opportunist',  glyph: '✦', accent: '#a85a5a' },
+  { clanId: 4, name: 'Verdant Wardens',  archetype: 'Patient Builder',       glyph: '❦', accent: '#6aa888' },
+] as const;

--- a/apps/web/tests/e2e/04-cockpit-shell.spec.ts
+++ b/apps/web/tests/e2e/04-cockpit-shell.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Phase A — Cockpit layout shell.
+ *
+ * Verifies the structural skeleton:
+ *   - /cockpit route renders without error
+ *   - 3-col 2-row grid is mounted
+ *   - all 4 mini-cockpits visible
+ *   - world map cell visible
+ *   - default tab on each mini-cockpit is "terminal"
+ *
+ * Phase B follow-up tests will cover:
+ *   - tab switching, tick counter live updates
+ *   - real Convex data → resource values, tmux mirror
+ */
+test.describe('cockpit shell (Phase A)', () => {
+  test('renders 3-col 2-row layout with 4 mini-cockpits + world map', async ({
+    page,
+  }, testInfo) => {
+    await page.goto('/cockpit');
+
+    // No error boundary crash.
+    const errorBoundary = page.locator('[data-testid="error-boundary"]');
+    await expect(errorBoundary).toHaveCount(0);
+
+    // Grid root mounts.
+    await expect(page.locator('[data-testid="cockpit-root"]')).toBeVisible();
+    await expect(page.locator('[data-testid="cockpit-grid"]')).toBeVisible();
+
+    // All 4 corner mini-cockpits visible.
+    for (const clanId of [1, 2, 3, 4]) {
+      await expect(
+        page.locator(`[data-testid="mini-cockpit-${clanId}"]`),
+      ).toBeVisible();
+    }
+
+    // Center world-map cell visible (the pixi canvas mounts inside it
+    // asynchronously, so we just assert the cell is in the DOM).
+    await expect(page.locator('[data-testid="cockpit-worldmap"]')).toBeVisible();
+
+    // Default tab on each mini-cockpit is "terminal" — verify by checking
+    // the terminal content placeholder is the one rendered initially.
+    for (const clanId of [1, 2, 3, 4]) {
+      const terminalTab = page.locator(
+        `[data-testid="mini-cockpit-${clanId}-tab-terminal"]`,
+      );
+      await expect(terminalTab).toHaveAttribute('data-active', 'true');
+      await expect(
+        page.locator(`[data-testid="mini-cockpit-${clanId}-content-terminal"]`),
+      ).toBeVisible();
+    }
+
+    // Tick counter is rendered on each panel.
+    for (const clanId of [1, 2, 3, 4]) {
+      await expect(
+        page.locator(`[data-testid="mini-cockpit-${clanId}-tick"]`),
+      ).toBeVisible();
+    }
+
+    // Visual debug aid.
+    await page.screenshot({
+      path: testInfo.outputPath('04-cockpit-shell.png'),
+      fullPage: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase A of the Elder Cockpit — structural shell only. Pure frontend, no engine touch, no chain interaction.

**Stacked on PR #88 (`feat/playwright-e2e-harness`)** because the new `04-cockpit-shell.spec.ts` test extends that harness. Once #88 merges to `dev`, GitHub will auto-retarget this PR's base. If the orchestrator prefers a flat branch off `dev`, this can be rebased — the only file conflict would be the shared playwright config, which is identical in both branches.

Implements Liam's spec from his cockpit-design Telegram message verbatim (3-col 2-row grid, 4 mini-cockpits with 5 tabs each, center spans both rows for the WorldMap).

## Layout

```
1  |    | 2     ← Storm Riders (NW)  /  Iron Guard (NE)
-- | 5  | --   ← WorldMap canvas (full height)
3  |    | 4     ← Crimson (SW)       /  Verdant Wardens (SE)
```

Each mini-cockpit has 5 tabs (default = Terminal):

- **Terminal** — placeholder tmux mirror w/ scanline CRT effect, 5 stub Elder-thinking lines, "Phase B: live tmux stream" footer
- **Vault** — 4-resource grid (gold/wood/ore/stone) with delta indicators + asset movement log strip
- **Clansman** — 4 worker rows (mission/location/ETA/cooldown/hunger bar), red border on hunger > 0.7
- **0G** — iNFT metadata block, kv state list, memory CRUD log (READ/WRITE), bulletin posts
- **Comms** — 5 example bubbles tagged WHISPER (AXL chain) / HUMAN (Liam directives) / ORCH (orchestrator), color-coded with vertical accent bars

Tab bar layout per spec: icon-stacked-on-tiny-text on left, clan badge center, `T 4/10` tick counter right.

## Aesthetic

Parchment-on-iron + cosmic-dark void to match the existing WorldMap canvas. Cinzel display / Inter body / JetBrains Mono for data, warm-gold (`#d4a544`) accent for active state. All tokens centralized in `src/styles/cockpit-tokens.ts`.

## Screenshots

- Hero (default state, all panels on Terminal): https://shared.claude.do/public/tmp/cockpit-phaseA-hero-20260427-122434.png
- Vault tab on clan-1 (resources + movement log): https://shared.claude.do/public/tmp/cockpit-phaseA-vault-20260427-122434.png
- Comms tab on clan-1 (bubble taxonomy): https://shared.claude.do/public/tmp/cockpit-phaseA-comms-20260427-122434.png

## Files added

```
apps/web/src/
├── App.tsx                                         (modified — add /cockpit route gate)
├── main.tsx                                        (modified — stub Convex client on cockpit path)
├── pages/Cockpit.tsx                               (3-col 2-row CSS grid + responsive media)
├── styles/cockpit-tokens.ts                        (palette, typography, spacing, ELDERS roster)
├── components/cockpit/
│   ├── MiniCockpit.tsx                             (tabbed corner panel container)
│   ├── shared/
│   │   ├── CockpitTabBar.tsx                       (icon-stack tabs + tick counter)
│   │   └── WorldMapBoundary.tsx                    (error boundary scoped to center cell)
│   └── tabs/{Terminal,Vault,Clansman,ZeroG,Comms}Tab.tsx
└── tests/e2e/04-cockpit-shell.spec.ts              (Phase A smoke test)
```

## Routing

Lightweight `window.location.pathname.startsWith('/cockpit')` switch in `App.tsx` — avoids a router dep for a single side route. The early-return is **before any hooks** so the cockpit branch never instantiates the World-App / IDKit hooks (which would warn in a plain browser).

`main.tsx` was also taught to route past the "Backend not configured" fallback when the path is `/cockpit`, falling through to a stub Convex client (RFC 5737 documentation IP). `useQuery` returns undefined forever in that case, which `WorldMapBoundary` catches and replaces with a "World Map Offline" placeholder. This keeps the 4 mini-cockpits rendering even on a fully-offline judge build.

## Responsive

- Desktop (≥960px): 3 cols × 2 rows, center spans both rows
- Mobile (<960px): single column — world map first, then 4 panels stacked

## Verification

- `pnpm --filter @clan-world/web typecheck` → clean
- `pnpm --filter @clan-world/web build` → clean (4.5s, 316.91 kB main bundle gzipped to 99.91 kB)
- `pnpm exec playwright test 04-cockpit-shell` → 2/2 pass (chromium-desktop + chromium-mobile)
- Full e2e list now shows **10 tests** (8 existing + 2 new from this PR, one per project)

Pre-existing typecheck errors in `apps/server/convex/*.ts` (Convex codegen drift) are unchanged by this PR — confirmed by running typecheck against `origin/feat/playwright-e2e-harness` directly.

## Phase B follow-ups (separate PR)

- Live tmux capture-pane stream → Terminal tab
- Convex queries → real vault / clansman / 0G / comms data
- Reactive tick counter sourced from engine state
- Per-tab message-taxonomy v4.6 visual treatments (kind-styles map already seeded in `CommsTab.tsx`)
- Hunger bar + cooldown/ETA from real clansman state
- iNFT metadata fetched from chain reads

## Test plan

- [x] `pnpm --filter @clan-world/web typecheck` clean
- [x] `pnpm --filter @clan-world/web build` clean
- [x] `pnpm exec playwright test 04-cockpit-shell` passes both desktop + mobile projects
- [x] `/cockpit` renders in standalone browser (no World App, no Convex env) with map fallback
- [x] All 5 tabs switchable on every mini-cockpit; default is Terminal
- [x] Mobile layout (<960px) stacks vertically with map first