### PR TITLE
feat: post-bundle-A dev-tooling followups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,4 +155,8 @@ docs/planning/V1/
 **/playwright/.cache/
 # port-for: ports.yml is tracked, ports.lock is per-worktree state
 .world/ports.lock
-**/.vercel/project.json
+# Vercel: ignore tooling cache + auth tokens, but COMMIT per-app project link
+# so vercel CLI doesn't auto-create projects + mis-alias domains on fresh checkouts.
+# Note: .vercel/* (not .vercel/) — git can't re-include files inside an excluded directory.
+**/.vercel/*
+!**/.vercel/project.json

--- a/apps/landing/.vercel/project.json
+++ b/apps/landing/.vercel/project.json
@@ -1,0 +1,1 @@
+{"projectId":"prj_9LDcAPedFBu2SSO3zTlFZelNIRRX","orgId":"team_YZdNnTlbEqyXPmeEe0JmPZ93"}

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/main.ts",
+    "dev": "tsx watch --env-file=../../.env.local src/main.ts",
     "start": "tsx src/main.ts",
     "build": "tsc -b",
     "typecheck": "tsc --noEmit",

--- a/apps/web/.vercel/project.json
+++ b/apps/web/.vercel/project.json
@@ -1,0 +1,1 @@
+{"projectId":"prj_II3YJz4tWFSGaxOCmmepjn1aMHBL","orgId":"team_YZdNnTlbEqyXPmeEe0JmPZ93"}

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -578,7 +578,17 @@ export function WorldMap() {
       };
       viewportRef.current = null;
       appRef.current = null;
-      a?.destroy(true);
+      // PIXI v8 + React StrictMode double-invoke guard: the second cleanup
+      // pass hits an already-destroyed Application where internal fields like
+      // _cancelResize are undefined. Wrap in try/catch — first destroy is the
+      // real one, second is benign noise.
+      try {
+        a?.destroy(true);
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.debug('[WorldMap] destroy noop (StrictMode double-invoke):', err);
+        }
+      }
     };
   }, []);
 

--- a/apps/web/tests/e2e/00-smoke.spec.ts
+++ b/apps/web/tests/e2e/00-smoke.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Smoke test — captures all browser console + pageerror events on initial
+ * load and surfaces them. This is the orchestrator's "remote DevTools" for
+ * the mini app: instead of asking the user to paste console logs, run this
+ * and read the failure output.
+ *
+ * Usage:
+ *   PLAYWRIGHT_BASE_URL=http://127.0.0.1:5173 \
+ *     pnpm --filter @clan-world/web exec playwright test tests/e2e/00-smoke.spec.ts
+ *
+ * Or with the dev server already running (default config attempts to spawn one):
+ *   pnpm --filter @clan-world/web exec playwright test tests/e2e/00-smoke.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+// Filter out known-benign messages that aren't actionable.
+// Keep this list minimal — false negatives (real errors swallowed) are worse
+// than false positives (expected warnings re-flagged).
+const BENIGN_PATTERNS: RegExp[] = [
+  /SES Removing unpermitted intrinsics/i, // Worldcoin SDK lockdown.js — informational
+  /MiniKit is not installed/i, // expected outside World App
+  /favicon\.ico.*404/i, // no favicon shipped yet
+  /Download the React DevTools/i, // dev hint
+];
+
+const isBenign = (text: string) => BENIGN_PATTERNS.some((re) => re.test(text));
+
+test('mini app loads with no console errors', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  const consoleWarnings: string[] = [];
+  const pageErrors: { message: string; stack: string | undefined }[] = [];
+
+  page.on('console', (msg) => {
+    const text = msg.text();
+    if (isBenign(text)) return;
+    if (msg.type() === 'error') consoleErrors.push(`[error] ${text}`);
+    if (msg.type() === 'warning') consoleWarnings.push(`[warn] ${text}`);
+  });
+  page.on('pageerror', (err) => {
+    if (isBenign(err.message)) return;
+    pageErrors.push({ message: err.message, stack: err.stack });
+  });
+
+  await page.goto('/');
+
+  // Wait for canvas to mount — WorldMap renders one.
+  // 10s gives PIXI v8 + Convex client + IDKit time to initialize.
+  await page.waitForSelector('canvas', { timeout: 10_000 });
+
+  // Give async effects a beat to fire so we capture any post-mount errors.
+  await page.waitForTimeout(500);
+
+  // Surface everything we captured before asserting — in CI/dev failure logs
+  // we want to see the full picture, not just "expected 0 to equal N".
+  if (pageErrors.length > 0 || consoleErrors.length > 0 || consoleWarnings.length > 0) {
+    console.log('\n=== Smoke test captured browser output ===');
+    if (pageErrors.length > 0) {
+      console.log(`\n--- page errors (${pageErrors.length}) ---`);
+      pageErrors.forEach((e) => {
+        console.log(`* ${e.message}`);
+        if (e.stack) console.log(e.stack.split('\n').slice(0, 6).join('\n'));
+      });
+    }
+    if (consoleErrors.length > 0) {
+      console.log(`\n--- console errors (${consoleErrors.length}) ---`);
+      consoleErrors.forEach((e) => console.log(e));
+    }
+    if (consoleWarnings.length > 0) {
+      console.log(`\n--- console warnings (${consoleWarnings.length}) ---`);
+      consoleWarnings.forEach((w) => console.log(w));
+    }
+    console.log('=== end captured output ===\n');
+  }
+
+  expect(pageErrors, 'page errors during initial load').toHaveLength(0);
+  expect(consoleErrors, 'console.error during initial load').toHaveLength(0);
+  // Warnings are not a failure but logged above for visibility.
+});

