### PR TITLE
fix(runner): harden tick-loop and delivery against abort/rate-limit races

### DIFF
--- a/packages/agents/src/seams/IRunnerInbox.ts
+++ b/packages/agents/src/seams/IRunnerInbox.ts
@@ -19,7 +19,7 @@ export interface IRunnerInbox {
    * - Idempotent: re-delivering tick N's block while the Elder is still processing tick N
    *   must be a no-op (same tick, same block = skip).
    */
-  deliverSituationBlock(tick: number, block: string): Promise<DeliveryStatus>;
+  deliverSituationBlock(tick: number, block: string, signal?: AbortSignal): Promise<DeliveryStatus>;
 
   /**
    * Wait for the Elder's ack-clear signal, then trigger a context reset.

--- a/packages/runner/src/tickLoop.ts
+++ b/packages/runner/src/tickLoop.ts
@@ -110,8 +110,10 @@ export async function tickLoop(deps: TickLoopDeps): Promise<void> {
               deps.signal,
               `composeSituationBlock(elder=${elder})`,
             );
-            // MED-1: per-delivery AbortController so a timeout actually cancels the tmux child.
+            // MED-1: per-delivery AbortController so a timeout OR shutdown cancels the tmux child.
             const deliveryAbort = new AbortController();
+            const linkAbort = (): void => deliveryAbort.abort();
+            deps.signal.addEventListener('abort', linkAbort, { once: true });
             let status: DeliveryStatus;
             try {
               status = await withTimeout(
@@ -120,7 +122,8 @@ export async function tickLoop(deps: TickLoopDeps): Promise<void> {
                 `deliverSituationBlock(elder=${elder}, tick=${chainTick})`,
               );
             } finally {
-              deliveryAbort.abort(); // cancels tmux child whether delivery succeeded or timed out
+              deliveryAbort.abort(); // cancels tmux child whether delivery succeeded, timed out, or shutdown
+              deps.signal.removeEventListener('abort', linkAbort);
             }
             if (!status.ok) {
               log.warn(`elder ${elder}: delivery returned not-ok: ${status.reason}`);

--- a/packages/runner/src/tickLoop.ts
+++ b/packages/runner/src/tickLoop.ts
@@ -163,7 +163,12 @@ export async function tickLoop(deps: TickLoopDeps): Promise<void> {
             await sleepWithSignal(waitMs, deps.signal);
             if (deps.signal.aborted) break;
             // Re-poll: if tick advanced during the wait, heartbeat already fired.
-            const freshTick = await pollChainTick(deps.convex).catch(() => chainTick);
+            // Wrapped in raceAbort so a hung Convex query doesn't block past SIGTERM.
+            const freshTick = await raceAbort(
+              pollChainTick(deps.convex),
+              deps.signal,
+              'pollChainTick(re-poll)',
+            ).catch(() => chainTick);
             if (freshTick > chainTick) {
               log.info(`chainTick advanced to ${freshTick} during rate-limit wait — stale tick ${chainTick} dropped`);
               break;

--- a/packages/runner/src/tickLoop.ts
+++ b/packages/runner/src/tickLoop.ts
@@ -1,5 +1,6 @@
 import {
   HeartbeatRateLimitedError,
+  type DeliveryStatus,
   type IElderMemoryStore,
   type IElderPeerInbox,
   type IHeartbeatCaller,
@@ -83,8 +84,9 @@ export async function tickLoop(deps: TickLoopDeps): Promise<void> {
   while (!deps.signal.aborted) {
     let chainTick: number;
     try {
-      chainTick = await pollChainTick(deps.convex);
+      chainTick = await raceAbort(pollChainTick(deps.convex), deps.signal, 'pollChainTick');
     } catch (err) {
+      if (deps.signal.aborted) break;
       log.error('pollChainTick failed:', err);
       await sleepWithSignal(deps.config.pollIntervalMs, deps.signal);
       continue;
@@ -100,19 +102,31 @@ export async function tickLoop(deps: TickLoopDeps): Promise<void> {
         ELDER_IDS.map(async elder => {
           const per = deps.perElder[elder];
           try {
-            const block = await composeSituationBlock(
-              { elder, clanId: deps.config.elderToClanId[elder], tick: chainTick },
-              { convex: deps.convex, memory: per.memory, peerInbox: per.peerInbox },
+            const block = await raceAbort(
+              composeSituationBlock(
+                { elder, clanId: deps.config.elderToClanId[elder], tick: chainTick },
+                { convex: deps.convex, memory: per.memory, peerInbox: per.peerInbox },
+              ),
+              deps.signal,
+              `composeSituationBlock(elder=${elder})`,
             );
-            const status = await withTimeout(
-              per.inbox.deliverSituationBlock(chainTick, block),
-              deps.config.deliveryTimeoutMs,
-              `deliverSituationBlock(elder=${elder}, tick=${chainTick})`,
-            );
+            // MED-1: per-delivery AbortController so a timeout actually cancels the tmux child.
+            const deliveryAbort = new AbortController();
+            let status: DeliveryStatus;
+            try {
+              status = await withTimeout(
+                per.inbox.deliverSituationBlock(chainTick, block, deliveryAbort.signal),
+                deps.config.deliveryTimeoutMs,
+                `deliverSituationBlock(elder=${elder}, tick=${chainTick})`,
+              );
+            } finally {
+              deliveryAbort.abort(); // cancels tmux child whether delivery succeeded or timed out
+            }
             if (!status.ok) {
               log.warn(`elder ${elder}: delivery returned not-ok: ${status.reason}`);
             }
           } catch (err) {
+            if (deps.signal.aborted) return; // clean shutdown
             log.error(`elder ${elder}: deliver/compose failed:`, err);
           }
         }),
@@ -131,7 +145,7 @@ export async function tickLoop(deps: TickLoopDeps): Promise<void> {
       let heartbeatDone = false;
       while (!heartbeatDone && !deps.signal.aborted) {
         try {
-          const { txHash } = await deps.heartbeatCaller.callHeartbeat();
+          const { txHash } = await raceAbort(deps.heartbeatCaller.callHeartbeat(), deps.signal, 'callHeartbeat');
           log.info(`heartbeat tx confirmed: ${txHash}`);
           lastProcessedTick = chainTick;
           heartbeatDone = true;
@@ -144,6 +158,13 @@ export async function tickLoop(deps: TickLoopDeps): Promise<void> {
               ).toISOString()}`,
             );
             await sleepWithSignal(waitMs, deps.signal);
+            if (deps.signal.aborted) break;
+            // Re-poll: if tick advanced during the wait, heartbeat already fired.
+            const freshTick = await pollChainTick(deps.convex).catch(() => chainTick);
+            if (freshTick > chainTick) {
+              log.info(`chainTick advanced to ${freshTick} during rate-limit wait — stale tick ${chainTick} dropped`);
+              break;
+            }
             continue; // retry callHeartbeat
           }
           log.error('heartbeat failed (non-rate-limit):', err);
@@ -187,4 +208,22 @@ async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+/**
+ * Race `p` against the abort signal. Rejects with "aborted" if signal fires first.
+ * Does NOT cancel `p` — it continues running in the background (underlying ops
+ * don't support cancellation). This prevents the outer loop from waiting on them
+ * past the shutdown signal.
+ */
+function raceAbort<T>(p: Promise<T>, signal: AbortSignal, label: string): Promise<T> {
+  if (signal.aborted) return Promise.reject(new Error(`aborted: ${label}`));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => reject(new Error(`aborted: ${label}`));
+    signal.addEventListener('abort', onAbort, { once: true });
+    p.then(
+      v => { signal.removeEventListener('abort', onAbort); resolve(v); },
+      e => { signal.removeEventListener('abort', onAbort); reject(e); },
+    );
+  });
 }

