### PR TITLE
chore(web): migrate Playwright default port to port-for lookup

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -6,7 +6,8 @@ import { defineConfig, devices } from '@playwright/test';
 // unavailable (CI, non-do-box hosts). PLAYWRIGHT_BASE_URL override takes precedence.
 const DEFAULT_PORT = (() => {
   try {
-    return parseInt(execSync('port-for clan-world-frontend-test', { encoding: 'utf8' }).trim(), 10);
+    const port = parseInt(execSync('port-for clan-world-frontend-test', { encoding: 'utf8' }).trim(), 10);
+    return Number.isNaN(port) ? 58770 : port;
   } catch {
     return 58770;
   }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,61 @@
+import { execSync } from 'node:child_process';
+import { defineConfig, devices } from '@playwright/test';
+
+// Canonical port resolved from port-for registry (clan-world slot 587, env=test).
+// Falls back to 58770 (canonical value from .world/ports.yml) when port-for is
+// unavailable (CI, non-do-box hosts). PLAYWRIGHT_BASE_URL override takes precedence.
+const DEFAULT_PORT = (() => {
+  try {
+    return parseInt(execSync('port-for clan-world-frontend-test', { encoding: 'utf8' }).trim(), 10);
+  } catch {
+    return 58770;
+  }
+})();
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${DEFAULT_PORT}`;
+
+// Derive the dev-server PORT from baseURL so that an external override of
+// PLAYWRIGHT_BASE_URL also relocates the spawned Vite server. If the URL has
+// no explicit port (e.g. http://staging.example.com), fall through to default.
+const webServerPort = (() => {
+  try {
+    const parsed = new URL(baseURL);
+    return parsed.port || String(DEFAULT_PORT);
+  } catch {
+    return String(DEFAULT_PORT);
+  }
+})();
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  outputDir: 'test-results',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'chromium-mobile',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+  webServer: {
+    command: `PORT=${webServerPort} pnpm --filter @clan-world/web dev`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});


### PR DESCRIPTION
## Summary

Replaces the hardcoded `DEFAULT_PORT = 58840` in `apps/web/playwright.config.ts` with a `port-for` lookup now that PR #102 registered the clan-world port slot.

- `port-for clan-world-frontend-test` resolves to `58770` (slot 587, env=test, per `.world/ports.yml`)
- Falls back to `58770` explicitly when `port-for` is unavailable (CI, non-do-box hosts)
- `PLAYWRIGHT_BASE_URL` env override still takes precedence for custom setups
- Removes the TODO comment that was tracking this migration

**Note:** Base branch is `feat/port-for-init` (PR #102). This PR retargets to `dev` when #102 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)