--- a/docs/reviews/pr132-review-claude-opus.md
+++ b/docs/reviews/pr132-review-claude-opus.md
@@ -1,0 +1,124 @@
+# PR #132 Review — merge: bundle B — Base Sepolia chain pivot (#125)
+
+| Field | Value |
+|-------|-------|
+| **PR** | [#132](https://github.com/OmniPass-world/clan-world/pull/132) |
+| **Branch** | `merge/bundle-b` → `dev` |
+| **Author** | claude-do |
+| **Review date** | 2026-04-28 |
+| **Review model** | Claude Opus 4.6 |
+| **Method** | 8-agent swarm (6 parallel Wave 1 + 2 sequential Wave 2) |
+
+## PR Summary
+
+Pivots the entire app from World Chain Sepolia (chainId 4801) to Base Sepolia (chainId 84532). New ClanWorld deployment at `0x1BF5649f29CbB53E117a5aE969A18A71790f83E8`. Touches 4 files, +31/−11 lines. Self-assessed as **high risk** — any service still hardcoding the old chainId or address breaks silently.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `.env.template` | `CHAIN=base-sepolia`, RPC URLs updated |
+| `packages/contracts/deployments/base-sepolia.json` | NEW deployment record (contract + tokens + pools) |
+| `packages/contracts/foundry.toml` | Removed `worldchain_sepolia` rpc alias, added `via_ir = true` |
+| `packages/shared/src/adapters/IChainClient.ts` | Chain definition + default address → Base Sepolia |
+
+---
+
+## Review Agents
+
+| Wave | Agent | Role | Key result |
+|------|-------|------|------------|
+| 1 | Stale Reference Hunter | Find old chain refs in codebase | No runtime-breaking refs; heartbeat script + docs + landing stale |
+| 1 | Deployment & Contract Verifier | Validate base-sepolia.json consistency | All addresses valid, consistent with IChainClient |
+| 1 | Config Completeness Auditor | Check all config surfaces | Only gap: heartbeat script chain string |
+| 1 | Type Safety & Adapter Integration | Verify IChainClient changes | Clean — interface unchanged, both client sites updated, no worldChainSepolia refs |
+| 1 | Security & Secrets Scanner | Check for leaked secrets | All clear — no secrets, proper placeholders |
+| 1 | Convention & Process Compliance | Check gitflow, commits, PR process | Missing `Closes #N`, no 3-tier swarm evidence |
+| 2 | Cross-Cutting Integration Validator | Verify webhook handler, landing scope, Convex env | Confirmed webhook ignores body; landing is deployed; Convex doesn't use CHAIN_ID |
+| 2 | Foundry via_ir Impact Check | Assess via_ir safety | Justified for ClanWorld.sol (~1,428 lines); safe with solc 0.8.24 |
+
+---
+
+## Triage Table
+
+| # | File | Line | Finding | Category |
+|---|------|------|---------|----------|
+| 1 | *(PR body)* | — | PR body mentions #125 but lacks a `Closes #125` keyword. AGENTS.md §3 and §9 require `Closes #N` in every PR body for issue auto-close. | **MUST FIX** |
+| 2 | *(PR process)* | — | No evidence of local 3-tier swarm (Claude subagent + Codex + Gemini flash). Only Gemini Code Assist (cloud) reviewed. `pr-review.md` requires all 3 local tiers GREEN for Wave 1+ contract code before merge. | **MUST FIX** |
+| 3 | `scripts/start-heartbeat-loop.sh` | 57 | Webhook payload hardcodes `"chain":"worldchain-sepolia"` while the entire stack is now Base Sepolia. **Verified not breaking** — the Convex `heartbeatWebhook` handler (`apps/server/convex/heartbeat.ts`) never reads the POST body. Stale for observability, logging, and any future body parsing. | **SHOULD FIX** |
+| 4 | `apps/landing/src/pages/LandingPage.tsx` | 63 | `<span>v1 · world chain</span>` — user-facing copy on a deployed Vercel app still says "world chain". | **SHOULD FIX** |
+| 5 | `apps/landing/src/pages/LorePage.tsx` | 444 | Lore text: "foundry loop on world chain" — stale chain reference in deployed landing page. | **SHOULD FIX** |
+| 6 | `apps/landing/src/components/Footer.tsx` | 17 | Footer: "Built on Base · 0G · **World Chain**" — mixed messaging. | **SHOULD FIX** |
+| 7 | `packages/contracts/src/ClanWorldStub.sol` | 6 | NatSpec: "Stub implementation of IClanWorld for World Chain Sepolia deployment" — outdated after pivot. | **SHOULD FIX** |
+| 8 | *(commit messages)* | — | First two commits cite `#123` while the bundle tracks `#125`. Mixed issue refs make history harder to trace. | **SHOULD FIX** |
+| 9 | *(commit messages)* | — | Third commit uses type `merge:` which is not in the documented gitflow types (feat, fix, docs, chore, etc.). | **SHOULD FIX** |
+| 10 | `packages/contracts/foundry.toml` | 8 | `via_ir = true` added without inline comment or AGENTS.md documentation explaining the 24KB bytecode motivation. Justified for ClanWorld.sol (~1,428 lines), but undocumented. | **SHOULD FIX** |
+| 11 | *(commit messages)* | — | Second commit has truncated headline: `fix(contracts): remove stale worldchain_sepolia rpc_endpoint alias (#…` — sloppy truncation visible on GitHub. | **SHOULD FIX** |
+| 12 | `packages/contracts/deployments/worldchain-sepolia.json` | — | Stale S1 deployment record (chainId 4801, ClanWorldStub address). Not imported by any TS code. Risks confusion if scripts or humans reference wrong file. | **DEFER** |
+| 13 | `packages/shared/src/adapters/IChainClient.ts` | 15–22 | `defineChain` omits `blockExplorers`, `contracts.multicall3`, and `testnet: true`. Not used by current impl but would improve parity with canonical viem chain definition. Gemini Code Assist also flagged this. | **DEFER** |
+| 14 | `README.md`, `AGENTS.md`, `BUILD_PLAN.md`, `docs/*` | various | Extensive doc drift — ~30+ locations still reference "World Chain Sepolia", old chainId 4801, or old contract address `0xC012…56e`. Not runtime-breaking but contradicts the PR narrative of "pivoting the entire app". | **DEFER** |
+| 15 | *(branch naming)* | — | `merge/bundle-*` pattern not documented in `docs/conventions/gitflow.md`. Acceptable if team codifies it. | **DEFER** |
+| 16 | *(UAT checklist)* | — | Checklist item "Convex deployment env shows new CHAIN_ID + CLAN_WORLD_ADDRESS" is misleading — Convex handlers don't use either variable. Checklist is aspirational rather than matching current code. | **DEFER** |
+| 17 | `packages/contracts/foundry.toml` | 8 | `via_ir` increases compile time/memory for the large ClanWorld.sol. No CI in-repo to validate; ensure manual `forge test` passes before merge. | **DEFER** |
+| 18 | *(security)* | — | No secrets, private keys, or API keys in diff. `.env.template` uses proper placeholders. `base-sepolia.json` contains only public contract addresses. | **SKIP** |
+| 19 | `packages/shared/src/adapters/IChainClient.ts` | — | IChainClient interface unchanged. Adapter factory (stub vs real) unaffected. Both `createPublicClient` and `createWalletClient` correctly use `baseSepolia`. | **SKIP** |
+| 20 | `apps/web/` | — | Web app resolves game state through Convex, not on-chain. No chain-specific hardcoding. Chain pivot is transparent to the frontend. | **SKIP** |
+| 21 | `packages/contracts/deployments/base-sepolia.json` | — | Well-formed JSON. chainId 84532 matches defineChain. ClanWorld address matches DEFAULT_CONTRACT_ADDRESS. All token/pool addresses valid checksummed hex (42 chars). | **SKIP** |
+| 22 | *(PR target)* | — | PR targets `dev` branch, correct per gitflow. | **SKIP** |
+
+---
+
+## Summary Stats
+
+| Category | Count |
+|----------|-------|
+| **MUST FIX** | 2 |
+| **SHOULD FIX** | 9 |
+| **DEFER** | 6 |
+| **SKIP / FALSE POSITIVE** | 5 |
+| **Total findings** | 22 |
+
+---
+
+## Recommended Next Steps
+
+### 1. MUST FIX (blocking merge)
+
+1. **Add `Closes #125` to PR body.** Required by AGENTS.md §3 and §9 for issue auto-close and traceability.
+2. **Run the local 3-tier swarm** (Claude subagent + Codex + Gemini flash) and post signed tier comments on PR #132. Per `pr-review.md`, "Wave 1+ contract code: full 3-tier mandatory." Cloud Gemini Code Assist alone does not satisfy the convergence gate.
+
+### 2. SHOULD FIX (address in this PR)
+
+Grouped by theme:
+
+**Stale chain references in code/scripts:**
+- Update `scripts/start-heartbeat-loop.sh` line 57: change `"chain":"worldchain-sepolia"` → `"chain":"base-sepolia"`
+- Update `ClanWorldStub.sol` NatSpec (line 6): change "World Chain Sepolia" → "Base Sepolia" or remove chain-specific mention
+
+**Landing page copy (deployed Vercel app):**
+- `LandingPage.tsx` line 63: "v1 · world chain" → "v1 · base sepolia" (or appropriate branding)
+- `LorePage.tsx` line 444: update "world chain" reference
+- `Footer.tsx` line 17: remove "World Chain" from chain list or replace
+
+**Foundry documentation:**
+- Add a one-line comment in `foundry.toml` above `via_ir = true` explaining bytecode size motivation
+- Optionally update `packages/contracts/AGENTS.md` to mention via_ir
+
+**Commit hygiene (informational — cannot retroactively fix, note for future):**
+- Issue ref consistency (#123 vs #125), `merge:` type, truncated headline
+
+### 3. DEFER (open new GH issues)
+
+- **Doc drift cleanup:** Open a single issue to sweep ~30+ doc/README locations that still reference World Chain Sepolia. Low priority, high volume.
+- **defineChain enrichment:** Add `blockExplorers`, `multicall3`, `testnet: true` to the chain definition when a consumer needs them.
+- **Stale deployment archive:** Decide whether to keep, archive, or remove `worldchain-sepolia.json`.
+- **gitflow docs update:** Document the `merge/bundle-*` branch naming convention.
+- **Compile time monitoring:** Track `forge build`/`forge test` times with `via_ir` if CI is added.
+
+### 4. Overall PR Health Assessment
+
+**Needs work.** The core code changes are clean, well-scoped, and internally consistent. Type safety is maintained, security is clear, and the adapter pattern correctly encapsulates the chain switch. However, the PR cannot merge until:
+- The `Closes #N` keyword is added (trivial fix)
+- The local 3-tier swarm review gate is satisfied (process requirement)
+
+The SHOULD FIX items (heartbeat script, landing copy, foundry docs) are low-effort and would meaningfully improve the PR's completeness. The extensive doc drift is best tracked as a separate issue rather than blocking this PR.

--- a/docs/reviews/pr133-review-claude-opus.md
+++ b/docs/reviews/pr133-review-claude-opus.md
@@ -1,0 +1,174 @@
+# PR #133 Review — Bundle D: Web Shell + Cockpit
+
+| Field | Value |
+|-------|-------|
+| **PR** | [#133 — merge: bundle D — web shell + cockpit](https://github.com/OmniPass-world/clan-world/pull/133) |
+| **Author** | claude-do |
+| **Base** | `dev` ← `merge/bundle-d` |
+| **Scope** | +2,317 / -324 across 23 files (all `apps/web/` + `.world/ports.yml` + `.gitignore`) |
+| **Review date** | 2026-04-28 |
+| **Model** | Claude Opus 4.6 |
+| **Method** | 12-agent swarm (3 waves: 7 parallel broad → 3 parallel deep → 2 parallel specialist) |
+
+## Bundles combined
+
+- **#110** — Migrate Playwright default port to port-for lookup
+- **#112** — Phase 4-B DEMO_MODE flag gating mock data in WorldMap
+- **#100** — Cockpit Phase A 3-col 2-row layout shell with placeholder tabs
+- **#106** — Cockpit Phase A.5b live tmux iframes + app header + connection indicator
+
+---
+
+## Summary Stats
+
+| Category | Count |
+|----------|-------|
+| **MUST FIX** | 3 |
+| **SHOULD FIX** | 18 |
+| **DEFER** | 12 |
+| **SKIP / FALSE POSITIVE** | 8 |
+| **Total unique findings** | 41 |
+
+---
+
+## Triage Table
+
+### MUST FIX — Blocking merge
+
+| # | File | Lines | Finding | Agents |
+|---|------|-------|---------|--------|
+| 1 | `apps/web/tests/e2e/02-demo-mode.spec.ts` | 25–52 | **Demo-mode test skip vs build mismatch.** Skip condition reads `process.env.VITE_CLANWORLD_DEMO_MODE` with no default, while `playwright.config.ts` defaults to `'true'` in `webServer.env`. When env is unset (typical `pnpm test:e2e`), the OFF test block runs against an ON build — assertions will either false-pass or false-fail. The ON block is always skipped when env is unset. Tests cannot be trusted as-is. **Fix:** Align skip logic with `?? 'true'` matching the webServer default, or use Playwright projects with explicit env per suite. | W1-A1, W1-A5, W3-A11 (confirmed ×3) |
+| 2 | `apps/web/src/WorldMap.tsx` | 1203–1212 | **Canned travel `setTimeout` IDs never cancelled on unmount.** The initial burst fires 4 `setTimeout(..., i * 250)` calls, but cleanup only runs `clearInterval(interval)`. Timer IDs are not stored or cleared, so callbacks can fire after teardown and call `spawnTravel` on destroyed Pixi objects — potential runtime error or stale graphics. **Fix:** Store `setTimeout` IDs in an array, `clearTimeout` each in the effect cleanup. | W1-A1, W1-A7, W2-A8 (confirmed ×3) |
+| 3 | `apps/web/src/WorldMap.tsx` | 9, 56; `App.tsx` 5 | **Circular module dependency: `WorldMap` ↔ `App`.** `WorldMap.tsx` imports `DEMO_MODE` from `./App`; `App.tsx` imports `WorldMap` (via `MainApp`). This creates a module cycle that can cause undefined bindings during initialization, breaks test isolation, and complicates refactoring/lazy-loading. **Fix:** Extract `DEMO_MODE` (and related env flags) to a leaf module like `config/env.ts` imported by both files. | W1-A1, W1-A3, W2-A8 (confirmed ×3) |
+
+### SHOULD FIX — Address in this PR before merge
+
+| # | File | Lines | Finding | Agents |
+|---|------|-------|---------|--------|
+| 4 | `apps/web/src/hooks/useConnectionStatus.ts` | 60, 108–112 | **Initial state `'connected'` before any probe completes.** Users briefly see a green "connected" pill before the first `no-cors` HEAD probe resolves. **Fix:** Initialize as `'reconnecting'` or add a `'checking'` state for mount. | W1-A1, W2-A9 |
+| 5 | `apps/web/src/hooks/useConnectionStatus.ts` | 6–8, 116–123 | **MAX_RETRIES=3 but 4 failed probes trigger disconnect (off-by-one).** `retryCount >= MAX_RETRIES` checked before increment means the fourth failure triggers disconnect, not the third. **Fix:** Rename constant or adjust predicate to match intent. | W1-A1, W2-A9 |
+| 6 | `apps/web/src/WorldMap.tsx` | 1222–1251 | **`scoreboardClans` computed as unmemoized IIFE every render.** Sorting + mapping snapshot rows runs on every parent re-render. **Fix:** Wrap in `useMemo` keyed on `snapshot`, `agentLogs`. | W1-A7, W2-A8 |
+| 7 | `apps/web/src/WorldMap.tsx` | 1059–1088 | **Bandit pulse Pixi ticker runs every frame even when `shouldPulse` is false.** `onTick` is always registered and runs per-frame, resetting alphas. **Fix:** Conditionally register ticker only when `shouldPulse` is true; remove when false. | W1-A7, W2-A8 |
+| 8 | `apps/web/src/WorldMap.tsx` | 1216–1221 | **Misleading comment about scoreboard when DEMO_MODE is off.** Comment says scoreboard hides when demo is off, but live snapshot data will populate it. **Fix:** Update comment to reflect actual behavior. | W1-A1, W2-A8 |
+| 9 | `apps/web/src/main.tsx` 64–66; `App.tsx` 64–68 | — | **`isCockpitPath` / `isCockpitRoute()` duplicated.** Same `startsWith('/cockpit')` logic in two files — drift risk. **Fix:** Extract to a shared `config/routes.ts` module. | W1-A3, W2-A10 |
+| 10 | `apps/web/src/pages/Cockpit.tsx`; `WorldMap.tsx` 60–71; `cockpit-tokens.ts` 79–84 | — | **ELDERS roster vs MOCK_CLANS identity mismatch.** Cockpit panels show Storm Riders/Iron Guard/Crimson/Verdant Wardens; WorldMap mock shows Iron Guard/Ember Hand/Dawn Watch/Storm Riders. Same grid position can display different clan names. **Fix:** Single source of truth for clan roster. | W1-A3, W2-A10 |
+| 11 | `apps/web/src/WorldMap.tsx` | 183–184 | **`anyApi` with eslint suppression bypasses Convex type safety.** `useQuery(anyApi.getSnapshot)` is cast to `SnapshotData | undefined` — no compile-time check against Convex schema. **Fix:** Import generated `api` types from `convex/_generated/api`. | W1-A4, W2-A8 |
+| 12 | `apps/web/src/components/cockpit/shared/WorldMapBoundary.tsx` | 8–79; `WorldMap.tsx` 324–548 | **Error boundary does not catch async Pixi init failures.** `WorldMapBoundary` is a class error boundary (catches synchronous render errors only). Pixi init runs in `useEffect` via `.then()` with no `.catch()` — rejected promises are unhandled rejections, not caught by the boundary. **Fix:** Add `.catch()` on `app.init()` chain that sets error state, or catch async failures inside WorldMap. | W1-A3, W2-A8, W2-A10 |
+| 13 | `apps/web/src/components/cockpit/tabs/TerminalTab.tsx` | 53–57 | **Iframe `sandbox="allow-scripts allow-same-origin"` is permissive.** Scripts in the iframe run in `cockpit.clan-world.com` origin. Any XSS/bug in ttyd assets can interact with same-origin cookies/APIs. **Fix:** Ensure ttyd is started read-only; restrict who can reach ttyd URLs via network/auth; consider `referrerPolicy="no-referrer"`. | W1-A2 |
+| 14 | `apps/web/.env.example` | 22 | **`VITE_CLANWORLD_DEMO_MODE=true` in committed example file.** Building from `.env.example` without editing bakes mock data into production. **Fix:** Default to `false` or blank with a comment; keep `true` only in `.env.development.local`. | W1-A2, W2-A10 |
+| 15 | `apps/web/src/WorldMap.tsx` | 694–766 | **Async `Assets.load` callbacks lack mount guard.** Clan sigil/base asset loads resolve with `.then()` but only check `mounted`/`appRef` loosely. Fast unmount can still run `viewport.addChild(sprite)` after teardown. **Fix:** Add `if (cancelled) return` guard inside each `.then()` callback. | W2-A8 (new) |
+| 16 | `apps/web/src/components/cockpit/shared/CockpitTabBar.tsx` | 62–114 | **Missing ARIA tab semantics.** Tabs use `<button>` with `aria-pressed` but no `role="tablist"`, `role="tab"`, `aria-selected`, `aria-controls`, or `role="tabpanel"` on content. Screen readers cannot identify this as a tab widget. **Fix:** Implement WAI-ARIA APG Tabs pattern. | W3-A12 |
+| 17 | `apps/web/src/components/cockpit/CockpitHeader.tsx` | 148–211 | **Connection status changes not announced to assistive tech.** Status transitions are visual-only + `title` attribute (unreliable for SR). No `aria-live` region. **Fix:** Add `aria-live="polite"` region or `role="status"` wrapper. | W3-A12 |
+| 18 | (PR metadata) | — | **PR body missing `Closes #N`.** Repo convention requires one PR closing one issue. Bundle body references #110/#112/#100/#106 but no tracking issue. **Fix:** Add `Closes #<tracking-issue>` or document exception. | W1-A6 |
+| 19 | `apps/web/tests/e2e/04-cockpit-shell.spec.ts` | 83–117 | **Disconnected-state test is timing-heavy (~14s worst case, 30s timeout).** Backoff schedule (2s/4s/8s × 4 failures) means slow CI can flirt with timeout ceiling. **Fix:** Consider shorter backoff override for test builds, or increase timeout buffer. | W1-A5, W3-A11 |
+| 20 | `apps/web/tests/e2e/02-demo-mode.spec.ts` | 40–44, 62 | **Assertions coupled to literal `"IG"` substring.** Renames to Iron Guard mock data break tests without a real regression. **Fix:** Use `data-testid` on scoreboard entries. | W1-A5, W3-A11 |
+| 21 | `apps/web/src/components/cockpit/tabs/TerminalTab.tsx` + all tabs | — | **Four ttyd iframes load simultaneously (default tab).** Each iframe boots xterm + WebSocket; no lazy loading or viewport-gating. High memory/CPU on initial cockpit load. **Fix:** Mount terminal iframe only for the active/focused panel, or use `loading="lazy"`. | W1-A7 |
+
+### DEFER — Valid concern, track as follow-up issue
+
+| # | File | Lines | Finding | Agents |
+|---|------|-------|---------|--------|
+| 22 | `apps/web/src/WorldMap.tsx` | 186–194 | **Local `SnapshotData`/`SnapshotClan` duplicate types from `@clan-world/shared`.** Divergence risk. Should import shared types. | W1-A4, W2-A8 |
+| 23 | `apps/web/src/WorldMap.tsx` | 209–215 | **`MOCK_WALL_LEVELS` / `WALL_LEVEL_MAX` are dead code.** Never referenced after definition. | W1-A6, W2-A8 |
+| 24 | `apps/web/src/App.tsx` | 71–79; `vite.config.ts` | **SPA fallback not configured for `/cockpit`.** Direct navigation or refresh yields 404 on static hosts without rewrite rules. | W1-A3, W2-A10 |
+| 25 | `apps/web/src/App.tsx` | 64–80 | **`/cockpit` has no in-app authentication.** Intentional for judge view, but production deployment needs edge protection (VPN, Cloudflare Access, etc.). | W1-A2 |
+| 26 | `apps/web/src/main.tsx` | 100–105 | **Stub Convex client (`203.0.113.1`) produces WebSocket retry console noise.** Convex client retries connections to an unroutable host. Not a bug but noisy in dev. | W1-A3, W2-A10 |
+| 27 | `apps/web/src/hooks/useConnectionStatus.ts` | 93–100 | **`no-cors` HEAD probe gives limited health signal.** Opaque response settles on reachability, not health — 502/503 proxied responses look "up". | W1-A1, W2-A9 |
+| 28 | `apps/web/src/WorldMap.tsx` | 1046–1056 | **Multiple `eslint-disable-next-line react-hooks/exhaustive-deps`.** Suppressed deps can hide stale-closure bugs. | W1-A4 |
+| 29 | `apps/web/src/styles/cockpit-tokens.ts` | 68–84 | **ELDERS roster data mixed with visual tokens.** Separation-of-concerns: move roster to `cockpit-data.ts`. | W1-A6 |
+| 30 | `apps/web/src/components/cockpit/CockpitHeader.tsx` | 126–130 | **Raw hex `#7a8a6a` instead of token for connected status color.** Minor inconsistency with cockpit token approach. | W1-A6 |
+| 31 | `apps/web/src/WorldMap.tsx` | 309–311, 1301 | **`liveTick` derived from `max(snapshot?.tick, logs.length)`.** Surprising semantics for production — tick jumps based on agent log volume. | W2-A8 (new) |
+| 32 | `apps/web/src/components/cockpit/tabs/ClansmanTab.tsx` | 132–157 | **HungerBar lacks `role="progressbar"` and ARIA value attributes.** "Starving" is communicated by border color alone (`1.4.1 Use of Color`). | W3-A12 |
+| 33 | `apps/web/src/pages/Cockpit.tsx` | 43–126 | **No `<h1>` or heading hierarchy on cockpit page.** CockpitHeader title is a styled `<div>`. | W3-A12 |
+
+### SKIP / FALSE POSITIVE
+
+| # | File | Lines | Finding | Rationale |
+|---|------|-------|---------|-----------|
+| 34 | `apps/web/src/main.tsx` | 52–56 | ConvexProvider cast to ComponentType — library typing mismatch. | Documented workaround; not a safety issue. |
+| 35 | `apps/web/src/main.tsx` | 34 | `(window as unknown as ...)` for Telegram WebApp. | Contained double-assertion; acceptable for external API. |
+| 36 | `apps/web/playwright.config.ts` | 7–14 | `execSync('port-for ...')` — command injection concern. | Fixed command string, no external interpolation. |
+| 37 | `apps/web/src/components/cockpit/tabs/TerminalTab.tsx` | 25 | iframe URL injection via `clanId`. | `clanId` comes from fixed `ELDERS` array (1–4), not user input. |
+| 38 | `apps/web/src/hooks/useConnectionStatus.ts` | 73–148 | Timer/interval cleanup on unmount. | Cleanup is correct — `cancelled` flag + `clearTimers()` + `removeEventListener`. |
+| 39 | `apps/web/src/pages/Cockpit.tsx` | 62–93 | Responsive uses CSS media queries vs JS. | Good pattern — no resize listener overhead. |
+| 40 | `apps/web/playwright.config.ts` | 7–14 | port-for fallback when binary not installed. | try/catch + NaN guard + `58770` fallback — robust. |
+| 41 | `apps/web/tests/e2e/04-cockpit-shell.spec.ts` | 22–35 | page.route vs page.goto race condition. | Route stubs are `await`-ed before `page.goto` — correct ordering. |
+
+---
+
+## Recommended Next Steps
+
+### 1. Address MUST FIX items first (3 items)
+
+**MF-1: Fix demo-mode test env alignment** (Finding #1)
+- In `02-demo-mode.spec.ts`, change to: `const DEMO_MODE_BUILD_VALUE = process.env.VITE_CLANWORLD_DEMO_MODE ?? 'true'`
+- This aligns the skip logic with the `playwright.config.ts` webServer default
+- Consider separate CI jobs for ON vs OFF suites
+
+**MF-2: Fix travel setTimeout leak** (Finding #2)
+- Store timeout IDs from the stagger loop: `const staggerIds = MOCK_CLANS.map((c, i) => setTimeout(..., i * 250))`
+- In cleanup: `staggerIds.forEach(clearTimeout)`
+
+**MF-3: Break circular dependency** (Finding #3)
+- Create `apps/web/src/config/env.ts` with `DEMO_MODE` and related env flag exports
+- Update imports in both `App.tsx` and `WorldMap.tsx`
+
+### 2. SHOULD FIX items grouped by theme
+
+**State machine / hooks** (Findings #4, #5)
+- Initialize `useConnectionStatus` as `'reconnecting'` and set `'connected'` only after first successful probe
+- Clarify MAX_RETRIES naming vs actual behavior
+
+**Type safety** (Findings #11, #15)
+- Replace `anyApi` with generated Convex API types
+- Add mount guard to async asset load callbacks
+
+**Test robustness** (Findings #19, #20)
+- Use `data-testid` instead of literal text assertions
+- Consider shorter backoff for test builds
+
+**Architecture** (Findings #9, #10, #12)
+- Deduplicate `isCockpitPath`/`isCockpitRoute()` into shared module
+- Unify clan roster between cockpit tokens and WorldMap mocks
+- Add `.catch()` to Pixi init chain in WorldMap
+
+**Security** (Findings #13, #14)
+- Ensure ttyd is started in read-only mode; document trust model
+- Change `.env.example` DEMO_MODE default to `false`
+
+**Accessibility** (Findings #16, #17)
+- Add proper ARIA tab pattern to CockpitTabBar
+- Add `aria-live` region for connection status changes
+
+**Performance** (Findings #6, #7, #21)
+- Memoize `scoreboardClans` derivation
+- Conditionally register bandit pulse ticker
+- Consider lazy-loading terminal iframes
+
+**Conventions** (Finding #18)
+- Add `Closes #<issue>` to PR body
+
+### 3. DEFER items → New GitHub issues
+
+Findings #22–#33 should be tracked as GitHub issues for Phase B or post-hackathon cleanup. Key themes:
+- Align types with `@clan-world/shared` (#22)
+- Remove dead code (#23)
+- Configure SPA fallback for production (#24)
+- Add edge auth for `/cockpit` in production (#25)
+- Silence stub Convex console noise (#26)
+- Improve connection health signal (#27)
+- Accessibility deep pass: headings, progress bars, color contrast (#32, #33)
+
+---
+
+## Overall PR Health Assessment
+
+**Verdict: NEEDS WORK** — 3 MUST FIX items block merge.
+
+The PR delivers a well-structured cockpit UI with good component decomposition, proper responsive layout (CSS media queries), correct timer cleanup in `useConnectionStatus`, and reasonable e2e test coverage for a hackathon scope. The architecture is sound — composition over inheritance, intentional auth bypass for the judge view, and a clean separation between cockpit tabs.
+
+However, the test env mismatch (Finding #1) means e2e test results cannot be trusted, the `setTimeout` leak (Finding #2) can cause runtime errors on navigation, and the circular dependency (Finding #3) is fragile enough to warrant extraction before merging more code on top.
+
+Once the 3 MUST FIX items are addressed, the SHOULD FIX items can be triaged by priority — type safety and test robustness items are highest value, accessibility can be batched, and performance items are optimization opportunities for later.
+
+**Estimated effort to reach merge-ready:** ~1–2 hours for MUST FIX; ~3–4 hours for high-priority SHOULD FIX items.

--- a/docs/reviews/pr136-review-claude-opus.md
+++ b/docs/reviews/pr136-review-claude-opus.md
@@ -1,0 +1,171 @@
+# PR #136 Review — Bundle C: Runner Stack
+
+| Field | Value |
+|-------|-------|
+| **PR** | [#136](https://github.com/OmniPass-world/clan-world/pull/136) |
+| **Title** | merge: bundle C — runner stack (combines #93 #114 #103 #99 #111) |
+| **Branch** | `merge/bundle-c` → `dev` |
+| **Size** | +5,424 / −28 across 33 files |
+| **Review date** | 2026-04-28 |
+| **Model** | Claude Opus 4.6 (Cursor) |
+| **Methodology** | 10-agent swarm: 7 parallel Wave 1 (broad sweep) + 3 parallel Wave 2 (targeted deep dives) |
+
+---
+
+## Summary Stats
+
+| Category | Count |
+|----------|-------|
+| **MUST FIX** | 3 |
+| **SHOULD FIX** | 9 |
+| **DEFER** (new GH issue) | 16 |
+| **SKIP / FALSE POSITIVE** | 14 |
+| **Total findings** | **42** |
+
+---
+
+## Triage Table
+
+### MUST FIX — Blocking merge
+
+| # | File | Line(s) | Finding | Domain |
+|---|------|---------|---------|--------|
+| 1 | `runner/src/tickLoop.ts` | 87–137 | **Partial Elder failure still advances `lastProcessedTick` and calls `markSettled`.** After `Promise.all`, the code always runs `settleWindow` → `markSettled(chainTick)` → `lastProcessedTick = chainTick`, even when some per-Elder deliveries failed (caught and logged). A failed Elder never gets a retry for that tick since `chainTick > lastProcessedTick` becomes false. Heartbeat can advance via `settleLatch` even when not all Elders received the situation block. Wave 2 **CONFIRMED** — the code documents intentional degradation for liveness, but the consequence (silent tick skip + premature heartbeat) is undocumented and likely unintended for game correctness. | Correctness |
+| 2 | `runner/src/filePeerInbox.ts` | 50–52 | **Path traversal in `send(toClanId, ...)`.** `inboxKeyForClanId(toClanId)` returns the raw clan ID if unmapped. No validation that it is a safe single path segment — a value containing `..` or `/` can escape `inboxDir`. Unlike `axlPeerInbox.ts` which has `assertSafeClanId`, the file backend lacks this guard. | Security / Correctness |
+| 3 | `runner/src/filePeerInbox.ts` | 39–47 | **`ELDER_N` env overrides per-instance elder resolution in multi-elder mode.** Constructor reads `process.env['ELDER_N']`, and if set (e.g. from `.env.example` which defaults `ELDER_N=1`), every `FilePeerInbox` instance reads the same `elder-1.jsonl` regardless of `ownClanId` and the `elder` argument. In the multi-elder runner (`main.ts`), this causes **cross-talk** — all 4 Elders share one inbox file. | Correctness |
+
+### SHOULD FIX — Address in this PR before merge
+
+| # | File | Line(s) | Finding | Domain |
+|---|------|---------|---------|--------|
+| 4 | `runner/src/tickLoop.ts` | 163–173 | **`withTimeout` does not take an `AbortSignal`.** On SIGTERM during long delivery, shutdown can be delayed up to `deliveryTimeoutMs`. Wave 2 **QUALIFIED**: normal abort path is faster since `deliveryAbort` kills tmux children, but worst-case bound (stuck delivery) is real. Fix: race delivery against `deps.signal` or make `withTimeout` abort-aware. | Correctness |
+| 5 | `runner/src/zeroGMemoryStore.ts` | 315–341 | **`OG_STORAGE_API_KEY` is a feature flag, not an API credential.** It is never passed to `buildRealBatcherFactory` or any SDK call — only its presence gates 0G mode. `README.md` calls it "0G API key", misleading operators about the security posture. Real auth depends on `ELDER_MNEMONIC`-derived wallets. Rename to `OG_STORAGE_ENABLED` or document honestly. | Security / Docs |
+| 6 | `runner/src/main.ts` | 98 | **`{} as Record<ElderId, PerElderDeps>` unsafe type assertion.** Asserts a fully populated record before any keys exist. If the loop stops early, downstream code sees phantom entries. Use a builder pattern or reduce from `ELDER_IDS`. | Type Safety |
+| 7 | `runner/src/axlPeerInbox.ts` | 517–519 | **`as ElderId` unsafe narrowing from `parseInt`.** Fallback path casts unchecked `parseInt(env['ELDER_N'])` to `ElderId` without validation. Could yield values outside 1–4 or NaN. | Type Safety |
+| 8 | `AGENTS.md` | 9–18 | **Root `AGENTS.md` still says "Six workspace packages" and omits `packages/runner`.** Breaks progressive discovery for new contributors. | Docs |
+| 9 | `.env.template` | (whole file) | **Root `.env.template` has no runner keys** (`RUNNER_*`, `OG_*`, `AXL_*`, `ELDER_*`). AGENTS.md §7 requires the root template to list all variables. | Docs |
+| 10 | `runner/src/tmuxRunnerInbox.ts` | 45–46, 53–54 | **Abort-driven cancellation returns `reason: 'timeout'` instead of `'aborted'`.** Semantic mismatch — downstream logs/metrics will mis-attribute shutdown as timeout. Extend `DeliveryStatus` with `'aborted'` or map to a distinct reason. | Correctness |
+| 11 | `runner/src/axlPeerInbox.ts` | 404–412 | **Missing `sentAt` defaults to empty string `''`.** `IElderPeerInbox` specifies `sentAt` as ISO 8601 — empty string violates the contract and confuses Elders. Default to `new Date().toISOString()`. | Correctness |
+| 12 | `runner/README.md` | 8–18 | **Heartbeat loop pseudocode is stale.** Shows heartbeat inside the tick loop, but code decouples Cycle A (heartbeat scheduler) from Cycle B (tick loop) via `settleLatch`. Misleads readers about architecture. | Docs |
+
+### DEFER — Valid concerns, open new GitHub issues
+
+| # | File | Line(s) | Finding | Domain |
+|---|------|---------|---------|--------|
+| 13 | `runner/clanworld-runner.service` | 6–25 | **Missing systemd service hardening.** No `PrivateTmp`, `ProtectSystem`, `NoNewPrivileges`, `CapabilityBoundingSet`, memory limits, etc. Process holds private keys and API keys. | Security |
+| 14 | `runner/src/axlPeerInbox.ts` | 29–34 | **AXL trust model — no cryptographic verification.** Inbound routing trusts the local AXL node; signing is TODO. Compromise of AXL sidecar could influence routing. | Security |
+| 15 | `runner/src/axlPeerInbox.ts` | 171–205 | **AXL API key sent over non-TLS.** Default `AXL_NODE_URL` is `http://127.0.0.1:9002`. If operators set a remote URL, bearer token is exposed. Enforce `https:` for non-loopback hosts. | Security |
+| 16 | `runner/src/axlPeerInbox.ts` | 236–287, 399–457 | **Unbounded AXL inbox memory.** `#seenMsgIds` Set and `#inbox` array grow monotonically. Journal is append-only with no rotation. Long-lived runner → unbounded RAM and disk. | Performance |
+| 17 | `runner/src/composeSituationBlock.ts` + `tickLoop.ts` | 37–42, 92–104 | **5 redundant `getSnapshot()` calls per tick.** Each of 4 Elders calls `convex.getSnapshot()` independently, plus `pollChainTick`. Fetch once per tick and pass to compose. | Performance |
+| 18 | `runner/src/zeroGMemoryStore.ts` | 248–252 | **Full JSON cache rewrite on every `save()`.** `writeCacheToDisk` serializes the entire `#cache` Map each time. Switch to incremental append log with periodic checkpoint. | Performance |
+| 19 | `runner/src/filePeerInbox.ts` | 71–80 | **Full JSONL read per `inbox()` call.** `readFileSync` + split on entire history every tick per Elder. Append-only file grows without bound. | Performance |
+| 20 | `runner/src/tickLoop.ts` | (entire module) | **Zero test coverage for tick loop.** Core orchestration path (poll → compose → deliver → settle → latch) has no tests. At minimum, one integration-style test with fakes. | Tests |
+| 21 | (package layout) | — | **No `packages/runner/AGENTS.md`.** Other first-class packages have per-package guides. Inconsistent with progressive discovery pattern. | Conventions |
+| 22 | (commit history) | — | **Several commits missing `(#N)` issue refs.** Affects: `feat(runner): add ClanWorld runner daemon prototype`, `fix(runner): fix-round PR #93`, `feat(runner): Phase 7/8`, `fix(runner): narrow heartbeat error upgrade`. | Conventions |
+| 23 | `runner/.env.example` + `zeroGMemoryStore.ts` | 49, 15–19 | **`CHAIN_ID=16661` documented but unused.** No `env['CHAIN_ID']` read in runner source. | Docs |
+| 24 | `runner/src/zeroGMemoryStore.ts` vs `fileMemoryStore.ts` | 355–363, 52–56 | **Corrupt JSON: ZeroG throws, FileMemoryStore returns `{}`.** Toggling `OG_STORAGE_API_KEY` changes startup behavior on the same file. Align policies. | Correctness |
+| 25 | `runner/src/filePeerInbox.ts` + `zeroGMemoryStore.ts` | — | **`JSON.parse(...) as Record<string, string>` unvalidated.** Valid JSON with non-string values silently becomes wrong types. Add runtime shape validation. | Type Safety |
+| 26 | `runner/src/zeroGMemoryStore.ts` + `axlPeerInbox.ts` | 75–83, 449–456 | **Sensitive data at rest without restrictive file permissions.** Cache and journal files follow default `umask`. Use `0o600` for sensitive files. | Security |
+| 27 | `runner/src/tmuxRunnerInbox.ts` | 101–129 | **TOCTOU gap between spawn and abort listener.** Short window where abort fires after the sync check but before `addEventListener`. Partial mitigation exists. | Correctness |
+| 28 | `runner/src/tickLoop.ts` | 79–84 | **No exponential backoff on `pollChainTick` failure.** During Convex outages, runner polls at constant cadence. Add backoff with jitter. | Performance |
+
+### SKIP / FALSE POSITIVE
+
+| # | File | Line(s) | Finding | Reason |
+|---|------|---------|---------|--------|
+| 29 | `runner/src/tickLoop.ts` | 175–190 | `raceAbort` doesn't cancel underlying promise | By design; documented in comments. Non-cancelled work is bounded. |
+| 30 | `runner/src/main.ts` | 98–123 | Partial adapter creation on startup failure | Process exits on failure; no leaked resources. |
+| 31 | `runner/src/tmuxRunnerInbox.ts` | 152–159 | `waitForFile` lacks `AbortSignal` | Bounded by `timeoutMs`; only used in delivery path. |
+| 32 | `runner/src/pollChainTick.ts` | 12–14 | Full snapshot for tick query | Documented TODO for cheaper query; correctness is fine. |
+| 33 | `runner/src/fileMemoryStore.ts` | 33 | `elder: number` vs `ElderId` | Minor type style; values are constrained at call sites. |
+| 34 | `agents/package.json` | 7–8 | Missing `"types"` condition on `./seams` export | TypeScript resolves it anyway; minor polish. |
+| 35 | `runner/tsconfig.json` | — | `include` adds `test/**/*` unlike agents | Reasonable for test support; not inconsistent. |
+| 36 | `runner/src/zeroGMemoryStore.ts` | 25 | `.js` extension in import vs extensionless elsewhere | Both resolve under tsx; style-only. |
+| 37 | `runner/package.json` | — | Missing `exports` map | Private package; `main` field sufficient. |
+| 38 | `runner/package.json` | 7–14 | Stub `build`/`lint` scripts | Hackathon acceptable; no functional impact. |
+| 39 | (commit history) | — | Merge commits non-conventional | Common practice for bundle PRs. |
+| 40 | `runner/src/axlPeerInbox.ts` | 338–343 | `peerToClan` Map rebuilt per drain | Minor CPU cost; not hot path. |
+| 41 | `runner/.env.example` | 9–10 | Concrete contract address in templates | Not a secret; testnet reference. |
+| 42 | `runner/src/zeroGMemoryStore.ts` | 23 | Unused `os` import | Likely merge residue; no functional impact. |
+
+---
+
+## Review Methodology
+
+### Wave 1 — Broad Sweep (7 agents, parallel)
+
+| Agent | Domain | Key Findings |
+|-------|--------|--------------|
+| 1.1 | Correctness & Bug Hunter | CRITICAL tick loop partial failure (#1); HIGH path traversal (#2); HIGH withTimeout gap (#4) |
+| 1.2 | Security & Secrets | HIGH AXL trust model (#14); HIGH systemd hardening (#13); HIGH OG_STORAGE_API_KEY naming (#5) |
+| 1.3 | Architecture & Integration | MEDIUM seams placement; verified no circular deps, correct subpath exports |
+| 1.4 | Type Safety & Contracts | HIGH unsafe type assertions (#6, #7); zero `any` usage confirmed |
+| 1.5 | Test Coverage | HIGH tickLoop untested (#20); MEDIUM tautological wallet test; MEDIUM misleading test names |
+| 1.6 | Style, Conventions & Docs | HIGH AGENTS.md gap (#8); HIGH .env.template gap (#9); MEDIUM commit message issues (#22) |
+| 1.7 | Performance & Scalability | HIGH redundant snapshots (#17); HIGH unbounded caches (#16, #18, #19) |
+
+### Wave 2 — Targeted Deep Dives (3 agents, parallel)
+
+| Agent | Domain | Key Findings |
+|-------|--------|--------------|
+| 2.1 | Concurrency & Abort Handling | CONFIRMED CRITICAL #1 with full signal trace; QUALIFIED #4; CONFIRMED #10, #27 |
+| 2.2 | 0G SDK Integration | CONFIRMED #5, #24, #25; wallet derivation is correct; cache coherency is maintained |
+| 2.3 | Merge Conflicts & Consistency | Found HIGH #3 (ELDER_N cross-talk); no conflict markers; lockfile synced; stale README |
+
+### Wave 3 — Not needed
+
+Wave 1 + 2 provided comprehensive coverage across all subsystems.
+
+---
+
+## Recommended Next Steps
+
+### 1. Address MUST FIX items (3 items — do first)
+
+**#1 — Tick loop partial failure handling** (highest priority)
+- Option A: Gate `markSettled` / `lastProcessedTick` on all deliveries succeeding; retry failed Elders before settling
+- Option B: Accept degraded mode but document it explicitly in code comments, README, and log a prominent warning when an Elder is skipped
+- Option C: Retry failed Elders up to N times within the settle window before marking settled
+
+**#2 — filePeerInbox path traversal**
+- Add `assertSafeClanId()` validation (same pattern already in `axlPeerInbox.ts`) before constructing file paths in `send()`
+
+**#3 — ELDER_N env override in multi-elder mode**
+- `FilePeerInbox` constructor should prefer the explicit `elder` parameter over `process.env['ELDER_N']` when running in multi-elder mode
+- Alternatively, the multi-elder runner should `delete process.env['ELDER_N']` at startup, or `FilePeerInbox` should ignore it when `opts.elder` is provided
+
+### 2. Address SHOULD FIX items (9 items — before merge)
+
+Grouped by effort:
+
+**Quick fixes** (< 10 min each):
+- #5: Rename `OG_STORAGE_API_KEY` to `OG_STORAGE_ENABLED` or add clear docs
+- #8: Update `AGENTS.md` to list runner as 7th package
+- #9: Add runner env vars to root `.env.template`
+- #10: Add `'aborted'` reason to `DeliveryStatus` and use it
+- #11: Default `sentAt` to `new Date().toISOString()` when absent
+- #12: Update README pseudocode to show decoupled Cycle A / Cycle B
+
+**Medium effort** (30–60 min each):
+- #4: Make `withTimeout` abort-aware or wrap delivery in `raceAbort`
+- #6: Replace `as Record<ElderId, PerElderDeps>` with a builder
+- #7: Validate `elderN` before casting to `ElderId`
+
+### 3. Create DEFER issues (16 items)
+
+Open GitHub issues for tracking. Suggested grouping:
+- **Security hardening**: #13 (systemd), #14 (AXL signing), #15 (AXL TLS), #26 (file permissions)
+- **Performance**: #16 (unbounded caches), #17 (snapshot dedup), #18 (cache rewrite), #19 (JSONL reads), #28 (backoff)
+- **Correctness**: #24 (corrupt JSON alignment), #25 (JSON.parse validation), #27 (TOCTOU)
+- **Docs & conventions**: #21 (runner AGENTS.md), #22 (commit refs), #23 (CHAIN_ID cleanup)
+- **Tests**: #20 (tickLoop coverage)
+
+### 4. Overall PR Health Assessment
+
+**Status: NEEDS WORK**
+
+The 3 MUST FIX items are real bugs that affect game correctness (tick skipping, cross-talk between Elders) and security (path traversal). The 9 SHOULD FIX items are mostly quick documentation and type safety improvements.
+
+The code quality is generally high — zero `any` usage, good abort signal threading, thoughtful adapter pattern, comprehensive tests for most modules. The 4 fix rounds (r3–r6) on the 0G adapter show healthy iteration. The main gaps are in the tick loop orchestration (the CRITICAL #1), the file-based peer inbox (MUST FIX #2 and #3), and documentation keeping pace with architecture changes.
+
+After addressing the 3 MUST FIX and 9 SHOULD FIX items, the PR should be merge-ready.

--- a/docs/reviews/pr137-review-claude-opus.md
+++ b/docs/reviews/pr137-review-claude-opus.md
@@ -1,0 +1,159 @@
+# PR #137 Review — merge: bundle E — Phase 2 economy (#91 post-rebase)
+
+| Field | Value |
+|-------|-------|
+| **PR** | [#137](https://github.com/OmniPass-world/clan-world/pull/137) |
+| **Branch** | `merge/bundle-e` → `dev` |
+| **Author** | claude-do |
+| **Review date** | 2026-04-28 |
+| **Review model** | Claude Opus 4.6 |
+| **Method** | 10-agent swarm (7 parallel Wave 1 + 3 parallel Wave 2) |
+
+## PR Summary
+
+Implements Phase 2 economy: constant-product AMM pool (`StubPool`), market sell/buy execution, FIFO scheduled queue with commit-sequence ordering, treasury initialization, and pool seeding. Touches 6 files in `packages/contracts/`, +804/−31 lines. Self-assessed as **medium risk** — substantial Solidity additions (AMM math, scheduled queue, `via_ir = true`).
+
+Previously reviewed in R1 and R2 rounds (fixes preserved in rebase): heartbeat try/catch, stale queued action invalidation, ceiling division overflow safety, market events with realized amounts, test naming.
+
+### Files changed
+
+| File | +/- | Change |
+|------|-----|--------|
+| `packages/contracts/foundry.toml` | +1/−0 | `via_ir = true` for stack-depth relief |
+| `packages/contracts/script/Deploy.s.sol` | +9/−9 | Deploy ordering: ClanWorld before pools |
+| `packages/contracts/src/ClanWorld.sol` | +325/−15 | initTreasury, seedPools, scheduled market actions, FIFO queue, heartbeat execution |
+| `packages/contracts/src/StubPool.sol` | +70/−4 | Upgraded from address-only stub to real constant-product AMM |
+| `packages/contracts/test/ClanWorld.t.sol` | +397/−1 | 7 new Phase 2 tests (23 total green) |
+| `packages/contracts/test/ClanWorldStub.t.sol` | +2/−2 | Minor test fixture updates |
+
+---
+
+## Review Agents
+
+| Wave | Agent | Role | Key result |
+|------|-------|------|------------|
+| 1 | Correctness & Logic | Line-by-line bug hunting, state transitions | 3 confirmed issues + 2 false positives (resolved in Wave 2) |
+| 1 | Security & Access Control | Reentrancy, access control, overflow, MEV, DOS | 3 actionable, 2 deferred, reentrancy confirmed safe |
+| 1 | AMM Math & Economics | Constant-product formulas, rounding, K-invariant | All formulas correct; 2 economic concerns flagged |
+| 1 | Architecture & Integration | Deploy script, interface compliance, cross-file | PoolsSeeded event mismatch, deploy script incomplete |
+| 1 | Test Coverage & Quality | Feature-to-test mapping, gap analysis | Coverage adequate for hackathon; 6 gaps noted |
+| 1 | Gas & Performance | Storage patterns, unbounded loops, via_ir | Unbounded queue is the main functional risk |
+| 1 | Style, Conventions & Docs | NatSpec, naming, commits, PR body | Stale Phase 2 "stubbed" comments, initTreasury not on interface |
+| 2 | Cross-cutting Conflict Resolution | Resolved vault-deduction-before-call dispute | Agent 1 false positive: external self-call rolls back state |
+| 2 | FIFO Queue & Stale Guard Deep Dive | Same-type mission replacement scenarios | CONFIRMED: stale guard incomplete for same-type replacement |
+| 2 | Economic Invariant Verification | Gold/resource conservation, K-invariant, pool freeze | All conservation invariants hold; sell-side freeze is theoretical |
+
+---
+
+## Triage Table
+
+| # | File | Line | Finding | Category |
+|---|------|------|---------|----------|
+| 1 | `src/ClanWorld.sol` | 991–1057 | **Stale queue guard incomplete for same-type mission replacement.** `ScheduledMarketAction` has no `missionNonce` field; the guard only checks `m.action != sma.action`. Replacing MarketSell→MarketSell (different token/amount) leaves the old queue entry valid with stale parameters. Old entries execute with wrong token/amount, causing incorrect vault debits. Confirmed by Agents 1, 9. | **MUST FIX** |
+| 2 | `src/ClanWorld.sol` | 1366–1371 | **`PoolsSeeded` event emission order mismatched vs `IClanWorld`.** Interface declares `(wood, wheat, fish, iron)` but implementation emits `(wood, iron, wheat, fish)`. Args 2–4 are swapped. Off-chain indexers decoding by position assign wrong pool addresses. Confirmed by Agents 1, 4, 8. | **SHOULD FIX** |
+| 3 | `src/ClanWorld.sol` | 991–1075 | **Unbounded per-tick market queue.** No cap on `_scheduledMarketActions[tick].length`. `mintClan` is permissionless (no fee), so an attacker can create many clans and schedule many actions for the same tick. `heartbeat` iterates the full array — risk of OOG revert stalling progression. Confirmed by Agents 2, 6. | **SHOULD FIX** |
+| 4 | `src/ClanWorld.sol`, `src/IClanWorld.sol` | 1331–1350 | **`initTreasury` not declared on `IClanWorld`.** Required lifecycle step missing from canonical interface. Typed clients that code against the interface miss this mandatory call before `seedPools`. Confirmed by Agents 2, 4, 7. | **SHOULD FIX** |
+| 5 | `src/ClanWorld.sol` | 7–13 | **Contract-level NatSpec still says "Phase 2 … are stubbed."** Phase 2 scheduling and AMM execution are now implemented. Misleading for readers and NatSpec-consuming tools. Confirmed by Agents 4, 7. | **SHOULD FIX** |
+| 6 | `src/ClanWorld.sol` | 1378–1394 | **OTC transfer functions still `revert("... Phase 2")`.** The string "Phase 2" is misleading now that Phase 2 market economy is implemented. Should clarify these are OTC-specific stubs. Agent 7. | **SHOULD FIX** |
+| 7 | `script/Deploy.s.sol` | 30–46 | **Deploy script never calls `initTreasury` / `seedPools`.** Deployments using only this script leave the market offline (`poolsSeeded = false`). Operator must run separate transactions. Agent 4. | **SHOULD FIX** |
+| 8 | `src/ClanWorld.sol` | 1060–1072 | **Catch-all `ERR_INVALID_ACTION` masks real failure modes.** All pool reverts, math errors, slippage failures, and missing-resource errors collapse to the same status code. Undermines debugging, monitoring, and UX. Confirmed by Agents 1, 2, 7. | **SHOULD FIX** |
+| 9 | `src/ClanWorld.sol` | 1655–1663 | **`spotPriceGoldPerResource` can overflow.** `rB * 1e18` overflows if `reserveB` exceeds `~1.15e59`. Pathological for typical seeds but a sharp edge for view-layer availability. Agent 2. | **SHOULD FIX** |
+| 10 | `src/ClanWorld.sol` | 1296–1320 | **Market token validation skipped before `initTreasury`.** If treasury is uninitialized, `marketToken` checks are bypassed. Orders enqueue with bogus tokens; execution fails later but queue state is wasted. Agent 2. | **SHOULD FIX** |
+| 11 | `src/IClanWorld.sol` | 362–367 | **No sell-side slippage protection.** Only buys carry `maxGoldIn`. Sellers have no on-chain worst-case proceeds guarantee. Agents 3, 10. | **DEFER** |
+| 12 | `src/StubPool.sol` | 43–49 | **Pool can become one-sided unusable.** Repeated sells can drain gold reserves to dust, causing `require(goldOut > 0)` to revert on all subsequent sells. Buys can recapitalize but require clan gold. Agents 3, 10. | **DEFER** |
+| 13 | `script/Deploy.s.sol` | 15–35 | **Deploy script comment numbering inconsistent.** Steps labeled 1, 3, 2 instead of 1, 2, 3. Agents 4, 7. | **DEFER** |
+| 14 | `foundry.toml` | 8 | **`via_ir = true` applies to all contracts.** Should be scoped to a profile or documented. Slows compilation. Agents 4, 6. | **DEFER** |
+| 15 | `src/ClanWorld.sol` | 1078–1103 | **Leading underscore on `external` functions.** `_executeMarketSellExternal` / `_executeMarketBuyExternal` use internal naming convention on external visibility. Justified by try/catch pattern but unconventional. Agent 7. | **DEFER** |
+| 16 | `src/IClanWorld.sol` | 692–693 | **Interface NatSpec wording drift.** `seedPools` says "deploy time" but requires `initTreasury` first. Agent 7. | **DEFER** |
+| 17 | `test/ClanWorld.t.sol` | — | **`getMarketState()` never tested.** Pool reserves and queue state view function has no test coverage. Agent 5. | **DEFER** |
+| 18 | `test/ClanWorld.t.sol` | — | **Stale action invalidation path untested.** The `m.action != sma.action` continue branch has no dedicated test. Agent 5. | **DEFER** |
+| 19 | `test/ClanWorld.t.sol` | — | **Double-init and access control guards untested.** `initTreasury` and `seedPools` revert-on-repeat and owner-only restrictions lack explicit tests. Agent 5. | **DEFER** |
+| 20 | — | — | **MEV / front-running against scheduled ticks.** Scheduled actions are public; attackers can reorder transactions. Standard AMM/game expectation, not a single-contract bug. Agent 2. | **DEFER** |
+| 21 | `src/ClanWorld.sol` | 1655–1663 | **Spot price oracle is manipulable.** Instantaneous midpoint, not TWAP. Acceptable if clients don't treat it as an ungameable price feed. Agents 3, 10. | **DEFER** |
+| 22 | `src/StubPool.sol` | 46, 57–58 | **`reserveB * amountIn` overflow on extreme values.** Checked math reverts on overflow — DOS for unrealistic magnitudes, not fund loss. Agent 3. | **DEFER** |
+| 23 | `src/ClanWorld.sol` | 1207–1224 | **Buy path double-reads pool reserves.** `quoteBuy` then `buyResource` both read reserves. Minor gas overhead. Agent 6. | **DEFER** |
+| 24 | `src/ClanWorld.sol` | 1156–1199 | **Treasury SLOAD caching opportunity.** Multiple `_treasury.*` reads per execution. Could cache storage pointer. Agent 6. | **DEFER** |
+| 25 | `test/ClanWorld.t.sol` | 538–539 | **Stale comment about "second clansman".** Test only uses one clansman for buy; comment misleads. Agent 5. | **DEFER** |
+| 26 | `src/ClanWorld.sol` | 1147–1185 | **Vault deduction before pool call loses resources on revert.** Agent 1 flagged as MUST FIX. **FALSE POSITIVE** — Agent 8 verified: `try this._executeMarketSellExternal(...)` is an external self-call; if `sellResource` reverts, the entire external frame (including `_deductFromVault`) is rolled back. The catch runs in the caller's frame with pre-try state. | **SKIP** |
+| 27 | `src/StubPool.sol` | 43–49 | **`require(goldOut > 0)` revert on small sells causes resource loss.** Same root cause as #26. The external self-call pattern rolls back all state including vault deductions. **FALSE POSITIVE.** | **SKIP** |
+| 28 | `src/StubPool.sol` | 43–74 | **Constant-product formula correctness.** Verified: `sellResource` implements `dy = floor(y·dx/(x+dx))`, `buyResource` implements `goldIn = ceil(y·amountOut/(x−amountOut))`. Both correct. Agent 3. | **SKIP** |
+| 29 | `src/StubPool.sol` | 54–73 | **`quoteBuy` / `buyResource` math consistency.** Verified: identical formula, view matches charging path. Agent 3. | **SKIP** |
+| 30 | `src/StubPool.sol` | 43–74 | **K-invariant preservation.** Verified: floor on output (sell) and ceil on input (buy) both preserve or increase K. Rounding favors the pool/protocol. Agents 3, 10. | **SKIP** |
+| 31 | `src/ClanWorld.sol` | 1059–1103 | **Reentrancy via external self-call.** Verified safe: `StubPool` has no callbacks into `ClanWorld`; `onlyEngine` restricts all mutating pool functions. Replacing `StubPool` with malicious code is an owner trust issue. Agent 2. | **SKIP** |
+| 32 | `src/ClanWorld.sol` | 991–1006 | **FIFO queue ordering / cross-clan manipulation.** Verified correct: `commitSequence` is globally monotonic; clans cannot submit orders for other clans; push order matches FIFO. Agents 2, 9. | **SKIP** |
+| 33 | `test/ClanWorld.t.sol` | 27–29 | **Test isolation.** Verified sound: fresh `ClanWorld` per test in `setUp`; `_setupMarket` redeploys tokens/pools. Agent 5. | **SKIP** |
+| 34 | — | — | **Gold conservation.** Verified: gold is created only via `mintClan` starter gold and iron mining RNG. Market swaps transfer gold between clan balance and pool reserves with no leak. Agent 10. | **SKIP** |
+| 35 | — | — | **Resource conservation.** Verified: sell deducts exact `amount` from vault, pool receives same; buy receives exact `amountOut` from pool, vault credits same. Agent 10. | **SKIP** |
+
+---
+
+## Summary Stats
+
+| Category | Count |
+|----------|-------|
+| **MUST FIX** | 1 |
+| **SHOULD FIX** | 9 |
+| **DEFER** | 15 |
+| **SKIP / FALSE POSITIVE** | 10 |
+| **Total** | 35 |
+
+---
+
+## Key Wave 2 Resolutions
+
+### False Positive: Vault deduction before pool call (Findings #26, #27)
+
+Agent 1 (Correctness) flagged `_executeMarketSell` deducting vault resources before calling `StubPool.sellResource` as a MUST FIX — claiming that if the pool reverts, resources are permanently lost.
+
+**Agent 8 definitively resolved this as a false positive.** The execution path uses `try this._executeMarketSellExternal(...)`, which is an **external self-call** (`CALL` opcode to `address(this)`). Both `_deductFromVault` and `StubPool.sellResource` run inside this external call frame. If `sellResource` reverts, **all state changes in that frame — including the vault deduction — are rolled back**. The `catch` block executes in the original caller's frame with pre-try state intact.
+
+### Confirmed: Stale queue guard incomplete (Finding #1)
+
+Agent 9 traced five scenarios and confirmed Agent 1's concern: replacing a MarketSell mission with a different MarketSell (different token or amount) does **not** invalidate the old queue entry. The guard checks only `m.action != sma.action`, which passes `true` (both are `MarketSell`). The old entry executes with stale parameters. Cross-type replacement (MarketSell → Gather) is correctly handled.
+
+### Verified: Economic invariants hold (Findings #34, #35)
+
+Agent 10 confirmed gold and resource conservation, K-invariant preservation, and that `reserveB == 0` is effectively unreachable (though the sell side can freeze at dust levels).
+
+---
+
+## Recommended Next Steps
+
+### 1. Address MUST FIX (blocking merge)
+
+**Finding #1: Stale queue guard.** Add a `missionNonce` field to `ScheduledMarketAction` and check it against `_missions[clansmanId].nonce` during execution. Alternatively, remove superseded queue entries when installing a replacement market mission (more gas but simpler invariant). This is the only merge-blocking issue.
+
+### 2. Address SHOULD FIX (before merge)
+
+Priority order:
+
+1. **#2 PoolsSeeded event order** — Swap emit args to match `IClanWorld` declaration: `(wood, wheat, fish, iron)`
+2. **#3 Unbounded queue** — Add a per-tick cap or total clan cap. Even a generous limit (e.g., 100 actions/tick) prevents OOG grief
+3. **#4 initTreasury on IClanWorld** — Add to interface for typed client discoverability
+4. **#8 Catch-all error code** — Add 2–3 specific status codes (ERR_MISSING_RESOURCES, ERR_NOT_ENOUGH_GOLD, ERR_SLIPPAGE_EXCEEDED)
+5. **#5, #6 Stale comments** — Quick fix: update NatSpec and OTC revert strings
+6. **#7 Deploy script** — Add `initTreasury` + `seedPools` calls (or document as intentionally separate)
+7. **#9 Spot price overflow** — Use `mulDiv`-style arithmetic or saturate
+8. **#10 Market validation pre-init** — Reject market orders when `_treasury.woodToken == address(0)`
+
+### 3. DEFER items (new GitHub issues)
+
+Group by theme for follow-up issues:
+- **Economic UX**: #11 (sell-side slippage), #12 (pool freeze), #20 (MEV), #21 (oracle manipulation)
+- **Gas optimization**: #14 (via_ir scoping), #22 (overflow DOS), #23 (double reads), #24 (SLOAD caching)
+- **Test coverage**: #17 (getMarketState), #18 (stale action path), #19 (double-init guards)
+- **Code hygiene**: #13 (deploy comments), #15 (naming convention), #16 (NatSpec drift), #25 (stale test comment)
+
+---
+
+## Overall PR Health Assessment
+
+**Verdict: NEEDS WORK — one MUST FIX, nine SHOULD FIX**
+
+The core AMM math is **correct and economically sound** — constant-product formulas, rounding, K-invariant all verified. The try/catch external self-call pattern for atomic market execution is **well-designed**. Test coverage is **adequate for hackathon standards**. Gold and resource conservation **hold**.
+
+The single blocking issue is the **incomplete stale queue guard** (Finding #1): same-type mission replacement can cause stale market actions to execute with wrong parameters. This is a correctness bug that affects fairness and economic integrity.
+
+The nine SHOULD FIX items are individually minor but collectively represent rough edges that could cause integration issues (event order mismatch, missing interface method), operational risk (unbounded queue, deploy script gaps), and developer confusion (stale comments, generic error codes).
+
+After fixing Finding #1 and addressing the SHOULD FIX items, this PR should be merge-ready.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -7,7 +7,7 @@
     "elder": "./bin/elder"
   },
   "scripts": {
-    "dev": "tsx watch src/cli.ts",
+    "dev": "tsx watch --env-file=../../.env.local src/cli.ts",
     "build": "echo 'uses tsx at runtime; no emit build needed'",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
Three small dev-tooling fixes + 4 review docs that didn't make it into PR #131 before merge:

- \`1ad5d78\` chore(dev): env-file loading for tsx workspaces + Vercel project links
- \`b77b794\` fix(web): guard PIXI Application destroy against StrictMode double-invoke
- \`ae5c017\` test(web): smoke spec — capture console + pageerror as debug surface
- \`75dab61\` docs(reviews): Claude Opus review docs for PRs 132/133/136/137

Cherry-picked from local commits on \`merge/bundle-a\` that weren't pushed before #131 merged.

Low-risk dev-tooling — typecheck clean, no behavior change in prod (env-file fix only affects tsx-watched workspaces in dev; vercel project.json was already on disk; PIXI guard only affects React StrictMode dev double-invoke).