### PR TITLE
feat: cockpit Phase A.5b — live tmux iframes + app header + connection indicator

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -4,6 +4,8 @@ import { defineConfig, devices } from '@playwright/test';
 // `port-for --init <worktree>` slot for clan-world is registered. Until then
 // PLAYWRIGHT_BASE_URL env override is the canonical way to point tests at the
 // real dev server.
+// Migrate to port-for clan-world-frontend-test (58770) after PR #102
+// (port-for-init) merges.
 const DEFAULT_PORT = 58840;
 const baseURL =
   process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${DEFAULT_PORT}`;

--- a/apps/web/src/components/cockpit/CockpitHeader.tsx
+++ b/apps/web/src/components/cockpit/CockpitHeader.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState } from 'react';
+import { tokens } from '../../styles/cockpit-tokens';
+import { useConnectionStatus, type ConnectionStatus } from '../../hooks/useConnectionStatus';
+
+/**
+ * Phase A.5b stub: returns hardcoded tick so the header has something to show.
+ *
+ * TODO(phase-b): wire to a Convex query (likely `api.engine.currentTick`)
+ * so the value updates live as the engine ticks. The pulse animation in
+ * <TickCounter> will then visibly fire on each increment.
+ */
+function useCurrentTick(): { tick: number; tickMax: number } {
+  return { tick: 4, tickMax: 10 };
+}
+
+/**
+ * App-level cockpit header — replaces the per-mini-cockpit chrome that used
+ * to repeat the tick counter four times. Single instance now.
+ *
+ * Layout: title left, tick counter middle-right, connection pill far right.
+ */
+export function CockpitHeader() {
+  const { tick, tickMax } = useCurrentTick();
+  const { status, retry } = useConnectionStatus();
+
+  return (
+    <header
+      data-testid="cockpit-chrome"
+      style={{
+        height: '40px',
+        background: tokens.bg.ironDeep,
+        borderBottom: `1px solid ${tokens.border.iron}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: `0 ${tokens.space.md}`,
+        flexShrink: 0,
+        gap: tokens.space.md,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: tokens.font.display,
+          fontSize: '12px',
+          letterSpacing: '0.24em',
+          color: tokens.text.onIron,
+          textTransform: 'uppercase',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        ClanWorld Cockpit
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: tokens.space.lg,
+        }}
+      >
+        <TickCounter tick={tick} tickMax={tickMax} />
+        <ConnectionPill status={status} onRetry={retry} />
+      </div>
+    </header>
+  );
+}
+
+interface TickProps {
+  tick: number;
+  tickMax: number;
+}
+
+/**
+ * Mono "T n/N" counter with a 200ms border-glow flash on each increment.
+ * Uses a ref-tracked previous tick so the flash fires only on actual change,
+ * not on remount.
+ */
+function TickCounter({ tick, tickMax }: TickProps) {
+  const [pulsing, setPulsing] = useState(false);
+  const prevTickRef = useRef(tick);
+
+  useEffect(() => {
+    if (tick === prevTickRef.current) return;
+    prevTickRef.current = tick;
+    setPulsing(true);
+    const t = setTimeout(() => setPulsing(false), 200);
+    return () => clearTimeout(t);
+  }, [tick]);
+
+  return (
+    <div
+      data-testid="cockpit-header-tick"
+      data-pulsing={pulsing}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        padding: '4px 10px',
+        border: `1px solid ${pulsing ? tokens.text.accent : tokens.border.iron}`,
+        borderRadius: tokens.radius.sm,
+        background: tokens.bg.ink,
+        boxShadow: pulsing
+          ? `0 0 12px ${tokens.text.accent}, inset 0 0 6px rgba(212,165,68,0.25)`
+          : 'none',
+        fontFamily: tokens.font.mono,
+        fontSize: '12px',
+        color: tokens.text.accent,
+        fontWeight: 600,
+        letterSpacing: '0.08em',
+        transition: 'box-shadow 200ms ease, border-color 200ms ease',
+      }}
+      title="Engine tick"
+    >
+      <span style={{ opacity: 0.6 }}>T</span>
+      <span>{tick}</span>
+      <span style={{ opacity: 0.4 }}>/</span>
+      <span style={{ opacity: 0.6 }}>{tickMax}</span>
+    </div>
+  );
+}
+
+interface PillProps {
+  status: ConnectionStatus;
+  onRetry: () => void;
+}
+
+const STATUS_COLORS: Record<ConnectionStatus, string> = {
+  connected: '#7a8a6a',
+  reconnecting: tokens.text.accent,
+  disconnected: tokens.text.danger,
+};
+
+const STATUS_LABELS: Record<ConnectionStatus, string> = {
+  connected: 'connected',
+  reconnecting: 'reconnecting',
+  disconnected: 'disconnected',
+};
+
+const STATUS_GLYPHS: Record<ConnectionStatus, string> = {
+  connected: '●',
+  reconnecting: '⟳',
+  disconnected: '●',
+};
+
+/**
+ * Connection state pill. Shows current heartbeat status with a glyph + label,
+ * and exposes a manual "Reconnect" button when fully disconnected.
+ */
+function ConnectionPill({ status, onRetry }: PillProps) {
+  const color = STATUS_COLORS[status];
+  return (
+    <div
+      data-testid="cockpit-connection-pill"
+      data-status={status}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '4px 10px',
+        border: `1px solid ${tokens.border.iron}`,
+        borderRadius: tokens.radius.sm,
+        background: tokens.bg.ink,
+        fontFamily: tokens.font.mono,
+        fontSize: '11px',
+        color: tokens.text.onIronDim,
+        letterSpacing: '0.06em',
+      }}
+      title={`Cockpit backend: ${STATUS_LABELS[status]}`}
+    >
+      <span
+        aria-hidden
+        style={{
+          color,
+          fontSize: '13px',
+          lineHeight: 1,
+          display: 'inline-block',
+          animation: status === 'reconnecting' ? 'cockpit-pill-spin 1.2s linear infinite' : undefined,
+        }}
+      >
+        {STATUS_GLYPHS[status]}
+      </span>
+      <span style={{ color: tokens.text.onIron }}>{STATUS_LABELS[status]}</span>
+      {status === 'disconnected' && (
+        <button
+          data-testid="cockpit-connection-pill-retry"
+          type="button"
+          onClick={onRetry}
+          style={{
+            marginLeft: '4px',
+            padding: '2px 8px',
+            border: `1px solid ${tokens.border.ironLight}`,
+            borderRadius: tokens.radius.sm,
+            background: 'transparent',
+            color: tokens.text.accent,
+            fontFamily: tokens.font.mono,
+            fontSize: '10px',
+            letterSpacing: '0.08em',
+            cursor: 'pointer',
+            textTransform: 'uppercase',
+          }}
+        >
+          Reconnect
+        </button>
+      )}
+      <style>{`
+        @keyframes cockpit-pill-spin {
+          from { transform: rotate(0deg); }
+          to   { transform: rotate(360deg); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/web/src/components/cockpit/MiniCockpit.tsx
+++ b/apps/web/src/components/cockpit/MiniCockpit.tsx
@@ -9,16 +9,17 @@ import { CommsTab } from './tabs/CommsTab';
 
 interface Props {
   elder: ElderDef;
-  /** Stub tick counter — Phase B will source this from the engine. */
-  tick?: number;
-  tickMax?: number;
 }
 
 /**
  * One corner panel — tab bar on top, content below. Default tab is Terminal
  * per Liam's spec ("First tab is terminal").
+ *
+ * Phase A.5b: tick counter moved out of this component and into the global
+ * CockpitHeader (rendered once at the top of the page). MiniCockpit no
+ * longer takes a `tick` prop.
  */
-export function MiniCockpit({ elder, tick = 4, tickMax = 10 }: Props) {
+export function MiniCockpit({ elder }: Props) {
   const [active, setActive] = useState<TabId>('terminal');
   const testIdPrefix = `mini-cockpit-${elder.clanId}`;
 
@@ -43,8 +44,6 @@ export function MiniCockpit({ elder, tick = 4, tickMax = 10 }: Props) {
       <CockpitTabBar
         active={active}
         onSelect={setActive}
-        tick={tick}
-        tickMax={tickMax}
         clanName={elder.name}
         clanAccent={elder.accent}
         clanGlyph={elder.glyph}

--- a/apps/web/src/components/cockpit/shared/CockpitTabBar.tsx
+++ b/apps/web/src/components/cockpit/shared/CockpitTabBar.tsx
@@ -21,9 +21,6 @@ export const TABS: ReadonlyArray<TabDef> = [
 interface Props {
   active: TabId;
   onSelect: (id: TabId) => void;
-  /** Current engine tick for this Elder. Rendered as `T/10` on the right side. */
-  tick: number;
-  tickMax: number;
   /** Clan name / accent — colors the active-tab underline. */
   clanName: string;
   clanAccent: string;
@@ -33,17 +30,18 @@ interface Props {
 }
 
 /**
- * Compact tab bar — icon-stacked-on-text on the left, clan badge in the center,
- * X/10 tick counter on the right. Matches Liam's spec verbatim.
+ * Compact tab bar — icon-stacked-on-text on the left, clan badge on the right.
  *
- * Layout chosen so the bar is dense at small panel widths (corner cells in a
- * 3-col grid get ~340px on a 1440 desktop). Each tab is fixed ~44px wide.
+ * Phase A.5b: tick counter removed from per-tab bar; it now lives on the
+ * single app-level CockpitHeader so we render it once per page instead of
+ * four times.
+ *
+ * Layout chosen so the bar stays dense at small panel widths. Each tab is
+ * fixed ~44px wide.
  */
 export function CockpitTabBar({
   active,
   onSelect,
-  tick,
-  tickMax,
   clanName,
   clanAccent,
   clanGlyph,
@@ -115,7 +113,7 @@ export function CockpitTabBar({
         })}
       </div>
 
-      {/* Center: clan badge — pushes spacer between tabs and tick counter */}
+      {/* Right: clan badge */}
       <div
         style={{
           flex: 1,
@@ -144,31 +142,6 @@ export function CockpitTabBar({
         >
           {clanName}
         </span>
-      </div>
-
-      {/* Right: tick counter */}
-      <div
-        data-testid={`${testIdPrefix}-tick`}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '4px',
-          padding: `0 ${tokens.space.md}`,
-          borderLeft: `1px solid ${tokens.border.iron}`,
-          fontFamily: tokens.font.mono,
-          fontSize: '11px',
-          color: tokens.text.accent,
-          fontWeight: 600,
-          letterSpacing: '0.08em',
-          minWidth: '52px',
-          justifyContent: 'flex-end',
-        }}
-        title="Engine tick"
-      >
-        <span style={{ opacity: 0.6 }}>T</span>
-        <span>{tick}</span>
-        <span style={{ opacity: 0.4 }}>/</span>
-        <span style={{ opacity: 0.6 }}>{tickMax}</span>
       </div>
     </div>
   );

--- a/apps/web/src/components/cockpit/tabs/TerminalTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/TerminalTab.tsx
@@ -7,86 +7,61 @@ interface Props {
 }
 
 /**
- * Terminal tab — placeholder for the future tmux read-only mirror.
+ * Terminal tab — live ttyd iframe pointing at this Elder's tmux mirror.
  *
- * Phase A: renders a faux terminal with a few lines of stubbed output so the
- * panel "looks alive". Phase B will wire a real tmux capture-pane → WebSocket
- * stream (similar to CPC's terminal pane).
+ * The iframe loads `https://cockpit.clan-world.com/elder-{N}-tty/`, which is
+ * served by Caddy in front of `ttyd-elder-{N}.service`. ttyd renders the
+ * Elder's tmux session as a read-only WebSocket-fed terminal in the browser.
+ *
+ * If the upstream service is down, the iframe will show the browser's
+ * default connection-refused chrome — the global ConnectionPill in the
+ * cockpit header is responsible for surfacing connection state to the user.
+ *
+ * `sandbox="allow-scripts allow-same-origin"` is required because ttyd
+ * upgrades to a WebSocket on the same origin; stripping `allow-same-origin`
+ * breaks the WS handshake.
  */
 export function TerminalTab({ elder, testIdPrefix }: Props) {
-  // Hardcoded sample lines — make them feel like Elder LLM thinking-out-loud.
-  const lines = [
-    `$ elder-${elder.clanId} stream --tail`,
-    `[T03] situation-block ingested (12.4kb)`,
-    `[T03] thinking — wood low; mill before raid`,
-    `[T03] directive: queue clansman-2 → forest`,
-    `[T04] tick boundary; awaiting orchestrator`,
-  ];
+  const url = `https://cockpit.clan-world.com/elder-${elder.clanId}-tty/`;
 
   return (
     <div
       data-testid={`${testIdPrefix}-content-terminal`}
       style={{
         flex: 1,
-        background: '#0d0d0d',
-        color: '#9ec792',
-        fontFamily: tokens.font.mono,
-        fontSize: '11px',
-        lineHeight: 1.6,
-        padding: tokens.space.md,
-        overflowY: 'auto',
-        position: 'relative',
-        boxShadow: 'inset 0 0 24px rgba(0,0,0,0.6)',
+        display: 'flex',
+        flexDirection: 'column',
+        background: '#000',
+        minHeight: 0,
       }}
     >
-      {/* CRT scanline effect — subtle, parchment aesthetic still dominant */}
-      <div
-        style={{
-          position: 'absolute',
-          inset: 0,
-          pointerEvents: 'none',
-          background:
-            'repeating-linear-gradient(0deg, rgba(0,0,0,0.06) 0 1px, transparent 1px 3px)',
-        }}
-      />
       <div
         style={{
           color: tokens.text.onIronDim,
           fontSize: '9px',
           letterSpacing: '0.15em',
-          marginBottom: '8px',
+          padding: `4px ${tokens.space.md}`,
           textTransform: 'uppercase',
+          fontFamily: tokens.font.mono,
+          background: tokens.bg.ironDeep,
+          borderBottom: `1px solid ${tokens.border.iron}`,
+          flexShrink: 0,
         }}
       >
         ── Elder-{elder.clanId} tmux mirror (read-only) ──
       </div>
-      {lines.map((l, i) => (
-        <div key={i} style={{ position: 'relative', zIndex: 1 }}>
-          {l}
-        </div>
-      ))}
-      <div
+      <iframe
+        src={url}
+        title={`Elder ${elder.clanId} tmux mirror`}
+        className="cockpit-terminal-iframe"
+        sandbox="allow-scripts allow-same-origin"
         style={{
-          position: 'relative',
-          zIndex: 1,
-          marginTop: '4px',
-          color: '#d4a544',
+          flex: 1,
+          width: '100%',
+          border: 'none',
+          background: '#000',
         }}
-      >
-        ▊
-      </div>
-      <div
-        style={{
-          position: 'absolute',
-          bottom: tokens.space.sm,
-          right: tokens.space.sm,
-          fontSize: '9px',
-          color: tokens.text.muted,
-          fontFamily: tokens.font.mono,
-        }}
-      >
-        Phase B: live tmux stream
-      </div>
+      />
     </div>
   );
 }

--- a/apps/web/src/hooks/useConnectionStatus.ts
+++ b/apps/web/src/hooks/useConnectionStatus.ts
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type ConnectionStatus = 'connected' | 'reconnecting' | 'disconnected';
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
+const MAX_RETRIES = 3;
+/** 2s, 4s, 8s exponential backoff. */
+const BACKOFF_MS = [2_000, 4_000, 8_000];
+/**
+ * Heartbeat target — ttyd is the canonical "is the cockpit backend reachable"
+ * probe. We hit elder-1 specifically because that's the always-on Elder; the
+ * other ttyd services start lazily at demo time.
+ *
+ * Tests stub this URL via Playwright `page.route()`.
+ *
+ * Known limitation: this is a *reachability* probe, not a *health* probe.
+ * `mode: 'no-cors'` resolves for any HTTP response (including 502/503 from
+ * Caddy when the upstream ttyd is down). We accept this trade-off for now —
+ * a same-origin /healthz endpoint on app.clan-world.com would be more
+ * accurate but requires a server-side proxy that's out of scope here.
+ * Phase B may revisit by adding a Convex query that the server polls.
+ */
+export const HEARTBEAT_URL =
+  'https://cockpit.clan-world.com/elder-1-tty/';
+
+interface Options {
+  /** Override the heartbeat URL (for tests). */
+  url?: string;
+  /** Override the heartbeat poll interval (for tests). */
+  intervalMs?: number;
+}
+
+/**
+ * Heartbeat-driven connection state machine.
+ *
+ *   connected ──fail──▶ reconnecting ──MAX_RETRIES fails──▶ disconnected
+ *       ▲                    │                                  │
+ *       └─────────success─────┘──manual retry()──────────────────┘
+ *
+ * The fetch uses `mode: 'no-cors'` because the cockpit page lives on a
+ * different subdomain than ttyd — the response is opaque, but `fetch`
+ * resolving (vs rejecting) is enough signal that the host is reachable.
+ *
+ * On `visibilitychange` → visible, we fire an immediate heartbeat ONLY if
+ * the state is `connected` or `reconnecting`. We never auto-leave the
+ * `disconnected` state — that state is sticky until the user clicks
+ * Reconnect, by design.
+ *
+ * Implementation note: the entire state machine is implemented inside a
+ * single `useEffect` so the closure variables (retryCount, in-flight flag,
+ * timer handles) are scoped to a single mount. External callers interact
+ * through `status` (state) and `retry()` (a stable callback that bumps a
+ * counter; the effect picks up the change and resets the state machine).
+ */
+export function useConnectionStatus(options: Options = {}): {
+  status: ConnectionStatus;
+  retry: () => void;
+} {
+  const { url = HEARTBEAT_URL, intervalMs = HEARTBEAT_INTERVAL_MS } = options;
+  const [status, setStatus] = useState<ConnectionStatus>('connected');
+  const [retryToken, setRetryToken] = useState(0);
+
+  // Status ref so the visibility handler can check current state without
+  // re-running the effect on every transition (which would tear down + rearm
+  // the timer chain on each tick).
+  const statusRef = useRef<ConnectionStatus>(status);
+  statusRef.current = status;
+
+  const retry = useCallback(() => {
+    setRetryToken((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let pollTimer: ReturnType<typeof setTimeout> | undefined;
+    let backoffTimer: ReturnType<typeof setTimeout> | undefined;
+    let retryCount = 0;
+    /** Guard against overlapping probes when visibilitychange fires mid-flight. */
+    let inFlight = false;
+
+    // Manual retry resets the state machine.
+    if (retryToken > 0) {
+      setStatus('reconnecting');
+    }
+
+    const clearTimers = () => {
+      if (pollTimer) clearTimeout(pollTimer);
+      if (backoffTimer) clearTimeout(backoffTimer);
+      pollTimer = undefined;
+      backoffTimer = undefined;
+    };
+
+    const probe = async (): Promise<boolean> => {
+      try {
+        await fetch(url, { method: 'HEAD', mode: 'no-cors', cache: 'no-store' });
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    const heartbeat = async () => {
+      if (inFlight || cancelled) return;
+      inFlight = true;
+      // Clear any pending timers — we're firing now.
+      clearTimers();
+      try {
+        const ok = await probe();
+        if (cancelled) return;
+        if (ok) {
+          retryCount = 0;
+          setStatus('connected');
+          pollTimer = setTimeout(() => void heartbeat(), intervalMs);
+          return;
+        }
+        // Failure path
+        if (retryCount >= MAX_RETRIES) {
+          setStatus('disconnected');
+          return;
+        }
+        setStatus('reconnecting');
+        const delay = BACKOFF_MS[retryCount] ?? BACKOFF_MS[BACKOFF_MS.length - 1];
+        retryCount += 1;
+        backoffTimer = setTimeout(() => void heartbeat(), delay);
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    const onVisibility = () => {
+      if (cancelled) return;
+      if (document.visibilityState !== 'visible') return;
+      // Don't auto-revive from disconnected — that state is sticky until
+      // the user clicks the Reconnect button. Visibility change only
+      // accelerates the next probe in the polling loop.
+      if (statusRef.current === 'disconnected') return;
+      void heartbeat();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+
+    void heartbeat();
+
+    return () => {
+      cancelled = true;
+      clearTimers();
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [url, intervalMs, retryToken]);
+
+  return { status, retry };
+}

--- a/apps/web/src/pages/Cockpit.tsx
+++ b/apps/web/src/pages/Cockpit.tsx
@@ -1,5 +1,6 @@
 import { tokens, ELDERS } from '../styles/cockpit-tokens';
 import { MiniCockpit } from '../components/cockpit/MiniCockpit';
+import { CockpitHeader } from '../components/cockpit/CockpitHeader';
 import { WorldMap } from '../WorldMap';
 import { WorldMapBoundary } from '../components/cockpit/shared/WorldMapBoundary';
 
@@ -13,10 +14,13 @@ import { WorldMapBoundary } from '../components/cockpit/shared/WorldMapBoundary'
  * Panels 1-4 are mini-cockpits (one per Elder, hardcoded clans 1-4).
  * Panel 5 is the existing WorldMap pixi canvas, spanning both rows.
  *
+ * Phase A.5b: terminal tabs render a live ttyd iframe; tick counter +
+ * connection indicator hoisted to a single app-level CockpitHeader.
+ *
  * Desktop-first; corners stack vertically below md (≤960px) so phones still
  * see the world map + each agent panel.
  *
- * Phase B (separate PR) wires real Convex data + tmux mirror + tick counter.
+ * Phase B (separate PR) wires real Convex data + tick subscription.
  */
 export function Cockpit() {
   // Elder slot mapping — physical grid position → clanId.
@@ -48,7 +52,7 @@ export function Cockpit() {
         flexDirection: 'column',
       }}
     >
-      <CockpitChrome />
+      <CockpitHeader />
 
       {/* Responsive grid:
           - desktop (≥960px): 3 cols × 2 rows, center spans both rows
@@ -122,49 +126,5 @@ export function Cockpit() {
         </div>
       </div>
     </main>
-  );
-}
-
-/**
- * Cockpit chrome — thin top bar with title + global tick / status placeholder.
- * Kept slim so the panels dominate vertical space.
- */
-function CockpitChrome() {
-  return (
-    <header
-      data-testid="cockpit-chrome"
-      style={{
-        height: '32px',
-        background: tokens.bg.ironDeep,
-        borderBottom: `1px solid ${tokens.border.iron}`,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        padding: `0 ${tokens.space.md}`,
-        flexShrink: 0,
-      }}
-    >
-      <div
-        style={{
-          fontFamily: tokens.font.display,
-          fontSize: '11px',
-          letterSpacing: '0.24em',
-          color: tokens.text.onIron,
-          textTransform: 'uppercase',
-        }}
-      >
-        ClanWorld · Elder Cockpit
-      </div>
-      <div
-        style={{
-          fontFamily: tokens.font.mono,
-          fontSize: '10px',
-          color: tokens.text.onIronDim,
-          letterSpacing: '0.08em',
-        }}
-      >
-        Phase A · layout shell
-      </div>
-    </header>
   );
 }

--- a/apps/web/tests/e2e/04-cockpit-shell.spec.ts
+++ b/apps/web/tests/e2e/04-cockpit-shell.spec.ts
@@ -9,12 +9,26 @@ import { test, expect } from '@playwright/test';
  *   - all 4 mini-cockpits visible
  *   - world map cell visible
  *   - default tab on each mini-cockpit is "terminal"
+ *   - app-level header has tick counter + connection pill (Phase A.5b)
  *
  * Phase B follow-up tests will cover:
  *   - tab switching, tick counter live updates
  *   - real Convex data → resource values, tmux mirror
  */
 test.describe('cockpit shell (Phase A)', () => {
+  // Default to stubbing all 4 ttyd iframes with tiny HTML so the test never
+  // depends on external network. Individual tests override the route to
+  // simulate connection failures.
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/cockpit.clan-world.com/elder-*-tty/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<!DOCTYPE html><html><body data-stub="ttyd"></body></html>',
+      }),
+    );
+  });
+
   test('renders 3-col 2-row layout with 4 mini-cockpits + world map', async ({
     page,
   }, testInfo) => {
@@ -51,17 +65,55 @@ test.describe('cockpit shell (Phase A)', () => {
       ).toBeVisible();
     }
 
-    // Tick counter is rendered on each panel.
-    for (const clanId of [1, 2, 3, 4]) {
-      await expect(
-        page.locator(`[data-testid="mini-cockpit-${clanId}-tick"]`),
-      ).toBeVisible();
-    }
+    // Phase A.5b: tick counter is now app-level (single instance), not
+    // per-mini-cockpit. The connection pill is also rendered once.
+    await expect(page.locator('[data-testid="cockpit-header-tick"]')).toBeVisible();
+    await expect(page.locator('[data-testid="cockpit-header-tick"]')).toHaveCount(1);
+    await expect(
+      page.locator('[data-testid="cockpit-connection-pill"]'),
+    ).toBeVisible();
 
     // Visual debug aid.
     await page.screenshot({
       path: testInfo.outputPath('04-cockpit-shell.png'),
       fullPage: true,
+    });
+  });
+
+  test('connection pill transitions to disconnected when heartbeat fails', async ({
+    page,
+  }) => {
+    // Override the beforeEach stub: abort all elder-* iframe + heartbeat
+    // requests so the heartbeat probe fails. After MAX_RETRIES (3) at
+    // 2s/4s/8s backoff, total worst-case wall time to disconnected is ~14s
+    // plus initial probe fail; allow a generous 30s timeout.
+    await page.route('**/cockpit.clan-world.com/elder-*-tty/**', (route) =>
+      route.abort('failed'),
+    );
+
+    await page.goto('/cockpit');
+
+    const pill = page.locator('[data-testid="cockpit-connection-pill"]');
+    await expect(pill).toBeVisible();
+
+    // Wait for the pill to transition to disconnected. The state machine
+    // must traverse `reconnecting` first, but we just assert the terminal
+    // state to keep the test deterministic.
+    await expect(pill).toHaveAttribute('data-status', 'disconnected', {
+      timeout: 30_000,
+    });
+
+    // Manual reconnect button is rendered in the disconnected state.
+    const retryBtn = page.locator('[data-testid="cockpit-connection-pill-retry"]');
+    await expect(retryBtn).toBeVisible();
+
+    // Clicking Reconnect bumps the state machine back into the retry loop;
+    // since the route is still aborted, the pill should re-enter
+    // `reconnecting` before flipping back to `disconnected`. We assert it
+    // doesn't crash and remains in a known state after a click.
+    await retryBtn.click();
+    await expect(pill).toHaveAttribute('data-status', /reconnecting|disconnected/, {
+      timeout: 5_000,
     });
   });
 });


### PR DESCRIPTION
## Summary

Stacks on #100 (cockpit-shell-A). Will auto-retarget to `dev` when #100 merges, OR orchestrator can rebase earlier.

- TerminalTab placeholder → real iframe at `https://cockpit.clan-world.com/elder-{N}-tty/`
- Tick counter de-duplicated: per-tab (4×) → single app-level header (1×)
- New `CockpitHeader` component replaces the inline `CockpitChrome`
- New `ConnectionPill` + `useConnectionStatus()` hook — green/amber/red states with heartbeat (15s HEAD probe), 2s/4s/8s exponential backoff, manual reconnect button, inFlight guard against overlapping probes, sticky disconnected state (visibility change does not auto-leave)
- E2E test updated: `beforeEach` stubs all `cockpit.clan-world.com/elder-*-tty/**` for hermeticity; renders test asserts header-tick + pill; new disconnected-state test simulates heartbeat failure and asserts pill transitions + Reconnect button reachable

## Retarget note

Base = `feat/cockpit-shell-A` (PR #100). When #100 merges into `dev`, this PR's base auto-rebases. If #100 is delayed, orchestrator may rebase this branch onto `dev` directly.

## Known limitations (documented in code)

- **Heartbeat = reachability, not health** — `mode: 'no-cors'` resolves for any HTTP response (including Caddy 502 when ttyd is down). Catches DNS/connection failures only. A same-origin `/healthz` would be more accurate but needs server proxy work out of scope here.
- **iframe sandbox `allow-same-origin`** — required for ttyd's WebSocket upgrade. ttyd is on a different subdomain (`cockpit.clan-world.com`) than the app (`app.clan-world.com`), so it does not share session cookies. Verified intentional by the orchestrator brief.

## Test plan

- [x] tsc --noEmit clean
- [x] vite build clean
- [x] playwright e2e clean (chromium-desktop) — 2/2 in 04-cockpit-shell.spec.ts pass
- [x] local 2-tier swarm clean (codex + claude self-review; gemini r1 findings addressed in r2 fixes)

## Hero screenshot

https://shared.claude.do/public/tmp/cockpit-phaseA5b-hero-20260427T130847.png

Shows: app-level header (title + T 4/10 + green connected pill) + 4 mini-cockpits with tab bars + Elder-1 iframe rendering live ttyd content (others black because services unstarted by design) + WorldMap fallback (no Convex backend in test env).

## Files changed

- `apps/web/src/components/cockpit/tabs/TerminalTab.tsx` — placeholder → iframe
- `apps/web/src/components/cockpit/CockpitHeader.tsx` — NEW (tick + pill)
- `apps/web/src/hooks/useConnectionStatus.ts` — NEW (state machine)
- `apps/web/src/components/cockpit/MiniCockpit.tsx` — drop tick props
- `apps/web/src/components/cockpit/shared/CockpitTabBar.tsx` — remove tick block
- `apps/web/src/pages/Cockpit.tsx` — use CockpitHeader, drop inline CockpitChrome
- `apps/web/tests/e2e/04-cockpit-shell.spec.ts` — beforeEach stubs + new test
- `apps/web/playwright.config.ts` — TODO comment for port-for migration after #102