### PR TITLE
feat(contracts): Phase 3.3 — mission timing rules (Closes #164)

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -153,6 +153,21 @@
               "internalType": "uint64"
             },
             {
+              "name": "submittedAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "executesAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "settlesAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
               "name": "clansmanId",
               "type": "uint32",
               "internalType": "uint32"
@@ -221,6 +236,83 @@
         }
       ],
       "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMissionTiming",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "submitted",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "executes",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "settles",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getActionDuration",
+      "inputs": [
+        {
+          "name": "action",
+          "type": "uint8",
+          "internalType": "enum ActionType"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getTravelTicks",
+      "inputs": [
+        {
+          "name": "fromRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "toRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
     },
     {
       "type": "function",
@@ -651,6 +743,21 @@
                           "internalType": "uint64"
                         },
                         {
+                          "name": "submittedAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "executesAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "settlesAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
                           "name": "clansmanId",
                           "type": "uint32",
                           "internalType": "uint32"
@@ -741,6 +848,21 @@
                     },
                     {
                       "name": "nonce",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "submittedAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "executesAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "settlesAtTick",
                       "type": "uint64",
                       "internalType": "uint64"
                     },
@@ -1171,6 +1293,21 @@
                 },
                 {
                   "name": "nonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "submittedAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "executesAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "settlesAtTick",
                   "type": "uint64",
                   "internalType": "uint64"
                 },

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -275,6 +275,11 @@ contract ClanWorld is IClanWorld {
         return _distMatrix(fromRegion, toRegion);
     }
 
+    function _addTicksClamped(uint64 tick, uint64 delta) private pure returns (uint64) {
+        if (type(uint64).max - tick < delta) return type(uint64).max;
+        return tick + delta;
+    }
+
     // =========================================================================
     // INTERNAL SETTLEMENT
     // =========================================================================
@@ -1036,7 +1041,7 @@ contract ClanWorld is IClanWorld {
 
         // Compute travel
         ctx.travelTicks = _travelTicks(ctx.fromRegion, ctx.gotoRegion);
-        ctx.arrivalTick = _world.currentTick + uint64(ctx.travelTicks);
+        ctx.arrivalTick = _addTicksClamped(_world.currentTick, uint64(ctx.travelTicks));
 
         // New nonce
         ctx.newNonce = cs.lastMissionNonce + 1;
@@ -1108,6 +1113,9 @@ contract ClanWorld is IClanWorld {
         m.active = true;
         m.nonce = ctx.newNonce;
         m.clansmanId = cs.clansmanId;
+        m.submittedAtTick = _world.currentTick;
+        m.executesAtTick = ctx.arrivalTick;
+        m.settlesAtTick = _addTicksClamped(ctx.arrivalTick, getActionDuration(order.action));
         m.startRegion = ctx.fromRegion;
         m.targetRegion = ctx.gotoRegion;
         m.action = order.action;
@@ -1588,6 +1596,42 @@ contract ClanWorld is IClanWorld {
 
     function getActiveMission(uint32 clansmanId) external view override returns (Mission memory) {
         return _missions[clansmanId];
+    }
+
+    function getMissionTiming(uint32 clanId, uint32 clansmanId)
+        external
+        view
+        override
+        returns (uint64 submitted, uint64 executes, uint64 settles)
+    {
+        Mission memory m = _missions[clansmanId];
+        if (!m.active || _clansmen[clansmanId].clanId != clanId) {
+            return (0, 0, 0);
+        }
+        return (m.submittedAtTick, m.executesAtTick, m.settlesAtTick);
+    }
+
+    function getActionDuration(ActionType action) public pure override returns (uint64) {
+        if (
+            action == ActionType.ChopWood || action == ActionType.MineIron || action == ActionType.FishDocks
+                || action == ActionType.FishDeepSea || action == ActionType.HarvestWheat
+        ) {
+            return 4;
+        }
+
+        if (
+            action == ActionType.DepositResources || action == ActionType.BuildWall || action == ActionType.UpgradeBase
+                || action == ActionType.UpgradeMonument || action == ActionType.MarketBuy
+                || action == ActionType.MarketSell
+        ) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    function getTravelTicks(uint8 fromRegion, uint8 toRegion) external pure override returns (uint64) {
+        return uint64(_travelTicks(fromRegion, toRegion));
     }
 
     function getBanditTroop(uint32) external pure override returns (BanditTroop memory) {

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -168,6 +168,9 @@ contract ClanWorldStub is IClanWorld {
         return Mission({
             active: false,
             nonce: 0,
+            submittedAtTick: 0,
+            executesAtTick: 0,
+            settlesAtTick: 0,
             clansmanId: 0,
             startRegion: 0,
             targetRegion: 0,
@@ -182,6 +185,23 @@ contract ClanWorldStub is IClanWorld {
             marketAmount: 0,
             maxGoldIn: 0
         });
+    }
+
+    function getMissionTiming(uint32, uint32)
+        external
+        pure
+        override
+        returns (uint64 submitted, uint64 executes, uint64 settles)
+    {
+        return (0, 0, 0);
+    }
+
+    function getActionDuration(ActionType) external pure override returns (uint64) {
+        return 0;
+    }
+
+    function getTravelTicks(uint8, uint8) external pure override returns (uint64) {
+        return 0;
     }
 
     function getBanditTroop(uint32) external pure override returns (BanditTroop memory) {

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -273,6 +273,9 @@ struct Mission {
     bool active;
 
     uint64 nonce;
+    uint64 submittedAtTick;
+    uint64 executesAtTick;
+    uint64 settlesAtTick;
     uint32 clansmanId;
 
     uint8 startRegion;
@@ -694,6 +697,15 @@ interface IClanWorld is IClanWorldEvents {
     function getClansman(uint32 clansmanId) external view returns (Clansman memory);
 
     function getActiveMission(uint32 clansmanId) external view returns (Mission memory);
+
+    function getMissionTiming(uint32 clanId, uint32 clansmanId)
+        external
+        view
+        returns (uint64 submitted, uint64 executes, uint64 settles);
+
+    function getActionDuration(ActionType action) external pure returns (uint64);
+
+    function getTravelTicks(uint8 fromRegion, uint8 toRegion) external pure returns (uint64);
 
     function getBanditTroop(uint32 banditId) external view returns (BanditTroop memory);
 

--- a/packages/contracts/test/MissionTiming.t.sol
+++ b/packages/contracts/test/MissionTiming.t.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {
+    ClanWorldConstants,
+    ActionType,
+    StatusCode,
+    ClanFullView,
+    ClanOrder,
+    OrderResult,
+    Mission
+} from "../src/IClanWorld.sol";
+
+contract MissionTimingTest is Test {
+    ClanWorld world;
+    address elder = address(0xA1);
+
+    function setUp() public {
+        world = new ClanWorld();
+    }
+
+    function _advanceTick() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+    }
+
+    function _mintClan() internal returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
+    }
+
+    function _firstCs(uint32 clanId) internal view returns (uint32) {
+        ClanFullView memory view_ = world.getClanFullView(clanId);
+        return view_.clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _submitOrder(uint32 clanId, uint32 csId, uint8 gotoRegion, ActionType action)
+        internal
+        returns (OrderResult[] memory)
+    {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: gotoRegion,
+            action: action,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function test_submitStoresSubmittedExecutesAndSettlesTicks() public {
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+        uint64 submittedAt = world.getWorldState().currentTick;
+        uint64 travel = world.getTravelTicks(ClanWorldConstants.REGION_FOREST, ClanWorldConstants.REGION_MOUNTAINS);
+        uint64 duration = world.getActionDuration(ActionType.MineIron);
+
+        OrderResult[] memory results =
+            _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "order should be accepted");
+
+        Mission memory mission = world.getActiveMission(csId);
+        assertEq(mission.submittedAtTick, submittedAt, "submitted tick");
+        assertEq(mission.executesAtTick, submittedAt + travel, "executes tick");
+        assertEq(mission.settlesAtTick, submittedAt + travel + duration, "settles tick");
+
+        assertEq(mission.startTick, mission.submittedAtTick, "legacy start tick mirrors submitted");
+        assertEq(mission.actionStartTick, mission.executesAtTick, "legacy action start mirrors executes");
+
+        (uint64 submitted, uint64 executes, uint64 settles) = world.getMissionTiming(clanId, csId);
+        assertEq(submitted, mission.submittedAtTick, "getter submitted");
+        assertEq(executes, mission.executesAtTick, "getter executes");
+        assertEq(settles, mission.settlesAtTick, "getter settles");
+    }
+
+    function test_getActionDuration_eachActionType() public view {
+        assertEq(world.getActionDuration(ActionType.None), 0, "none");
+        assertEq(world.getActionDuration(ActionType.ChopWood), 4, "chop wood");
+        assertEq(world.getActionDuration(ActionType.MineIron), 4, "mine iron");
+        assertEq(world.getActionDuration(ActionType.FishDocks), 4, "fish docks");
+        assertEq(world.getActionDuration(ActionType.FishDeepSea), 4, "fish deep sea");
+        assertEq(world.getActionDuration(ActionType.HarvestWheat), 4, "harvest wheat");
+        assertEq(world.getActionDuration(ActionType.DepositResources), 1, "deposit");
+        assertEq(world.getActionDuration(ActionType.BuildWall), 1, "build wall");
+        assertEq(world.getActionDuration(ActionType.UpgradeBase), 1, "upgrade base");
+        assertEq(world.getActionDuration(ActionType.UpgradeMonument), 1, "upgrade monument");
+        assertEq(world.getActionDuration(ActionType.DefendBase), 0, "defend base");
+        assertEq(world.getActionDuration(ActionType.MarketBuy), 1, "market buy");
+        assertEq(world.getActionDuration(ActionType.MarketSell), 1, "market sell");
+        assertEq(world.getActionDuration(ActionType.Wait), 0, "wait");
+    }
+
+    function test_getTravelTicks_adjacentAndDistantMatchTable() public view {
+        assertEq(
+            world.getTravelTicks(ClanWorldConstants.REGION_FOREST, ClanWorldConstants.REGION_MOUNTAINS), 1, "adjacent"
+        );
+        assertEq(
+            world.getTravelTicks(ClanWorldConstants.REGION_FOREST, ClanWorldConstants.REGION_EAST_DOCKS), 4, "distant"
+        );
+        assertEq(
+            world.getTravelTicks(ClanWorldConstants.REGION_FOREST, ClanWorldConstants.REGION_FOREST), 0, "same region"
+        );
+    }
+
+    function test_missionOverwriteResetsSubmittedAtTick() public {
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory first = _submitOrder(clanId, csId, ClanWorldConstants.REGION_NOOP, ActionType.Wait);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first wait");
+        uint64 firstSubmitted = world.getActiveMission(csId).submittedAtTick;
+
+        _advanceTick();
+
+        OrderResult[] memory second = _submitOrder(clanId, csId, ClanWorldConstants.REGION_NOOP, ActionType.Wait);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "second wait");
+        uint64 secondSubmitted = world.getActiveMission(csId).submittedAtTick;
+
+        assertEq(firstSubmitted, 0, "first submit starts at tick 0");
+        assertEq(secondSubmitted, world.getWorldState().currentTick, "second submit uses current tick");
+        assertGt(secondSubmitted, firstSubmitted, "countdown restarts");
+    }
+
+    function test_getMissionTimingReturnsZerosForNonExistentMission() public view {
+        (uint64 submitted, uint64 executes, uint64 settles) = world.getMissionTiming(123, 456);
+
+        assertEq(submitted, 0, "submitted");
+        assertEq(executes, 0, "executes");
+        assertEq(settles, 0, "settles");
+    }
+}


### PR DESCRIPTION
Adds submittedAtTick / executesAtTick / settlesAtTick fields + getActionDuration / getTravelTicks pure getters. Tests cover travel + duration + overwrite reset. Closes #164.

Base: dev-phase-3-mission-core (Phase 3 stacked PR shape).