### PR TITLE
fix(web+agents): PR #153 review — must-fix + should-fix slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ web_modules/
 # TypeScript cache
 *.tsbuildinfo
 
+# Codex local state
+.codex
+.codex/
+
 # Optional npm cache directory
 .npm
 

--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -14,8 +14,12 @@ import type {
   FunctionReference,
 } from "convex/server";
 import type * as agentLogs from "../agentLogs.js";
+import type * as crons from "../crons.js";
 import type * as getSnapshot from "../getSnapshot.js";
+import type * as heartbeat from "../heartbeat.js";
+import type * as http from "../http.js";
 import type * as mock from "../mock.js";
+import type * as verify from "../verify.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -27,8 +31,12 @@ import type * as mock from "../mock.js";
  */
 declare const fullApi: ApiFromModules<{
   agentLogs: typeof agentLogs;
+  crons: typeof crons;
   getSnapshot: typeof getSnapshot;
+  heartbeat: typeof heartbeat;
+  http: typeof http;
   mock: typeof mock;
+  verify: typeof verify;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,7 @@ import { useIDKitRequest } from '@worldcoin/idkit';
 import type { IDKitRequestHookConfig } from '@worldcoin/idkit';
 import { WorldMap } from './WorldMap';
 import { Cockpit } from './pages/Cockpit';
+import { WorldMapBoundary } from './components/cockpit/shared/WorldMapBoundary';
 
 // Convex HTTP actions are served at <deployment>.convex.site (not .convex.cloud)
 const CONVEX_SITE_URL =
@@ -175,7 +176,11 @@ function MainApp() {
           Claim Your Clan Identity
         </button>
       )}
