### PR TITLE
merge: bundle A — foundations & docs (combines #115 #90 #102 #105 #98)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -21,9 +21,6 @@ DEPLOYER_PRIVATE_KEY=
 # --- Convex backend ---
 CONVEX_URL=
 
-# --- LLM (Submission 1 Elders use Claude Code OAuth sessions; this is for narrator/utility uses) ---
-ANTHROPIC_API_KEY=
-
 # --- World mini app (server-side World ID verify, webhook secret) ---
 # Server-side base name; browser variant is VITE_WORLD_APP_ID below. ONE concept.
 WORLD_APP_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,4 @@ docs/planning/V1/
 **/playwright/.cache/
 # port-for: ports.yml is tracked, ports.lock is per-worktree state
 .world/ports.lock
+**/.vercel/project.json

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ vite.config.ts.timestamp-*
 
 # Local planning extraction (V1.zip already committed; the unzipped tree is per-checkout)
 docs/planning/V1/
+
+# port-for: ports.yml is tracked, ports.lock is per-worktree state
+.world/ports.lock

--- a/.world/ports.yml
+++ b/.world/ports.yml
@@ -1,0 +1,60 @@
+# Port declarations for port-for allocation (ADR 0003 + 2026-04-11 amendment).
+#
+# Schema: Option D (project-sharded slots).
+#   ClanWorld owns the 387xx backend slot and 587xx frontend slot.
+#   Sub-bands within each slot (per ADR 0003 amendment):
+#     00-09 core   10-39 prod   40-69 dev   70-89 test   90-99 scratch
+#
+# Slot assignment rationale: 388 (CPC), 385 (Inbox), 389 (Meridian FX),
+# 386 (gh-stats partial — 38610 taken) were already claimed. 387/587 was
+# the cleanest unclaimed adjacent slot. Reserved for ClanWorld.
+#
+# Initial purposes (apps/web frontend + apps/server Convex/Hono backend +
+# Playwright e2e test). Add more as runner daemon, ttyd web view, etc. land.
+
+repo: clan-world
+purposes:
+  - name: clan-world-frontend-dev
+    type: frontend
+    env: dev
+    canonical: 58740   # Vite dev server for apps/web
+
+  - name: clan-world-backend-dev
+    type: backend
+    env: dev
+    canonical: 38740   # Hono dev server for apps/server (Convex local emulator port too)
+
+  - name: clan-world-frontend-test
+    type: frontend
+    env: test
+    canonical: 58770   # Playwright webServer (replaces hardcoded 58840 inherited from PR #88)
+
+  - name: clan-world-frontend-prod
+    type: frontend
+    env: prod
+    canonical: 58730   # Vercel-deployed bundle proxy if we ever localhost-test prod build
+
+  - name: clan-world-runner-daemon
+    type: backend
+    env: dev
+    canonical: 38745   # runner daemon HTTP port (if it ever exposes one for health/debug)
+
+  - name: clan-world-ttyd-elder-1
+    type: backend
+    env: scratch
+    canonical: 38790   # ttyd web view for elder-1 tmux session (Phase 5.E10 stretch)
+
+  - name: clan-world-ttyd-elder-2
+    type: backend
+    env: scratch
+    canonical: 38791
+
+  - name: clan-world-ttyd-elder-3
+    type: backend
+    env: scratch
+    canonical: 38792
+
+  - name: clan-world-ttyd-elder-4
+    type: backend
+    env: scratch
+    canonical: 38793

--- a/docs/planning/phase-3-test-spec.md
+++ b/docs/planning/phase-3-test-spec.md
@@ -1,0 +1,506 @@
+# Phase 3 — Foundry Test Specification
+
+**Status:** pre-stage (Phase 3 not yet dispatched; Phase 2 PR #91 gate pending)
+**Target file:** `packages/contracts/test/ClanWorld.t.sol` (extend existing suite)
+**Spec references:** v4.2 §2.4, §7.7, §7.9-7.11, §8.2, §11.1, §15; dispatch brief `plans/drafts/20260426-phase3-dispatch-brief.md`
+**Existing test count:** 19 (Phase 1 + Phase 2); Phase 3 adds ~39 cases below.
+
+---
+
+## Conventions
+
+Helpers assumed available in the extended test contract:
+
+```solidity
+function _mintClan() internal returns (uint32 clanId)
+function _advanceTick() internal          // vm.warp + heartbeat()
+function _advanceTicks(uint n) internal   // repeat n times
+function _submitDefend(uint32 clanId, uint32 csId, uint32 targetClanId) internal
+function _submitOrder(uint32 clanId, uint32 csId, uint8 gotoRegion, ActionType action) internal
+```
+
+Region constants (from `ClanWorldConstants` or inline):
+- `REGION_UNICORN_TOWN` — excluded from bandit spawn
+- `REGION_DEEP_SEA` — excluded from bandit spawn
+
+Tick advancement uses `vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS)` before each `world.heartbeat()`.
+
+---
+
+## 3.E1 — Bandit spawn / camp / attack
+
+### test_banditSpawn_rejectsUnicornTownAndDeepSea
+
+**Setup:** Deploy fresh `ClanWorld`. Force spawn probability to 100% (set `currentBanditSpawnChanceBps = 10_000`). Manipulate `tickSeed` (via known block hash / `vm.roll`) so region selection would land on Unicorn Town.
+
+**Action:** Advance tick (heartbeat). Observe region assigned to spawned bandit (or absence of spawn).
+
+**Assert:** Either (a) no bandit spawns (spawn skipped due to excluded region) OR (b) bandit's `currentRegion` is NOT Unicorn Town and NOT Deep Sea.
+
+**Edge cases:**
+- Seed produces Deep Sea — same assertion.
+- Seed cycles through all excluded regions — no spawn until a valid region is available.
+
+---
+
+### test_banditSpawn_maxOneActiveBanditAtOnce
+
+**Setup:** Spawn one bandit (probability 100%, valid region). Confirm `activeBanditId != 0`.
+
+**Action:** Advance tick again with spawn probability 100%.
+
+**Assert:** `WorldState.activeBanditId` unchanged (same bandit ID); no second bandit created. (v4.2 §15 invariant.)
+
+---
+
+### test_banditSpawn_setsStateAndNextActionTick
+
+**Setup:** 100% spawn probability, valid region, known tick N.
+
+**Action:** Advance tick → bandit spawns.
+
+**Assert:**
+- `BanditTroop.state == BanditState.Camping`
+- `BanditTroop.nextActionTick == N + CAMPING_DURATION` (e.g. 2 or 3 per implementation)
+- `BanditTroop.stateEnteredTick == N`
+- `BanditTroop.currentRegion` is a valid non-excluded region.
+
+---
+
+### test_banditCamping_doesNotAdvanceBeforeNextActionTick
+
+**Setup:** Spawn bandit at tick N with `nextActionTick = N + 3`.
+
+**Action:** Advance 1 tick (tick N+1), advance 2 ticks (N+2).
+
+**Assert:** Both times, `BanditTroop.state == BanditState.Camping`.
+
+---
+
+### test_banditTransition_campingToAttacking_atNextActionTick
+
+**Setup:** Spawn bandit at tick N, `nextActionTick = N + 2`. Mint a clan in the bandit's region (so target selection can succeed).
+
+**Action:** Advance to tick N + 2.
+
+**Assert:** `BanditTroop.state == BanditState.Attacking`.
+
+---
+
+### test_banditSpawn_nextEligibleTickAdvances
+
+**Setup:** After bandit spawns, read `WorldState.nextBanditSpawnEligibleTick`.
+
+**Assert:** `nextBanditSpawnEligibleTick > currentTick` (spawn cooldown is set).
+
+---
+
+## 3.E2 — Eager settlement of touched clans
+
+### test_eagerSettle_banditTargetVaultReflectsSettledState
+
+**Setup:**
+- Mint two clans, both in same region as incoming bandit.
+- Clan A has workers gathering — unsettled resource surplus exists.
+- Clan B has starvation developing — unsettled penalty.
+- Spawn bandit, advance to attack tick.
+
+**Action:** Heartbeat resolves the attack.
+
+**Assert:**
+- At attack resolution, vault values used for target-selection / loot reflect settled state (not stale lazy state).
+- Specifically: if Clan A's vault would be higher post-settle and that increases its loot value, the bandit targeted it (or loot drawn is the correct settled amount).
+
+**Note:** This test is correctness-sensitive per v4.2 §2.4 — lazy targeting = wrong outcome.
+
+---
+
+### test_eagerSettle_defendersInRegionAreSettledBeforeTargetPick
+
+**Setup:**
+- Clan A in region R (homebase).
+- Clan B has a worker registered as defender at Clan A's base.
+- Bandit targets region R.
+
+**Assert:** At bandit target-pick step, Clan B's worker is included in defender registry with correct `defensePoints` (earned via prior settle).
+
+---
+
+## 3.E3 — Defender registry
+
+### test_defenderRegistry_addOnDefendBaseMissionArrival
+
+**Setup:** Mint defender clan, send worker to target clan's base (`DefendBase(targetClanId)`). Travel duration = 1 tick.
+
+**Action:** Advance tick (worker arrives).
+
+**Assert:**
+- `getActiveDefenders(targetClanId)` includes the worker's clansman ID.
+- `defendingBaseOfClansman[csId] == targetClanId`.
+- `defenderIndexPlusOne[csId] != 0`.
+
+---
+
+### test_defenderRegistry_removedOnMissionInterrupt
+
+**Setup:** Register worker as defender. Confirm in registry.
+
+**Action:** Submit new mission for that worker (interrupting DefendBase). Advance tick.
+
+**Assert:**
+- `getActiveDefenders(targetClanId)` no longer includes worker.
+- `defendingBaseOfClansman[csId] == 0`.
+- `defenderIndexPlusOne[csId] == 0`.
+
+---
+
+### test_defenderRegistry_swapPopIntegrity_middleRemoval
+
+**Setup:** Register 3 workers (A, B, C) as defenders of same base. Confirm registry = [A, B, C].
+
+**Action:** Interrupt worker B (middle of array).
+
+**Assert:**
+- Registry has 2 entries.
+- No duplicate IDs.
+- No zero-ID entries (swap-pop replaced B with C correctly).
+- `defenderIndexPlusOne` for A and C are updated; B's entry is 0.
+
+---
+
+### test_defenderRegistry_removedOnWorkerDeath
+
+**Setup:** Register worker as defender. Set worker HP to 0 (or advance starvation until death).
+
+**Action:** Trigger worker death (via heartbeat starvation or forced state).
+
+**Assert:** Worker removed from defender registry (`getActiveDefenders` excludes it).
+
+---
+
+### test_defenderRegistry_persistsAcrossMultipleBanditCycles
+
+**Setup:** Register worker W as defender of Clan A. Let bandit attack and resolve (defender wins or loses). Do not interrupt W.
+
+**Action:** Advance several ticks. Let second bandit spawn and attack same base.
+
+**Assert:** W is still in `getActiveDefenders(A)` for the second attack. (v4.2 §8.2 — DefendBase is continuous.)
+
+---
+
+### test_defenderRegistry_removedOnClanDeath
+
+**Setup:** Register worker of Clan B as defender of Clan A. Kill Clan A (set workers = 0 / mark dead).
+
+**Assert:** Worker is removed from `activeDefendersByBase[A]`.
+
+---
+
+## 3.E4 — Deterministic combat
+
+### test_combat_defenderWins_whenTotalDefenseGeAttackPower
+
+**Setup:**
+- Mint attacker clan, mint defender clan.
+- Register N defenders at defender clan's base; their combined `defensePoints` > bandit's `attackPower`.
+- Spawn bandit targeting defender clan.
+
+**Action:** Advance to attack tick.
+
+**Assert:**
+- `BanditTroop.state == BanditState.Defeated`.
+- `BanditAttackResolved` event emitted with `defended == true`.
+- Defender clan vault unchanged (no vault damage).
+
+---
+
+### test_combat_attackerWins_whenTotalDefenseLtAttackPower
+
+**Setup:**
+- Defender clan has 0 defenders registered (or weak defenders: `totalDefense < attackPower`).
+- Spawn bandit.
+
+**Action:** Advance to attack tick.
+
+**Assert:**
+- `BanditTroop.state == BanditState.Retreating` (or `Defeated` per implementation).
+- Defender clan wall HP decremented.
+- Defender clan vault decremented by bandit carry amount.
+- `BanditAttackResolved` event emitted with `defended == false`.
+
+---
+
+### test_combat_determinism_sameSeedSameOutcome
+
+**Setup:**
+- Snapshot full state at start of tick T (bandit + defenders + seed).
+- Record outcome (winner, loot amounts, any randomized values like wound chance).
+
+**Action:** Re-fork same block via `vm.snapshot` / `vm.revertTo`. Replay heartbeat.
+
+**Assert:** Outcome byte-for-byte identical. (v4.2 §11.1 — tickSeed as sole randomness source.)
+
+---
+
+### test_combat_determinism_differentSeedDifferentOutcome
+
+**Setup:** Same bandit + defender state, but different `tickSeed` (advance one extra block to change block hash before deriving seed).
+
+**Assert:** At least one randomized outcome differs (e.g. crit, wound chance). Confirms seed is actually wired into resolution logic.
+
+---
+
+### test_combat_noReentrancy_defenderCallbackHarmless
+
+**Setup:** Deploy a mock defender that re-enters `heartbeat()` on `BanditAttackResolved` callback.
+
+**Assert:** Reentrancy guard triggers (revert) or re-entry has no effect on state consistency. (v4.2 §11.4.)
+
+---
+
+## 3.E5 — Loot split / wall damage / blueprint reward
+
+### test_lootDistribution_proportionalToDefensePoints
+
+**Setup:**
+- Two defenders: Clansman A with `defensePoints = 3`, Clansman B with `defensePoints = 1`.
+- Bandit carry: 100 wood (total loot = 100).
+- Defenders win (combined 4 > bandit attack power).
+
+**Action:** Advance to attack resolution.
+
+**Assert:**
+- Clansman A's clan receives 75 wood.
+- Clansman B's clan receives 25 wood.
+- Proportional split within ±1 rounding error.
+
+---
+
+### test_lootDistribution_blueprintAwardedToTopContributor
+
+**Setup:** Three defenders, Clansman X has highest `defensePoints`. Defenders win.
+
+**Assert:** `BlueprintAwarded` event emitted with `clanId == X.clanId`.
+
+---
+
+### test_lootDistribution_contributionsClearedAfterResolution
+
+**Setup:** Resolve one bandit attack. Read `defenseContributionsByBanditId[banditId]`.
+
+**Assert:** Array is empty after resolution. (v4.2 §7.11 — entries cleared after distribution.)
+
+---
+
+### test_wallDamage_onDefenderLoss
+
+**Setup:** Defender clan with `wallHpCurrent = 100`. Bandit attack power exceeds defense.
+
+**Action:** Attack resolves (defender loses).
+
+**Assert:** `Clan.wallHpCurrent < 100`. (Exact delta per implementation formula.)
+
+---
+
+### test_vaultLoss_onDefenderLoss
+
+**Setup:** Defender clan vault has 200 wood. Bandit `attackPower` overshoot carries 50 wood.
+
+**Assert:** Defender clan vault decremented by 50 wood. Bandit `carryWood` incremented by 50.
+
+---
+
+### test_vaultLoss_cappedAtVaultContents
+
+**Setup:** Defender clan vault has 10 wood. Bandit carry capacity exceeds vault.
+
+**Assert:** Bandit takes at most 10 wood (no underflow). Vault reaches 0, not negative.
+
+---
+
+### test_lootSnapshot_usesContributionAtAttackNotCurrentRegistry
+
+**Setup:**
+- Register defender D at base of Clan A at tick T.
+- At tick T+1 (before attack resolves): interrupt D's mission.
+- Attack resolves at tick T+2.
+
+**Assert:** D's `defensePoints` contribution IS included in loot distribution (snapshot was taken at attack initiation, not at resolution). (Per dispatch brief §3.E5.)
+
+---
+
+## 3.E6 — Wall / base / monument upgrades
+
+### test_buildWall_incrementsTierAndResetsHp
+
+**Setup:** Clan starts at `wallTier = 0`, `wallHpCurrent = 0`. Clan has required stone in vault.
+
+**Action:** Submit `BuildWall` mission. Advance until complete.
+
+**Assert:**
+- `Clan.wallTier == 1`.
+- `Clan.wallHpCurrent == Clan.wallHpMax` (reset to max).
+
+---
+
+### test_repairWall_resetsHpWithoutChangingTier
+
+**Setup:** Clan has `wallTier = 2`, `wallHpCurrent = 50` (damaged). Sufficient stone in vault.
+
+**Action:** Submit `RepairWall`. Advance until complete.
+
+**Assert:**
+- `Clan.wallTier == 2` (unchanged).
+- `Clan.wallHpCurrent == Clan.wallHpMax`.
+
+---
+
+### test_upgradeBase_incrementsTier
+
+**Setup:** Clan has `baseTier = 0`. Sufficient wood + stone.
+
+**Action:** Submit `UpgradeBase`.
+
+**Assert:** `Clan.baseTier == 1`.
+
+---
+
+### test_buildMonument_incrementsTier
+
+**Setup:** Clan has `monumentTier = 0`. Sufficient gold + blueprints.
+
+**Action:** Submit `BuildMonument`.
+
+**Assert:** `Clan.monumentTier == 1`.
+
+---
+
+### test_upgrade_rejectsInsufficientResources
+
+**Setup:** Clan vault has 0 stone. Attempt `BuildWall`.
+
+**Assert:** Revert (or order result error). State unchanged.
+
+---
+
+### test_upgrade_costScalesWithTier
+
+**Setup:** Upgrade wall from tier 0 → 1 (cost C0). Record cost. Upgrade from tier 1 → 2 (cost C1).
+
+**Assert:** `C1 > C0`. Confirms geometric cost scaling.
+
+---
+
+## 3.E7 — Leaderboard
+
+### test_leaderboard_rankConsistentWithCompositeScore
+
+**Setup:** Mint 3 clans with different gold, worker count, wallTier, monumentTier. Set known values so expected score order is deterministic.
+
+**Action:** Call `getLeaderboard()`.
+
+**Assert:** Returned clan order matches descending composite score:
+```
+score = vaultGold + (workers * N) + (wallTier * M) + (monumentTier * K) - banditDamageTaken
+```
+
+---
+
+### test_leaderboard_rankUpdatesAfterBanditAttack
+
+**Setup:** Clan A has higher score than Clan B. Bandit attacks Clan A (defender loss) — Clan A takes vault loss.
+
+**Action:** Call `getLeaderboard()` post-attack.
+
+**Assert:** Scores reflect vault/wall damage. Rank may have changed if Clan B now scores higher.
+
+---
+
+### test_getClanRank_matchesLeaderboardPosition
+
+**Setup:** Leaderboard returns [C3, C1, C2] (rank 1, 2, 3).
+
+**Assert:** `getClanRank(C3) == 1`, `getClanRank(C1) == 2`, `getClanRank(C2) == 3`.
+
+---
+
+### test_leaderboard_handlesMaxClans
+
+**Setup:** Mint 12 clans (canonical map cap).
+
+**Action:** Call `getLeaderboard()`.
+
+**Assert:** Returns 12 entries, no revert, correct sort. Confirms gas-acceptable for ≤12 clans.
+
+---
+
+## 3.E8 — Integration / invariant harness
+
+### test_integration_fullBanditCycle_twoClansDefend
+
+End-to-end script per dispatch brief exit criteria:
+
+**Setup:**
+- Mint Clan A, Clan B.
+- Both deposit resources into vaults.
+- Clan A sends 2 defenders to Clan B's base.
+- Set spawn probability 100%, seed into valid region (Clan B's region).
+
+**Actions (in order):**
+1. Advance tick → bandit spawns in Clan B's region.
+2. Advance `CAMPING_DURATION` ticks → bandit transitions to Attacking.
+3. Submit additional defender orders if needed.
+4. Advance tick → attack resolution heartbeat.
+5. Call `getLeaderboard()`.
+
+**Assert:**
+- Bandit state is `Defeated` (defenders win) OR `Retreating` (defender loss) — no stuck state.
+- Loot/damage events emitted.
+- Leaderboard reflects post-attack scores.
+- `defenseContributionsByBanditId[banditId]` empty after resolution.
+- `activeBanditId == 0` (bandit cleared from world state on defeat/retreat).
+
+---
+
+### test_invariant_atMostOneBanditAtOnce
+
+**Fuzzer:** For any sequence of heartbeats, `WorldState.activeBanditId != 0` for at most one bandit ID at any point.
+
+Implement as Foundry invariant test (Foundry `invariant_*` naming) with a handler that calls `heartbeat()` with varying `vm.warp` increments.
+
+---
+
+### test_invariant_banditNeverInExcludedRegion
+
+**Fuzzer:** For any spawned bandit, `BanditTroop.currentRegion != REGION_UNICORN_TOWN && != REGION_DEEP_SEA`.
+
+Implement as invariant test.
+
+---
+
+## Test count summary
+
+| Deliverable | Tests |
+|-------------|-------|
+| 3.E1 Bandit spawn | 6 |
+| 3.E2 Eager settle | 2 |
+| 3.E3 Defender registry | 6 |
+| 3.E4 Deterministic combat | 5 |
+| 3.E5 Loot / wall damage | 7 |
+| 3.E6 Upgrades | 6 |
+| 3.E7 Leaderboard | 4 |
+| 3.E8 Integration / invariants | 3 |
+| **Total** | **39** |
+
+Existing Phase 1/2 suite: 19. Post-Phase-3: **58 tests**.
+
+---
+
+## Implementation notes for the implementor
+
+- All randomness must come from `WorldState.currentTickSeed` (v4.2 §11.1). Tests that verify determinism should use `vm.snapshot` / `vm.revertTo` to replay the same tick.
+- The `_eagerSettleForBandit(banditId)` call MUST happen before target selection AND before damage application (3.E2). Tests 3.E2-a and 3.E2-b directly verify this ordering.
+- Swap-pop integrity in `defenderIndexPlusOne` is critical — get 3.E3 middle-removal test passing before integration tests.
+- Loot snapshot (3.E5 last test) verifies that `defenseContributionsByBanditId` is populated at mission-start not resolution — this affects test setup sequence.
+- For 3.E7 gas test: `getLeaderboard()` with 12 clans must not revert. If it does, the view function needs gas optimization (insertion-sort rather than bubble-sort).
+- `NEVER_CUT` per dispatch brief: 3.E1-3.E4, 3.E2 eager-settle, 3.E8 combat-determinism + registry-integrity tests.

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -128,6 +128,8 @@ export async function runCommand(
 
   if (ns === 'peer' && cmd === 'inbox') {
     const n = getElderN(env);
+    // Reads by ELDER_N, not clanId. Round-trips with 'peer whisper' only when
+    // clanId === String(elderN). Issue #94 tracks the fix (option A: ELDER_CLAN_ID).
     const file = inboxFile(n, homeBase);
     if (!fs.existsSync(file)) return 'inbox empty\n';
     const lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);

--- a/packages/agents/src/seams/IElderMemoryStore.ts
+++ b/packages/agents/src/seams/IElderMemoryStore.ts
@@ -1,0 +1,34 @@
+/**
+ * IElderMemoryStore — durable Elder memory across context resets.
+ *
+ * S2 stub: local JSON file at ~/.world/clanworld-runner/state/elder-{N}-memory.json
+ * Phase 7: 0G iNFT memory (ERC-7857 linked storage per clan; survives ownership transfer)
+ *
+ * Contract:
+ * - Key/value store scoped to a single Elder (N).
+ * - All keys are strings; values are JSON-serialisable strings.
+ * - reads must not throw on missing keys (return undefined).
+ * - writes must be durable: a read after a successful write must return the written value.
+ * - Implementations must be safe for single-Elder single-writer use (no concurrent write guarantee required).
+ */
+export interface IElderMemoryStore {
+  /**
+   * Read the value stored for topic/key, or undefined if not set.
+   */
+  recall(key: string): Promise<string | undefined>;
+
+  /**
+   * Persist a value for key. Overwrites any previous value.
+   *
+   * Contract:
+   * - Must complete before the tick loop continues (caller does not fire-and-forget).
+   * - Must throw on storage failure (full disk, permission denied, 0G write error).
+   */
+  save(key: string, value: string): Promise<void>;
+
+  /**
+   * Return all stored key/value pairs (snapshot at call time).
+   * Used by the runner to compose the continuity summary block on final-tick warning.
+   */
+  snapshot(): Promise<Record<string, string>>;
+}

--- a/packages/agents/src/seams/IElderPeerInbox.ts
+++ b/packages/agents/src/seams/IElderPeerInbox.ts
@@ -1,0 +1,45 @@
+/**
+ * IElderPeerInbox — private Elder-to-Elder diplomacy transport.
+ *
+ * S2 stub: file-based jsonl at ~/.world/clanworld-runner/state/peer-inbox/elder-{recipientClanId}.jsonl
+ * Phase 8: Gensyn AXL private messaging transport
+ *
+ * Contract:
+ * - Messages are ordered (FIFO) within a sender/recipient pair per tick.
+ * - Peer messages are agent-private: not mirrored to Convex or the UI in S2.
+ *   (Phase 8: Convex getPeerMessagesFor() switches from file to AXL transport.)
+ * - send() writes to the RECIPIENT's inbox (indexed by recipient clan ID), not the sender's.
+ * - inbox() reads the caller Elder's own inbox (indexed by the Elder's own clan ID).
+ * - Implementations must be idempotent: the runner may re-deliver a whisper on retry;
+ *   implementations that guarantee exactly-once must deduplicate by (fromClanId, tick, msgId).
+ */
+export interface IElderPeerInbox {
+  /**
+   * Send a whisper to another clan's Elder.
+   *
+   * @param toClanId - recipient clan ID (determines which inbox file / AXL channel to write)
+   * @param message  - free-text message content (≤ 500 chars recommended for AXL compat)
+   * @param tick     - current game tick (used for ordering and deduplication)
+   */
+  send(toClanId: string, message: string, tick: number): Promise<void>;
+
+  /**
+   * Read all unread messages in this Elder's own inbox.
+   *
+   * Contract:
+   * - Returns messages in arrival order.
+   * - Does NOT consume/delete messages — same messages returned on next call.
+   *   (Stateful consumption is the Elder's responsibility via memory store.)
+   * - Must not throw if inbox is empty or does not yet exist.
+   */
+  inbox(): Promise<PeerMessage[]>;
+}
+
+export interface PeerMessage {
+  fromClanId: string;
+  toClanId: string;
+  message: string;
+  tick: number;
+  /** ISO 8601 timestamp of when the message was sent. */
+  sentAt: string;
+}

--- a/packages/agents/src/seams/IHeartbeatCaller.ts
+++ b/packages/agents/src/seams/IHeartbeatCaller.ts
@@ -1,0 +1,43 @@
+/**
+ * IHeartbeatCaller — caller of ClanWorld.heartbeat() on-chain.
+ *
+ * S2 bootstrap: runner-side `cast send` (or viem writeContract) using a dedicated runner wallet.
+ *   The runner calls heartbeat() after each Elder settle window (default 90s).
+ * Phase 6: KeeperHub workflow fires heartbeat() automatically; runner stops calling it
+ *   and instead consumes the resulting /keeperHubHeartbeat webhook via Convex.
+ *
+ * Contract:
+ * - Caller must be permissionless: anyone may call heartbeat(); the contract self-rate-limits.
+ * - callHeartbeat() must wait for tx confirmation before resolving (not fire-and-forget).
+ * - If the chain rejects because the rate limit hasn't elapsed, implementations must
+ *   surface HeartbeatRateLimitedError, not a generic Error, so the runner can back off.
+ * - Implementations must NOT use the same wallet as any Elder (Elder wallets sign clan orders;
+ *   mixing nonces causes order submission failures).
+ */
+export interface IHeartbeatCaller {
+  /**
+   * Call ClanWorld.heartbeat() and wait for confirmation.
+   *
+   * @returns confirmed tx hash on success
+   * @throws HeartbeatRateLimitedError if the on-chain rate limit has not elapsed
+   * @throws Error on other chain/network failures
+   */
+  callHeartbeat(): Promise<{ txHash: string }>;
+
+  /**
+   * Check whether the rate limit window has elapsed without submitting a tx.
+   * Used by the runner to decide whether to attempt a heartbeat call.
+   */
+  isHeartbeatDue(): Promise<boolean>;
+}
+
+/** Thrown when heartbeat() is called before nextHeartbeatAtTs has elapsed. */
+export class HeartbeatRateLimitedError extends Error {
+  constructor(
+    /** Unix seconds when the next heartbeat will be accepted. */
+    public readonly nextAllowedAt: number,
+  ) {
+    super(`heartbeat rate-limited: next allowed at ${new Date(nextAllowedAt * 1000).toISOString()}`);
+    this.name = 'HeartbeatRateLimitedError';
+  }
+}

--- a/packages/agents/src/seams/IRunnerInbox.ts
+++ b/packages/agents/src/seams/IRunnerInbox.ts
@@ -1,0 +1,43 @@
+/**
+ * IRunnerInbox — contract between the runner daemon and each Elder session.
+ *
+ * The runner pushes per-tick situation blocks into the Elder's tmux session;
+ * the Elder acknowledges consolidation readiness before a context reset.
+ * Implementations must be idempotent: delivering the same situation block
+ * twice for the same tick must not cause duplicate processing.
+ */
+export interface IRunnerInbox {
+  /**
+   * Deliver a per-tick situation block to the Elder.
+   *
+   * The block is a free-text summary of world state, clan state, recent events,
+   * and peer messages, composed by the runner from Convex data.
+   *
+   * Contract:
+   * - Must complete (resolve or reject) within the runner's per-Elder delivery timeout.
+   * - Must not throw on transient Elder session unavailability — surface via returned status.
+   * - Idempotent: re-delivering tick N's block while the Elder is still processing tick N
+   *   must be a no-op (same tick, same block = skip).
+   */
+  deliverSituationBlock(tick: number, block: string): Promise<DeliveryStatus>;
+
+  /**
+   * Wait for the Elder's ack-clear signal, then trigger a context reset.
+   *
+   * Flow:
+   * 1. Runner sends final-tick warning to Elder.
+   * 2. Runner calls waitForAckAndClear(timeout).
+   * 3. If Elder calls `elder ack-clear` within timeout: runner issues /clear then bootstraps.
+   * 4. If timeout elapses with no ack: runner issues /clear anyway (Elder loses the turn's reasoning).
+   *
+   * Contract:
+   * - timeoutMs is the maximum wait; implementations must not block beyond it.
+   * - Returns 'ack' if Elder acknowledged, 'timeout' if not.
+   * - Must never deadlock the tick loop.
+   */
+  waitForAckAndClear(timeoutMs: number): Promise<'ack' | 'timeout'>;
+}
+
+export type DeliveryStatus =
+  | { ok: true }
+  | { ok: false; reason: 'session-down' | 'timeout' | 'duplicate-tick' };

--- a/packages/agents/src/seams/index.ts
+++ b/packages/agents/src/seams/index.ts
@@ -1,0 +1,5 @@
+export type { IRunnerInbox, DeliveryStatus } from './IRunnerInbox';
+export type { IElderMemoryStore } from './IElderMemoryStore';
+export type { IElderPeerInbox, PeerMessage } from './IElderPeerInbox';
+export type { IHeartbeatCaller } from './IHeartbeatCaller';
+export { HeartbeatRateLimitedError } from './IHeartbeatCaller';

--- a/packages/agents/test/cli.test.ts
+++ b/packages/agents/test/cli.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { IConvexClient, IChainClient } from '@clan-world/shared/adapters';
+import type { WorldSnapshot, ClanFullView, Whisper, Tick } from '@clan-world/shared';
+import { runCommand, UsageError, inboxFile, recipientInboxFile, ackFile } from '../src/cli.js';
+
+// ---------------------------------------------------------------------------
+// Stub data
+// ---------------------------------------------------------------------------
+
+const STUB_SNAPSHOT: WorldSnapshot = {
+  tick: 7,
+  tickEpoch: { startedAt: 1700000000, durationMs: 60000 },
+  regions: [{ id: 'r1', name: 'Forest', ownerClanId: '1' }],
+  clans: [{ id: '1', name: 'Wolfclan', treasury: '1000' }],
+};
+
+const STUB_CLAN_VIEW: ClanFullView = {
+  clan: { id: '1', name: 'Wolfclan', treasury: '1000' },
+  controlledRegions: [{ id: 'r1', name: 'Forest', ownerClanId: '1' }],
+  pendingOrders: [],
+  whispers: [],
+};
+
+// ---------------------------------------------------------------------------
+// Stub factories
+// ---------------------------------------------------------------------------
+
+function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
+  return {
+    async getSnapshot() { return STUB_SNAPSHOT; },
+    async getClanFullView() { return STUB_CLAN_VIEW; },
+    async postLog() {},
+    subscribeWhispers(_clanId: string, _onWhisper: (w: Whisper) => void): () => void { return () => {}; },
+    ...overrides,
+  };
+}
+
+function makeChain(overrides: Partial<IChainClient> = {}): IChainClient {
+  return {
+    async submitOrders() { return { txHash: '0xdeadbeef' }; },
+    async getCurrentTick(): Promise<Tick> { return 0; },
+    async getClanFullView(clanId: string): Promise<ClanFullView> {
+      return {
+        clan: { id: clanId, name: `chain-${clanId}`, treasury: '0' },
+        controlledRegions: [],
+        pendingOrders: [],
+        whispers: [],
+      };
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let deps: { convex: ReturnType<typeof makeConvex>; chain: ReturnType<typeof makeChain> };
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'elder-cli-test-'));
+  deps = { convex: makeConvex(), chain: makeChain() };
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// world snapshot
+// ---------------------------------------------------------------------------
+
+describe('world snapshot', () => {
+  it('returns JSON-parseable WorldSnapshot with correct tick', async () => {
+    const out = await runCommand('world', 'snapshot', [], deps, {}, tmpDir);
+    const parsed = JSON.parse(out) as WorldSnapshot;
+    expect(parsed.tick).toBe(7);
+    expect(parsed.regions).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clan view
+// ---------------------------------------------------------------------------
+
+describe('clan view', () => {
+  it('returns ClanFullView with correct clan name', async () => {
+    const out = await runCommand('clan', 'view', ['1'], deps, {}, tmpDir);
+    const parsed = JSON.parse(out) as ClanFullView;
+    expect(parsed.clan.name).toBe('Wolfclan');
+    expect(parsed.clan.id).toBe('1');
+  });
+
+  it('throws UsageError when clanId is missing', async () => {
+    await expect(
+      runCommand('clan', 'view', [], deps, {}, tmpDir),
+    ).rejects.toBeInstanceOf(UsageError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clan submit-orders
+// ---------------------------------------------------------------------------
+
+describe('clan submit-orders', () => {
+  it('reads orders file, calls chain.submitOrders, returns txHash', async () => {
+    const ordersFile = path.join(tmpDir, 'orders.json');
+    fs.writeFileSync(ordersFile, JSON.stringify({ clanId: '1', orders: [{ kind: 'mission', payload: {} }] }));
+    const out = await runCommand('clan', 'submit-orders', [ordersFile], deps, {}, tmpDir);
+    expect(out).toContain('0xdeadbeef');
+  });
+
+  it('throws UsageError when file does not exist', async () => {
+    await expect(
+      runCommand('clan', 'submit-orders', [path.join(tmpDir, 'no-such-file.json')], deps, {}, tmpDir),
+    ).rejects.toBeInstanceOf(UsageError);
+  });
+
+  it('throws UsageError on bad JSON', async () => {
+    const badFile = path.join(tmpDir, 'bad.json');
+    fs.writeFileSync(badFile, 'not valid json {{');
+    await expect(
+      runCommand('clan', 'submit-orders', [badFile], deps, {}, tmpDir),
+    ).rejects.toBeInstanceOf(UsageError);
+  });
+
+  it('throws UsageError when clanId is missing from file', async () => {
+    const ordersFile = path.join(tmpDir, 'orders.json');
+    fs.writeFileSync(ordersFile, JSON.stringify({ orders: [{ kind: 'mission', payload: {} }] }));
+    await expect(
+      runCommand('clan', 'submit-orders', [ordersFile], deps, {}, tmpDir),
+    ).rejects.toBeInstanceOf(UsageError);
+  });
+
+  it('throws UsageError when orders is not an array', async () => {
+    const ordersFile = path.join(tmpDir, 'orders.json');
+    fs.writeFileSync(ordersFile, JSON.stringify({ clanId: '1', orders: 'not-an-array' }));
+    await expect(
+      runCommand('clan', 'submit-orders', [ordersFile], deps, {}, tmpDir),
+    ).rejects.toBeInstanceOf(UsageError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// memory recall / save
+// ---------------------------------------------------------------------------
+
+describe('memory recall/save', () => {
+  const env = { ELDER_N: '1' };
+
+  it('recall with no saved memory returns "no memory for <key>"', async () => {
+    const out = await runCommand('memory', 'recall', ['strategy'], deps, env, tmpDir);
+    expect(out).toBe('no memory for strategy\n');
+  });
+
+  it('save + recall round-trips value (including multi-word)', async () => {
+    await runCommand('memory', 'save', ['plan', 'expand', 'east', 'now'], deps, env, tmpDir);
+    const out = await runCommand('memory', 'recall', ['plan'], deps, env, tmpDir);
+    expect(out.trim()).toBe('expand east now');
+  });
+
+  it('throws UsageError when topic is missing from recall', async () => {
+    await expect(
+      runCommand('memory', 'recall', [], deps, env, tmpDir),
+    ).rejects.toBeInstanceOf(UsageError);
+  });
+
+  it('throws UsageError when value is missing from save', async () => {
+    await expect(
+      runCommand('memory', 'save', ['key'], deps, env, tmpDir),
+    ).rejects.toBeInstanceOf(UsageError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// peer whisper
+// ---------------------------------------------------------------------------
+
+describe('peer whisper', () => {
+  it('writes JSON line to recipientInboxFile with correct from/to/msg', async () => {
+    await runCommand('peer', 'whisper', ['5', 'attack at dawn'], deps, { ELDER_N: '2' }, tmpDir);
+
+    const file = recipientInboxFile('5', tmpDir);
+    expect(fs.existsSync(file)).toBe(true);
+
+    const line = fs.readFileSync(file, 'utf8').trim();
+    const entry = JSON.parse(line) as { from: number; to: string; msg: string };
+    expect(entry.from).toBe(2);
+    expect(entry.to).toBe('5');
+    expect(entry.msg).toBe('attack at dawn');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// peer inbox
+// ---------------------------------------------------------------------------
+
+describe('peer inbox', () => {
+  it('returns "inbox empty" when no messages', async () => {
+    const out = await runCommand('peer', 'inbox', [], deps, { ELDER_N: '1' }, tmpDir);
+    expect(out).toBe('inbox empty\n');
+  });
+
+  it('returns formatted message line after whisper written to own inbox', async () => {
+    // Write a whisper entry directly to elder-1's inbox (ELDER_N=1 reads elder-1.jsonl)
+    const inboxPath = inboxFile(1, tmpDir);
+    fs.mkdirSync(path.dirname(inboxPath), { recursive: true });
+    const entry = JSON.stringify({ from: 2, to: '1', msg: 'hello from elder 2', ts: '2024-01-01T00:00:00.000Z' });
+    fs.writeFileSync(inboxPath, entry + '\n', 'utf8');
+
+    const out = await runCommand('peer', 'inbox', [], deps, { ELDER_N: '1' }, tmpDir);
+    expect(out).toContain('from=2');
+    expect(out).toContain('hello from elder 2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ack-clear
+// ---------------------------------------------------------------------------
+
+describe('ack-clear', () => {
+  it('writes the ack flag file and returns "ack cleared"', async () => {
+    const out = await runCommand('ack-clear', undefined, [], deps, { ELDER_N: '1' }, tmpDir);
+    expect(out).toBe('ack cleared\n');
+
+    const flagPath = ackFile(1, tmpDir);
+    expect(fs.existsSync(flagPath)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unknown command
+// ---------------------------------------------------------------------------
+
+describe('unknown command', () => {
+  it('throws UsageError with usage text', async () => {
+    await expect(
+      runCommand('mystery', 'cmd', [], deps, {}, tmpDir),
+    ).rejects.toBeInstanceOf(UsageError);
+
+    try {
+      await runCommand('mystery', 'cmd', [], deps, {}, tmpDir);
+    } catch (err) {
+      expect(err).toBeInstanceOf(UsageError);
+      expect((err as UsageError).message).toContain('usage:');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #94 regression: peer whisper/inbox desync when ELDER_N != clanId
+// ---------------------------------------------------------------------------
+
+describe('issue #94 regression — peer whisper/inbox desync', () => {
+  it('demonstrates desync when ELDER_N != clanId', async () => {
+    // Issue #94: inbox reads by ELDER_N, whisper writes by clanId.
+    // Round-trip works only when clanId === String(elderN) (S2 default).
+    // Fix tracked in issue #94.
+
+    // Elder 2 whispers to clan "5" (which is NOT elder 5's default clanId in S2 1:1 mapping)
+    await runCommand('peer', 'whisper', ['5', 'hello'], deps, { ELDER_N: '2' }, tmpDir);
+
+    // Whisper written to elder-5.jsonl (keyed by recipient clanId)
+    expect(fs.existsSync(recipientInboxFile('5', tmpDir))).toBe(true);
+
+    // But peer inbox for ELDER_N=1 reads elder-1.jsonl — NOT elder-5.jsonl
+    // If elder 1's actual clanId were "5", it would miss this whisper
+    const out = await runCommand('peer', 'inbox', [], deps, { ELDER_N: '1' }, tmpDir);
+    expect(out).toBe('inbox empty\n');
+
+    // Document: fix tracked in issue #94 (option A: ELDER_CLAN_ID env + read by clanId)
+  });
+});

--- a/packages/agents/tsconfig.json
+++ b/packages/agents/tsconfig.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1949,7 +1949,7 @@
           "internalType": "uint256"
         }
       ],
-      "stateMutability": "payable"
+      "stateMutability": "nonpayable"
     },
     {
       "type": "function",

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1,3474 +1,3476 @@
-[
-  {
-    "type": "constructor",
-    "inputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "finalizeSeason",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "getActiveBanditView",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct ActiveBanditView",
-        "components": [
-          {
-            "name": "exists",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "banditId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "state",
-            "type": "uint8",
-            "internalType": "enum BanditState"
-          },
-          {
-            "name": "currentRegion",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "attackAttemptsMade",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "maxAttemptsRemaining",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "stateEnteredTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "nextActionTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "tier",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "attackPower",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "carryWood",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryIron",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryWheat",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryFish",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "projectedTargetClanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "projectedTargetLootValue",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "pure"
-  },
-  {
-    "type": "function",
-    "name": "getActiveDefenders",
-    "inputs": [
-      {
-        "name": "targetClanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint32[]",
-        "internalType": "uint32[]"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getActiveMission",
-    "inputs": [
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Mission",
-        "components": [
-          {
-            "name": "active",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "nonce",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "clansmanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "startRegion",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "targetRegion",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "action",
-            "type": "uint8",
-            "internalType": "enum ActionType"
-          },
-          {
-            "name": "startTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "arrivalTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "actionStartTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "missionSeed",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "marketMode",
-            "type": "uint8",
-            "internalType": "enum MarketExecutionMode"
-          },
-          {
-            "name": "targetClanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "marketToken",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "marketAmount",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "maxGoldIn",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getBanditTargetPreview",
-    "inputs": [
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "stateMutability": "pure"
-  },
-  {
-    "type": "function",
-    "name": "getBanditTroop",
-    "inputs": [
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct BanditTroop",
-        "components": [
-          {
-            "name": "banditId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "state",
-            "type": "uint8",
-            "internalType": "enum BanditState"
-          },
-          {
-            "name": "currentRegion",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "attackAttemptsMade",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "stateEnteredTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "nextActionTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "tier",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "attackPower",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "carryWood",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryIron",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryWheat",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryFish",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "pure"
-  },
-  {
-    "type": "function",
-    "name": "getClan",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Clan",
-        "components": [
-          {
-            "name": "clanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "iftTokenId",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "owner",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "clanState",
-            "type": "uint8",
-            "internalType": "enum ClanState"
-          },
-          {
-            "name": "baseRegion",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "baseLevel",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "wallLevel",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "monumentLevel",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "livingClansmen",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "lastSettledTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "starvationStartsAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "coldDamage",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "goldBalance",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "blueprintBalance",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "vaultWood",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "vaultIron",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "vaultWheat",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "vaultFish",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getClanFullView",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct ClanFullView",
-        "components": [
-          {
-            "name": "clan",
-            "type": "tuple",
-            "internalType": "struct DerivedClanState",
-            "components": [
-              {
-                "name": "clan",
-                "type": "tuple",
-                "internalType": "struct Clan",
-                "components": [
-                  {
-                    "name": "clanId",
-                    "type": "uint32",
-                    "internalType": "uint32"
-                  },
-                  {
-                    "name": "iftTokenId",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "owner",
-                    "type": "address",
-                    "internalType": "address"
-                  },
-                  {
-                    "name": "clanState",
-                    "type": "uint8",
-                    "internalType": "enum ClanState"
-                  },
-                  {
-                    "name": "baseRegion",
-                    "type": "uint8",
-                    "internalType": "uint8"
-                  },
-                  {
-                    "name": "baseLevel",
-                    "type": "uint8",
-                    "internalType": "uint8"
-                  },
-                  {
-                    "name": "wallLevel",
-                    "type": "uint8",
-                    "internalType": "uint8"
-                  },
-                  {
-                    "name": "monumentLevel",
-                    "type": "uint8",
-                    "internalType": "uint8"
-                  },
-                  {
-                    "name": "livingClansmen",
-                    "type": "uint8",
-                    "internalType": "uint8"
-                  },
-                  {
-                    "name": "lastSettledTick",
-                    "type": "uint64",
-                    "internalType": "uint64"
-                  },
-                  {
-                    "name": "starvationStartsAtTick",
-                    "type": "uint64",
-                    "internalType": "uint64"
-                  },
-                  {
-                    "name": "coldDamage",
-                    "type": "uint16",
-                    "internalType": "uint16"
-                  },
-                  {
-                    "name": "goldBalance",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "blueprintBalance",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "vaultWood",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "vaultIron",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "vaultWheat",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "vaultFish",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  }
-                ]
-              },
-              {
-                "name": "isStarving",
-                "type": "bool",
-                "internalType": "bool"
-              },
-              {
-                "name": "lootValue",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "derivedAtTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              }
-            ]
-          },
-          {
-            "name": "clansmen",
-            "type": "tuple[]",
-            "internalType": "struct ClansmanFullView[]",
-            "components": [
-              {
-                "name": "clansman",
-                "type": "tuple",
-                "internalType": "struct DerivedClansmanState",
-                "components": [
-                  {
-                    "name": "clansman",
-                    "type": "tuple",
-                    "internalType": "struct Clansman",
-                    "components": [
-                      {
-                        "name": "clansmanId",
-                        "type": "uint32",
-                        "internalType": "uint32"
-                      },
-                      {
-                        "name": "clanId",
-                        "type": "uint32",
-                        "internalType": "uint32"
-                      },
-                      {
-                        "name": "state",
-                        "type": "uint8",
-                        "internalType": "enum ClansmanState"
-                      },
-                      {
-                        "name": "currentRegion",
-                        "type": "uint8",
-                        "internalType": "uint8"
-                      },
-                      {
-                        "name": "cooldownEndsAtTs",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                      },
-                      {
-                        "name": "lastMissionNonce",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                      },
-                      {
-                        "name": "carryWood",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                      },
-                      {
-                        "name": "carryIron",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                      },
-                      {
-                        "name": "carryWheat",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                      },
-                      {
-                        "name": "carryFish",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "activeMission",
-                    "type": "tuple",
-                    "internalType": "struct Mission",
-                    "components": [
-                      {
-                        "name": "active",
-                        "type": "bool",
-                        "internalType": "bool"
-                      },
-                      {
-                        "name": "nonce",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                      },
-                      {
-                        "name": "clansmanId",
-                        "type": "uint32",
-                        "internalType": "uint32"
-                      },
-                      {
-                        "name": "startRegion",
-                        "type": "uint8",
-                        "internalType": "uint8"
-                      },
-                      {
-                        "name": "targetRegion",
-                        "type": "uint8",
-                        "internalType": "uint8"
-                      },
-                      {
-                        "name": "action",
-                        "type": "uint8",
-                        "internalType": "enum ActionType"
-                      },
-                      {
-                        "name": "startTick",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                      },
-                      {
-                        "name": "arrivalTick",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                      },
-                      {
-                        "name": "actionStartTick",
-                        "type": "uint64",
-                        "internalType": "uint64"
-                      },
-                      {
-                        "name": "missionSeed",
-                        "type": "bytes32",
-                        "internalType": "bytes32"
-                      },
-                      {
-                        "name": "marketMode",
-                        "type": "uint8",
-                        "internalType": "enum MarketExecutionMode"
-                      },
-                      {
-                        "name": "targetClanId",
-                        "type": "uint32",
-                        "internalType": "uint32"
-                      },
-                      {
-                        "name": "marketToken",
-                        "type": "address",
-                        "internalType": "address"
-                      },
-                      {
-                        "name": "marketAmount",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                      },
-                      {
-                        "name": "maxGoldIn",
-                        "type": "uint256",
-                        "internalType": "uint256"
-                      }
-                    ]
-                  },
-                  {
-                    "name": "effectiveRegion",
-                    "type": "uint8",
-                    "internalType": "uint8"
-                  },
-                  {
-                    "name": "derivedAtTick",
-                    "type": "uint64",
-                    "internalType": "uint64"
-                  }
-                ]
-              },
-              {
-                "name": "activeMission",
-                "type": "tuple",
-                "internalType": "struct Mission",
-                "components": [
-                  {
-                    "name": "active",
-                    "type": "bool",
-                    "internalType": "bool"
-                  },
-                  {
-                    "name": "nonce",
-                    "type": "uint64",
-                    "internalType": "uint64"
-                  },
-                  {
-                    "name": "clansmanId",
-                    "type": "uint32",
-                    "internalType": "uint32"
-                  },
-                  {
-                    "name": "startRegion",
-                    "type": "uint8",
-                    "internalType": "uint8"
-                  },
-                  {
-                    "name": "targetRegion",
-                    "type": "uint8",
-                    "internalType": "uint8"
-                  },
-                  {
-                    "name": "action",
-                    "type": "uint8",
-                    "internalType": "enum ActionType"
-                  },
-                  {
-                    "name": "startTick",
-                    "type": "uint64",
-                    "internalType": "uint64"
-                  },
-                  {
-                    "name": "arrivalTick",
-                    "type": "uint64",
-                    "internalType": "uint64"
-                  },
-                  {
-                    "name": "actionStartTick",
-                    "type": "uint64",
-                    "internalType": "uint64"
-                  },
-                  {
-                    "name": "missionSeed",
-                    "type": "bytes32",
-                    "internalType": "bytes32"
-                  },
-                  {
-                    "name": "marketMode",
-                    "type": "uint8",
-                    "internalType": "enum MarketExecutionMode"
-                  },
-                  {
-                    "name": "targetClanId",
-                    "type": "uint32",
-                    "internalType": "uint32"
-                  },
-                  {
-                    "name": "marketToken",
-                    "type": "address",
-                    "internalType": "address"
-                  },
-                  {
-                    "name": "marketAmount",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "maxGoldIn",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "westPlot",
-            "type": "tuple",
-            "internalType": "struct WheatPlot",
-            "components": [
-              {
-                "name": "state",
-                "type": "uint8",
-                "internalType": "enum WheatPlotState"
-              },
-              {
-                "name": "region",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "remainingWheat",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "regrowUntilTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              }
-            ]
-          },
-          {
-            "name": "eastPlot",
-            "type": "tuple",
-            "internalType": "struct WheatPlot",
-            "components": [
-              {
-                "name": "state",
-                "type": "uint8",
-                "internalType": "enum WheatPlotState"
-              },
-              {
-                "name": "region",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "remainingWheat",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "regrowUntilTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              }
-            ]
-          },
-          {
-            "name": "incomingDefenderIds",
-            "type": "uint32[]",
-            "internalType": "uint32[]"
-          },
-          {
-            "name": "thisClanDefendingBaseId",
-            "type": "uint32",
-            "internalType": "uint32"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getClansman",
-    "inputs": [
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Clansman",
-        "components": [
-          {
-            "name": "clansmanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "clanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "state",
-            "type": "uint8",
-            "internalType": "enum ClansmanState"
-          },
-          {
-            "name": "currentRegion",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "cooldownEndsAtTs",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "lastMissionNonce",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "carryWood",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryIron",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryWheat",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryFish",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getDerivedClanState",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct DerivedClanState",
-        "components": [
-          {
-            "name": "clan",
-            "type": "tuple",
-            "internalType": "struct Clan",
-            "components": [
-              {
-                "name": "clanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "iftTokenId",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "owner",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "clanState",
-                "type": "uint8",
-                "internalType": "enum ClanState"
-              },
-              {
-                "name": "baseRegion",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "baseLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "wallLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "monumentLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "livingClansmen",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "lastSettledTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "starvationStartsAtTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "coldDamage",
-                "type": "uint16",
-                "internalType": "uint16"
-              },
-              {
-                "name": "goldBalance",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "blueprintBalance",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "vaultWood",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "vaultIron",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "vaultWheat",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "vaultFish",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          },
-          {
-            "name": "isStarving",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "lootValue",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "derivedAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getDerivedClansmanState",
-    "inputs": [
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct DerivedClansmanState",
-        "components": [
-          {
-            "name": "clansman",
-            "type": "tuple",
-            "internalType": "struct Clansman",
-            "components": [
-              {
-                "name": "clansmanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "clanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "state",
-                "type": "uint8",
-                "internalType": "enum ClansmanState"
-              },
-              {
-                "name": "currentRegion",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "cooldownEndsAtTs",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "lastMissionNonce",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "carryWood",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "carryIron",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "carryWheat",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "carryFish",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          },
-          {
-            "name": "activeMission",
-            "type": "tuple",
-            "internalType": "struct Mission",
-            "components": [
-              {
-                "name": "active",
-                "type": "bool",
-                "internalType": "bool"
-              },
-              {
-                "name": "nonce",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "clansmanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "startRegion",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "targetRegion",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "action",
-                "type": "uint8",
-                "internalType": "enum ActionType"
-              },
-              {
-                "name": "startTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "arrivalTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "actionStartTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "missionSeed",
-                "type": "bytes32",
-                "internalType": "bytes32"
-              },
-              {
-                "name": "marketMode",
-                "type": "uint8",
-                "internalType": "enum MarketExecutionMode"
-              },
-              {
-                "name": "targetClanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "marketToken",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "marketAmount",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "maxGoldIn",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          },
-          {
-            "name": "effectiveRegion",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "derivedAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getMarketState",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct MarketState",
-        "components": [
-          {
-            "name": "wood",
-            "type": "tuple",
-            "internalType": "struct PoolReserves",
-            "components": [
-              {
-                "name": "resourceToken",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "resourceReserve",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "goldReserve",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "spotPriceGoldPerResource",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          },
-          {
-            "name": "wheat",
-            "type": "tuple",
-            "internalType": "struct PoolReserves",
-            "components": [
-              {
-                "name": "resourceToken",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "resourceReserve",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "goldReserve",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "spotPriceGoldPerResource",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          },
-          {
-            "name": "fish",
-            "type": "tuple",
-            "internalType": "struct PoolReserves",
-            "components": [
-              {
-                "name": "resourceToken",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "resourceReserve",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "goldReserve",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "spotPriceGoldPerResource",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          },
-          {
-            "name": "iron",
-            "type": "tuple",
-            "internalType": "struct PoolReserves",
-            "components": [
-              {
-                "name": "resourceToken",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "resourceReserve",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "goldReserve",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "spotPriceGoldPerResource",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          },
-          {
-            "name": "currentTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "currentTickQueue",
-            "type": "tuple[]",
-            "internalType": "struct ScheduledMarketAction[]",
-            "components": [
-              {
-                "name": "executeAtTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "commitSequence",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "clanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "clansmanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "action",
-                "type": "uint8",
-                "internalType": "enum ActionType"
-              },
-              {
-                "name": "marketToken",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "marketAmount",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "maxGoldIn",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          },
-          {
-            "name": "nextTickQueue",
-            "type": "tuple[]",
-            "internalType": "struct ScheduledMarketAction[]",
-            "components": [
-              {
-                "name": "executeAtTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "commitSequence",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "clanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "clansmanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "action",
-                "type": "uint8",
-                "internalType": "enum ActionType"
-              },
-              {
-                "name": "marketToken",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "marketAmount",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "maxGoldIn",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getRegionPopulation",
-    "inputs": [
-      {
-        "name": "region",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct RegionOccupant[]",
-        "components": [
-          {
-            "name": "clansmanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "clanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "state",
-            "type": "uint8",
-            "internalType": "enum ClansmanState"
-          },
-          {
-            "name": "currentAction",
-            "type": "uint8",
-            "internalType": "enum ActionType"
-          },
-          {
-            "name": "missionNonce",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getScheduledMarketActionsForTick",
-    "inputs": [
-      {
-        "name": "tick",
-        "type": "uint64",
-        "internalType": "uint64"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct ScheduledMarketAction[]",
-        "components": [
-          {
-            "name": "executeAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "commitSequence",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "clanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "clansmanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "action",
-            "type": "uint8",
-            "internalType": "enum ActionType"
-          },
-          {
-            "name": "marketToken",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "marketAmount",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "maxGoldIn",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getTreasuryState",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct TreasuryState",
-        "components": [
-          {
-            "name": "treasuryOwner",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "prizePotGold",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "poolsSeeded",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "woodToken",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "wheatToken",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "fishToken",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "ironToken",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "goldToken",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "blueprintToken",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "woodGoldPool",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "wheatGoldPool",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "fishGoldPool",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "ironGoldPool",
-            "type": "address",
-            "internalType": "address"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getWheatPlots",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "west",
-        "type": "tuple",
-        "internalType": "struct WheatPlot",
-        "components": [
-          {
-            "name": "state",
-            "type": "uint8",
-            "internalType": "enum WheatPlotState"
-          },
-          {
-            "name": "region",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "remainingWheat",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "regrowUntilTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      },
-      {
-        "name": "east",
-        "type": "tuple",
-        "internalType": "struct WheatPlot",
-        "components": [
-          {
-            "name": "state",
-            "type": "uint8",
-            "internalType": "enum WheatPlotState"
-          },
-          {
-            "name": "region",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "remainingWheat",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "regrowUntilTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getWorldSnapshot",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct WorldSnapshot",
-        "components": [
-          {
-            "name": "currentTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonStartTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonEndTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonFinalized",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "winterActive",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "winterStartsAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "winterEndsAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "activeBanditId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "currentTickSeed",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "leaderboard",
-            "type": "tuple[]",
-            "internalType": "struct LeaderboardEntry[]",
-            "components": [
-              {
-                "name": "clanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "owner",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "monumentLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "baseLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "wallLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "livingClansmen",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "state",
-                "type": "uint8",
-                "internalType": "enum ClanState"
-              },
-              {
-                "name": "lootValue",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getWorldState",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct WorldState",
-        "components": [
-          {
-            "name": "currentTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonStartTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonEndTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonFinalized",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "nextHeartbeatAtTs",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "nextBanditSpawnEligibleTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "currentBanditSpawnChanceBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "currentTickSeed",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "activeBanditId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "winterActive",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "winterStartsAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "winterEndsAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "nextCommitSequence",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "heartbeat",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "mintClan",
-    "inputs": [
-      {
-        "name": "to",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "iftTokenId",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "payable"
-  },
-  {
-    "type": "function",
-    "name": "quoteLootValueRaw",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "quoteLootValueSettled",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "quoteTravel",
-    "inputs": [
-      {
-        "name": "srcRegion",
-        "type": "uint8",
-        "internalType": "uint8"
-      },
-      {
-        "name": "dstRegion",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "travelTicks",
-        "type": "uint8",
-        "internalType": "uint8"
-      },
-      {
-        "name": "path",
-        "type": "bytes8",
-        "internalType": "bytes8"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "seedPools",
-    "inputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct PoolSeedConfig",
-        "components": [
-          {
-            "name": "woodSeed",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "wheatSeed",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "fishSeed",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "ironSeed",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "goldSeedForWood",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "goldSeedForWheat",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "goldSeedForFish",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "goldSeedForIron",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "settleClan",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "submitClanOrders",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "orders",
-        "type": "tuple[]",
-        "internalType": "struct ClanOrder[]",
-        "components": [
-          {
-            "name": "clansmanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "gotoRegion",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "action",
-            "type": "uint8",
-            "internalType": "enum ActionType"
-          },
-          {
-            "name": "targetClanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "marketToken",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "marketAmount",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "maxGoldIn",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
-    ],
-    "outputs": [
-      {
-        "name": "results",
-        "type": "tuple[]",
-        "internalType": "struct OrderResult[]",
-        "components": [
-          {
-            "name": "clansmanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "status",
-            "type": "uint8",
-            "internalType": "enum StatusCode"
-          },
-          {
-            "name": "cooldownEndsAtTs",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "missionNonce",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "transferBlueprint",
-    "inputs": [
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "transferBundle",
-    "inputs": [
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "transferGold",
-    "inputs": [
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "transferVaultResource",
-    "inputs": [
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "",
-        "type": "uint8",
-        "internalType": "enum ResourceType"
-      },
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "event",
-    "name": "BanditAttackResolved",
-    "inputs": [
-      {
-        "name": "banditId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "targetClanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "defended",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      },
-      {
-        "name": "attackPower",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
-      },
-      {
-        "name": "totalDefense",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
-      },
-      {
-        "name": "wallLevelAfter",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
-      },
-      {
-        "name": "stolenWood",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "stolenIron",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "stolenWheat",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "stolenFish",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "BanditDefeated",
-    "inputs": [
-      {
-        "name": "banditId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "targetClanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "BanditEscaped",
-    "inputs": [
-      {
-        "name": "banditId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "BanditMoved",
-    "inputs": [
-      {
-        "name": "banditId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "fromRegion",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "toRegion",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "BanditSpawned",
-    "inputs": [
-      {
-        "name": "banditId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "region",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "tier",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "attackPower",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "BanditStateChanged",
-    "inputs": [
-      {
-        "name": "banditId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "oldState",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum BanditState"
-      },
-      {
-        "name": "newState",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum BanditState"
-      },
-      {
-        "name": "region",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "BaseLevelChanged",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "oldLevel",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "newLevel",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "BlueprintAwarded",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "banditId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "BlueprintTransferred",
-    "inputs": [
-      {
-        "name": "fromClanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "toClanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ClanEliminated",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "tick",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ClanSettled",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "settledToTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ClanSpawned",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "owner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "iftTokenId",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "baseRegion",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ClanStarvationChanged",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "isStarving",
-        "type": "bool",
-        "indexed": false,
-        "internalType": "bool"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ClansmanDiedFromCold",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ColdDamageApplied",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "oldDamage",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
-      },
-      {
-        "name": "newDamage",
-        "type": "uint16",
-        "indexed": false,
-        "internalType": "uint16"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "GoldTransferred",
-    "inputs": [
-      {
-        "name": "fromClanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "toClanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ImmediateMarketActionExecuted",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "tokenIn",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      },
-      {
-        "name": "tokenOut",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      },
-      {
-        "name": "amountIn",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "amountOut",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "LootDistributedToDefender",
-    "inputs": [
-      {
-        "name": "banditId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "wood",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "iron",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "wheat",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "fish",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "MarketActionFailed",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "action",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum ActionType"
-      },
-      {
-        "name": "reason",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum StatusCode"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "MissionAssigned",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "missionNonce",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      },
-      {
-        "name": "action",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum ActionType"
-      },
-      {
-        "name": "startRegion",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "targetRegion",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "startTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      },
-      {
-        "name": "arrivalTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "MissionCompleted",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "missionNonce",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      },
-      {
-        "name": "action",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum ActionType"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "MissionInterrupted",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "oldMissionNonce",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      },
-      {
-        "name": "newMissionNonce",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "MonumentLevelChanged",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "oldLevel",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "newLevel",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "PoolsSeeded",
-    "inputs": [
-      {
-        "name": "woodGoldPool",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      },
-      {
-        "name": "wheatGoldPool",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      },
-      {
-        "name": "fishGoldPool",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      },
-      {
-        "name": "ironGoldPool",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ResourcesDeposited",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "wood",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "iron",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "wheat",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "fish",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ResourcesGathered",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "action",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum ActionType"
-      },
-      {
-        "name": "woodGained",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "ironGained",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "wheatGained",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "fishGained",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "goldBonus",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ScheduledMarketActionCommitted",
-    "inputs": [
-      {
-        "name": "executeAtTick",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      },
-      {
-        "name": "commitSequence",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      },
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": false,
-        "internalType": "uint32"
-      },
-      {
-        "name": "action",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum ActionType"
-      },
-      {
-        "name": "marketToken",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      },
-      {
-        "name": "marketAmount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "maxGoldIn",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ScheduledMarketActionExecuted",
-    "inputs": [
-      {
-        "name": "executeAtTick",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      },
-      {
-        "name": "commitSequence",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      },
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": false,
-        "internalType": "uint32"
-      },
-      {
-        "name": "tokenIn",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      },
-      {
-        "name": "tokenOut",
-        "type": "address",
-        "indexed": false,
-        "internalType": "address"
-      },
-      {
-        "name": "amountIn",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "amountOut",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "SeasonFinalized",
-    "inputs": [
-      {
-        "name": "tick",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      },
-      {
-        "name": "rankedClanIds",
-        "type": "uint32[]",
-        "indexed": false,
-        "internalType": "uint32[]"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "TickAdvanced",
-    "inputs": [
-      {
-        "name": "closedTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      },
-      {
-        "name": "openedTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      },
-      {
-        "name": "tickSeed",
-        "type": "bytes32",
-        "indexed": false,
-        "internalType": "bytes32"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "VaultResourceTransferred",
-    "inputs": [
-      {
-        "name": "fromClanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "toClanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "resource",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "enum ResourceType"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "indexed": false,
-        "internalType": "uint256"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "WallLevelChanged",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "oldLevel",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "newLevel",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "atTick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "WinterEnded",
-    "inputs": [
-      {
-        "name": "tick",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "WinterStarted",
-    "inputs": [
-      {
-        "name": "tick",
-        "type": "uint64",
-        "indexed": true,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "WorkerArrived",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "region",
-        "type": "uint8",
-        "indexed": false,
-        "internalType": "uint8"
-      },
-      {
-        "name": "tick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  }
-]
+{
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "finalizeSeason",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "getActiveBanditView",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct ActiveBanditView",
+          "components": [
+            {
+              "name": "exists",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "banditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum BanditState"
+            },
+            {
+              "name": "currentRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackAttemptsMade",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "maxAttemptsRemaining",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "stateEnteredTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextActionTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "tier",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackPower",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "projectedTargetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "projectedTargetLootValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getActiveDefenders",
+      "inputs": [
+        {
+          "name": "targetClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getActiveMission",
+      "inputs": [
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct Mission",
+          "components": [
+            {
+              "name": "active",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "nonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "startRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "targetRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "action",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "startTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "arrivalTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "actionStartTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "missionSeed",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "marketMode",
+              "type": "uint8",
+              "internalType": "enum MarketExecutionMode"
+            },
+            {
+              "name": "targetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "marketToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "marketAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "maxGoldIn",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getBanditTargetPreview",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getBanditTroop",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct BanditTroop",
+          "components": [
+            {
+              "name": "banditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum BanditState"
+            },
+            {
+              "name": "currentRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackAttemptsMade",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "stateEnteredTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextActionTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "tier",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackPower",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getClan",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct Clan",
+          "components": [
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "iftTokenId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "clanState",
+              "type": "uint8",
+              "internalType": "enum ClanState"
+            },
+            {
+              "name": "baseRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "baseLevel",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "wallLevel",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "monumentLevel",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "livingClansmen",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "lastSettledTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "starvationStartsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "coldDamage",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "goldBalance",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "blueprintBalance",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getClanFullView",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct ClanFullView",
+          "components": [
+            {
+              "name": "clan",
+              "type": "tuple",
+              "internalType": "struct DerivedClanState",
+              "components": [
+                {
+                  "name": "clan",
+                  "type": "tuple",
+                  "internalType": "struct Clan",
+                  "components": [
+                    {
+                      "name": "clanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "iftTokenId",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "owner",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "clanState",
+                      "type": "uint8",
+                      "internalType": "enum ClanState"
+                    },
+                    {
+                      "name": "baseRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "baseLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "wallLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "monumentLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "livingClansmen",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "lastSettledTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "starvationStartsAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "coldDamage",
+                      "type": "uint16",
+                      "internalType": "uint16"
+                    },
+                    {
+                      "name": "goldBalance",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "blueprintBalance",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultWood",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultIron",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultWheat",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultFish",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "name": "isStarving",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "lootValue",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "derivedAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "clansmen",
+              "type": "tuple[]",
+              "internalType": "struct ClansmanFullView[]",
+              "components": [
+                {
+                  "name": "clansman",
+                  "type": "tuple",
+                  "internalType": "struct DerivedClansmanState",
+                  "components": [
+                    {
+                      "name": "clansman",
+                      "type": "tuple",
+                      "internalType": "struct Clansman",
+                      "components": [
+                        {
+                          "name": "clansmanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "clanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "state",
+                          "type": "uint8",
+                          "internalType": "enum ClansmanState"
+                        },
+                        {
+                          "name": "currentRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "cooldownEndsAtTs",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "lastMissionNonce",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "carryWood",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryIron",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryWheat",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryFish",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "activeMission",
+                      "type": "tuple",
+                      "internalType": "struct Mission",
+                      "components": [
+                        {
+                          "name": "active",
+                          "type": "bool",
+                          "internalType": "bool"
+                        },
+                        {
+                          "name": "nonce",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "clansmanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "startRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "targetRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "action",
+                          "type": "uint8",
+                          "internalType": "enum ActionType"
+                        },
+                        {
+                          "name": "startTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "arrivalTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "actionStartTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "missionSeed",
+                          "type": "bytes32",
+                          "internalType": "bytes32"
+                        },
+                        {
+                          "name": "marketMode",
+                          "type": "uint8",
+                          "internalType": "enum MarketExecutionMode"
+                        },
+                        {
+                          "name": "targetClanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "marketToken",
+                          "type": "address",
+                          "internalType": "address"
+                        },
+                        {
+                          "name": "marketAmount",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "maxGoldIn",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "effectiveRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "derivedAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    }
+                  ]
+                },
+                {
+                  "name": "activeMission",
+                  "type": "tuple",
+                  "internalType": "struct Mission",
+                  "components": [
+                    {
+                      "name": "active",
+                      "type": "bool",
+                      "internalType": "bool"
+                    },
+                    {
+                      "name": "nonce",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "clansmanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "startRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "targetRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "action",
+                      "type": "uint8",
+                      "internalType": "enum ActionType"
+                    },
+                    {
+                      "name": "startTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "arrivalTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "actionStartTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "missionSeed",
+                      "type": "bytes32",
+                      "internalType": "bytes32"
+                    },
+                    {
+                      "name": "marketMode",
+                      "type": "uint8",
+                      "internalType": "enum MarketExecutionMode"
+                    },
+                    {
+                      "name": "targetClanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "marketToken",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "marketAmount",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "maxGoldIn",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "westPlot",
+              "type": "tuple",
+              "internalType": "struct WheatPlot",
+              "components": [
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum WheatPlotState"
+                },
+                {
+                  "name": "region",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "remainingWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "regrowUntilTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "eastPlot",
+              "type": "tuple",
+              "internalType": "struct WheatPlot",
+              "components": [
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum WheatPlotState"
+                },
+                {
+                  "name": "region",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "remainingWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "regrowUntilTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "incomingDefenderIds",
+              "type": "uint32[]",
+              "internalType": "uint32[]"
+            },
+            {
+              "name": "thisClanDefendingBaseId",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getClansman",
+      "inputs": [
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct Clansman",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum ClansmanState"
+            },
+            {
+              "name": "currentRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "cooldownEndsAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "lastMissionNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getDerivedClanState",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct DerivedClanState",
+          "components": [
+            {
+              "name": "clan",
+              "type": "tuple",
+              "internalType": "struct Clan",
+              "components": [
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "iftTokenId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "owner",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "clanState",
+                  "type": "uint8",
+                  "internalType": "enum ClanState"
+                },
+                {
+                  "name": "baseRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "baseLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "wallLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "monumentLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "livingClansmen",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "lastSettledTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "starvationStartsAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "coldDamage",
+                  "type": "uint16",
+                  "internalType": "uint16"
+                },
+                {
+                  "name": "goldBalance",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "blueprintBalance",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultWood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultIron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultFish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "isStarving",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "lootValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "derivedAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getDerivedClansmanState",
+      "inputs": [
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct DerivedClansmanState",
+          "components": [
+            {
+              "name": "clansman",
+              "type": "tuple",
+              "internalType": "struct Clansman",
+              "components": [
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum ClansmanState"
+                },
+                {
+                  "name": "currentRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "cooldownEndsAtTs",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "lastMissionNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "carryWood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryIron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryFish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "activeMission",
+              "type": "tuple",
+              "internalType": "struct Mission",
+              "components": [
+                {
+                  "name": "active",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "startRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "targetRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "startTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "arrivalTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "actionStartTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "missionSeed",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "marketMode",
+                  "type": "uint8",
+                  "internalType": "enum MarketExecutionMode"
+                },
+                {
+                  "name": "targetClanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "effectiveRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "derivedAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMarketState",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct MarketState",
+          "components": [
+            {
+              "name": "wood",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "wheat",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "fish",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "iron",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "currentTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "currentTickQueue",
+              "type": "tuple[]",
+              "internalType": "struct ScheduledMarketAction[]",
+              "components": [
+                {
+                  "name": "executeAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "commitSequence",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "nextTickQueue",
+              "type": "tuple[]",
+              "internalType": "struct ScheduledMarketAction[]",
+              "components": [
+                {
+                  "name": "executeAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "commitSequence",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRegionPopulation",
+      "inputs": [
+        {
+          "name": "region",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct RegionOccupant[]",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum ClansmanState"
+            },
+            {
+              "name": "currentAction",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "missionNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getScheduledMarketActionsForTick",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct ScheduledMarketAction[]",
+          "components": [
+            {
+              "name": "executeAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "commitSequence",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "action",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "marketToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "marketAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "maxGoldIn",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getTreasuryState",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct TreasuryState",
+          "components": [
+            {
+              "name": "treasuryOwner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "prizePotGold",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "poolsSeeded",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "woodToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "wheatToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "fishToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "ironToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "goldToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "blueprintToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "woodGoldPool",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "wheatGoldPool",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "fishGoldPool",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "ironGoldPool",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getWheatPlots",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "west",
+          "type": "tuple",
+          "internalType": "struct WheatPlot",
+          "components": [
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum WheatPlotState"
+            },
+            {
+              "name": "region",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "remainingWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "regrowUntilTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        },
+        {
+          "name": "east",
+          "type": "tuple",
+          "internalType": "struct WheatPlot",
+          "components": [
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum WheatPlotState"
+            },
+            {
+              "name": "region",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "remainingWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "regrowUntilTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getWorldSnapshot",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct WorldSnapshot",
+          "components": [
+            {
+              "name": "currentTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonStartTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonEndTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonFinalized",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "winterActive",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "winterStartsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "winterEndsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "activeBanditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "currentTickSeed",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "leaderboard",
+              "type": "tuple[]",
+              "internalType": "struct LeaderboardEntry[]",
+              "components": [
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "owner",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "monumentLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "baseLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "wallLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "livingClansmen",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum ClanState"
+                },
+                {
+                  "name": "lootValue",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getWorldState",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct WorldState",
+          "components": [
+            {
+              "name": "currentTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonStartTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonEndTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonFinalized",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "nextHeartbeatAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextBanditSpawnEligibleTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "currentBanditSpawnChanceBps",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "currentTickSeed",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "activeBanditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "winterActive",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "winterStartsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "winterEndsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextCommitSequence",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "heartbeat",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "mintClan",
+      "inputs": [
+        {
+          "name": "to",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "iftTokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "quoteLootValueRaw",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "quoteLootValueSettled",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "quoteTravel",
+      "inputs": [
+        {
+          "name": "srcRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "dstRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "travelTicks",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "path",
+          "type": "bytes8",
+          "internalType": "bytes8"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "seedPools",
+      "inputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct PoolSeedConfig",
+          "components": [
+            {
+              "name": "woodSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "wheatSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "fishSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "ironSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "settleClan",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "submitClanOrders",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "orders",
+          "type": "tuple[]",
+          "internalType": "struct ClanOrder[]",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "gotoRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "action",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "targetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "marketToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "marketAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "maxGoldIn",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "results",
+          "type": "tuple[]",
+          "internalType": "struct OrderResult[]",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "status",
+              "type": "uint8",
+              "internalType": "enum StatusCode"
+            },
+            {
+              "name": "cooldownEndsAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "missionNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferBlueprint",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferBundle",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferGold",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferVaultResource",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint8",
+          "internalType": "enum ResourceType"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "BanditAttackResolved",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "targetClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "defended",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        },
+        {
+          "name": "attackPower",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "totalDefense",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "wallLevelAfter",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "stolenWood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "stolenIron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "stolenWheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "stolenFish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditDefeated",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "targetClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditEscaped",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditMoved",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "fromRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "toRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditSpawned",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "region",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "tier",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "attackPower",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditStateChanged",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldState",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum BanditState"
+        },
+        {
+          "name": "newState",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum BanditState"
+        },
+        {
+          "name": "region",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BaseLevelChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BlueprintAwarded",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BlueprintTransferred",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanEliminated",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanSettled",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "settledToTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanSpawned",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "iftTokenId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "baseRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanStarvationChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "isStarving",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClansmanDiedFromCold",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ColdDamageApplied",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldDamage",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "newDamage",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "GoldTransferred",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ImmediateMarketActionExecuted",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tokenIn",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "tokenOut",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "amountIn",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "amountOut",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "LootDistributedToDefender",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "wood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "iron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MarketActionFailed",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "reason",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum StatusCode"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MissionAssigned",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "missionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "startRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "targetRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "startTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "arrivalTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MissionCompleted",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "missionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MissionInterrupted",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldMissionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "newMissionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MonumentLevelChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PoolsSeeded",
+      "inputs": [
+        {
+          "name": "woodGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "wheatGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "fishGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "ironGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ResourcesDeposited",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "wood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "iron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ResourcesGathered",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "woodGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "ironGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheatGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fishGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "goldBonus",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ScheduledMarketActionCommitted",
+      "inputs": [
+        {
+          "name": "executeAtTick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "commitSequence",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "marketToken",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "marketAmount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "maxGoldIn",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ScheduledMarketActionExecuted",
+      "inputs": [
+        {
+          "name": "executeAtTick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "commitSequence",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tokenIn",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "tokenOut",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "amountIn",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "amountOut",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SeasonFinalized",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "rankedClanIds",
+          "type": "uint32[]",
+          "indexed": false,
+          "internalType": "uint32[]"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TickAdvanced",
+      "inputs": [
+        {
+          "name": "closedTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "openedTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "tickSeed",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "VaultResourceTransferred",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "resource",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ResourceType"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WallLevelChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WinterEnded",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WinterStarted",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WorkerArrived",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "region",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -718,10 +718,9 @@ contract ClanWorld is IClanWorld {
     // =========================================================================
 
     /// @notice Mint a new clan and spawn its homebase.
-    /// @dev payable per IClanWorld interface; the game has no mint fee — any ETH sent is silently held.
-    ///      A future upgrade may add a fee or revert on non-zero msg.value.
-    function mintClan(address to) external payable override returns (uint32 clanId, uint256 iftTokenId) {
+    function mintClan(address to) external override returns (uint32 clanId, uint256 iftTokenId) {
         require(to != address(0), "ClanWorld: zero address");
+        require(_allClanIds.length < 12, "ClanWorld: max clans");
         clanId = _nextClanId++;
         iftTokenId = uint256(clanId); // Phase 1 placeholder; real iNFT is Phase 7
 
@@ -931,6 +930,14 @@ contract ClanWorld is IClanWorld {
                 _removeDefender(oldTarget, cs.clansmanId);
                 _clanDefendingBase[cs.clansmanId] = 0;
             }
+        }
+
+        // DefendBase zero-travel: register synchronously so getActiveDefenders() has no drop window.
+        // When travelTicks == 0 the clansman is already at the target base — no travel window to wait out.
+        // The _resolveAction guard (clanDefendingBase != targetClanId) will be false next tick, preventing double-register.
+        if (order.action == ActionType.DefendBase && ctx.travelTicks == 0) {
+            _incomingDefenders[order.targetClanId].push(cs.clansmanId);
+            _clanDefendingBase[cs.clansmanId] = order.targetClanId;
         }
 
         if (ctx.wasActive) {

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -47,7 +47,7 @@ contract ClanWorldStub is IClanWorld {
     // Clan lifecycle
     // -------------------------------------------------------------------------
 
-    function mintClan(address) external payable override returns (uint32, uint256) {
+    function mintClan(address) external override returns (uint32, uint256) {
         return (1, 1);
     }
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -677,7 +677,7 @@ interface IClanWorld is IClanWorldEvents {
     // -------------------------------------------------------------------------
 
     /// @notice Mint a new clan iNFT and spawn its homebase in a valid region.
-    function mintClan(address to) external payable returns (uint32 clanId, uint256 iftTokenId);
+    function mintClan(address to) external returns (uint32 clanId, uint256 iftTokenId);
 
     /// @notice Submit one or more orders for a single clan's clansmen.
     ///         Per-order failures do not revert the tx.

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -394,4 +394,48 @@ contract ClanWorldTest is Test {
         assertGt(newCooldown, firstCooldown, "new cooldown must be later than first cooldown");
         assertGt(newCooldown, block.timestamp, "new cooldown must be in the future");
     }
+
+    // -------------------------------------------------------------------------
+    // Issue #95: DefendBase re-tasking — zero-travel same-target retask must not drop defender
+    // -------------------------------------------------------------------------
+
+    function test_defendBase_zeroTravel_retask_noDropWindow() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        uint8 baseRegion = v.clan.clan.baseRegion;
+
+        // First DefendBase: clansman defends its own clan (same region → zero travel).
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: baseRegion,
+            action: ActionType.DefendBase,
+            targetClanId: clanId,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        OrderResult[] memory r1 = world.submitClanOrders(clanId, orders);
+        assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "first DefendBase OK");
+
+        // Advance past cooldown and settle so defender is registered.
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
+        _advanceTick();
+
+        uint32[] memory defs = world.getActiveDefenders(clanId);
+        assertEq(defs.length, 1, "one defender registered");
+        assertEq(defs[0], csId, "csId is the defender");
+
+        // Second DefendBase to same target: zero-travel re-task — the regression case.
+        vm.prank(elder);
+        OrderResult[] memory r2 = world.submitClanOrders(clanId, orders);
+        assertEq(uint8(r2[0].status), uint8(StatusCode.OK), "re-task DefendBase OK");
+
+        // Defender must NOT be dropped — fix must register synchronously.
+        defs = world.getActiveDefenders(clanId);
+        assertEq(defs.length, 1, "defender count must not drop after re-task");
+        assertEq(defs[0], csId, "csId must still be defending after re-task");
+    }
 }


### PR DESCRIPTION
**Bundle A — Foundations & docs (zero-risk lead-in)**

Combines 5 independent low-risk PRs for batch UAT:

- #115 — Phase 3 Foundry test specification (docs only)
- #90 — Integration seam interfaces (types only)
- #102 — clan-world port-for ports.yml registration
- #105 — Elder CLI vitest suite + #94 regression
- #98 — Phase-1 contracts follow-ups (DefendBase drop, mintClan nonpayable+cap, ABI fix)

**UAT focus**:
- \`pnpm typecheck\` across the monorepo — must stay green
- \`cd packages/agents && pnpm test\` — 34/34 (#105 adds 18)
- \`cd packages/contracts && forge test\` — green with #98's regression
- Verify \`port-for clan-world-frontend-test\` resolves (#102)

**Risk**: low — no behavior change in dev/prod runtime. #98 contract-shape change (mintClan no longer payable) but on-chain deployment hasn't picked it up yet.

Individual PRs (#115, #90, #102, #105, #98) remain open until this bundle passes UAT.