--- a/packages/runner/src/tmuxRunnerInbox.ts
+++ b/packages/runner/src/tmuxRunnerInbox.ts
@@ -105,6 +105,13 @@ export const defaultTmuxRunner: TmuxRunner = {
       if (opts.literal) args.push('-l');
       args.push(...keys);
       const child = spawn('tmux', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      // TOCTOU guard: check again after spawning in case signal fired between
+      // the caller's pre-check and addEventListener registration below.
+      if (signal?.aborted) {
+        child.kill('SIGTERM');
+        reject(new Error('aborted: tmux send'));
+        return;
+      }
       let stderr = '';
       child.stderr.on('data', chunk => {
         stderr += String(chunk);
@@ -126,6 +133,7 @@ export const defaultTmuxRunner: TmuxRunner = {
 async function sendBlock(runner: TmuxRunner, target: string, block: string, signal?: AbortSignal): Promise<void> {
   // Two-step paste: literal block, then Enter to submit.
   await runner.send(target, [block], { literal: true }, signal);
+  if (signal?.aborted) return; // don't send Enter if aborted mid-paste
   await runner.send(target, ['Enter'], { literal: false }, signal);
 }
 

--- a/packages/runner/src/tmuxRunnerInbox.ts
+++ b/packages/runner/src/tmuxRunnerInbox.ts
@@ -42,13 +42,15 @@ export class TmuxRunnerInbox implements IRunnerInbox {
     this.runner = opts.runner ?? defaultTmuxRunner;
   }
 
-  async deliverSituationBlock(tick: number, block: string): Promise<DeliveryStatus> {
+  async deliverSituationBlock(tick: number, block: string, signal?: AbortSignal): Promise<DeliveryStatus> {
+    if (signal?.aborted) return { ok: false, reason: 'timeout' };
     const last = readLastTick(this.markerFile);
     if (last !== undefined && last >= tick) {
       return { ok: false, reason: 'duplicate-tick' };
     }
     try {
-      await sendBlock(this.runner, this.target, block);
+      await sendBlock(this.runner, this.target, block, signal);
+      if (signal?.aborted) return { ok: false, reason: 'timeout' }; // don't write marker on abort
       writeLastTick(this.markerFile, tick);
       return { ok: true };
     } catch (err) {
@@ -68,9 +70,10 @@ export class TmuxRunnerInbox implements IRunnerInbox {
     // says "if timeout: runner issues /clear anyway (Elder loses the turn's
     // reasoning)", so we always do the reset.
     try {
+      // /clear must be submitted with Enter before bootstrap is sent; otherwise
+      // the two concatenate as a single prompt and the /clear slash command is ignored.
       await this.runner.send(this.target, ['/clear'], { literal: false });
-      // Send a small delay between /clear and the bootstrap by issuing them
-      // as two separate send-keys invocations — tmux processes them in order.
+      await this.runner.send(this.target, ['Enter'], { literal: false });
       await sendBlock(this.runner, this.target, this.bootstrapBlock);
     } catch {
       // /clear failures are non-fatal — the next tick will try again.
@@ -92,11 +95,11 @@ export class TmuxRunnerInbox implements IRunnerInbox {
  * Tmux process abstraction so tests can swap in a recorder.
  */
 export interface TmuxRunner {
-  send(target: string, keys: string[], opts: { literal: boolean }): Promise<void>;
+  send(target: string, keys: string[], opts: { literal: boolean }, signal?: AbortSignal): Promise<void>;
 }
 
 export const defaultTmuxRunner: TmuxRunner = {
-  send(target, keys, opts) {
+  send(target, keys, opts, signal) {
     return new Promise((resolve, reject) => {
       const args = ['send-keys', '-t', target];
       if (opts.literal) args.push('-l');
@@ -111,14 +114,19 @@ export const defaultTmuxRunner: TmuxRunner = {
         if (code === 0) resolve();
         else reject(new Error(`tmux ${args.join(' ')} exited ${code}: ${stderr.trim()}`));
       });
+      if (signal) {
+        const onAbort = (): void => { child.kill('SIGTERM'); };
+        signal.addEventListener('abort', onAbort, { once: true });
+        child.on('close', () => signal.removeEventListener('abort', onAbort));
+      }
     });
   },
 };
 
-async function sendBlock(runner: TmuxRunner, target: string, block: string): Promise<void> {
+async function sendBlock(runner: TmuxRunner, target: string, block: string, signal?: AbortSignal): Promise<void> {
   // Two-step paste: literal block, then Enter to submit.
-  await runner.send(target, [block], { literal: true });
-  await runner.send(target, ['Enter'], { literal: false });
+  await runner.send(target, [block], { literal: true }, signal);
+  await runner.send(target, ['Enter'], { literal: false }, signal);
 }
 
 function readLastTick(file: string): number | undefined {

--- a/packages/runner/test/tmuxRunnerInbox.test.ts
+++ b/packages/runner/test/tmuxRunnerInbox.test.ts
@@ -14,7 +14,7 @@ class RecordingTmux implements TmuxRunner {
   calls: RecordedCall[] = [];
   shouldFail: false | { message: string } = false;
 
-  async send(target: string, keys: string[], opts: { literal: boolean }): Promise<void> {
+  async send(target: string, keys: string[], opts: { literal: boolean }, _signal?: AbortSignal): Promise<void> {
     this.calls.push({ target, keys, literal: opts.literal });
     if (this.shouldFail) {
       throw new Error(this.shouldFail.message);
@@ -140,11 +140,12 @@ describe('TmuxRunnerInbox.waitForAckAndClear', () => {
     });
     const result = await inbox.waitForAckAndClear(500);
     expect(result).toBe('timeout');
-    // /clear (non-literal) + bootstrap (literal) + Enter (non-literal) = 3 calls.
-    expect(tmux.calls).toHaveLength(3);
+    // /clear (non-literal) + Enter (non-literal) + bootstrap (literal) + Enter (non-literal) = 4 calls.
+    expect(tmux.calls).toHaveLength(4);
     expect(tmux.calls[0]).toEqual({ target: 'elder-1', keys: ['/clear'], literal: false });
-    expect(tmux.calls[1]).toEqual({ target: 'elder-1', keys: ['BOOT'], literal: true });
-    expect(tmux.calls[2]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
+    expect(tmux.calls[1]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
+    expect(tmux.calls[2]).toEqual({ target: 'elder-1', keys: ['BOOT'], literal: true });
+    expect(tmux.calls[3]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
   });
 
   it('returns ack and consumes the flag file when it exists', async () => {
@@ -161,5 +162,28 @@ describe('TmuxRunnerInbox.waitForAckAndClear', () => {
     const result = await inbox.waitForAckAndClear(500);
     expect(result).toBe('ack');
     expect(fs.existsSync(flagFile)).toBe(false);
+  });
+});
+
+describe('TmuxRunnerInbox.deliverSituationBlock — abort behavior', () => {
+  it('does not write last-tick marker when delivery is aborted mid-send', async () => {
+    const abort = new AbortController();
+    const tmux = new RecordingTmux();
+    // Abort before any send
+    abort.abort();
+    const inbox = new TmuxRunnerInbox({
+      elder: 1,
+      sessionPrefix: 'elder',
+      stateDir: tmpDir,
+      bootstrapBlock: 'b',
+      runner: tmux,
+    });
+    const status = await inbox.deliverSituationBlock(5, 'block', abort.signal);
+    expect(status).toEqual({ ok: false, reason: 'timeout' });
+    // No marker written because signal was aborted
+    const marker = path.join(tmpDir, 'elder-1-last-tick.txt');
+    expect(fs.existsSync(marker)).toBe(false);
+    // No tmux calls made (aborted before send)
+    expect(tmux.calls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #113

## Summary

4 hardening fixes from orch-r1 codex review gating PR #93 merge.

- **HIGH-1** (`tickLoop.ts`): re-poll `chainTick` after sleeping through a rate-limit window; if tick advanced the heartbeat already fired — drop stale tick and break rather than retrying against a done tick
- **HIGH-2** (`tickLoop.ts`): add `raceAbort()` helper that races any promise against `AbortSignal`; wrap `pollChainTick`, `composeSituationBlock`, `callHeartbeat` so SIGTERM immediately unblocks the loop instead of waiting up to settle-window + delivery-timeout + tx-confirmation time
- **MED-1** (3 files): per-delivery `AbortController` passed through `IRunnerInbox.deliverSituationBlock` → `TmuxRunner.send`; `defaultTmuxRunner` kills the tmux child process on abort; marker not written if signal fires mid-send
- **MED-2** (`tmuxRunnerInbox.ts`): send `Enter` keystroke immediately after `/clear` so the slash-command fires before bootstrap arrives — without it `/clear` and the bootstrap block concatenate as a single prompt and the reset is silently ignored

## Test plan

- [ ] `pnpm --filter @clan-world/runner typecheck` — clean
- [ ] `pnpm --filter @clan-world/agents typecheck` — clean
- [ ] `pnpm --filter @clan-world/runner test` — 14/14 pass
  - `waitForAckAndClear` timeout test updated: 3 → 4 tmux calls (new Enter after /clear)
  - new test: `deliverSituationBlock` does not write last-tick marker when aborted before send

🤖 Generated with [Claude Code](https://claude.com/claude-code)