-      {verified && <WorldMap />}
+      {verified && (
+        <WorldMapBoundary>
+          <WorldMap />
+        </WorldMapBoundary>
+      )}
     </main>
   );
 }

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -296,8 +296,10 @@ export function WorldMap() {
 
   // Zone-pulse ticker (visual heartbeat for clan zone halos).
   const zonePulseCbRef = useRef<(() => void) | null>(null);
+  const isMountedRef = useRef(true);
 
   const [pixiReady, setPixiReady] = useState(false);
+  const [pixiInitError, setPixiInitError] = useState<Error | null>(null);
   const [, setSize] = useState({ w: 800, h: 600 });
 
   const logs = useAgentLogs();
@@ -313,6 +315,7 @@ export function WorldMap() {
 
   // ---- Pixi init ------------------------------------------------------------
   useEffect(() => {
+    isMountedRef.current = true;
     let mounted = true;
     const app = new Application();
     appRef.current = app;
@@ -331,7 +334,7 @@ export function WorldMap() {
         autoDensity: true,
       })
       .then(async () => {
-        if (!mounted || !canvasWrapRef.current) return;
+        if (!mounted || !isMountedRef.current || !canvasWrapRef.current) return;
         canvasWrapRef.current.appendChild(app.canvas);
         // CSS: stretch to wrapper
         app.canvas.style.display = 'block';
@@ -382,7 +385,7 @@ export function WorldMap() {
         // Loaded async; sprite is added to viewport BEFORE buildScene so region circles render on top.
         try {
           const tex = await Assets.load(worldMapBg);
-          if (!mounted) return;
+          if (!mounted || !isMountedRef.current) return;
           const bg = new Sprite(tex);
           // Render at native world resolution; viewport handles screen-fit zoom.
           bg.width = MAP_WIDTH;
@@ -543,12 +546,19 @@ export function WorldMap() {
         // viewport handles screen-fit transformation. Children inside the viewport
         // are positioned in world coords and pixi-viewport scales them to screen.
         relayout(MAP_WIDTH, MAP_HEIGHT);
+        if (!mounted || !isMountedRef.current) return;
         setSize({ w: initialW, h: initialH });
         setPixiReady(true);
+      })
+      .catch((err: unknown) => {
+        console.error('[WorldMap] failed to initialize Pixi application', err);
+        if (!mounted || !isMountedRef.current) return;
+        setPixiInitError(err instanceof Error ? err : new Error(String(err)));
       });
 
     return () => {
       mounted = false;
+      isMountedRef.current = false;
       const a = appRef.current;
       if (a && tickerCbRef.current) a.ticker.remove(tickerCbRef.current);
       if (a && travelTickerCbRef.current) a.ticker.remove(travelTickerCbRef.current);
@@ -704,6 +714,7 @@ export function WorldMap() {
         // remains visible if load fails. Once loaded, sprite is positioned by relayout.
         Assets.load(clan.sigil)
           .then((texture) => {
+            if (!isMountedRef.current || !appRef.current) return;
             const sprite = new Sprite(texture);
             sprite.alpha = 0; // hidden until first relayout positions it
             viewport.addChild(sprite);
@@ -738,6 +749,7 @@ export function WorldMap() {
       // hides the fallback ring. Catch silently so the ring stays visible on failure.
       Assets.load('/sprites/bandit.png')
         .then((texture) => {
+          if (!isMountedRef.current || !appRef.current) return;
           const sprite = new Sprite(texture);
           sprite.anchor.set(0.5, 0.5);
           sprite.alpha = 0; // hidden until first redrawBandit positions it
@@ -763,6 +775,7 @@ export function WorldMap() {
 
         Assets.load(clan.basePng)
           .then((texture) => {
+            if (!isMountedRef.current || !appRef.current) return;
             const sprite = new Sprite(texture);
             sprite.anchor.set(0.5, 1); // anchored at bottom-center so it "stands" on the region
             sprite.alpha = 0;
@@ -781,6 +794,7 @@ export function WorldMap() {
         // If load fails we silently fall back to the colored Graphics dot.
         Assets.load(clan.clansmanPng)
           .then((texture) => {
+            if (!isMountedRef.current) return;
             clansmanTextureCache[clan.id] = texture;
           })
           .catch(() => {
@@ -1227,6 +1241,10 @@ export function WorldMap() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pixiReady]);
+
+  if (pixiInitError) {
+    throw pixiInitError;
+  }
 
   // ---- Scoreboard data: live snapshot if present, else mock metadata -------
   // Portrait + archetype label come from MOCK_CLANS (they are static metadata,

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -2,7 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import type { ClanOrder } from '@clan-world/shared';
+import { assertSafeInboxKey, type ClanOrder } from '@clan-world/shared';
 import type { IConvexClient, IChainClient } from '@clan-world/shared/adapters';
 import { createConvexClient, createChainClient } from '@clan-world/shared/adapters';
 
@@ -29,6 +29,7 @@ export function inboxFile(n: number, base?: string): string {
 }
 
 export function recipientInboxFile(clanId: string, base?: string): string {
+  assertSafeInboxKey(clanId);
   return path.join(stateDir(base), 'peer-inbox', `elder-${clanId}.jsonl`);
 }
 

--- a/packages/agents/test/cli.test.ts
+++ b/packages/agents/test/cli.test.ts
@@ -181,6 +181,18 @@ describe('memory recall/save', () => {
 // ---------------------------------------------------------------------------
 
 describe('peer whisper', () => {
+  it('rejects unsafe recipient clan ids before resolving an inbox path', async () => {
+    await expect(
+      runCommand('peer', 'whisper', ['../escape', 'attack at dawn'], deps, { ELDER_N: '2' }, tmpDir),
+    ).rejects.toThrow(/unsafe inbox key/);
+    expect(fs.existsSync(path.join(tmpDir, '.world', 'clanworld-runner', 'state', 'escape.jsonl'))).toBe(false);
+  });
+
+  it('allows safe hyphenated recipient clan ids', async () => {
+    await runCommand('peer', 'whisper', ['valid-clan', 'hold position'], deps, { ELDER_N: '2' }, tmpDir);
+    expect(fs.existsSync(recipientInboxFile('valid-clan', tmpDir))).toBe(true);
+  });
+
   it('writes JSON line to recipientInboxFile with correct from/to/msg', async () => {
     await runCommand('peer', 'whisper', ['5', 'attack at dawn'], deps, { ELDER_N: '2' }, tmpDir);
 

--- a/packages/runner/src/filePeerInbox.ts
+++ b/packages/runner/src/filePeerInbox.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { IElderPeerInbox, PeerMessage } from '@clan-world/agents/seams';
+import { assertSafeInboxKey } from '@clan-world/shared';
 import { ELDER_IDS, type ElderId } from './types';
 
 /**
@@ -99,21 +100,6 @@ function inboxKeyForClanId(clanId: string, env: NodeJS.ProcessEnv = process.env)
     if (mappedClanId === clanId) return String(elder);
   }
   return clanId;
-}
-
-/**
- * Reject inbox keys that aren't a single safe path segment. A clan id of `..`
- * or `foo/bar` or anything containing a path separator could escape the
- * `peer-inbox` directory when interpolated into a filename. Allow only
- * alphanumeric + `-` + `_` (matches the canonical Elder CLI clan-id shape).
- *
- * Same guard as axlPeerInbox.assertSafeClanId — kept inline rather than
- * exported because the two adapters can drift independently.
- */
-function assertSafeInboxKey(key: string): void {
-  if (!/^[A-Za-z0-9_-]+$/.test(key)) {
-    throw new Error(`filePeerInbox: unsafe inbox key '${key}' — must be alphanumeric + '-_' only`);
-  }
 }
 
 interface CliShape {

--- a/packages/runner/src/filePeerInbox.ts
+++ b/packages/runner/src/filePeerInbox.ts
@@ -53,6 +53,7 @@ export class FilePeerInbox implements IElderPeerInbox {
     } else {
       this.elderN = inboxKeyForClanId(ownClanId) || String(elder);
     }
+    assertSafeInboxKey(this.elderN);
   }
 
   async send(toClanId: string, message: string, tick: number): Promise<void> {
@@ -82,6 +83,7 @@ export class FilePeerInbox implements IElderPeerInbox {
   }
 
   async inbox(): Promise<PeerMessage[]> {
+    assertSafeInboxKey(this.elderN);
     const file = path.join(this.inboxDir, `elder-${this.elderN}.jsonl`);
     if (!fs.existsSync(file)) return [];
     const lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);

--- a/packages/runner/test/filePeerInbox.test.ts
+++ b/packages/runner/test/filePeerInbox.test.ts
@@ -73,4 +73,10 @@ describe('FilePeerInbox', () => {
     expect(fs.existsSync(oldClanFile)).toBe(false);
     expect(fs.readFileSync(mappedFile, 'utf8')).toContain('"toClanId":"clan-7"');
   });
+
+  it('rejects unsafe read-side inbox keys derived from own clan id', () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clanworld-peer-inbox-'));
+
+    expect(() => new FilePeerInbox(1, '../../escape', stateDir)).toThrow(/unsafe inbox key/);
+  });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
+export * from './utils/assertSafeInboxKey';
 export * as adapters from './adapters';
 export * from './mocks/clanWorldFixture';

--- a/packages/shared/src/utils/assertSafeInboxKey.ts
+++ b/packages/shared/src/utils/assertSafeInboxKey.ts
@@ -1,0 +1,10 @@
+/**
+ * Reject inbox keys that aren't a single safe path segment. A clan id of `..`
+ * or `foo/bar` or anything containing a path separator could escape the
+ * `peer-inbox` directory when interpolated into a filename.
+ */
+export function assertSafeInboxKey(key: string): void {
+  if (!/^[A-Za-z0-9_-]+$/.test(key)) {
+    throw new Error(`unsafe inbox key '${key}' - must be alphanumeric + '-_' only`);
+  }
+}


### PR DESCRIPTION
PR #153 review fix slice for **frontend (web) + CLI (agents)**.

## MUST FIX
- **CLI peer whisper path traversal** (packages/agents/src/cli.ts): now calls \`assertSafeInboxKey\` before path resolution. \`assertSafeInboxKey\` lifted to \`packages/shared/src/utils/assertSafeInboxKey.ts\` so CLI + runner share the canonical guard. \`filePeerInbox.ts\` now imports from shared (DRY). Test added in \`packages/agents/test/cli.test.ts\`.

## SHOULD FIX
- **WorldMap.tsx async PIXI init**: \`.catch()\` chained on \`app.init().then(...)\` so init failures no longer become unhandled promise rejections.
- **WorldMap.tsx async sigil load**: mounted-ref guard around \`Assets.load(clan.sigil).then(...)\` so component-unmount during load doesn't trigger setState-on-unmounted warnings.
- **App.tsx**: WorldMap route now wraps in \`<WorldMapBoundary>\` for consistency with the Cockpit route.

## Verification
- Local typecheck + lint were blocked in the codex sandbox by DNS (\`EAI_AGAIN\`); CI will validate.

## Source
Addresses items from \`docs/reviews/pr153-review-claude-opus.md\` + \`docs/reviews/pr153-review-codex-5-3.md\`.