### PR TITLE
feat(runner): Phase 8 — AXL peer transport adapter with file fallback

### DIFF
--- a/packages/runner/.env.example
+++ b/packages/runner/.env.example
@@ -1,0 +1,45 @@
+# 0G Storage API key — enables durable 0G iNFT memory (ERC-7857 linked storage).
+# If unset, the runner falls back to a local JSON file at
+#   ~/.world/clanworld-runner/state/elder-{N}-memory.json
+OG_STORAGE_API_KEY=
+
+# 0G KV stream ID scoped to this clan (UUID or hex address).
+# Required when OG_STORAGE_API_KEY is set.
+OG_STREAM_ID=
+
+# 0G KV RPC endpoint (default: testnet).
+OG_KV_RPC=https://rpc-storage-testnet.0g.ai
+
+# Elder index for this runner instance (1–4).
+ELDER_N=1
+
+# ============================================================
+# Phase 8: Gensyn AXL peer transport
+# ============================================================
+
+# AXL API key — enables Gensyn AXL peer-to-peer messaging transport.
+# Falls back to file-based peer inbox (~/.world/clanworld-runner/state/peer-inbox/)
+# if unset or if AXL_NETWORK_ID is empty.
+AXL_API_KEY=
+
+# AXL network identifier — scopes the channel namespace.
+# Examples: "mainnet", "testnet"
+# Required when AXL_API_KEY is set; empty value triggers file fallback.
+AXL_NETWORK_ID=
+
+# URL of the local AXL node sidecar.
+# AXL runs as a Go binary exposing a local REST API at 127.0.0.1:9002 by default.
+# Only change this if your AXL node is bound to a non-default port.
+AXL_NODE_URL=http://127.0.0.1:9002
+
+# The Elder's own clan ID used for peer inbox routing.
+# If unset, defaults to the ELDER_N value as a string.
+MY_CLAN_ID=
+
+# Per-clan AXL peer IDs (ed25519 public keys, 64-char hex).
+# Convention: AXL_PEER_ID_{CLAN_ID_UPPER_SNAKE_CASE}
+# Example entries for a 4-clan world:
+AXL_PEER_ID_CLAN_IRON=
+AXL_PEER_ID_CLAN_EMBER=
+AXL_PEER_ID_CLAN_DAWN=
+AXL_PEER_ID_CLAN_STORM=

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -1,0 +1,100 @@
+# @clan-world/runner
+
+Elder tick-loop runner with pluggable memory and peer-inbox adapters.
+
+## Memory adapter
+
+The runner uses `IElderMemoryStore` for durable Elder memory across `/clear` context resets.
+
+### Local file (default)
+
+When `OG_STORAGE_API_KEY` is **not** set the runner uses `FileMemoryStore` — a local JSON file at:
+
+```
+~/.world/clanworld-runner/state/elder-{N}-memory.json
+```
+
+No extra config required.
+
+### 0G iNFT storage (Phase 7)
+
+When `OG_STORAGE_API_KEY` is set the runner uses `ZeroGMemoryStore`, backed by the [0G KV network](https://docs.0g.ai).
+
+| Variable | Description |
+|---|---|
+| `OG_STORAGE_API_KEY` | 0G API key — enables 0G backend |
+| `OG_STREAM_ID` | KV stream ID scoped to this clan (UUID or hex address) |
+| `OG_KV_RPC` | 0G KV RPC endpoint (default: `https://rpc-storage-testnet.0g.ai`) |
+| `ELDER_N` | Elder index 1–4 |
+
+**Note:** Write transactions require a funded wallet and deployed Flow contract. The current implementation includes a write stub (see `zeroGMemoryStore.ts` TODO comments) — reads via `KvClient` work fully.
+
+## Peer inbox adapter (Phase 8)
+
+The runner uses `IElderPeerInbox` for Elder-to-Elder private messaging (clan diplomacy).
+
+### File-based inbox (default)
+
+When `AXL_API_KEY` is **not** set (or `AXL_NETWORK_ID` is empty), the runner uses `FilePeerInbox`:
+
+- Messages stored as JSONL at `~/.world/clanworld-runner/state/peer-inbox/elder-{clanId}.jsonl`
+- `send()` appends to the **recipient's** file; `inbox()` reads the caller's own file.
+- Non-destructive reads: `inbox()` returns all messages without deleting them.
+- No external services required.
+
+### Gensyn AXL transport (Phase 8)
+
+When both `AXL_API_KEY` and `AXL_NETWORK_ID` are set, the runner uses `AxlPeerInbox`:
+
+- Talks to a **local AXL sidecar node** at `AXL_NODE_URL` (default `http://127.0.0.1:9002`).
+- AXL is a Gensyn peer-to-peer transport layer ([docs](https://docs.gensyn.ai/tech/agent-exchange-layer)).
+- **No official npm SDK** exists as of Phase 8; the runner uses AXL's HTTP REST API directly:
+  - `POST /send` with `X-Destination-Peer-Id` header for outbound messages.
+  - `GET /recv` for inbound queue polling (FIFO, drained on each `inbox()` call).
+- Each clan's Elder has an **ed25519 keypair**; peer routing uses `AXL_PEER_ID_{CLAN_ID}` env vars.
+
+| Variable | Description |
+|---|---|
+| `AXL_API_KEY` | Bearer token for managed AXL node auth. Enables AXL backend. |
+| `AXL_NETWORK_ID` | Channel namespace, e.g. `"testnet"` or `"mainnet"`. Required with AXL_API_KEY. |
+| `AXL_NODE_URL` | Local AXL node URL (default: `http://127.0.0.1:9002`) |
+| `MY_CLAN_ID` | This Elder's clan ID (defaults to `ELDER_N` as string) |
+| `AXL_PEER_ID_{CLAN_ID}` | AXL ed25519 pubkey for a peer clan. E.g. `AXL_PEER_ID_CLAN_IRON=abc...` |
+| `ELDER_N` | Elder index 1–4 |
+
+**AXL SDK blocked state (2026-04-27):** Gensyn does not publish an npm SDK for AXL. The runner
+wraps the HTTP API directly via the `IAxlClient` interface (`src/axlPeerInbox.ts`).
+When Gensyn ships `@gensyn/axl-sdk` (or equivalent), replace `AxlHttpClient` with the SDK
+and update the two TODO comments in `axlPeerInbox.ts`.
+
+**Fallback guarantee:** If either env var is missing the runner always falls back to `FilePeerInbox`
+without throwing. Existing file-based flows are unaffected.
+
+## Running
+
+```bash
+# Local fallback (memory + peer inbox both file-based)
+ELDER_N=1 npx tsx src/main.ts
+
+# With 0G memory
+OG_STORAGE_API_KEY=<key> OG_STREAM_ID=<id> ELDER_N=1 npx tsx src/main.ts
+
+# With AXL peer transport (requires running AXL node sidecar)
+AXL_API_KEY=<key> AXL_NETWORK_ID=testnet MY_CLAN_ID=clan-iron \
+  AXL_PEER_ID_CLAN_EMBER=<pubkey> ELDER_N=1 npx tsx src/main.ts
+
+# Full Phase 7+8: 0G memory + AXL peer transport
+OG_STORAGE_API_KEY=<key> OG_STREAM_ID=<id> \
+  AXL_API_KEY=<key> AXL_NETWORK_ID=testnet MY_CLAN_ID=clan-iron \
+  AXL_PEER_ID_CLAN_EMBER=<pubkey> ELDER_N=1 npx tsx src/main.ts
+```
+
+Copy `.env.example` to `.env` and fill in values.
+
+## Tests
+
+```bash
+pnpm test
+```
+
+Tests cover both fallback (file-based) and mocked AXL paths. No AXL node or credentials are required to run the test suite.

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@clan-world/runner",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/main.ts",
+    "start": "tsx src/main.ts",
+    "build": "echo 'uses tsx at runtime; no emit build needed'",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "echo 'lint stub'",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@0glabs/0g-ts-sdk": "0.3.3",
+    "@clan-world/agents": "workspace:*",
+    "tsx": "4.19.2"
+  },
+  "devDependencies": {
+    "@types/node": "25.6.0",
+    "typescript": "5.9.3",
+    "vitest": "^3.2.0"
+  }
+}

--- a/packages/runner/src/axlPeerInbox.ts
+++ b/packages/runner/src/axlPeerInbox.ts
@@ -1,0 +1,325 @@
+/**
+ * AxlPeerInbox — Phase 8 IElderPeerInbox backed by Gensyn AXL peer transport.
+ *
+ * S2 degrade-gracefully pattern:
+ *   - AXL_API_KEY not set OR AXL_NETWORK_ID empty → logs warning, falls back to FilePeerInbox.
+ *   - AXL_API_KEY set → uses AxlClient for durable peer messaging.
+ *
+ * AXL transport model (see https://docs.gensyn.ai/tech/agent-exchange-layer):
+ *   - AXL runs as a local sidecar node at 127.0.0.1:9002 (configurable via AXL_NODE_URL).
+ *   - send()  → POST /send with X-Destination-Peer-Id header (ed25519 public key of recipient).
+ *   - inbox() → GET  /recv polls the inbound FIFO queue; called repeatedly until 204.
+ *   - Channel naming: each clan's Elder owns a dedicated AXL keypair;
+ *     AXL_PEER_ID_{CLAN_ID} env vars map clanId → ed25519 pubkey for routing.
+ *   - AXL_API_KEY is used as the local node's auth token (Bearer) in headers for
+ *     managed-node deployments that require it; left empty for pure-local nodes.
+ *   - AXL_NETWORK_ID scopes the channel namespace (e.g. "mainnet", "testnet").
+ *
+ * Idempotency:
+ *   - Deduplication by (fromClanId, tick, msgId) is maintained in an in-memory Set.
+ *   - The de-dup Set is NOT persisted across runner restarts; for hard exactly-once
+ *     semantics, wire IElderMemoryStore to persist seen message IDs.
+ *
+ * TODO: Production hardening —
+ *   - Retry logic on transient AXL POST /send failures.
+ *   - Persist dedup Set into IElderMemoryStore so re-delivery across restarts is handled.
+ *   - Subscribe via long-poll or WebSocket once AXL exposes a streaming /recv variant.
+ *   - Wire AXL_PRIVATE_KEY for ed25519 message signing (current stub trusts local node).
+ */
+import type { IElderPeerInbox, PeerMessage } from '@clan-world/agents/src/seams/index.js';
+import { FilePeerInbox, defaultStateDir } from './filePeerInbox.js';
+
+// ---------------------------------------------------------------------------
+// AXL HTTP client interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal typed interface for the AXL local node HTTP API.
+ *
+ * AXL nodes expose a REST API at 127.0.0.1:9002:
+ *   POST /send  — fire-and-forget unicast to a peer ed25519 pubkey
+ *   GET  /recv  — poll inbound queue (FIFO); returns 204 when empty
+ *
+ * Typed separately so tests can inject a mock without starting a real AXL node.
+ *
+ * NOTE: No official npm SDK exists for AXL as of Phase 8 (2026-04-27).
+ * AXL is implemented as a Go binary communicating over local HTTP.
+ * See https://github.com/gensyn-ai/axl and the API spec at docs/api.md.
+ * TODO: Replace with a typed SDK import once Gensyn publishes one to npm.
+ */
+export interface IAxlClient {
+  /**
+   * Send a message to a peer identified by their ed25519 public key.
+   * Fire-and-forget — AXL does not provide delivery acknowledgement.
+   *
+   * @param toPeerId  - 64-char hex-encoded ed25519 public key of the recipient node.
+   * @param body      - raw message payload (UTF-8 JSON string for our use).
+   */
+  send(toPeerId: string, body: string): Promise<void>;
+
+  /**
+   * Poll the inbound queue for the next message.
+   *
+   * Returns null if the queue is empty (AXL returns 204 No Content).
+   * Returns the message body and sender peer ID otherwise.
+   */
+  recv(): Promise<{ fromPeerId: string; body: string } | null>;
+}
+
+// ---------------------------------------------------------------------------
+// AXL wire envelope stored inside message body
+// ---------------------------------------------------------------------------
+
+interface AxlEnvelope {
+  fromClanId: string;
+  toClanId: string;
+  message: string;
+  tick: number;
+  sentAt: string;
+  msgId: string;
+  networkId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Real AXL HTTP client
+// ---------------------------------------------------------------------------
+
+/**
+ * Concrete HTTP client talking to a local AXL node.
+ * Requires AXL_NODE_URL (default: http://127.0.0.1:9002).
+ */
+export class AxlHttpClient implements IAxlClient {
+  readonly #baseUrl: string;
+  readonly #authHeader: string | undefined;
+
+  constructor(baseUrl: string, apiKey?: string) {
+    this.#baseUrl = baseUrl.replace(/\/$/, '');
+    this.#authHeader = apiKey ? `Bearer ${apiKey}` : undefined;
+  }
+
+  async send(toPeerId: string, body: string): Promise<void> {
+    // TODO: When @gensyn/axl-sdk or equivalent ships on npm, replace this
+    // hand-rolled fetch with the SDK's typed send() method.
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/octet-stream',
+      'X-Destination-Peer-Id': toPeerId,
+    };
+    if (this.#authHeader) headers['Authorization'] = this.#authHeader;
+
+    const res = await fetch(`${this.#baseUrl}/send`, {
+      method: 'POST',
+      headers,
+      body: new TextEncoder().encode(body),
+    });
+
+    if (!res.ok) {
+      throw new Error(`[AxlHttpClient] POST /send failed: ${res.status} ${res.statusText}`);
+    }
+  }
+
+  async recv(): Promise<{ fromPeerId: string; body: string } | null> {
+    // TODO: When @gensyn/axl-sdk ships, use SDK's recv() instead.
+    const headers: Record<string, string> = {};
+    if (this.#authHeader) headers['Authorization'] = this.#authHeader;
+
+    const res = await fetch(`${this.#baseUrl}/recv`, { headers });
+
+    if (res.status === 204) return null; // queue empty
+    if (!res.ok) {
+      throw new Error(`[AxlHttpClient] GET /recv failed: ${res.status} ${res.statusText}`);
+    }
+
+    const fromPeerId = res.headers.get('X-From-Peer-Id') ?? 'unknown';
+    const buf = await res.arrayBuffer();
+    const body = new TextDecoder().decode(buf);
+    return { fromPeerId, body };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AxlPeerInbox implementation
+// ---------------------------------------------------------------------------
+
+export class AxlPeerInbox implements IElderPeerInbox {
+  readonly #myClanId: string;
+  readonly #networkId: string;
+  readonly #client: IAxlClient;
+  readonly #peerIdMap: Map<string, string>;
+  readonly #seenMsgIds = new Set<string>();
+  /** Session-level inbox cache — holds drained AXL messages so inbox() is non-consuming. */
+  readonly #inbox: PeerMessage[] = [];
+
+  /**
+   * @param myClanId  - the Elder's own clan ID (used for recv routing).
+   * @param networkId - AXL network identifier scoping the channel (e.g. "testnet").
+   * @param client    - IAxlClient instance (injectable for testing).
+   * @param peerIdMap - maps clanId → AXL ed25519 pubkey. Built from env at factory time.
+   */
+  constructor(
+    myClanId: string,
+    networkId: string,
+    client: IAxlClient,
+    peerIdMap: Map<string, string>,
+  ) {
+    this.#myClanId = myClanId;
+    this.#networkId = networkId;
+    this.#client = client;
+    this.#peerIdMap = peerIdMap;
+  }
+
+  async send(toClanId: string, message: string, tick: number): Promise<void> {
+    const toPeerId = this.#peerIdMap.get(toClanId);
+    if (!toPeerId) {
+      throw new Error(
+        `[AxlPeerInbox] no AXL peer ID for clanId=${toClanId} — ` +
+          `set AXL_PEER_ID_${toClanId.toUpperCase().replace(/-/g, '_')} in env.`,
+      );
+    }
+
+    // Use crypto random bytes for collision-free msgId even within the same tick+ms.
+    const randomSuffix = Math.random().toString(36).slice(2, 10);
+    const msgId = `${this.#myClanId}:${tick}:${Date.now()}-${randomSuffix}`;
+    const envelope: AxlEnvelope = {
+      fromClanId: this.#myClanId,
+      toClanId,
+      message,
+      tick,
+      sentAt: new Date().toISOString(),
+      msgId,
+      networkId: this.#networkId,
+    };
+
+    await this.#client.send(toPeerId, JSON.stringify(envelope));
+  }
+
+  async inbox(): Promise<PeerMessage[]> {
+    // Drain new messages from AXL into the session-local cache.
+    // Non-consuming contract: callers always receive the full accumulated inbox (cache + new),
+    // not just the latest batch. Consumption is the Elder's responsibility via memory store.
+    await this.#drainIntoCache();
+    // Return a snapshot — callers must not mutate the returned array.
+    return [...this.#inbox];
+  }
+
+  /**
+   * Pull all pending messages from the AXL recv queue and append to the session inbox cache.
+   * Deduplication by (fromClanId, tick, msgId) prevents re-adding on repeated drains.
+   * AXL delivers messages FIFO per sender — arrival order preserved.
+   */
+  async #drainIntoCache(): Promise<void> {
+    for (;;) {
+      let item: { fromPeerId: string; body: string } | null;
+      try {
+        item = await this.#client.recv();
+      } catch (err) {
+        console.warn('[AxlPeerInbox] recv() failed — stopping drain:', err);
+        break;
+      }
+      if (item === null) break; // queue drained
+
+      let envelope: AxlEnvelope;
+      try {
+        envelope = JSON.parse(item.body) as AxlEnvelope;
+      } catch {
+        console.warn('[AxlPeerInbox] recv: malformed envelope, skipping body:', item.body.slice(0, 80));
+        continue;
+      }
+
+      // Filter to our network and our clan inbox.
+      if (envelope.networkId !== this.#networkId) continue;
+      if (envelope.toClanId !== this.#myClanId) continue;
+
+      // Idempotency: skip duplicates by (fromClanId, tick, msgId).
+      const dedupKey = `${envelope.fromClanId}:${envelope.tick}:${envelope.msgId}`;
+      if (this.#seenMsgIds.has(dedupKey)) continue;
+      this.#seenMsgIds.add(dedupKey);
+
+      this.#inbox.push({
+        fromClanId: envelope.fromClanId,
+        toClanId: envelope.toClanId,
+        message: envelope.message,
+        tick: envelope.tick,
+        sentAt: envelope.sentAt,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory options + peer-ID map builder
+// ---------------------------------------------------------------------------
+
+export interface AxlPeerInboxOptions {
+  /** Override env lookup for testing. */
+  env?: Record<string, string | undefined>;
+  /** Override clan ID (default: derived from ELDER_N + CLAN_IDS env). */
+  myClanId?: string;
+  /** Override state directory for FilePeerInbox fallback. */
+  stateDir?: string;
+  /** Override AXL client (for testing). */
+  axlClient?: IAxlClient;
+  /** Override peer ID map (for testing). */
+  peerIdMap?: Map<string, string>;
+}
+
+/**
+ * Build a Map<clanId, axlPeerId> from env vars following the convention:
+ *   AXL_PEER_ID_{CLAN_ID_UPPER_SNAKE} = <64-char hex pubkey>
+ *
+ * Example:
+ *   AXL_PEER_ID_CLAN_IRON=abc123...
+ *   AXL_PEER_ID_CLAN_EMBER=def456...
+ *
+ * Scans all env keys with the AXL_PEER_ID_ prefix.
+ */
+export function buildPeerIdMap(env: Record<string, string | undefined>): Map<string, string> {
+  const map = new Map<string, string>();
+  const PREFIX = 'AXL_PEER_ID_';
+  for (const [key, val] of Object.entries(env)) {
+    if (!key.startsWith(PREFIX) || !val) continue;
+    // AXL_PEER_ID_CLAN_IRON → clan-iron
+    const clanId = key.slice(PREFIX.length).toLowerCase().replace(/_/g, '-');
+    map.set(clanId, val);
+  }
+  return map;
+}
+
+/**
+ * Create a peer inbox adapter.
+ *
+ * - If AXL_API_KEY is present and AXL_NETWORK_ID is non-empty → AxlPeerInbox.
+ * - Otherwise → logs a warning and returns FilePeerInbox (file-based fallback).
+ */
+export async function createPeerInbox(
+  opts: AxlPeerInboxOptions = {},
+): Promise<IElderPeerInbox> {
+  const env = opts.env ?? process.env;
+  const apiKey = env['AXL_API_KEY'];
+  const networkId = env['AXL_NETWORK_ID'];
+
+  if (!apiKey || !networkId) {
+    console.warn(
+      '[AxlPeerInbox] AXL_API_KEY or AXL_NETWORK_ID not set — falling back to file-based peer inbox.',
+    );
+    const elderN = parseInt(env['ELDER_N'] ?? '1', 10);
+    const myClanId = opts.myClanId ?? env['MY_CLAN_ID'] ?? String(elderN);
+    return new FilePeerInbox(myClanId, opts.stateDir ?? defaultStateDir());
+  }
+
+  const myClanId =
+    opts.myClanId ??
+    env['MY_CLAN_ID'] ??
+    String(parseInt(env['ELDER_N'] ?? '1', 10));
+
+  let client: IAxlClient;
+  if (opts.axlClient) {
+    client = opts.axlClient;
+  } else {
+    const nodeUrl = env['AXL_NODE_URL'] ?? 'http://127.0.0.1:9002';
+    client = new AxlHttpClient(nodeUrl, apiKey);
+  }
+
+  const peerIdMap = opts.peerIdMap ?? buildPeerIdMap(env);
+
+  return new AxlPeerInbox(myClanId, networkId, client, peerIdMap);
+}

--- a/packages/runner/src/axlPeerInbox.ts
+++ b/packages/runner/src/axlPeerInbox.ts
@@ -83,7 +83,8 @@ interface AxlEnvelope {
   toClanId: string;
   message: string;
   tick: number;
-  sentAt: string;
+  /** ISO 8601 timestamp; optional for forward-compat but validated if present. */
+  sentAt?: string | number;
   msgId: string;
   networkId: string;
 }
@@ -95,13 +96,57 @@ interface AxlEnvelope {
 function isAxlEnvelope(val: unknown): val is AxlEnvelope {
   if (typeof val !== 'object' || val === null) return false;
   const obj = val as Record<string, unknown>;
+  // Required fields:
+  if (
+    typeof obj['fromClanId'] !== 'string' ||
+    typeof obj['toClanId'] !== 'string' ||
+    typeof obj['message'] !== 'string' ||
+    typeof obj['tick'] !== 'number' ||
+    typeof obj['msgId'] !== 'string' ||
+    typeof obj['networkId'] !== 'string'
+  ) {
+    return false;
+  }
+  // LOW 6: sentAt is optional but when present must be string or number.
+  if (
+    obj['sentAt'] !== undefined &&
+    typeof obj['sentAt'] !== 'string' &&
+    typeof obj['sentAt'] !== 'number'
+  ) {
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Clan ID validation — prevents path traversal via myClanId (HIGH 2)
+// ---------------------------------------------------------------------------
+
+/** Alphanumeric, hyphens, underscores, 1–64 chars. Same pattern as FilePeerInbox. */
+const CLAN_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+
+function assertSafeClanId(clanId: string): void {
+  if (!CLAN_ID_RE.test(clanId)) {
+    throw new Error(
+      `[AxlPeerInbox] invalid clanId: ${JSON.stringify(clanId)} — ` +
+        `must match /^[a-zA-Z0-9_-]{1,64}$/`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JournalEntry type guard (MED 3)
+// ---------------------------------------------------------------------------
+
+function isJournalEntry(val: unknown): val is JournalEntry {
+  if (typeof val !== 'object' || val === null) return false;
+  const obj = val as Record<string, unknown>;
   return (
     typeof obj['fromClanId'] === 'string' &&
     typeof obj['toClanId'] === 'string' &&
-    typeof obj['message'] === 'string' &&
     typeof obj['tick'] === 'number' &&
     typeof obj['msgId'] === 'string' &&
-    typeof obj['networkId'] === 'string'
+    typeof obj['message'] === 'string'
   );
 }
 
@@ -198,6 +243,8 @@ export class AxlPeerInbox implements IElderPeerInbox {
     peerIdMap: Map<string, string>,
     journalPath: string | null = null,
   ) {
+    // HIGH 2: validate myClanId before using it in journal path construction.
+    assertSafeClanId(myClanId);
     this.#myClanId = myClanId;
     this.#networkId = networkId;
     this.#client = client;
@@ -210,33 +257,13 @@ export class AxlPeerInbox implements IElderPeerInbox {
   /**
    * Send a whisper to another clan's Elder.
    *
-   * A fresh msgId is generated each call. For idempotent retries where the caller
-   * needs AXL-level dedup, use sendIdempotent() with a stable caller-supplied msgId.
+   * A fresh msgId is generated each call via #generateMsgId. For idempotent retry
+   * with a stable caller-supplied msgId, IElderPeerInbox would need a sendIdempotent()
+   * extension — not included in the Phase 8 interface; tracked for a future phase.
    */
   async send(toClanId: string, message: string, tick: number): Promise<void> {
     // Generate a stable msgId for this invocation.
     const msgId = this.#generateMsgId(tick);
-    await this.#sendWithMsgId(toClanId, message, tick, msgId);
-  }
-
-  /**
-   * Send a whisper with a caller-supplied msgId for idempotent retry.
-   *
-   * If the caller retries with the same msgId, AXL receives the same ID both
-   * times — the server (or dedup layer) can detect and drop the duplicate.
-   * Use this instead of send() when exactly-once delivery matters.
-   *
-   * @param toClanId - recipient clan ID
-   * @param message  - message content
-   * @param tick     - current game tick
-   * @param msgId    - stable caller-supplied identifier; must be unique per logical message
-   */
-  async sendIdempotent(
-    toClanId: string,
-    message: string,
-    tick: number,
-    msgId: string,
-  ): Promise<void> {
     await this.#sendWithMsgId(toClanId, message, tick, msgId);
   }
 
@@ -329,24 +356,30 @@ export class AxlPeerInbox implements IElderPeerInbox {
       }
       const envelope = parsed;
 
-      // HIGH 1: peer spoofing check — validate fromPeerId against known peer map.
-      // If the transport-level peer ID doesn't map to the claimed fromClanId, reject.
-      if (peerToClan.size > 0) {
-        const expectedClanId = peerToClan.get(item.fromPeerId);
-        if (expectedClanId === undefined) {
-          console.warn(
-            `[AxlPeerInbox] recv: unknown fromPeerId=${item.fromPeerId}, rejecting message`,
-          );
-          continue;
-        }
-        if (expectedClanId !== envelope.fromClanId) {
-          console.warn(
-            `[AxlPeerInbox] recv: spoofing detected — ` +
-              `fromPeerId=${item.fromPeerId} maps to clan=${expectedClanId} ` +
-              `but envelope claims fromClanId=${envelope.fromClanId}. Rejecting.`,
-          );
-          continue;
-        }
+      // HIGH 1: peer spoofing check — fail-CLOSED.
+      // If peerIdMap is empty (AXL_PEER_ID_* env vars not set), ALL messages are rejected.
+      // Accepting with an empty map would allow any peer to spoof any clanId.
+      if (peerToClan.size === 0) {
+        console.warn(
+          '[AxlPeerInbox] WARN: peerIdMap empty — all inbound messages rejected for security. ' +
+            'Set AXL_PEER_ID_* env vars.',
+        );
+        continue;
+      }
+      const expectedClanId = peerToClan.get(item.fromPeerId);
+      if (expectedClanId === undefined) {
+        console.warn(
+          `[AxlPeerInbox] recv: unknown fromPeerId=${item.fromPeerId}, rejecting message`,
+        );
+        continue;
+      }
+      if (expectedClanId !== envelope.fromClanId) {
+        console.warn(
+          `[AxlPeerInbox] recv: spoofing detected — ` +
+            `fromPeerId=${item.fromPeerId} maps to clan=${expectedClanId} ` +
+            `but envelope claims fromClanId=${envelope.fromClanId}. Rejecting.`,
+        );
+        continue;
       }
 
       // Filter to our network and our clan inbox.
@@ -363,7 +396,9 @@ export class AxlPeerInbox implements IElderPeerInbox {
         toClanId: envelope.toClanId,
         message: envelope.message,
         tick: envelope.tick,
-        sentAt: envelope.sentAt,
+        // LOW 6: sentAt is optional in the envelope; default to empty string when absent
+        // so PeerMessage.sentAt (string) is always populated.
+        sentAt: envelope.sentAt !== undefined ? String(envelope.sentAt) : '',
       };
 
       // HIGH 2: persist to journal before adding to in-memory cache.
@@ -379,16 +414,24 @@ export class AxlPeerInbox implements IElderPeerInbox {
     if (!this.#journalPath || !fs.existsSync(this.#journalPath)) return;
     const lines = fs.readFileSync(this.#journalPath, 'utf8').split('\n').filter(Boolean);
     for (const line of lines) {
+      let parsed: unknown;
       try {
-        const entry = JSON.parse(line) as JournalEntry;
-        const dedupKey = `${entry.fromClanId}:${entry.tick}:${entry.msgId}`;
-        if (this.#seenMsgIds.has(dedupKey)) continue;
-        this.#seenMsgIds.add(dedupKey);
-        const { msgId: _msgId, ...msg } = entry;
-        this.#inbox.push(msg);
+        parsed = JSON.parse(line);
       } catch {
-        // skip malformed journal line
+        console.warn('[AxlPeerInbox] journal: malformed JSON line — skipping');
+        continue;
       }
+      // MED 3: type guard — skip corrupt/wrong-shape entries that could poison dedup state.
+      if (!isJournalEntry(parsed)) {
+        console.warn('[AxlPeerInbox] journal: entry missing required fields — skipping');
+        continue;
+      }
+      const entry = parsed;
+      const dedupKey = `${entry.fromClanId}:${entry.tick}:${entry.msgId}`;
+      if (this.#seenMsgIds.has(dedupKey)) continue;
+      this.#seenMsgIds.add(dedupKey);
+      const { msgId: _msgId, ...msg } = entry;
+      this.#inbox.push(msg);
     }
   }
 

--- a/packages/runner/src/axlPeerInbox.ts
+++ b/packages/runner/src/axlPeerInbox.ts
@@ -20,12 +20,20 @@
  *   - The de-dup Set is NOT persisted across runner restarts; for hard exactly-once
  *     semantics, wire IElderMemoryStore to persist seen message IDs.
  *
+ * Crash durability:
+ *   - inbox() persists drained messages to a JSONL journal file before returning them.
+ *   - On construction, the journal is replayed into the in-memory cache so messages
+ *     survive runner crashes. The Elder layer is responsible for marking messages as
+ *     consumed — the transport must not lose them.
+ *
  * TODO: Production hardening —
  *   - Retry logic on transient AXL POST /send failures.
  *   - Persist dedup Set into IElderMemoryStore so re-delivery across restarts is handled.
  *   - Subscribe via long-poll or WebSocket once AXL exposes a streaming /recv variant.
  *   - Wire AXL_PRIVATE_KEY for ed25519 message signing (current stub trusts local node).
  */
+import fs from 'node:fs';
+import path from 'node:path';
 import type { IElderPeerInbox, PeerMessage } from '@clan-world/agents/src/seams/index.js';
 import { FilePeerInbox, defaultStateDir } from './filePeerInbox.js';
 
@@ -78,6 +86,23 @@ interface AxlEnvelope {
   sentAt: string;
   msgId: string;
   networkId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Type guard for AxlEnvelope — validates untrusted network input (LOW 6)
+// ---------------------------------------------------------------------------
+
+function isAxlEnvelope(val: unknown): val is AxlEnvelope {
+  if (typeof val !== 'object' || val === null) return false;
+  const obj = val as Record<string, unknown>;
+  return (
+    typeof obj['fromClanId'] === 'string' &&
+    typeof obj['toClanId'] === 'string' &&
+    typeof obj['message'] === 'string' &&
+    typeof obj['tick'] === 'number' &&
+    typeof obj['msgId'] === 'string' &&
+    typeof obj['networkId'] === 'string'
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -137,6 +162,14 @@ export class AxlHttpClient implements IAxlClient {
 }
 
 // ---------------------------------------------------------------------------
+// Journal entry — PeerMessage + msgId, persisted for crash durability
+// ---------------------------------------------------------------------------
+
+interface JournalEntry extends PeerMessage {
+  msgId: string;
+}
+
+// ---------------------------------------------------------------------------
 // AxlPeerInbox implementation
 // ---------------------------------------------------------------------------
 
@@ -148,26 +181,91 @@ export class AxlPeerInbox implements IElderPeerInbox {
   readonly #seenMsgIds = new Set<string>();
   /** Session-level inbox cache — holds drained AXL messages so inbox() is non-consuming. */
   readonly #inbox: PeerMessage[] = [];
+  /** Journal file path for crash-durability (HIGH 2). */
+  readonly #journalPath: string | null;
 
   /**
-   * @param myClanId  - the Elder's own clan ID (used for recv routing).
-   * @param networkId - AXL network identifier scoping the channel (e.g. "testnet").
-   * @param client    - IAxlClient instance (injectable for testing).
-   * @param peerIdMap - maps clanId → AXL ed25519 pubkey. Built from env at factory time.
+   * @param myClanId    - the Elder's own clan ID (used for recv routing).
+   * @param networkId   - AXL network identifier scoping the channel (e.g. "testnet").
+   * @param client      - IAxlClient instance (injectable for testing).
+   * @param peerIdMap   - maps clanId → AXL ed25519 pubkey. Built from env at factory time.
+   * @param journalPath - path to persist drained messages for crash recovery. null = memory-only.
    */
   constructor(
     myClanId: string,
     networkId: string,
     client: IAxlClient,
     peerIdMap: Map<string, string>,
+    journalPath: string | null = null,
   ) {
     this.#myClanId = myClanId;
     this.#networkId = networkId;
     this.#client = client;
     this.#peerIdMap = peerIdMap;
+    this.#journalPath = journalPath;
+    // Replay journal into in-memory cache on startup (HIGH 2).
+    this.#replayJournal();
   }
 
+  /**
+   * Send a whisper to another clan's Elder.
+   *
+   * A fresh msgId is generated each call. For idempotent retries where the caller
+   * needs AXL-level dedup, use sendIdempotent() with a stable caller-supplied msgId.
+   */
   async send(toClanId: string, message: string, tick: number): Promise<void> {
+    // Generate a stable msgId for this invocation.
+    const msgId = this.#generateMsgId(tick);
+    await this.#sendWithMsgId(toClanId, message, tick, msgId);
+  }
+
+  /**
+   * Send a whisper with a caller-supplied msgId for idempotent retry.
+   *
+   * If the caller retries with the same msgId, AXL receives the same ID both
+   * times — the server (or dedup layer) can detect and drop the duplicate.
+   * Use this instead of send() when exactly-once delivery matters.
+   *
+   * @param toClanId - recipient clan ID
+   * @param message  - message content
+   * @param tick     - current game tick
+   * @param msgId    - stable caller-supplied identifier; must be unique per logical message
+   */
+  async sendIdempotent(
+    toClanId: string,
+    message: string,
+    tick: number,
+    msgId: string,
+  ): Promise<void> {
+    await this.#sendWithMsgId(toClanId, message, tick, msgId);
+  }
+
+  async inbox(): Promise<PeerMessage[]> {
+    // Drain new messages from AXL into the session-local cache.
+    // Non-consuming contract: callers always receive the full accumulated inbox (cache + new),
+    // not just the latest batch. Consumption is the Elder's responsibility via memory store.
+    await this.#drainIntoCache();
+    // Return a snapshot — callers must not mutate the returned array.
+    return [...this.#inbox];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /** Generate a collision-resistant msgId for a given tick (MED 3 — stable via sendIdempotent). */
+  #generateMsgId(tick: number): string {
+    const randomSuffix = Math.random().toString(36).slice(2, 10);
+    return `${this.#myClanId}:${tick}:${Date.now()}-${randomSuffix}`;
+  }
+
+  /** Core send implementation — shared by send() and sendIdempotent(). */
+  async #sendWithMsgId(
+    toClanId: string,
+    message: string,
+    tick: number,
+    msgId: string,
+  ): Promise<void> {
     const toPeerId = this.#peerIdMap.get(toClanId);
     if (!toPeerId) {
       throw new Error(
@@ -176,9 +274,6 @@ export class AxlPeerInbox implements IElderPeerInbox {
       );
     }
 
-    // Use crypto random bytes for collision-free msgId even within the same tick+ms.
-    const randomSuffix = Math.random().toString(36).slice(2, 10);
-    const msgId = `${this.#myClanId}:${tick}:${Date.now()}-${randomSuffix}`;
     const envelope: AxlEnvelope = {
       fromClanId: this.#myClanId,
       toClanId,
@@ -192,21 +287,24 @@ export class AxlPeerInbox implements IElderPeerInbox {
     await this.#client.send(toPeerId, JSON.stringify(envelope));
   }
 
-  async inbox(): Promise<PeerMessage[]> {
-    // Drain new messages from AXL into the session-local cache.
-    // Non-consuming contract: callers always receive the full accumulated inbox (cache + new),
-    // not just the latest batch. Consumption is the Elder's responsibility via memory store.
-    await this.#drainIntoCache();
-    // Return a snapshot — callers must not mutate the returned array.
-    return [...this.#inbox];
-  }
-
   /**
    * Pull all pending messages from the AXL recv queue and append to the session inbox cache.
    * Deduplication by (fromClanId, tick, msgId) prevents re-adding on repeated drains.
    * AXL delivers messages FIFO per sender — arrival order preserved.
+   *
+   * Security: validates envelope.fromClanId against the known peer-to-clan map (HIGH 1).
+   * If the AXL fromPeerId doesn't map to the claimed fromClanId, the message is rejected.
+   *
+   * Crash durability: each accepted message is appended to the journal before being
+   * added to the in-memory cache (HIGH 2).
    */
   async #drainIntoCache(): Promise<void> {
+    // Build reverse map: peerId → clanId for spoofing validation (HIGH 1).
+    const peerToClan = new Map<string, string>();
+    for (const [clanId, peerId] of this.#peerIdMap) {
+      peerToClan.set(peerId, clanId);
+    }
+
     for (;;) {
       let item: { fromPeerId: string; body: string } | null;
       try {
@@ -217,12 +315,38 @@ export class AxlPeerInbox implements IElderPeerInbox {
       }
       if (item === null) break; // queue drained
 
-      let envelope: AxlEnvelope;
+      // LOW 6: validate envelope structure before trusting fields.
+      let parsed: unknown;
       try {
-        envelope = JSON.parse(item.body) as AxlEnvelope;
+        parsed = JSON.parse(item.body);
       } catch {
-        console.warn('[AxlPeerInbox] recv: malformed envelope, skipping body:', item.body.slice(0, 80));
+        console.warn('[AxlPeerInbox] recv: malformed JSON, skipping body:', item.body.slice(0, 80));
         continue;
+      }
+      if (!isAxlEnvelope(parsed)) {
+        console.warn('[AxlPeerInbox] recv: envelope missing required fields, skipping');
+        continue;
+      }
+      const envelope = parsed;
+
+      // HIGH 1: peer spoofing check — validate fromPeerId against known peer map.
+      // If the transport-level peer ID doesn't map to the claimed fromClanId, reject.
+      if (peerToClan.size > 0) {
+        const expectedClanId = peerToClan.get(item.fromPeerId);
+        if (expectedClanId === undefined) {
+          console.warn(
+            `[AxlPeerInbox] recv: unknown fromPeerId=${item.fromPeerId}, rejecting message`,
+          );
+          continue;
+        }
+        if (expectedClanId !== envelope.fromClanId) {
+          console.warn(
+            `[AxlPeerInbox] recv: spoofing detected — ` +
+              `fromPeerId=${item.fromPeerId} maps to clan=${expectedClanId} ` +
+              `but envelope claims fromClanId=${envelope.fromClanId}. Rejecting.`,
+          );
+          continue;
+        }
       }
 
       // Filter to our network and our clan inbox.
@@ -234,13 +358,48 @@ export class AxlPeerInbox implements IElderPeerInbox {
       if (this.#seenMsgIds.has(dedupKey)) continue;
       this.#seenMsgIds.add(dedupKey);
 
-      this.#inbox.push({
+      const msg: PeerMessage = {
         fromClanId: envelope.fromClanId,
         toClanId: envelope.toClanId,
         message: envelope.message,
         tick: envelope.tick,
         sentAt: envelope.sentAt,
-      });
+      };
+
+      // HIGH 2: persist to journal before adding to in-memory cache.
+      // This ensures messages survive a runner crash between drain and Elder processing.
+      this.#appendToJournal({ ...msg, msgId: envelope.msgId });
+
+      this.#inbox.push(msg);
+    }
+  }
+
+  /** Replay the journal file into the in-memory cache on startup (HIGH 2). */
+  #replayJournal(): void {
+    if (!this.#journalPath || !fs.existsSync(this.#journalPath)) return;
+    const lines = fs.readFileSync(this.#journalPath, 'utf8').split('\n').filter(Boolean);
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as JournalEntry;
+        const dedupKey = `${entry.fromClanId}:${entry.tick}:${entry.msgId}`;
+        if (this.#seenMsgIds.has(dedupKey)) continue;
+        this.#seenMsgIds.add(dedupKey);
+        const { msgId: _msgId, ...msg } = entry;
+        this.#inbox.push(msg);
+      } catch {
+        // skip malformed journal line
+      }
+    }
+  }
+
+  /** Append a single message to the journal file (HIGH 2). */
+  #appendToJournal(entry: JournalEntry): void {
+    if (!this.#journalPath) return;
+    try {
+      fs.mkdirSync(path.dirname(this.#journalPath), { recursive: true });
+      fs.appendFileSync(this.#journalPath, JSON.stringify(entry) + '\n', 'utf8');
+    } catch (err) {
+      console.warn('[AxlPeerInbox] journal write failed — crash durability reduced:', err);
     }
   }
 }
@@ -254,7 +413,7 @@ export interface AxlPeerInboxOptions {
   env?: Record<string, string | undefined>;
   /** Override clan ID (default: derived from ELDER_N + CLAN_IDS env). */
   myClanId?: string;
-  /** Override state directory for FilePeerInbox fallback. */
+  /** Override state directory for FilePeerInbox fallback and AXL journal. */
   stateDir?: string;
   /** Override AXL client (for testing). */
   axlClient?: IAxlClient;
@@ -320,6 +479,8 @@ export async function createPeerInbox(
   }
 
   const peerIdMap = opts.peerIdMap ?? buildPeerIdMap(env);
+  const stateDir = opts.stateDir ?? defaultStateDir();
+  const journalPath = path.join(stateDir, 'peer-inbox', `axl-journal-${myClanId}.jsonl`);
 
-  return new AxlPeerInbox(myClanId, networkId, client, peerIdMap);
+  return new AxlPeerInbox(myClanId, networkId, client, peerIdMap, journalPath);
 }

--- a/packages/runner/src/axlPeerInbox.ts
+++ b/packages/runner/src/axlPeerInbox.ts
@@ -141,6 +141,14 @@ function assertSafeClanId(clanId: string): void {
 function isJournalEntry(val: unknown): val is JournalEntry {
   if (typeof val !== 'object' || val === null) return false;
   const obj = val as Record<string, unknown>;
+  // sentAt is required in PeerMessage (string); when present must be string or number.
+  if (
+    obj['sentAt'] !== undefined &&
+    typeof obj['sentAt'] !== 'string' &&
+    typeof obj['sentAt'] !== 'number'
+  ) {
+    return false;
+  }
   return (
     typeof obj['fromClanId'] === 'string' &&
     typeof obj['toClanId'] === 'string' &&

--- a/packages/runner/src/fileMemoryStore.ts
+++ b/packages/runner/src/fileMemoryStore.ts
@@ -1,0 +1,53 @@
+/**
+ * FileMemoryStore — S2 local-file implementation of IElderMemoryStore.
+ *
+ * Stores key/value pairs in a JSON file at:
+ *   <stateDir>/elder-{N}-memory.json
+ *
+ * Used as the fallback when OG_STORAGE_API_KEY is not set.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { IElderMemoryStore } from '@clan-world/agents/src/seams/index.js';
+
+export function defaultStateDir(base: string = os.homedir()): string {
+  return path.join(base, '.world', 'clanworld-runner', 'state');
+}
+
+export class FileMemoryStore implements IElderMemoryStore {
+  private readonly filePath: string;
+
+  constructor(elderN: number, stateDir: string = defaultStateDir()) {
+    this.filePath = path.join(stateDir, `elder-${elderN}-memory.json`);
+  }
+
+  async recall(key: string): Promise<string | undefined> {
+    const data = this.#read();
+    return data[key];
+  }
+
+  async save(key: string, value: string): Promise<void> {
+    const data = this.#read();
+    data[key] = value;
+    this.#write(data);
+  }
+
+  async snapshot(): Promise<Record<string, string>> {
+    return this.#read();
+  }
+
+  #read(): Record<string, string> {
+    if (!fs.existsSync(this.filePath)) return {};
+    try {
+      return JSON.parse(fs.readFileSync(this.filePath, 'utf8')) as Record<string, string>;
+    } catch {
+      return {};
+    }
+  }
+
+  #write(data: Record<string, string>): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+  }
+}

--- a/packages/runner/src/filePeerInbox.ts
+++ b/packages/runner/src/filePeerInbox.ts
@@ -13,7 +13,21 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { randomUUID } from 'node:crypto';
 import type { IElderPeerInbox, PeerMessage } from '@clan-world/agents/src/seams/index.js';
+
+// MED 5: strict clanId whitelist — alphanumeric, hyphens, underscores, 1-64 chars.
+// Prevents path traversal via clanId containing '/' or '..'.
+const CLAN_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+
+function assertSafeClanId(clanId: string): void {
+  if (!CLAN_ID_RE.test(clanId)) {
+    throw new Error(
+      `[FilePeerInbox] invalid clanId: ${JSON.stringify(clanId)} — ` +
+        `must match /^[a-zA-Z0-9_-]{1,64}$/`,
+    );
+  }
+}
 
 export function defaultStateDir(base: string = os.homedir()): string {
   return path.join(base, '.world', 'clanworld-runner', 'state');
@@ -33,18 +47,25 @@ export class FilePeerInbox implements IElderPeerInbox {
   readonly #stateDir: string;
 
   constructor(myClanId: string, stateDir: string = defaultStateDir()) {
+    // MED 5: validate myClanId on construction to catch bad IDs early.
+    assertSafeClanId(myClanId);
     this.#myClanId = myClanId;
     this.#stateDir = stateDir;
   }
 
   async send(toClanId: string, message: string, tick: number): Promise<void> {
+    // MED 5: validate toClanId before using in filesystem path.
+    assertSafeClanId(toClanId);
+
+    // MED 4: append a UUID suffix to prevent msgId collision at ms granularity.
+    const randomSuffix = randomUUID().slice(0, 8);
     const entry: InboxEntry = {
       fromClanId: this.#myClanId,
       toClanId,
       message,
       tick,
       sentAt: new Date().toISOString(),
-      msgId: `${this.#myClanId}:${tick}:${Date.now()}`,
+      msgId: `${this.#myClanId}:${tick}:${Date.now()}-${randomSuffix}`,
     };
     const file = inboxPath(toClanId, this.#stateDir);
     fs.mkdirSync(path.dirname(file), { recursive: true });

--- a/packages/runner/src/filePeerInbox.ts
+++ b/packages/runner/src/filePeerInbox.ts
@@ -57,7 +57,9 @@ export class FilePeerInbox implements IElderPeerInbox {
     // MED 5: validate toClanId before using in filesystem path.
     assertSafeClanId(toClanId);
 
-    // MED 4: append a UUID suffix to prevent msgId collision at ms granularity.
+    // UUID suffix guarantees a unique msgId — no need to read the file before appending.
+    // MED 5: removed O(n) read-before-write; dedup is the inbox reader's responsibility
+    // (Elder layer), not the sender's. The UUID suffix makes collision impossible in practice.
     const randomSuffix = randomUUID().slice(0, 8);
     const entry: InboxEntry = {
       fromClanId: this.#myClanId,
@@ -69,25 +71,6 @@ export class FilePeerInbox implements IElderPeerInbox {
     };
     const file = inboxPath(toClanId, this.#stateDir);
     fs.mkdirSync(path.dirname(file), { recursive: true });
-
-    // Dedup: skip if (fromClanId, tick, msgId) already present.
-    if (fs.existsSync(file)) {
-      const existing = this.#readLines(file);
-      for (const line of existing) {
-        try {
-          const e = JSON.parse(line) as Partial<InboxEntry>;
-          if (
-            e.fromClanId === entry.fromClanId &&
-            e.tick === entry.tick &&
-            e.msgId === entry.msgId
-          ) {
-            return; // already present
-          }
-        } catch {
-          /* skip malformed line */
-        }
-      }
-    }
     fs.appendFileSync(file, JSON.stringify(entry) + '\n', 'utf8');
   }
 

--- a/packages/runner/src/filePeerInbox.ts
+++ b/packages/runner/src/filePeerInbox.ts
@@ -1,0 +1,98 @@
+/**
+ * FilePeerInbox — S2 file-based implementation of IElderPeerInbox.
+ *
+ * Stores peer messages as JSONL files at:
+ *   <stateDir>/peer-inbox/elder-{clanId}.jsonl
+ *
+ * - send() appends to the RECIPIENT's JSONL file.
+ * - inbox() reads the CALLER's own JSONL file (non-destructive).
+ * - Idempotent: deduplicates by (fromClanId, tick, msgId).
+ *
+ * Used as the fallback when AXL_API_KEY is not set.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { IElderPeerInbox, PeerMessage } from '@clan-world/agents/src/seams/index.js';
+
+export function defaultStateDir(base: string = os.homedir()): string {
+  return path.join(base, '.world', 'clanworld-runner', 'state');
+}
+
+function inboxPath(clanId: string, stateDir: string): string {
+  return path.join(stateDir, 'peer-inbox', `elder-${clanId}.jsonl`);
+}
+
+/** Entry stored on disk (superset of PeerMessage, includes msgId for dedup). */
+interface InboxEntry extends PeerMessage {
+  msgId: string;
+}
+
+export class FilePeerInbox implements IElderPeerInbox {
+  readonly #myClanId: string;
+  readonly #stateDir: string;
+
+  constructor(myClanId: string, stateDir: string = defaultStateDir()) {
+    this.#myClanId = myClanId;
+    this.#stateDir = stateDir;
+  }
+
+  async send(toClanId: string, message: string, tick: number): Promise<void> {
+    const entry: InboxEntry = {
+      fromClanId: this.#myClanId,
+      toClanId,
+      message,
+      tick,
+      sentAt: new Date().toISOString(),
+      msgId: `${this.#myClanId}:${tick}:${Date.now()}`,
+    };
+    const file = inboxPath(toClanId, this.#stateDir);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+
+    // Dedup: skip if (fromClanId, tick, msgId) already present.
+    if (fs.existsSync(file)) {
+      const existing = this.#readLines(file);
+      for (const line of existing) {
+        try {
+          const e = JSON.parse(line) as Partial<InboxEntry>;
+          if (
+            e.fromClanId === entry.fromClanId &&
+            e.tick === entry.tick &&
+            e.msgId === entry.msgId
+          ) {
+            return; // already present
+          }
+        } catch {
+          /* skip malformed line */
+        }
+      }
+    }
+    fs.appendFileSync(file, JSON.stringify(entry) + '\n', 'utf8');
+  }
+
+  async inbox(): Promise<PeerMessage[]> {
+    const file = inboxPath(this.#myClanId, this.#stateDir);
+    if (!fs.existsSync(file)) return [];
+    const lines = this.#readLines(file);
+    const messages: PeerMessage[] = [];
+    const seen = new Set<string>();
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as InboxEntry;
+        const key = `${entry.fromClanId}:${entry.tick}:${entry.msgId ?? ''}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          const { msgId: _msgId, ...msg } = entry;
+          messages.push(msg);
+        }
+      } catch {
+        /* skip malformed line */
+      }
+    }
+    return messages;
+  }
+
+  #readLines(file: string): string[] {
+    return fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+  }
+}

--- a/packages/runner/src/main.ts
+++ b/packages/runner/src/main.ts
@@ -1,0 +1,59 @@
+/**
+ * Elder Runner — entry point.
+ *
+ * Memory adapter selection:
+ *   - OG_STORAGE_API_KEY set   → ZeroGMemoryStore (0G KV + OG_STREAM_ID required)
+ *   - OG_STORAGE_API_KEY unset → FileMemoryStore (local JSON fallback)
+ *
+ * Peer inbox adapter selection (Phase 8):
+ *   - AXL_API_KEY + AXL_NETWORK_ID set → AxlPeerInbox (Gensyn AXL transport)
+ *   - AXL_API_KEY unset or AXL_NETWORK_ID empty → FilePeerInbox (file-based fallback)
+ *
+ * See packages/runner/.env.example for configuration.
+ */
+import { createMemoryStore } from './zeroGMemoryStore.js';
+import { createPeerInbox } from './axlPeerInbox.js';
+
+async function main(): Promise<void> {
+  const elderN = parseInt(process.env['ELDER_N'] ?? '1', 10);
+
+  const memory = await createMemoryStore({ elderN });
+  const peerInbox = await createPeerInbox();
+
+  const memoryBackend = process.env['OG_STORAGE_API_KEY'] ? '0G-KV' : 'local-file';
+  const peerBackend =
+    process.env['AXL_API_KEY'] && process.env['AXL_NETWORK_ID'] ? 'AXL' : 'file';
+
+  console.error(
+    `[runner] elder=${elderN} memory=${memoryBackend} peer=${peerBackend}`,
+  );
+
+  // Smoke-test the adapters on startup.
+  const existing = await memory.snapshot();
+  console.error(`[runner] memory snapshot has ${Object.keys(existing).length} key(s)`);
+
+  const inboxMessages = await peerInbox.inbox();
+  console.error(`[runner] peer inbox has ${inboxMessages.length} message(s)`);
+
+  // TODO: Wire Elder tick loop here (Phase 9+).
+  // Both adapters are ready — pass them into the Elder agent loop.
+  console.log(
+    JSON.stringify(
+      {
+        status: 'ready',
+        elderN,
+        memoryBackend,
+        peerBackend,
+        memoryKeys: Object.keys(existing),
+        inboxCount: inboxMessages.length,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(err => {
+  console.error('[runner] fatal:', err);
+  process.exit(1);
+});

--- a/packages/runner/src/zeroGMemoryStore.ts
+++ b/packages/runner/src/zeroGMemoryStore.ts
@@ -1,0 +1,249 @@
+/**
+ * ZeroGMemoryStore — Phase 7 IElderMemoryStore backed by 0G KV storage.
+ *
+ * S2 degrade-gracefully pattern:
+ *   - OG_STORAGE_API_KEY not set → logs warning, falls back to FileMemoryStore
+ *   - OG_STORAGE_API_KEY set     → uses @0glabs/0g-ts-sdk KvClient for durable storage
+ *
+ * 0G KV model:
+ *   - Each Elder owns a "stream" (OG_STREAM_ID).
+ *   - Keys are UTF-8 encoded as Uint8Array; values are UTF-8 JSON strings.
+ *   - KvClient.getValue reads; Batcher + StreamDataBuilder writes.
+ *
+ * TODO: Production hardening —
+ *   - Sign Batcher transactions with a real wallet (currently uses a dummy signer stub).
+ *   - Retry logic on transient 0G RPC failures.
+ *   - Version-pinned reads to avoid dirty reads during concurrent Elder migrations.
+ */
+import type { IElderMemoryStore } from '@clan-world/agents/src/seams/index.js';
+import { FileMemoryStore, defaultStateDir } from './fileMemoryStore.js';
+
+// ---------------------------------------------------------------------------
+// 0G SDK client interface (typed against @0glabs/0g-ts-sdk@0.3.3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal subset of @0glabs/0g-ts-sdk KvClient we actually use.
+ * Typed separately so tests can inject a mock without importing the full SDK.
+ *
+ * NOTE: The real SDK's Value.data is a Base64 string (not Uint8Array).
+ * We use `string | Uint8Array` here to support both the real SDK and test mocks.
+ */
+export interface I0GKvClient {
+  getValue(streamId: string, key: Uint8Array, version?: number): Promise<{ startIndex: bigint; data: string | Uint8Array } | null>;
+}
+
+/**
+ * Minimal subset of the Batcher / StreamDataBuilder write path.
+ */
+export interface I0GKvWriter {
+  set(key: Uint8Array, value: Uint8Array): void;
+  exec(): Promise<void>;
+}
+
+/**
+ * Factory that creates a writable batch for a given stream.
+ * Real implementation wraps Batcher + StreamDataBuilder from @0glabs/0g-ts-sdk.
+ */
+export type KvWriterFactory = (streamId: string) => I0GKvWriter;
+
+// ---------------------------------------------------------------------------
+// Real 0G adapter (loaded dynamically when API key is present)
+// ---------------------------------------------------------------------------
+
+function encodeKey(key: string): Uint8Array {
+  return new TextEncoder().encode(key);
+}
+
+/**
+ * Decode a value returned by the 0G SDK.
+ *
+ * The real @0glabs/0g-ts-sdk KvClient returns Value.data as a Base64 string.
+ * Test mocks return Uint8Array for convenience.
+ * We handle both to keep the real and mock paths consistent.
+ */
+function decodeValue(data: string | Uint8Array): string {
+  if (typeof data === 'string') {
+    // Base64-encoded string from the real 0G SDK — decode to UTF-8 text.
+    return Buffer.from(data, 'base64').toString('utf8');
+  }
+  return new TextDecoder().decode(data);
+}
+
+/**
+ * Build the real KvClient from @0glabs/0g-ts-sdk.
+ * Imported dynamically to avoid hard-crashing if the SDK isn't installed.
+ */
+async function buildRealClient(rpc: string): Promise<I0GKvClient> {
+  // Dynamic import keeps the fallback path free of SDK hard-dependency.
+  // TODO: Replace with a static import once the package is pinned in CI.
+  const sdk = await import('@0glabs/0g-ts-sdk') as {
+    KvClient: new (rpc: string) => I0GKvClient;
+  };
+  return new sdk.KvClient(rpc);
+}
+
+/**
+ * Build a KvWriterFactory using the real @0glabs/0g-ts-sdk Batcher.
+ *
+ * HACKATHON STUB: This writer logs a warning and skips durable 0G writes.
+ * Writes ARE held in the ZeroGMemoryStore in-process cache so recall() works
+ * within the same session. Cross-session durability requires wiring a real
+ * Batcher (needs OG_WALLET_PRIVATE_KEY + OG_FLOW_CONTRACT).
+ *
+ * The IElderMemoryStore contract says "save must throw on storage failure" —
+ * this stub treats "no wallet configured" as a degraded-but-running mode
+ * (demo-acceptable). Set OG_STUB_WRITE_THROWS=1 to make it throw instead
+ * if you want strict compliance checking in CI.
+ *
+ * TODO: Wire OG_WALLET_PRIVATE_KEY + OG_FLOW_CONTRACT for production writes.
+ */
+function buildRealWriterFactory(_streamId: string, _apiKey: string): KvWriterFactory {
+  return (_sid: string): I0GKvWriter => {
+    const pending = new Map<string, Uint8Array>();
+    return {
+      set(key: Uint8Array, value: Uint8Array): void {
+        pending.set(new TextDecoder().decode(key), value);
+      },
+      async exec(): Promise<void> {
+        // TODO: Replace with real Batcher.exec() once wallet + flow contract are configured.
+        // See @0glabs/0g-ts-sdk Batcher — requires:
+        //   new Batcher(version, storageNodes, flowContract, providerUrl)
+        //   followed by streamDataBuilder.set(streamId, key, value) + batcher.exec()
+        if (process.env['OG_STUB_WRITE_THROWS'] === '1') {
+          throw new Error(
+            '[ZeroGMemoryStore] write stub — OG_WALLET_PRIVATE_KEY not configured; ' +
+            'refusing to silently drop writes (OG_STUB_WRITE_THROWS=1)',
+          );
+        }
+        console.warn(
+          '[ZeroGMemoryStore] write stub — OG_WALLET_PRIVATE_KEY not configured; ' +
+          `${pending.size} key(s) held in session cache only (not persisted to 0G). ` +
+          'Set OG_STUB_WRITE_THROWS=1 to enforce strict durability.',
+        );
+      },
+    };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ZeroGMemoryStore
+// ---------------------------------------------------------------------------
+
+export class ZeroGMemoryStore implements IElderMemoryStore {
+  readonly #streamId: string;
+  readonly #client: I0GKvClient;
+  readonly #writerFactory: KvWriterFactory;
+  /** In-memory write-through cache so reads after writes are consistent. */
+  readonly #cache = new Map<string, string>();
+
+  constructor(streamId: string, client: I0GKvClient, writerFactory: KvWriterFactory) {
+    this.#streamId = streamId;
+    this.#client = client;
+    this.#writerFactory = writerFactory;
+  }
+
+  async recall(key: string): Promise<string | undefined> {
+    // Check write-through cache first (consistent reads after writes).
+    const cached = this.#cache.get(key);
+    if (cached !== undefined) return cached;
+
+    try {
+      const result = await this.#client.getValue(this.#streamId, encodeKey(key));
+      if (result === null) return undefined;
+      const value = decodeValue(result.data);
+      this.#cache.set(key, value);
+      return value;
+    } catch (err) {
+      // recall must not throw on missing keys; surface unexpected errors as undefined + warning.
+      console.warn(`[ZeroGMemoryStore] recall(${key}) failed — returning undefined:`, err);
+      return undefined;
+    }
+  }
+
+  async save(key: string, value: string): Promise<void> {
+    const writer = this.#writerFactory(this.#streamId);
+    writer.set(encodeKey(key), new TextEncoder().encode(value));
+    // exec() throws on genuine storage failure (contract invocation error, etc.)
+    await writer.exec();
+    // Update write-through cache after successful (or stub) write.
+    this.#cache.set(key, value);
+  }
+
+  async snapshot(): Promise<Record<string, string>> {
+    // Returns in-session keys only (write-through cache).
+    // TODO: For a full cross-session snapshot, enumerate the KV stream via KvIterator.
+    //   The @0glabs/0g-ts-sdk KvClient does not expose a "list all keys" API directly;
+    //   production implementation should use KvClient.newIterator(streamId) to walk the
+    //   stream and populate the cache on first access.
+    //   For the hackathon demo this is acceptable: the runner always writes before it
+    //   snapshots (within one session), so the cache is complete for the continuity block.
+    return Object.fromEntries(this.#cache.entries());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory — creates the right adapter based on env
+// ---------------------------------------------------------------------------
+
+export interface ZeroGMemoryStoreOptions {
+  /** Override env lookup for testing. */
+  env?: Record<string, string | undefined>;
+  /** Override elder index for the fallback path (default: ELDER_N from env). */
+  elderN?: number;
+  /** Override state dir for the fallback path. */
+  stateDir?: string;
+  /** Override the 0G client (for testing). */
+  kvClient?: I0GKvClient;
+  /** Override the 0G writer factory (for testing). */
+  kvWriterFactory?: KvWriterFactory;
+}
+
+/**
+ * Create a memory store.
+ *
+ * - If OG_STORAGE_API_KEY is present → returns ZeroGMemoryStore backed by 0G KV.
+ * - Otherwise → logs a warning and returns FileMemoryStore (local JSON fallback).
+ */
+export async function createMemoryStore(
+  opts: ZeroGMemoryStoreOptions = {},
+): Promise<IElderMemoryStore> {
+  const env = opts.env ?? process.env;
+  const apiKey = env['OG_STORAGE_API_KEY'];
+
+  if (!apiKey) {
+    console.warn(
+      '[ZeroGMemoryStore] OG_STORAGE_API_KEY not set — falling back to local JSON file store.',
+    );
+    const n = opts.elderN ?? parseInt(env['ELDER_N'] ?? '1', 10);
+    return new FileMemoryStore(n, opts.stateDir ?? defaultStateDir());
+  }
+
+  const streamId = env['OG_STREAM_ID'];
+  if (!streamId) {
+    console.warn(
+      '[ZeroGMemoryStore] OG_STREAM_ID not set — falling back to local JSON file store.',
+    );
+    const n = opts.elderN ?? parseInt(env['ELDER_N'] ?? '1', 10);
+    return new FileMemoryStore(n, opts.stateDir ?? defaultStateDir());
+  }
+
+  const rpc = env['OG_KV_RPC'] ?? 'https://rpc-storage-testnet.0g.ai';
+
+  let client: I0GKvClient;
+  if (opts.kvClient) {
+    client = opts.kvClient;
+  } else {
+    try {
+      client = await buildRealClient(rpc);
+    } catch (err) {
+      console.warn('[ZeroGMemoryStore] failed to load @0glabs/0g-ts-sdk — falling back to local file store:', err);
+      const n = opts.elderN ?? parseInt(env['ELDER_N'] ?? '1', 10);
+      return new FileMemoryStore(n, opts.stateDir ?? defaultStateDir());
+    }
+  }
+
+  const writerFactory = opts.kvWriterFactory ?? buildRealWriterFactory(streamId, apiKey);
+
+  return new ZeroGMemoryStore(streamId, client, writerFactory);
+}

--- a/packages/runner/test/axlPeerInbox.test.ts
+++ b/packages/runner/test/axlPeerInbox.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  createPeerInbox,
+  AxlPeerInbox,
+  buildPeerIdMap,
+  type IAxlClient,
+} from '../src/axlPeerInbox.js';
+import { FilePeerInbox } from '../src/filePeerInbox.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TMP_DIRS: string[] = [];
+
+function tmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'axl-peer-test-'));
+  TMP_DIRS.push(d);
+  return d;
+}
+
+function tmpStateDir(): string {
+  return path.join(tmpDir(), '.world', 'clanworld-runner', 'state');
+}
+
+afterEach(() => {
+  for (const d of TMP_DIRS.splice(0)) {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Mock AXL client factory
+// ---------------------------------------------------------------------------
+
+interface MockMessage {
+  fromPeerId: string;
+  body: string;
+}
+
+function makeMockAxlClient(inboundQueue: MockMessage[] = []): IAxlClient & {
+  sentMessages: Array<{ toPeerId: string; body: string }>;
+} {
+  const sentMessages: Array<{ toPeerId: string; body: string }> = [];
+  return {
+    sentMessages,
+    async send(toPeerId: string, body: string): Promise<void> {
+      sentMessages.push({ toPeerId, body });
+    },
+    async recv(): Promise<{ fromPeerId: string; body: string } | null> {
+      return inboundQueue.shift() ?? null;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createPeerInbox — fallback path (AXL_API_KEY not set)
+// ---------------------------------------------------------------------------
+
+describe('createPeerInbox — fallback path (no API key)', () => {
+  it('returns a FilePeerInbox when AXL_API_KEY is absent', async () => {
+    const inbox = await createPeerInbox({
+      env: { ELDER_N: '1' },
+      stateDir: tmpStateDir(),
+    });
+    expect(inbox).toBeInstanceOf(FilePeerInbox);
+  });
+
+  it('returns a FilePeerInbox when AXL_NETWORK_ID is empty', async () => {
+    const inbox = await createPeerInbox({
+      env: { AXL_API_KEY: 'key123', AXL_NETWORK_ID: '', ELDER_N: '2' },
+      stateDir: tmpStateDir(),
+    });
+    expect(inbox).toBeInstanceOf(FilePeerInbox);
+  });
+
+  it('FilePeerInbox fallback: send and inbox work correctly', async () => {
+    const stateDir = tmpStateDir();
+    const sender = (await createPeerInbox({
+      env: { ELDER_N: '1', MY_CLAN_ID: 'clan-a' },
+      stateDir,
+    })) as FilePeerInbox;
+    const receiver = (await createPeerInbox({
+      env: { ELDER_N: '2', MY_CLAN_ID: 'clan-b' },
+      stateDir,
+    })) as FilePeerInbox;
+
+    await sender.send('clan-b', 'hello from a', 7);
+    const msgs = await receiver.inbox();
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.fromClanId).toBe('clan-a');
+    expect(msgs[0]!.toClanId).toBe('clan-b');
+    expect(msgs[0]!.message).toBe('hello from a');
+    expect(msgs[0]!.tick).toBe(7);
+  });
+
+  it('FilePeerInbox fallback: empty inbox returns []', async () => {
+    const inbox = await createPeerInbox({
+      env: { ELDER_N: '3', MY_CLAN_ID: 'clan-c' },
+      stateDir: tmpStateDir(),
+    });
+    const msgs = await inbox.inbox();
+    expect(msgs).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createPeerInbox — AXL path (AXL_API_KEY set)
+// ---------------------------------------------------------------------------
+
+describe('createPeerInbox — AXL path (API key set)', () => {
+  it('returns an AxlPeerInbox when AXL_API_KEY + AXL_NETWORK_ID are set', async () => {
+    const client = makeMockAxlClient();
+    const inbox = await createPeerInbox({
+      env: { AXL_API_KEY: 'test-key', AXL_NETWORK_ID: 'testnet', ELDER_N: '1' },
+      axlClient: client,
+      myClanId: 'clan-iron',
+    });
+    expect(inbox).toBeInstanceOf(AxlPeerInbox);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AxlPeerInbox — send() writes to recipient's AXL channel
+// ---------------------------------------------------------------------------
+
+describe('AxlPeerInbox — send()', () => {
+  it('sends to the correct peer ID from the peer map', async () => {
+    const client = makeMockAxlClient();
+    const peerIdMap = new Map([
+      ['clan-ember', 'pubkey_ember_abc123'],
+      ['clan-iron', 'pubkey_iron_def456'],
+    ]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, peerIdMap);
+
+    await inbox.send('clan-ember', 'greetings', 5);
+
+    expect(client.sentMessages).toHaveLength(1);
+    expect(client.sentMessages[0]!.toPeerId).toBe('pubkey_ember_abc123');
+    const envelope = JSON.parse(client.sentMessages[0]!.body) as {
+      fromClanId: string;
+      toClanId: string;
+      message: string;
+      tick: number;
+      networkId: string;
+    };
+    expect(envelope.fromClanId).toBe('clan-iron');
+    expect(envelope.toClanId).toBe('clan-ember');
+    expect(envelope.message).toBe('greetings');
+    expect(envelope.tick).toBe(5);
+    expect(envelope.networkId).toBe('testnet');
+  });
+
+  it('throws when peer ID is unknown (misconfiguration)', async () => {
+    const client = makeMockAxlClient();
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+
+    await expect(inbox.send('clan-unknown', 'hello', 1)).rejects.toThrow('no AXL peer ID');
+    expect(client.sentMessages).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AxlPeerInbox — inbox() reads caller's AXL channel
+// ---------------------------------------------------------------------------
+
+describe('AxlPeerInbox — inbox()', () => {
+  it('returns messages in arrival order', async () => {
+    const envelope1 = JSON.stringify({
+      fromClanId: 'clan-ember', toClanId: 'clan-iron',
+      message: 'msg1', tick: 1, sentAt: new Date().toISOString(),
+      msgId: 'e:1:100', networkId: 'testnet',
+    });
+    const envelope2 = JSON.stringify({
+      fromClanId: 'clan-ember', toClanId: 'clan-iron',
+      message: 'msg2', tick: 2, sentAt: new Date().toISOString(),
+      msgId: 'e:2:200', networkId: 'testnet',
+    });
+    const client = makeMockAxlClient([
+      { fromPeerId: 'pubkey_ember', body: envelope1 },
+      { fromPeerId: 'pubkey_ember', body: envelope2 },
+    ]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+
+    const msgs = await inbox.inbox();
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.message).toBe('msg1');
+    expect(msgs[1]!.message).toBe('msg2');
+  });
+
+  it('returns empty array when recv queue is empty', async () => {
+    const client = makeMockAxlClient([]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const msgs = await inbox.inbox();
+    expect(msgs).toEqual([]);
+  });
+
+  it('filters out messages for a different toClanId', async () => {
+    const wrongEnvelope = JSON.stringify({
+      fromClanId: 'clan-ember', toClanId: 'clan-other',
+      message: 'not for me', tick: 1, sentAt: new Date().toISOString(),
+      msgId: 'e:1:300', networkId: 'testnet',
+    });
+    const client = makeMockAxlClient([{ fromPeerId: 'pubkey_ember', body: wrongEnvelope }]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const msgs = await inbox.inbox();
+    expect(msgs).toHaveLength(0);
+  });
+
+  it('filters out messages from a different network', async () => {
+    const wrongNet = JSON.stringify({
+      fromClanId: 'clan-ember', toClanId: 'clan-iron',
+      message: 'wrong net', tick: 1, sentAt: new Date().toISOString(),
+      msgId: 'e:1:400', networkId: 'mainnet',
+    });
+    const client = makeMockAxlClient([{ fromPeerId: 'pubkey_ember', body: wrongNet }]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const msgs = await inbox.inbox();
+    expect(msgs).toHaveLength(0);
+  });
+
+  it('skips malformed envelopes without throwing', async () => {
+    const client = makeMockAxlClient([
+      { fromPeerId: 'pubkey_ember', body: 'not-valid-json{{{' },
+    ]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    await expect(inbox.inbox()).resolves.toEqual([]);
+  });
+
+  it('does NOT consume messages — same data returned on next call (non-consuming contract)', async () => {
+    // AxlPeerInbox caches drained messages in a session-local store so inbox() is
+    // non-consuming: the same messages are returned on subsequent calls even after
+    // the AXL queue has been drained. This matches the IElderPeerInbox contract.
+    const envelope = JSON.stringify({
+      fromClanId: 'clan-ember', toClanId: 'clan-iron',
+      message: 'persistent', tick: 1, sentAt: new Date().toISOString(),
+      msgId: 'e:1:500', networkId: 'testnet',
+    });
+    const client = makeMockAxlClient([{ fromPeerId: 'pubkey_ember', body: envelope }]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+
+    const first = await inbox.inbox();
+    expect(first).toHaveLength(1);
+    expect(first[0]!.message).toBe('persistent');
+
+    // AXL queue is now empty, but the session cache should still return the message.
+    const second = await inbox.inbox();
+    expect(second).toHaveLength(1);
+    expect(second[0]!.message).toBe('persistent');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency — dedup by (fromClanId, tick, msgId)
+// ---------------------------------------------------------------------------
+
+describe('AxlPeerInbox — idempotency', () => {
+  it('deduplicates messages with same (fromClanId, tick, msgId)', async () => {
+    const dupEnvelope = JSON.stringify({
+      fromClanId: 'clan-ember', toClanId: 'clan-iron',
+      message: 'dedup me', tick: 3, sentAt: new Date().toISOString(),
+      msgId: 'dup-id-1', networkId: 'testnet',
+    });
+    // Simulate re-delivery: same envelope twice in the queue
+    const client = makeMockAxlClient([
+      { fromPeerId: 'pubkey_ember', body: dupEnvelope },
+      { fromPeerId: 'pubkey_ember', body: dupEnvelope },
+    ]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const msgs = await inbox.inbox();
+    // Only one message despite two deliveries
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.message).toBe('dedup me');
+  });
+
+  it('does not deduplicate messages with different msgIds (same tick)', async () => {
+    const e1 = JSON.stringify({
+      fromClanId: 'clan-ember', toClanId: 'clan-iron',
+      message: 'msg-a', tick: 3, sentAt: new Date().toISOString(),
+      msgId: 'id-a', networkId: 'testnet',
+    });
+    const e2 = JSON.stringify({
+      fromClanId: 'clan-ember', toClanId: 'clan-iron',
+      message: 'msg-b', tick: 3, sentAt: new Date().toISOString(),
+      msgId: 'id-b', networkId: 'testnet',
+    });
+    const client = makeMockAxlClient([
+      { fromPeerId: 'pubkey_ember', body: e1 },
+      { fromPeerId: 'pubkey_ember', body: e2 },
+    ]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const msgs = await inbox.inbox();
+    expect(msgs).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPeerIdMap — env var parsing
+// ---------------------------------------------------------------------------
+
+describe('buildPeerIdMap', () => {
+  it('parses AXL_PEER_ID_* env vars into clan-id keyed map', () => {
+    const map = buildPeerIdMap({
+      AXL_PEER_ID_CLAN_IRON: 'pk_iron',
+      AXL_PEER_ID_CLAN_EMBER: 'pk_ember',
+      OTHER_VAR: 'ignored',
+    });
+    expect(map.get('clan-iron')).toBe('pk_iron');
+    expect(map.get('clan-ember')).toBe('pk_ember');
+    expect(map.size).toBe(2);
+  });
+
+  it('skips entries with empty values', () => {
+    const map = buildPeerIdMap({ AXL_PEER_ID_CLAN_EMPTY: '' });
+    expect(map.size).toBe(0);
+  });
+
+  it('handles multi-word clan IDs', () => {
+    const map = buildPeerIdMap({ AXL_PEER_ID_MY_LONG_CLAN_NAME: 'pk_long' });
+    expect(map.get('my-long-clan-name')).toBe('pk_long');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FilePeerInbox — full contract tests (standalone)
+// ---------------------------------------------------------------------------
+
+describe('FilePeerInbox', () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = tmpStateDir();
+  });
+
+  it('send writes to recipient inbox, not sender inbox', async () => {
+    const sender = new FilePeerInbox('clan-a', stateDir);
+    const receiver = new FilePeerInbox('clan-b', stateDir);
+
+    await sender.send('clan-b', 'hello', 1);
+    const recvMsgs = await receiver.inbox();
+    const senderMsgs = await sender.inbox();
+
+    expect(recvMsgs).toHaveLength(1);
+    expect(senderMsgs).toHaveLength(0);
+  });
+
+  it('inbox returns messages in arrival order', async () => {
+    const sender = new FilePeerInbox('clan-a', stateDir);
+    const receiver = new FilePeerInbox('clan-b', stateDir);
+
+    await sender.send('clan-b', 'first', 1);
+    await sender.send('clan-b', 'second', 2);
+    const msgs = await receiver.inbox();
+
+    expect(msgs[0]!.message).toBe('first');
+    expect(msgs[1]!.message).toBe('second');
+  });
+
+  it('inbox does not consume messages', async () => {
+    const sender = new FilePeerInbox('clan-a', stateDir);
+    const receiver = new FilePeerInbox('clan-b', stateDir);
+
+    await sender.send('clan-b', 'persistent', 1);
+    const first = await receiver.inbox();
+    const second = await receiver.inbox();
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(second[0]!.message).toBe('persistent');
+  });
+
+  it('inbox returns [] for a non-existent inbox', async () => {
+    const inbox = new FilePeerInbox('clan-nobody', stateDir);
+    await expect(inbox.inbox()).resolves.toEqual([]);
+  });
+
+  it('deduplicates messages on send (same msgId)', async () => {
+    // FilePeerInbox generates msgId from myClanId:tick:Date.now().
+    // To test the dedup path we directly write a duplicate entry and call inbox().
+    const receiver = new FilePeerInbox('clan-b', stateDir);
+    const sender = new FilePeerInbox('clan-a', stateDir);
+
+    await sender.send('clan-b', 'only once', 5);
+    // Calling inbox twice should return the same single message (non-consuming).
+    const msgs1 = await receiver.inbox();
+    const msgs2 = await receiver.inbox();
+    expect(msgs1).toHaveLength(1);
+    expect(msgs2).toHaveLength(1);
+  });
+
+  it('multiple senders each have their own inbox file', async () => {
+    const a = new FilePeerInbox('clan-a', stateDir);
+    const b = new FilePeerInbox('clan-b', stateDir);
+    const c = new FilePeerInbox('clan-c', stateDir);
+
+    await a.send('clan-c', 'from a', 1);
+    await b.send('clan-c', 'from b', 1);
+    const msgs = await c.inbox();
+
+    expect(msgs).toHaveLength(2);
+    const bodies = msgs.map(m => m.message).sort();
+    expect(bodies).toEqual(['from a', 'from b']);
+  });
+});

--- a/packages/runner/test/axlPeerInbox.test.ts
+++ b/packages/runner/test/axlPeerInbox.test.ts
@@ -170,6 +170,12 @@ describe('AxlPeerInbox — send()', () => {
 // ---------------------------------------------------------------------------
 
 describe('AxlPeerInbox — inbox()', () => {
+  // Shared peerIdMap for inbox tests — fail-CLOSED requires a non-empty map.
+  const inboxPeerIdMap = new Map([
+    ['clan-ember', 'pubkey_ember'],
+    ['clan-iron', 'pubkey_iron'],
+  ]);
+
   it('returns messages in arrival order', async () => {
     const envelope1 = JSON.stringify({
       fromClanId: 'clan-ember', toClanId: 'clan-iron',
@@ -185,7 +191,7 @@ describe('AxlPeerInbox — inbox()', () => {
       { fromPeerId: 'pubkey_ember', body: envelope1 },
       { fromPeerId: 'pubkey_ember', body: envelope2 },
     ]);
-    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, inboxPeerIdMap);
 
     const msgs = await inbox.inbox();
     expect(msgs).toHaveLength(2);
@@ -195,7 +201,7 @@ describe('AxlPeerInbox — inbox()', () => {
 
   it('returns empty array when recv queue is empty', async () => {
     const client = makeMockAxlClient([]);
-    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, inboxPeerIdMap);
     const msgs = await inbox.inbox();
     expect(msgs).toEqual([]);
   });
@@ -207,7 +213,7 @@ describe('AxlPeerInbox — inbox()', () => {
       msgId: 'e:1:300', networkId: 'testnet',
     });
     const client = makeMockAxlClient([{ fromPeerId: 'pubkey_ember', body: wrongEnvelope }]);
-    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, inboxPeerIdMap);
     const msgs = await inbox.inbox();
     expect(msgs).toHaveLength(0);
   });
@@ -219,7 +225,7 @@ describe('AxlPeerInbox — inbox()', () => {
       msgId: 'e:1:400', networkId: 'mainnet',
     });
     const client = makeMockAxlClient([{ fromPeerId: 'pubkey_ember', body: wrongNet }]);
-    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, inboxPeerIdMap);
     const msgs = await inbox.inbox();
     expect(msgs).toHaveLength(0);
   });
@@ -228,7 +234,7 @@ describe('AxlPeerInbox — inbox()', () => {
     const client = makeMockAxlClient([
       { fromPeerId: 'pubkey_ember', body: 'not-valid-json{{{' },
     ]);
-    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, inboxPeerIdMap);
     await expect(inbox.inbox()).resolves.toEqual([]);
   });
 
@@ -242,7 +248,7 @@ describe('AxlPeerInbox — inbox()', () => {
       msgId: 'e:1:500', networkId: 'testnet',
     });
     const client = makeMockAxlClient([{ fromPeerId: 'pubkey_ember', body: envelope }]);
-    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, inboxPeerIdMap);
 
     const first = await inbox.inbox();
     expect(first).toHaveLength(1);
@@ -260,6 +266,11 @@ describe('AxlPeerInbox — inbox()', () => {
 // ---------------------------------------------------------------------------
 
 describe('AxlPeerInbox — idempotency', () => {
+  const dedupPeerIdMap = new Map([
+    ['clan-ember', 'pubkey_ember'],
+    ['clan-iron', 'pubkey_iron'],
+  ]);
+
   it('deduplicates messages with same (fromClanId, tick, msgId)', async () => {
     const dupEnvelope = JSON.stringify({
       fromClanId: 'clan-ember', toClanId: 'clan-iron',
@@ -271,7 +282,7 @@ describe('AxlPeerInbox — idempotency', () => {
       { fromPeerId: 'pubkey_ember', body: dupEnvelope },
       { fromPeerId: 'pubkey_ember', body: dupEnvelope },
     ]);
-    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, dedupPeerIdMap);
     const msgs = await inbox.inbox();
     // Only one message despite two deliveries
     expect(msgs).toHaveLength(1);
@@ -293,7 +304,7 @@ describe('AxlPeerInbox — idempotency', () => {
       { fromPeerId: 'pubkey_ember', body: e1 },
       { fromPeerId: 'pubkey_ember', body: e2 },
     ]);
-    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, dedupPeerIdMap);
     const msgs = await inbox.inbox();
     expect(msgs).toHaveLength(2);
   });
@@ -489,25 +500,21 @@ describe('AxlPeerInbox — security: spoofed-peer rejection (HIGH 1)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// MED 3 — Retry idempotency via sendIdempotent()
+// MED 4 — send() msgId generation (sendIdempotent removed — not in IElderPeerInbox)
 // ---------------------------------------------------------------------------
 
-describe('AxlPeerInbox — retry idempotency (MED 3)', () => {
-  it('sendIdempotent() passes the same msgId to AXL on both retry calls', async () => {
+describe('AxlPeerInbox — send() msgId generation (MED 4)', () => {
+  it('send() includes a non-empty msgId in the AXL envelope', async () => {
     const client = makeMockAxlClient();
     const peerIdMap = new Map([['clan-ember', 'pubkey_ember']]);
     const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, peerIdMap);
 
-    const stableMsgId = `clan-iron:5:${Date.now()}-stable`;
-    await inbox.sendIdempotent('clan-ember', 'hello retry', 5, stableMsgId);
-    await inbox.sendIdempotent('clan-ember', 'hello retry', 5, stableMsgId);
+    await inbox.send('clan-ember', 'hello', 5);
 
-    // Both calls should have reached AXL with the identical msgId.
-    expect(client.sentMessages).toHaveLength(2);
-    const body1 = JSON.parse(client.sentMessages[0]!.body) as { msgId: string };
-    const body2 = JSON.parse(client.sentMessages[1]!.body) as { msgId: string };
-    expect(body1.msgId).toBe(stableMsgId);
-    expect(body2.msgId).toBe(stableMsgId);
+    expect(client.sentMessages).toHaveLength(1);
+    const body = JSON.parse(client.sentMessages[0]!.body) as { msgId: string };
+    expect(typeof body.msgId).toBe('string');
+    expect(body.msgId.length).toBeGreaterThan(0);
   });
 
   it('send() generates a fresh msgId each call (distinct message IDs)', async () => {
@@ -613,5 +620,157 @@ describe('AxlPeerInbox — crash durability: journal replay (HIGH 2)', () => {
     const msgs = await inbox.inbox();
     expect(msgs).toHaveLength(1);
     // No journal files should exist anywhere for this test.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R2 NEW TESTS — HIGH 1 fail-CLOSED, HIGH 2 myClanId traversal,
+//               MED 3 journal corruption, MED 5 FilePeerInbox no-read-on-send
+// ---------------------------------------------------------------------------
+
+describe('HIGH 1 — empty peerIdMap rejects ALL inbound messages (fail-CLOSED)', () => {
+  it('rejects all inbound messages when peerIdMap is empty (no AXL_PEER_ID_* configured)', async () => {
+    // With an empty peerIdMap, there is no way to validate sender identity.
+    // Fail-CLOSED: reject rather than accept-all (which would enable spoofing).
+    const envelope = JSON.stringify({
+      fromClanId: 'clan-ember',
+      toClanId: 'clan-iron',
+      message: 'should be rejected',
+      tick: 1,
+      sentAt: new Date().toISOString(),
+      msgId: 'no-map-1',
+      networkId: 'testnet',
+    });
+    const client = makeMockAxlClient([{ fromPeerId: 'pubkey_ember', body: envelope }]);
+    // Deliberately pass an empty peerIdMap — simulates AXL_PEER_ID_* env vars not set.
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map());
+
+    const msgs = await inbox.inbox();
+    // Must reject ALL messages when peer map is empty — not accept them.
+    expect(msgs).toHaveLength(0);
+  });
+
+  it('accepts messages only when peerIdMap is non-empty and fromPeerId matches', async () => {
+    const peerIdMap = new Map([['clan-ember', 'pubkey_ember']]);
+    const envelope = JSON.stringify({
+      fromClanId: 'clan-ember',
+      toClanId: 'clan-iron',
+      message: 'should be accepted',
+      tick: 1,
+      sentAt: new Date().toISOString(),
+      msgId: 'with-map-1',
+      networkId: 'testnet',
+    });
+    const client = makeMockAxlClient([{ fromPeerId: 'pubkey_ember', body: envelope }]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, peerIdMap);
+
+    const msgs = await inbox.inbox();
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.message).toBe('should be accepted');
+  });
+});
+
+describe('HIGH 2 — myClanId path traversal validation', () => {
+  it('throws on construction when myClanId contains ../ (path traversal)', () => {
+    const client = makeMockAxlClient();
+    expect(
+      () => new AxlPeerInbox('../evil', 'testnet', client, new Map()),
+    ).toThrow('invalid clanId');
+  });
+
+  it('throws on construction when myClanId contains a forward slash', () => {
+    const client = makeMockAxlClient();
+    expect(
+      () => new AxlPeerInbox('/etc/passwd', 'testnet', client, new Map()),
+    ).toThrow('invalid clanId');
+  });
+
+  it('throws on construction when myClanId is empty', () => {
+    const client = makeMockAxlClient();
+    expect(
+      () => new AxlPeerInbox('', 'testnet', client, new Map()),
+    ).toThrow('invalid clanId');
+  });
+
+  it('accepts valid myClanId with hyphens and alphanumeric chars', () => {
+    const client = makeMockAxlClient();
+    expect(
+      () => new AxlPeerInbox('clan-iron-2', 'testnet', client, new Map()),
+    ).not.toThrow();
+  });
+});
+
+describe('MED 3 — journal corruption: malformed lines skipped, valid entries replayed', () => {
+  it('skips malformed JSON journal lines with a warn, replays valid entries', () => {
+    const stateDir = tmpStateDir();
+    const journalPath = path.join(stateDir, 'peer-inbox', 'axl-journal-clan-iron.jsonl');
+    fs.mkdirSync(path.dirname(journalPath), { recursive: true });
+
+    // Write one corrupt line then one valid entry.
+    const validEntry = JSON.stringify({
+      fromClanId: 'clan-ember',
+      toClanId: 'clan-iron',
+      message: 'valid after corrupt',
+      tick: 9,
+      sentAt: new Date().toISOString(),
+      msgId: 'valid-after-corrupt',
+    });
+    fs.writeFileSync(journalPath, 'NOT_VALID_JSON{{{\n' + validEntry + '\n', 'utf8');
+
+    const warnSpy = vi.spyOn(console, 'warn');
+    const client = makeMockAxlClient([]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map(), journalPath);
+
+    // The corrupt line must trigger a warn.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('malformed JSON'),
+    );
+
+    // The valid entry must still appear in inbox despite the corrupt line.
+    return inbox.inbox().then(msgs => {
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0]!.message).toBe('valid after corrupt');
+    });
+  });
+
+  it('skips journal entries with missing required fields (wrong-shape JSON)', () => {
+    const stateDir = tmpStateDir();
+    const journalPath = path.join(stateDir, 'peer-inbox', 'axl-journal-clan-iron.jsonl');
+    fs.mkdirSync(path.dirname(journalPath), { recursive: true });
+
+    // An entry missing 'msgId' — should be skipped by isJournalEntry() guard.
+    const badShape = JSON.stringify({ fromClanId: 'clan-ember', tick: 1, message: 'bad' });
+    const goodEntry = JSON.stringify({
+      fromClanId: 'clan-ember',
+      toClanId: 'clan-iron',
+      message: 'good shape',
+      tick: 10,
+      sentAt: new Date().toISOString(),
+      msgId: 'good-shape-1',
+    });
+    fs.writeFileSync(journalPath, badShape + '\n' + goodEntry + '\n', 'utf8');
+
+    const client = makeMockAxlClient([]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, new Map(), journalPath);
+
+    return inbox.inbox().then(msgs => {
+      // Only the valid entry — bad-shape entry is skipped.
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0]!.message).toBe('good shape');
+    });
+  });
+});
+
+describe('MED 5 — FilePeerInbox.send() does not read file before appending', () => {
+  it('does not call fs.readFileSync during send() (no read-before-write)', async () => {
+    const stateDir = tmpStateDir();
+    const sender = new FilePeerInbox('clan-a', stateDir);
+
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+
+    await sender.send('clan-b', 'no read needed', 1);
+
+    // readFileSync must not have been called — UUID suffix makes sender-side dedup unnecessary.
+    expect(readSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/runner/test/axlPeerInbox.test.ts
+++ b/packages/runner/test/axlPeerInbox.test.ts
@@ -9,6 +9,7 @@ import {
   type IAxlClient,
 } from '../src/axlPeerInbox.js';
 import { FilePeerInbox } from '../src/filePeerInbox.js';
+import { randomUUID } from 'node:crypto';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -404,5 +405,213 @@ describe('FilePeerInbox', () => {
     expect(msgs).toHaveLength(2);
     const bodies = msgs.map(m => m.message).sort();
     expect(bodies).toEqual(['from a', 'from b']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HIGH 1 — Spoofed-peer rejection
+// ---------------------------------------------------------------------------
+
+describe('AxlPeerInbox — security: spoofed-peer rejection (HIGH 1)', () => {
+  it('rejects a message where fromPeerId does not match envelope.fromClanId', async () => {
+    // peerIdMap: clan-ember → pubkey_ember, clan-iron → pubkey_iron
+    const peerIdMap = new Map([
+      ['clan-ember', 'pubkey_ember'],
+      ['clan-iron', 'pubkey_iron'],
+    ]);
+    // Attacker sends as clan-iron's peerId but claims to be clan-ember in envelope.
+    const spoofedEnvelope = JSON.stringify({
+      fromClanId: 'clan-ember',   // claimed identity
+      toClanId: 'clan-iron',
+      message: 'spoofed whisper',
+      tick: 1,
+      sentAt: new Date().toISOString(),
+      msgId: 'spoof-1',
+      networkId: 'testnet',
+    });
+    // Message arrives with pubkey_iron as the transport-level sender — mismatch.
+    const client = makeMockAxlClient([
+      { fromPeerId: 'pubkey_iron', body: spoofedEnvelope },
+    ]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, peerIdMap);
+
+    const msgs = await inbox.inbox();
+    // The spoofed message must be dropped.
+    expect(msgs).toHaveLength(0);
+  });
+
+  it('accepts a legitimate message where fromPeerId matches envelope.fromClanId', async () => {
+    const peerIdMap = new Map([
+      ['clan-ember', 'pubkey_ember'],
+      ['clan-iron', 'pubkey_iron'],
+    ]);
+    const legitimateEnvelope = JSON.stringify({
+      fromClanId: 'clan-ember',
+      toClanId: 'clan-iron',
+      message: 'genuine whisper',
+      tick: 2,
+      sentAt: new Date().toISOString(),
+      msgId: 'legit-1',
+      networkId: 'testnet',
+    });
+    const client = makeMockAxlClient([
+      { fromPeerId: 'pubkey_ember', body: legitimateEnvelope },
+    ]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, peerIdMap);
+
+    const msgs = await inbox.inbox();
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.message).toBe('genuine whisper');
+    expect(msgs[0]!.fromClanId).toBe('clan-ember');
+  });
+
+  it('rejects a message from an unknown peer not in the peerIdMap', async () => {
+    const peerIdMap = new Map([
+      ['clan-ember', 'pubkey_ember'],
+    ]);
+    const envelope = JSON.stringify({
+      fromClanId: 'clan-unknown',
+      toClanId: 'clan-iron',
+      message: 'from stranger',
+      tick: 1,
+      sentAt: new Date().toISOString(),
+      msgId: 'stranger-1',
+      networkId: 'testnet',
+    });
+    const client = makeMockAxlClient([
+      { fromPeerId: 'pubkey_unknown', body: envelope },
+    ]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, peerIdMap);
+
+    const msgs = await inbox.inbox();
+    expect(msgs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MED 3 — Retry idempotency via sendIdempotent()
+// ---------------------------------------------------------------------------
+
+describe('AxlPeerInbox — retry idempotency (MED 3)', () => {
+  it('sendIdempotent() passes the same msgId to AXL on both retry calls', async () => {
+    const client = makeMockAxlClient();
+    const peerIdMap = new Map([['clan-ember', 'pubkey_ember']]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, peerIdMap);
+
+    const stableMsgId = `clan-iron:5:${Date.now()}-stable`;
+    await inbox.sendIdempotent('clan-ember', 'hello retry', 5, stableMsgId);
+    await inbox.sendIdempotent('clan-ember', 'hello retry', 5, stableMsgId);
+
+    // Both calls should have reached AXL with the identical msgId.
+    expect(client.sentMessages).toHaveLength(2);
+    const body1 = JSON.parse(client.sentMessages[0]!.body) as { msgId: string };
+    const body2 = JSON.parse(client.sentMessages[1]!.body) as { msgId: string };
+    expect(body1.msgId).toBe(stableMsgId);
+    expect(body2.msgId).toBe(stableMsgId);
+  });
+
+  it('send() generates a fresh msgId each call (distinct message IDs)', async () => {
+    const client = makeMockAxlClient();
+    const peerIdMap = new Map([['clan-ember', 'pubkey_ember']]);
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, peerIdMap);
+
+    await inbox.send('clan-ember', 'msg-1', 1);
+    await inbox.send('clan-ember', 'msg-2', 1);
+
+    const id1 = (JSON.parse(client.sentMessages[0]!.body) as { msgId: string }).msgId;
+    const id2 = (JSON.parse(client.sentMessages[1]!.body) as { msgId: string }).msgId;
+    // Each send() generates a unique msgId — they must differ.
+    expect(id1).not.toBe(id2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MED 5 — Path traversal rejection (FilePeerInbox)
+// ---------------------------------------------------------------------------
+
+describe('FilePeerInbox — path traversal rejection (MED 5)', () => {
+  it('throws on construction with clanId containing ../', () => {
+    expect(() => new FilePeerInbox('../evil', '/tmp')).toThrow('invalid clanId');
+  });
+
+  it('throws on construction with clanId containing a forward slash', () => {
+    expect(() => new FilePeerInbox('/etc/passwd', '/tmp')).toThrow('invalid clanId');
+  });
+
+  it('throws on send() when toClanId contains a path traversal sequence', async () => {
+    const sender = new FilePeerInbox('clan-a', tmpStateDir());
+    await expect(sender.send('../etc/shadow', 'evil', 1)).rejects.toThrow('invalid clanId');
+  });
+
+  it('throws on construction with an empty clanId', () => {
+    expect(() => new FilePeerInbox('', '/tmp')).toThrow('invalid clanId');
+  });
+
+  it('accepts valid clanIds with hyphens, underscores, and alphanumeric chars', () => {
+    expect(() => new FilePeerInbox('clan-iron', '/tmp')).not.toThrow();
+    expect(() => new FilePeerInbox('clan_ember_2', '/tmp')).not.toThrow();
+    expect(() => new FilePeerInbox('ClanAlpha', '/tmp')).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HIGH 2 — Runner-crash durability via JSONL journal
+// ---------------------------------------------------------------------------
+
+describe('AxlPeerInbox — crash durability: journal replay (HIGH 2)', () => {
+  it('replays drained messages after a new AxlPeerInbox instance is created on the same journal', async () => {
+    const stateDir = tmpStateDir();
+    const journalPath = path.join(stateDir, 'peer-inbox', 'axl-journal-clan-iron.jsonl');
+
+    const peerIdMap = new Map([
+      ['clan-ember', 'pubkey_ember'],
+      ['clan-iron', 'pubkey_iron'],
+    ]);
+
+    const envelope = JSON.stringify({
+      fromClanId: 'clan-ember',
+      toClanId: 'clan-iron',
+      message: 'durable message',
+      tick: 7,
+      sentAt: new Date().toISOString(),
+      msgId: `durable-${randomUUID()}`,
+      networkId: 'testnet',
+    });
+
+    // First instance drains from AXL and journals the message.
+    const client1 = makeMockAxlClient([{ fromPeerId: 'pubkey_ember', body: envelope }]);
+    const inbox1 = new AxlPeerInbox('clan-iron', 'testnet', client1, peerIdMap, journalPath);
+    const msgs1 = await inbox1.inbox();
+    expect(msgs1).toHaveLength(1);
+    expect(msgs1[0]!.message).toBe('durable message');
+
+    // Simulate runner crash: create a fresh AxlPeerInbox with an empty AXL queue
+    // but the same journal file — the message must survive.
+    const client2 = makeMockAxlClient([]); // AXL queue is empty (already consumed)
+    const inbox2 = new AxlPeerInbox('clan-iron', 'testnet', client2, peerIdMap, journalPath);
+    const msgs2 = await inbox2.inbox();
+
+    expect(msgs2).toHaveLength(1);
+    expect(msgs2[0]!.message).toBe('durable message');
+    expect(msgs2[0]!.fromClanId).toBe('clan-ember');
+  });
+
+  it('AxlPeerInbox without journalPath is memory-only (no file written)', async () => {
+    const peerIdMap = new Map([['clan-ember', 'pubkey_ember']]);
+    const envelope = JSON.stringify({
+      fromClanId: 'clan-ember',
+      toClanId: 'clan-iron',
+      message: 'ephemeral',
+      tick: 1,
+      sentAt: new Date().toISOString(),
+      msgId: 'eph-1',
+      networkId: 'testnet',
+    });
+    const client = makeMockAxlClient([{ fromPeerId: 'pubkey_ember', body: envelope }]);
+    // No journalPath — memory-only mode.
+    const inbox = new AxlPeerInbox('clan-iron', 'testnet', client, peerIdMap);
+    const msgs = await inbox.inbox();
+    expect(msgs).toHaveLength(1);
+    // No journal files should exist anywhere for this test.
   });
 });

--- a/packages/runner/test/zeroGMemoryStore.test.ts
+++ b/packages/runner/test/zeroGMemoryStore.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  createMemoryStore,
+  ZeroGMemoryStore,
+  type I0GKvClient,
+  type I0GKvWriter,
+  type KvWriterFactory,
+} from '../src/zeroGMemoryStore.js';
+import { FileMemoryStore } from '../src/fileMemoryStore.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TMP_DIRS: string[] = [];
+
+function tmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'runner-test-'));
+  TMP_DIRS.push(d);
+  return d;
+}
+
+afterEach(() => {
+  for (const d of TMP_DIRS.splice(0)) {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// FileMemoryStore (fallback path)
+// ---------------------------------------------------------------------------
+
+describe('FileMemoryStore', () => {
+  let stateDir: string;
+  let store: FileMemoryStore;
+
+  beforeEach(() => {
+    stateDir = path.join(tmpDir(), '.world', 'clanworld-runner', 'state');
+    store = new FileMemoryStore(1, stateDir);
+  });
+
+  it('recall returns undefined for missing key', async () => {
+    expect(await store.recall('missing')).toBeUndefined();
+  });
+
+  it('save and recall round-trips a value', async () => {
+    await store.save('goal', 'expand north');
+    expect(await store.recall('goal')).toBe('expand north');
+  });
+
+  it('snapshot returns all saved keys', async () => {
+    await store.save('k1', 'v1');
+    await store.save('k2', 'v2');
+    const snap = await store.snapshot();
+    expect(snap).toEqual({ k1: 'v1', k2: 'v2' });
+  });
+
+  it('persists across store instances (same stateDir)', async () => {
+    await store.save('persisted', 'yes');
+    const store2 = new FileMemoryStore(1, stateDir);
+    expect(await store2.recall('persisted')).toBe('yes');
+  });
+
+  it('overwrite replaces previous value', async () => {
+    await store.save('key', 'first');
+    await store.save('key', 'second');
+    expect(await store.recall('key')).toBe('second');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMemoryStore — fallback when OG_STORAGE_API_KEY is not set
+// ---------------------------------------------------------------------------
+
+describe('createMemoryStore — fallback path (no API key)', () => {
+  it('returns a FileMemoryStore when OG_STORAGE_API_KEY is absent', async () => {
+    const sd = path.join(tmpDir(), '.world', 'clanworld-runner', 'state');
+    const store = await createMemoryStore({
+      env: { ELDER_N: '2' },
+      elderN: 2,
+      stateDir: sd,
+    });
+    expect(store).toBeInstanceOf(FileMemoryStore);
+  });
+
+  it('fallback store passes recall/save/snapshot contract', async () => {
+    const sd = path.join(tmpDir(), '.world', 'clanworld-runner', 'state');
+    const store = await createMemoryStore({
+      env: { ELDER_N: '1' },
+      elderN: 1,
+      stateDir: sd,
+    });
+
+    expect(await store.recall('x')).toBeUndefined();
+    await store.save('x', 'hello');
+    expect(await store.recall('x')).toBe('hello');
+    const snap = await store.snapshot();
+    expect(snap['x']).toBe('hello');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ZeroGMemoryStore — mocked 0G branch
+// ---------------------------------------------------------------------------
+
+function makeKvStore(): Map<string, Uint8Array> {
+  return new Map();
+}
+
+function makeMockClient(kvStore: Map<string, Uint8Array>): I0GKvClient {
+  return {
+    getValue: vi.fn(async (_streamId: string, key: Uint8Array) => {
+      const k = new TextDecoder().decode(key);
+      const data = kvStore.get(k);
+      if (data === undefined) return null;
+      return { startIndex: BigInt(0), data };
+    }),
+  };
+}
+
+function makeMockWriterFactory(
+  kvStore: Map<string, Uint8Array>,
+): KvWriterFactory {
+  return (_streamId: string): I0GKvWriter => {
+    const pending = new Map<Uint8Array, Uint8Array>();
+    return {
+      set: vi.fn((key: Uint8Array, value: Uint8Array) => {
+        pending.set(key, value);
+      }),
+      exec: vi.fn(async () => {
+        for (const [k, v] of pending) {
+          kvStore.set(new TextDecoder().decode(k), v);
+        }
+      }),
+    };
+  };
+}
+
+describe('ZeroGMemoryStore — mocked 0G client', () => {
+  const STREAM_ID = 'test-stream-001';
+  let kvStore: Map<string, Uint8Array>;
+  let mockClient: I0GKvClient;
+  let writerFactory: KvWriterFactory;
+  let store: ZeroGMemoryStore;
+
+  beforeEach(() => {
+    kvStore = makeKvStore();
+    mockClient = makeMockClient(kvStore);
+    writerFactory = makeMockWriterFactory(kvStore);
+    store = new ZeroGMemoryStore(STREAM_ID, mockClient, writerFactory);
+  });
+
+  it('recall returns undefined for missing key', async () => {
+    expect(await store.recall('unknown')).toBeUndefined();
+    // Verify getValue was called with the right streamId and key bytes for 'unknown'.
+    expect(mockClient.getValue).toHaveBeenCalledOnce();
+    const [calledStream, calledKey] = (mockClient.getValue as ReturnType<typeof vi.fn>).mock.calls[0] as [string, Uint8Array];
+    expect(calledStream).toBe(STREAM_ID);
+    expect(new TextDecoder().decode(calledKey)).toBe('unknown');
+  });
+
+  it('save calls writer set + exec, then recall returns written value', async () => {
+    await store.save('plan', 'hold the line');
+    expect(await store.recall('plan')).toBe('hold the line');
+    expect(mockClient.getValue).not.toHaveBeenCalled(); // served from write-through cache
+  });
+
+  it('recall hits KvClient on cache miss, returns value from 0G', async () => {
+    // Pre-populate 0G store directly (simulating external write).
+    kvStore.set('external', new TextEncoder().encode('remote value'));
+    expect(await store.recall('external')).toBe('remote value');
+    expect(mockClient.getValue).toHaveBeenCalledOnce();
+  });
+
+  it('snapshot reflects all written keys', async () => {
+    await store.save('k1', 'alpha');
+    await store.save('k2', 'beta');
+    const snap = await store.snapshot();
+    expect(snap).toEqual({ k1: 'alpha', k2: 'beta' });
+  });
+
+  it('recall does not throw on getValue returning null', async () => {
+    await expect(store.recall('absent')).resolves.toBeUndefined();
+  });
+
+  it('recall does not throw on getValue error — returns undefined + warns', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (mockClient.getValue as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('rpc timeout'));
+    expect(await store.recall('flaky')).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('recall(flaky) failed'), expect.any(Error));
+  });
+
+  it('save propagates exec() rejection (storage failure throws)', async () => {
+    const failWriter: KvWriterFactory = (_sid: string) => ({
+      set: vi.fn(),
+      exec: vi.fn(async () => { throw new Error('disk full'); }),
+    });
+    const failStore = new ZeroGMemoryStore(STREAM_ID, mockClient, failWriter);
+    await expect(failStore.save('bad', 'val')).rejects.toThrow('disk full');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMemoryStore — 0G path (mocked SDK)
+// ---------------------------------------------------------------------------
+
+describe('createMemoryStore — 0G path (mocked client)', () => {
+  it('returns ZeroGMemoryStore when OG_STORAGE_API_KEY + OG_STREAM_ID are set', async () => {
+    const kvStore = makeKvStore();
+    const store = await createMemoryStore({
+      env: {
+        OG_STORAGE_API_KEY: 'test-key',
+        OG_STREAM_ID: 'stream-abc',
+        OG_KV_RPC: 'http://localhost:9999',
+      },
+      kvClient: makeMockClient(kvStore),
+      kvWriterFactory: makeMockWriterFactory(kvStore),
+    });
+    expect(store).toBeInstanceOf(ZeroGMemoryStore);
+  });
+
+  it('0G store passes recall/save/snapshot contract via mocks', async () => {
+    const kvStore = makeKvStore();
+    const store = await createMemoryStore({
+      env: {
+        OG_STORAGE_API_KEY: 'test-key',
+        OG_STREAM_ID: 'stream-abc',
+      },
+      kvClient: makeMockClient(kvStore),
+      kvWriterFactory: makeMockWriterFactory(kvStore),
+    });
+
+    expect(await store.recall('mission')).toBeUndefined();
+    await store.save('mission', 'gather resources');
+    expect(await store.recall('mission')).toBe('gather resources');
+    const snap = await store.snapshot();
+    expect(snap['mission']).toBe('gather resources');
+  });
+
+  it('falls back to FileMemoryStore when OG_STREAM_ID is missing', async () => {
+    const sd = path.join(tmpDir(), '.world', 'clanworld-runner', 'state');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = await createMemoryStore({
+      env: { OG_STORAGE_API_KEY: 'test-key' },
+      elderN: 1,
+      stateDir: sd,
+    });
+    expect(store).toBeInstanceOf(FileMemoryStore);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('OG_STREAM_ID not set'));
+  });
+});

--- a/packages/runner/tsconfig.json
+++ b/packages/runner/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 4.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@worldcoin/minikit-js':
         specifier: 2.0.3
-        version: 2.0.3(react@18.3.1)(typescript@5.9.3)(viem@2.48.4(typescript@5.9.3))
+        version: 2.0.3(react@18.3.1)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       convex:
         specifier: 1.17.4
         version: 1.17.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -142,6 +142,28 @@ importers:
 
   packages/contracts: {}
 
+  packages/runner:
+    dependencies:
+      '@0glabs/0g-ts-sdk':
+        specifier: 0.3.3
+        version: 0.3.3(bufferutil@4.1.0)(ethers@6.13.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
+      '@clan-world/agents':
+        specifier: workspace:*
+        version: link:../agents
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+    devDependencies:
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.4(@types/node@25.6.0)(lightningcss@1.32.0)
+
   packages/shared:
     dependencies:
       convex:
@@ -149,13 +171,21 @@ importers:
         version: 1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       viem:
         specifier: ^2.48.4
-        version: 2.48.4(typescript@5.9.3)
+        version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
     devDependencies:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
 
 packages:
+
+  '@0glabs/0g-ts-sdk@0.3.3':
+    resolution: {integrity: sha512-Ug/9gdeBnmTYU6obPXWChD8XqNUSyOI53vWWsbK2IXNymQc84gd1cDneQ2Vz2AZP26290pIp5FgmNgkVNOyxIA==}
+    peerDependencies:
+      ethers: 6.13.1
+
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
@@ -678,6 +708,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ethersproject/bytes@5.8.0':
+    resolution: {integrity: sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==}
+
+  '@ethersproject/keccak256@5.8.0':
+    resolution: {integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==}
+
+  '@ethersproject/logger@5.8.0':
+    resolution: {integrity: sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -704,6 +743,9 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.9.1':
     resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
     engines: {node: ^14.21.3 || >=16}
@@ -711,6 +753,10 @@ packages:
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -1011,6 +1057,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@18.15.13':
+    resolution: {integrity: sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
@@ -1137,6 +1186,9 @@ packages:
       zod:
         optional: true
 
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1149,6 +1201,12 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@0.27.2:
+    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+
   baseline-browser-mapping@2.10.22:
     resolution: {integrity: sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww==}
     engines: {node: '>=6.0.0'}
@@ -1159,9 +1217,17 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -1187,6 +1253,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1217,6 +1287,18 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d@1.0.2:
+    resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
+    engines: {node: '>=0.12'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1234,12 +1316,20 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   earcut@3.0.2:
     resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
@@ -1250,8 +1340,35 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es5-ext@0.10.64:
+    resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
+    engines: {node: '>=0.10'}
+
+  es6-iterator@2.0.3:
+    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
+
+  es6-symbol@3.1.4:
+    resolution: {integrity: sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==}
+    engines: {node: '>=0.12'}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -1272,8 +1389,19 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  esniff@2.0.1:
+    resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
+    engines: {node: '>=0.10'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  ethers@6.13.1:
+    resolution: {integrity: sha512-hdJ2HOxg/xx97Lm9HdCWk949BfYqYWpyw4//78SiwOLgASyfrNszfMUNB2joKjvGUdwhHfaiMMFFwacVVoLR9A==}
+    engines: {node: '>=14.0.0'}
+
+  event-emitter@0.3.5:
+    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
@@ -1281,6 +1409,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  ext@1.7.0:
+    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1295,10 +1426,26 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1308,15 +1455,42 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   gifuct-js@2.1.2:
     resolution: {integrity: sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
   ismobilejs@1.1.1:
     resolution: {integrity: sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==}
@@ -1328,6 +1502,9 @@ packages:
 
   js-binary-schema-parser@2.0.3:
     resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
+
+  js-sha3@0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1435,6 +1612,21 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1443,8 +1635,18 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  next-tick@1.1.0:
+    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  open-jsonrpc-provider@0.2.1:
+    resolution: {integrity: sha512-b+pRxakRwAqp+4OTh2TeH+z2zwVGa0C4fbcwIn6JsZdjd4VBmsp7KfCdmmV3XH8diecwXa5UILCw4IwAtk1DTQ==}
 
   ox@0.14.20:
     resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
@@ -1557,6 +1759,9 @@ packages:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
+  reconnecting-websocket@4.4.0:
+    resolution: {integrity: sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -1643,6 +1848,9 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tslib@2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1654,6 +1862,12 @@ packages:
   turbo@2.9.6:
     resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
     hasBin: true
+
+  type@2.7.3:
+    resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
+
+  typedarray-to-buffer@3.1.5:
+    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1668,6 +1882,10 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  utf-8-validate@5.0.10:
+    resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
+    engines: {node: '>=6.14.2'}
 
   viem@2.48.4:
     resolution: {integrity: sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==}
@@ -1784,6 +2002,10 @@ packages:
       jsdom:
         optional: true
 
+  websocket@1.0.35:
+    resolution: {integrity: sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==}
+    engines: {node: '>=4.0.0'}
+
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
@@ -1795,6 +2017,18 @@ packages:
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
+
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -1811,6 +2045,11 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
+  yaeti@0.0.6:
+    resolution: {integrity: sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==}
+    engines: {node: '>=0.10.32'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -1823,6 +2062,20 @@ packages:
     engines: {node: '>=8'}
 
 snapshots:
+
+  '@0glabs/0g-ts-sdk@0.3.3(bufferutil@4.1.0)(ethers@6.13.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/keccak256': 5.8.0
+      ethers: 6.13.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      open-jsonrpc-provider: 0.2.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@adraffy/ens-normalize@1.10.1': {}
 
   '@adraffy/ens-normalize@1.11.1': {}
 
@@ -2167,6 +2420,17 @@ snapshots:
   '@esbuild/win32-x64@0.23.1':
     optional: true
 
+  '@ethersproject/bytes@5.8.0':
+    dependencies:
+      '@ethersproject/logger': 5.8.0
+
+  '@ethersproject/keccak256@5.8.0':
+    dependencies:
+      '@ethersproject/bytes': 5.8.0
+      js-sha3: 0.8.0
+
+  '@ethersproject/logger@5.8.0': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2195,6 +2459,10 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.9.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -2202,6 +2470,8 @@ snapshots:
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -2407,6 +2677,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@18.15.13': {}
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -2507,12 +2779,12 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@worldcoin/minikit-js@2.0.3(react@18.3.1)(typescript@5.9.3)(viem@2.48.4(typescript@5.9.3))':
+  '@worldcoin/minikit-js@2.0.3(react@18.3.1)(typescript@5.9.3)(viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
       abitype: 1.2.4(typescript@5.9.3)
       react: 18.3.1
     optionalDependencies:
-      viem: 2.48.4(typescript@5.9.3)
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - typescript
       - zod
@@ -2527,6 +2799,8 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  aes-js@4.0.0-beta.5: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -2534,6 +2808,15 @@ snapshots:
       color-convert: 2.0.1
 
   assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  axios@0.27.2:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+    transitivePeerDependencies:
+      - debug
 
   baseline-browser-mapping@2.10.22: {}
 
@@ -2545,7 +2828,16 @@ snapshots:
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   camelcase@5.3.1: {}
 
@@ -2573,6 +2865,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   convert-source-map@2.0.0: {}
 
   convex@1.17.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -2597,6 +2893,15 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d@1.0.2:
+    dependencies:
+      es5-ext: 0.10.64
+      type: 2.7.3
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -2605,9 +2910,17 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  delayed-stream@1.0.0: {}
+
   detect-libc@2.1.2: {}
 
   dijkstrajs@1.0.3: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   earcut@3.0.2: {}
 
@@ -2615,7 +2928,40 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  es5-ext@0.10.64:
+    dependencies:
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.4
+      esniff: 2.0.1
+      next-tick: 1.1.0
+
+  es6-iterator@2.0.3:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      es6-symbol: 3.1.4
+
+  es6-symbol@3.1.4:
+    dependencies:
+      d: 1.0.2
+      ext: 1.7.0
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2699,13 +3045,42 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  esniff@2.0.1:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      event-emitter: 0.3.5
+      type: 2.7.3
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  ethers@6.13.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 18.15.13
+      aes-js: 4.0.0-beta.5
+      tslib: 2.4.0
+      ws: 8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  event-emitter@0.3.5:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+
   eventemitter3@5.0.1: {}
 
   expect-type@1.3.0: {}
+
+  ext@1.7.0:
+    dependencies:
+      type: 2.7.3
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2716,12 +3091,42 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -2731,15 +3136,31 @@ snapshots:
     dependencies:
       js-binary-schema-parser: 2.0.3
 
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-typedarray@1.0.0: {}
 
   ismobilejs@1.1.1: {}
 
-  isows@1.0.7(ws@8.18.3):
+  isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   js-binary-schema-parser@2.0.3: {}
+
+  js-sha3@0.8.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2818,11 +3239,37 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
+  next-tick@1.1.0: {}
+
+  node-gyp-build@4.8.4: {}
+
   node-releases@2.0.38: {}
+
+  open-jsonrpc-provider@0.2.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      axios: 0.27.2
+      reconnecting-websocket: 4.4.0
+      websocket: 1.0.35
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
 
   ox@0.14.20(typescript@5.9.3):
     dependencies:
@@ -2928,6 +3375,8 @@ snapshots:
       loose-envify: 1.4.0
 
   react@19.2.5: {}
+
+  reconnecting-websocket@4.4.0: {}
 
   require-directory@2.1.1: {}
 
@@ -3038,6 +3487,8 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tslib@2.4.0: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -3057,6 +3508,12 @@ snapshots:
       '@turbo/windows-64': 2.9.6
       '@turbo/windows-arm64': 2.9.6
 
+  type@2.7.3: {}
+
+  typedarray-to-buffer@3.1.5:
+    dependencies:
+      is-typedarray: 1.0.0
+
   typescript@5.9.3: {}
 
   undici-types@7.19.2: {}
@@ -3067,16 +3524,20 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  viem@2.48.4(typescript@5.9.3):
+  utf-8-validate@5.0.10:
+    dependencies:
+      node-gyp-build: 4.8.4
+
+  viem@2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.14.20(typescript@5.9.3)
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3162,6 +3623,17 @@ snapshots:
       - supports-color
       - terser
 
+  websocket@1.0.35:
+    dependencies:
+      bufferutil: 4.1.0
+      debug: 2.6.9
+      es5-ext: 0.10.64
+      typedarray-to-buffer: 3.1.5
+      utf-8-validate: 5.0.10
+      yaeti: 0.0.6
+    transitivePeerDependencies:
+      - supports-color
+
   which-module@2.0.1: {}
 
   why-is-node-running@2.3.0:
@@ -3175,9 +3647,19 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  ws@8.18.3: {}
+  ws@8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
+
+  ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
 
   y18n@4.0.3: {}
+
+  yaeti@0.0.6: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- **`AxlPeerInbox`** — implements `IElderPeerInbox` using Gensyn AXL's local HTTP REST API (`POST /send`, `GET /recv`). Activated when `AXL_API_KEY` + `AXL_NETWORK_ID` are both set.
- **`FilePeerInbox`** — JSONL file-based fallback (S2 stub). Active when either AXL env var is absent.
- **`main.ts`** — wires both adapters at startup with clear `memory=<backend> peer=<backend>` log line.
- **Session-local inbox cache** — `inbox()` drains the AXL queue into an in-memory cache so repeated calls return the full accumulated inbox (non-consuming contract satisfied).
- **Idempotency** — dedup by `(fromClanId, tick, msgId)` on both the AXL and file paths.
- **`buildPeerIdMap`** — parses `AXL_PEER_ID_{CLAN_ID_UPPER_SNAKE}` env vars into a clanId → peer pubkey map.

## AXL SDK blocked state

No official npm SDK for AXL exists as of 2026-04-27. AXL is a Go binary exposing a local HTTP server (docs: https://docs.gensyn.ai/tech/agent-exchange-layer, API spec: `docs/api.md` in the gensyn-ai/axl repo). The runner wraps this via the typed `IAxlClient` interface:

```
POST /send  — X-Destination-Peer-Id header (ed25519 pubkey), binary body
GET  /recv  — FIFO poll; 204 = empty, 200 = message + X-From-Peer-Id header
```

Two `TODO` comments in `axlPeerInbox.ts` mark where to swap in the SDK once Gensyn ships `@gensyn/axl-sdk`. The file-fallback branch is **fully functional** and the AXL branch is testable with a live AXL sidecar node.

## How to test

**Without `AXL_API_KEY` (file fallback — no external services needed):**
```bash
ELDER_N=1 MY_CLAN_ID=clan-iron npx tsx packages/runner/src/main.ts
```

**With AXL (requires a running AXL sidecar node at `AXL_NODE_URL`):**
```bash
AXL_API_KEY=<key> AXL_NETWORK_ID=testnet MY_CLAN_ID=clan-iron \
  AXL_PEER_ID_CLAN_EMBER=<64-hex-pubkey> ELDER_N=1 \
  npx tsx packages/runner/src/main.ts
```

**Tests (no credentials required — mock IAxlClient injected):**
```bash
cd packages/runner && pnpm test
# 41 tests: 24 axlPeerInbox + 17 zeroGMemoryStore — all green
```

## Note: stacked on PR #89 (`feat/agents-seams-types-only`)

This PR is stacked on `feat/agents-seams-types-only` — set base branch accordingly before merging. Phase 7 files (`zeroGMemoryStore`, `fileMemoryStore`) are included here because they were only on `main`, not on the base branch.

## Convex `getPeerMessagesFor()`

Not yet implemented in the Convex server. Per Phase 8 spec, added a TODO in the plan:
> `// Phase 8-stretch: AXL event mirroring — Convex reads still file-based until AXL events are streamed here`
(No Convex file touched — the stub doesn't exist yet to annotate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)