### PR TITLE
fix(runtime): tighten elder sandbox + mirror live improvements

### DIFF
--- a/runtime/elders/Makefile
+++ b/runtime/elders/Makefile
@@ -63,21 +63,21 @@ help:
 
 install:
 	@echo "=== installing elder harness to $(DEST) ==="
-	@mkdir -p $(DEST)/.claude/skills
-	@mkdir -p $(DEST)/bin
-	@cp -p $(REPO_DIR)/parent/AGENTS.md $(DEST)/AGENTS.md
+	@mkdir -p "$(DEST)"/.claude/skills
+	@mkdir -p "$(DEST)"/bin
+	@cp -p "$(REPO_DIR)"/parent/AGENTS.md "$(DEST)"/AGENTS.md
 	@ln -sf AGENTS.md $(DEST)/CLAUDE.md
-	@cp -p $(REPO_DIR)/parent/.claude/settings.json $(DEST)/.claude/settings.json
+	@cp -p "$(REPO_DIR)"/parent/.claude/settings.json "$(DEST)"/.claude/settings.json
 	@for skill in cleared-context-start elder-base-context final-tick-continuity \
 	              uniswap-arb-camping uniswap-market-overview \
 	              uniswap-sell-immediate uniswap-sell-scheduled; do \
 	    mkdir -p $(DEST)/.claude/skills/$$skill; \
-	    cp -p $(REPO_DIR)/parent/.claude/skills/$$skill/SKILL.md \
-	          $(DEST)/.claude/skills/$$skill/SKILL.md; \
+	    cp -p "$(REPO_DIR)"/parent/.claude/skills/$$skill/SKILL.md \
+	          "$(DEST)"/.claude/skills/$$skill/SKILL.md; \
 	done
-	@cp -p $(REPO_DIR)/Makefile $(DEST)/Makefile
-	@cp -p $(REPO_DIR)/aliases.sh $(DEST)/aliases.sh
-	@cp -p $(REPO_DIR)/bin/* $(DEST)/bin/
+	@cp -p "$(REPO_DIR)"/Makefile "$(DEST)"/Makefile
+	@cp -p "$(REPO_DIR)"/aliases.sh "$(DEST)"/aliases.sh
+	@cp -p "$(REPO_DIR)"/bin/* "$(DEST)"/bin/
 	@for n in $(ELDER_NUMBERS); do \
 	    mkdir -p $(DEST)/elder-$$n/.claude; \
 	    mkdir -p $(DEST)/elder-$$n/state/plugin-cache; \
@@ -146,12 +146,12 @@ elders-up: $(addprefix elder-,$(ELDER_NUMBERS))
 # Slash commands are processed by the CC input layer, not by env or model — they
 # have to be physically typed into the running REPL. Helper at bin/elder-inject-startup.sh.
 elders-greet:
-	@$(ELDER_DIR)/bin/elder-inject-startup.sh all
+	@"$(ELDER_DIR)"/bin/elder-inject-startup.sh all
 
-elder-greet-1: ; @$(ELDER_DIR)/bin/elder-inject-startup.sh 1
-elder-greet-2: ; @$(ELDER_DIR)/bin/elder-inject-startup.sh 2
-elder-greet-3: ; @$(ELDER_DIR)/bin/elder-inject-startup.sh 3
-elder-greet-4: ; @$(ELDER_DIR)/bin/elder-inject-startup.sh 4
+elder-greet-1: ; @"$(ELDER_DIR)"/bin/elder-inject-startup.sh 1
+elder-greet-2: ; @"$(ELDER_DIR)"/bin/elder-inject-startup.sh 2
+elder-greet-3: ; @"$(ELDER_DIR)"/bin/elder-inject-startup.sh 3
+elder-greet-4: ; @"$(ELDER_DIR)"/bin/elder-inject-startup.sh 4
 
 elder-%:
 	@if tmux has-session -t elder-$* 2>/dev/null; then \

--- a/runtime/elders/Makefile
+++ b/runtime/elders/Makefile
@@ -14,6 +14,8 @@
 #   make elders-down      Kill all 4 Elder tmux sessions
 #   make elders-status    Show which sessions are alive
 #   make elder-N          Start one Elder (N = 1..4)
+#   make elders-greet     Inject /clear + /rename + /color into all 4 REPLs
+#   make elder-greet-N    Inject startup commands into one Elder
 #   make ttyd-up          Start all 4 ttyd readonly web services
 #   make ttyd-down        Stop all 4 ttyd services
 #   make ttyd-status      Show ttyd service state
@@ -30,8 +32,9 @@ SYSTEMD_USER_DIR := $(HOME)/.config/systemd/user
 
 .PHONY: help install setup elders-up elders-down elders-status \
         ttyd-up ttyd-down ttyd-status ttyd-units \
-        seed-liquidity \
-        $(addprefix elder-,$(ELDER_NUMBERS))
+        seed-liquidity elders-greet \
+        $(addprefix elder-,$(ELDER_NUMBERS)) \
+        $(addprefix elder-greet-,$(ELDER_NUMBERS))
 
 help:
 	@echo "ClanWorld Elders harness"
@@ -42,6 +45,8 @@ help:
 	@echo "  make elders-down      Kill all 4 Elder tmux sessions"
 	@echo "  make elders-status    Show which sessions are alive"
 	@echo "  make elder-N          Start one Elder (N = 1..4)"
+	@echo "  make elders-greet     Inject /clear + /rename + /color into all 4 REPLs"
+	@echo "  make elder-greet-N    Inject startup commands into one Elder"
 	@echo "  make ttyd-up          Start all 4 ttyd readonly web services"
 	@echo "  make ttyd-down        Stop all 4 ttyd services"
 	@echo "  make ttyd-status      Show ttyd service state"
@@ -54,11 +59,12 @@ help:
 # Idempotent. Safe to re-run. Will NOT clobber:
 #   .env, agent-directive.secret.md, state/, existing CLAUDE.md (personality)
 # WILL overwrite (source-controlled, always safe to update):
-#   AGENTS.md, settings.json, skills/, run.sh, Makefile, aliases.sh
+#   AGENTS.md, settings.json, skills/, run.sh, bin/, Makefile, aliases.sh
 
 install:
 	@echo "=== installing elder harness to $(DEST) ==="
 	@mkdir -p $(DEST)/.claude/skills
+	@mkdir -p $(DEST)/bin
 	@cp -p $(REPO_DIR)/parent/AGENTS.md $(DEST)/AGENTS.md
 	@ln -sf AGENTS.md $(DEST)/CLAUDE.md
 	@cp -p $(REPO_DIR)/parent/.claude/settings.json $(DEST)/.claude/settings.json
@@ -71,6 +77,7 @@ install:
 	done
 	@cp -p $(REPO_DIR)/Makefile $(DEST)/Makefile
 	@cp -p $(REPO_DIR)/aliases.sh $(DEST)/aliases.sh
+	@cp -p $(REPO_DIR)/bin/* $(DEST)/bin/
 	@for n in $(ELDER_NUMBERS); do \
 	    mkdir -p $(DEST)/elder-$$n/.claude; \
 	    mkdir -p $(DEST)/elder-$$n/state/plugin-cache; \
@@ -97,7 +104,7 @@ install:
 	@echo ""
 	@echo "Install complete → $(DEST)"
 	@echo "  source $(DEST)/aliases.sh        # shell shortcuts"
-	@echo "  make -C $(DEST) elders-up        # spawn elder sessions (OAuth wizard on first run)"
+	@echo "  make -C $(DEST) elders-up        # spawn elder sessions"
 	@echo "  make -C $(DEST) ttyd-up          # start ttyd services (after elders are running)"
 
 setup: install
@@ -125,7 +132,7 @@ ttyd-units:
 	        echo "  unchanged: $$unit"; \
 	    fi; \
 	done
-	@systemctl --user daemon-reload
+	@systemctl --user daemon-reload || echo "  warning: systemctl --user daemon-reload unavailable — skipped"
 	@for n in $(ELDER_NUMBERS); do \
 	    systemctl --user enable ttyd-elder-$$n.service 2>&1 | grep -v "already enabled" || true; \
 	done
@@ -134,6 +141,17 @@ ttyd-units:
 
 elders-up: $(addprefix elder-,$(ELDER_NUMBERS))
 	@$(MAKE) --no-print-directory elders-status
+
+# Inject /clear + /rename + /color into a running elder REPL via tmux send-keys.
+# Slash commands are processed by the CC input layer, not by env or model — they
+# have to be physically typed into the running REPL. Helper at bin/elder-inject-startup.sh.
+elders-greet:
+	@$(ELDER_DIR)/bin/elder-inject-startup.sh all
+
+elder-greet-1: ; @$(ELDER_DIR)/bin/elder-inject-startup.sh 1
+elder-greet-2: ; @$(ELDER_DIR)/bin/elder-inject-startup.sh 2
+elder-greet-3: ; @$(ELDER_DIR)/bin/elder-inject-startup.sh 3
+elder-greet-4: ; @$(ELDER_DIR)/bin/elder-inject-startup.sh 4
 
 elder-%:
 	@if tmux has-session -t elder-$* 2>/dev/null; then \

--- a/runtime/elders/aliases.sh
+++ b/runtime/elders/aliases.sh
@@ -6,6 +6,8 @@
 #   elders-up             start all 4 Elder sessions (Makefile-backed)
 #   elders-down           kill all 4 Elder sessions
 #   elders-status         list which Elder sessions are alive
+#   elders-greet          inject /clear + /rename + /color into all 4 REPLs
+#   elder-greet <N>       inject startup commands into one Elder
 #   elder-up <N>          start one Elder
 #
 # These aliases delegate to the Makefile at $_ELDER_DIR/Makefile
@@ -23,6 +25,16 @@ fi
 elders-up()     { make -C "$_ELDER_DIR" --no-print-directory elders-up; }
 elders-down()   { make -C "$_ELDER_DIR" --no-print-directory elders-down; }
 elders-status() { make -C "$_ELDER_DIR" --no-print-directory elders-status; }
+elders-greet()  { make -C "$_ELDER_DIR" --no-print-directory elders-greet; }
+
+elder-greet() {
+  local n="$1"
+  if [[ ! "$n" =~ ^[1-4]$ ]]; then
+    echo "usage: elder-greet <N>   where N is 1, 2, 3, or 4" >&2
+    return 1
+  fi
+  make -C "$_ELDER_DIR" --no-print-directory "elder-greet-$n"
+}
 
 elder-up() {
   local n="$1"

--- a/runtime/elders/bin/elder-inject-startup.sh
+++ b/runtime/elders/bin/elder-inject-startup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# elder-inject-startup.sh <N>
+#
+# Inject the 3-command startup sequence into elder-N's tmux REPL:
+#   /clear
+#   /rename "Clan World: <Name>"
+#   /color <color>
+#
+# Usage:
+#   ~/clan-world/bin/elder-inject-startup.sh 1     # inject into elder-1 only
+#   ~/clan-world/bin/elder-inject-startup.sh all   # inject into all 4
+#
+# Pauses 300ms between each command to let the CLI process them in order.
+# Safe to re-run — /clear is idempotent, /rename + /color are stateless setters.
+#
+# Why a separate helper instead of running these inline in run.sh:
+#   Slash commands like /clear, /rename, /color are processed by the Claude
+#   Code CLI's input layer (typed-in commands), NOT by the model or by env
+#   vars. They have to be physically typed into the REPL after it's running.
+#   tmux send-keys with sleeps is the only reliable way.
+
+set -euo pipefail
+
+# Per-elder name + color mapping
+declare -A NAMES=(
+  [1]="Storm Riders"
+  [2]="Iron Guard"
+  [3]="Crimson"
+  [4]="Verdant Wardens"
+)
+declare -A COLORS=(
+  [1]="blue"
+  [2]="cyan"
+  [3]="red"
+  [4]="green"
+)
+
+inject_one() {
+  local n="$1"
+  local name="${NAMES[$n]:-}"
+  local color="${COLORS[$n]:-}"
+
+  if [ -z "$name" ] || [ -z "$color" ]; then
+    echo "elder-$n: not in mapping" >&2
+    return 1
+  fi
+
+  if ! tmux has-session -t "elder-$n" 2>/dev/null; then
+    echo "elder-$n: tmux session not running — skip" >&2
+    return 1
+  fi
+
+  echo "elder-$n: injecting /clear + /rename \"Clan World: $name\" + /color $color"
+
+  tmux send-keys -t "elder-$n" "/clear"; sleep 0.3
+  tmux send-keys -t "elder-$n" Enter; sleep 0.3
+  tmux send-keys -t "elder-$n" "/rename \"Clan World: $name\""; sleep 0.3
+  tmux send-keys -t "elder-$n" Enter; sleep 0.3
+  tmux send-keys -t "elder-$n" "/color $color"; sleep 0.3
+  tmux send-keys -t "elder-$n" Enter
+}
+
+target="${1:-}"
+if [ -z "$target" ]; then
+  echo "usage: $0 <N>|all" >&2
+  exit 2
+fi
+
+if [ "$target" = "all" ]; then
+  for n in 1 2 3 4; do
+    inject_one "$n" || true
+  done
+else
+  inject_one "$target"
+fi

--- a/runtime/elders/parent/.claude/settings.json
+++ b/runtime/elders/parent/.claude/settings.json
@@ -5,6 +5,23 @@
     "TZ": "America/New_York"
   },
   "permissions": {
-    "defaultMode": "acceptEdits"
+    "defaultMode": "default",
+    "allow": [
+      "Bash(elder *)",
+      "Bash(date)",
+      "Read",
+      "Write",
+      "Edit"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(curl *)",
+      "Bash(wget *)",
+      "Bash(git *)",
+      "Bash(systemctl *)",
+      "Bash(sudo *)",
+      "WebFetch",
+      "WebSearch"
+    ]
   }
 }

--- a/runtime/elders/template/run.sh.template
+++ b/runtime/elders/template/run.sh.template
@@ -18,10 +18,10 @@ export CLAUDE_CODE_HIDE_ACCOUNT_INFO=1
 # CLAUDE_CODE_OAUTH_TOKEN env var avoids the per-elder wizard dance.
 # Token is shared across all elders (tied to user's MAX subscription).
 # Stored in ~/code/clan-world/.env.local (gitignored).
-if [ -f "$HOME/code/clan-world/.env.local" ]; then
+if [ -f "${CLAN_WORLD_REPO:-$HOME/code/clan-world}/.env.local" ]; then
   set -a
   # shellcheck disable=SC1091
-  source "$HOME/code/clan-world/.env.local"
+  source "${CLAN_WORLD_REPO:-$HOME/code/clan-world}/.env.local"
   set +a
 fi
 

--- a/runtime/elders/template/run.sh.template
+++ b/runtime/elders/template/run.sh.template
@@ -12,6 +12,18 @@ AGENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # === Core isolation — OAuth via CLAUDE_CONFIG_DIR per ADR 0013 ===
 # NEVER use ANTHROPIC_API_KEY, NEVER use --bare (forces API key).
 export CLAUDE_CONFIG_DIR="$AGENT_DIR/.claude"
+export CLAUDE_CODE_HIDE_ACCOUNT_INFO=1
+
+# === Token-based auth (skips interactive OAuth wizard) ===
+# CLAUDE_CODE_OAUTH_TOKEN env var avoids the per-elder wizard dance.
+# Token is shared across all elders (tied to user's MAX subscription).
+# Stored in ~/code/clan-world/.env.local (gitignored).
+if [ -f "$HOME/code/clan-world/.env.local" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$HOME/code/clan-world/.env.local"
+  set +a
+fi
 
 # OAuth credentials: symlink to host-shared credentials so token refresh stays fresh.
 # Run once during agent setup if not already present:
@@ -53,17 +65,6 @@ export PATH="$HOME/code/omnipass-world/clan-world/packages/agents/bin:$PATH"
 cd "$AGENT_DIR"
 echo "[$AGENT_NAME] Starting... model=$ANTHROPIC_MODEL $(date '+%Y-%m-%d %H:%M:%S %Z')"
 
-# Per-cwd session continuation. Encoded path matches Claude Code's projects/ layout.
-CWD_ENCODED="${PWD//\//-}"
-CONTINUE_FLAG="--continue"
-if [ ! -d "$CLAUDE_CONFIG_DIR/projects/$CWD_ENCODED" ]; then
-  CONTINUE_FLAG=""
-  echo "[$AGENT_NAME] No prior session for $PWD — starting fresh"
-fi
-
 # Elders don't need the Telegram plugin (no inbound Telegram), so omit --channels.
 # The runner injects situation blocks via tmux send-keys directly to this REPL.
-exec claude \
-  --dangerously-skip-permissions \
-  $CONTINUE_FLAG \
-  "$@"
+exec claude "$@"


### PR DESCRIPTION
## Summary

Tighten the elder agent sandbox by dropping `--dangerously-skip-permissions` (replaced by tight permissions allowlist), drop `--continue` from template, and mirror live runtime improvements that have been validated on the host but were missing from the in-repo source.

## Changes

- **Sandbox**: parent `.claude/settings.json` gets a tight permissions allowlist
  (`Bash(elder *)` + bare `Read`/`Write`/`Edit` which auto-scope to CWD; deny dangerous bash + `WebFetch`/`WebSearch`)
- **Template `run.sh`**: drop `--dangerously-skip-permissions`, drop `--continue`, add `CLAUDE_CODE_HIDE_ACCOUNT_INFO=1`, source `~/code/clan-world/.env.local` for `CLAUDE_CODE_OAUTH_TOKEN`
- **`bin/elder-inject-startup.sh`**: helper for `/clear` + `/rename` + `/color` tmux send-keys
- **Makefile**: install copies `bin/` to DEST; new `elders-greet` + `elder-greet-N` targets
- **`aliases.sh`**: matching shell wrappers

## Why now

- Liam directive 2026-04-28 23:14 ET: `--dangerously-skip-permissions` is wrong for autonomous agents
- Token auth via `CLAUDE_CODE_OAUTH_TOKEN` replaces interactive OAuth dance (4 manual logins → 0)
- `/rename` + `/color` injection auto-runs after each `/clear`
- All five changes validated on the live host runtime; this PR mirrors them into the in-repo template so `make install` reproduces the validated state on any deploy target

## Verification (pre-push, by codex agent)

- `make -C runtime/elders install DEST=/tmp/test-elder-cluster` succeeded
- `dangerously|continue` grep returned no output
- Permissions block present in parent settings.json
- `bin/elder-inject-startup.sh` exists and is executable
- Conflict-marker grep clean
- `git diff --check -- runtime/elders` passed

Direct follow-up to PR #154.