### PR TITLE
feat(contracts): Phase 3.4 — defend_base mission (Closes #165)

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -114,7 +114,7 @@
       ],
       "outputs": [
         {
-          "name": "clanIds",
+          "name": "clansmanIds",
           "type": "uint32[]",
           "internalType": "uint32[]"
         }

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1,11 +1,6 @@
 {
   "abi": [
     {
-      "type": "constructor",
-      "inputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
       "type": "function",
       "name": "finalizeSeason",
       "inputs": [],
@@ -105,7 +100,7 @@
           ]
         }
       ],
-      "stateMutability": "pure"
+      "stateMutability": "view"
     },
     {
       "type": "function",
@@ -119,7 +114,7 @@
       ],
       "outputs": [
         {
-          "name": "",
+          "name": "clanIds",
           "type": "uint32[]",
           "internalType": "uint32[]"
         }
@@ -319,26 +314,26 @@
       "name": "getBanditTargetPreview",
       "inputs": [
         {
-          "name": "",
+          "name": "banditId",
           "type": "uint32",
           "internalType": "uint32"
         }
       ],
       "outputs": [
         {
-          "name": "",
+          "name": "previewClanId",
           "type": "uint32",
           "internalType": "uint32"
         }
       ],
-      "stateMutability": "pure"
+      "stateMutability": "view"
     },
     {
       "type": "function",
       "name": "getBanditTroop",
       "inputs": [
         {
-          "name": "",
+          "name": "banditId",
           "type": "uint32",
           "internalType": "uint32"
         }
@@ -412,7 +407,7 @@
           ]
         }
       ],
-      "stateMutability": "pure"
+      "stateMutability": "view"
     },
     {
       "type": "function",
@@ -1077,6 +1072,25 @@
     },
     {
       "type": "function",
+      "name": "getDefendingClans",
+      "inputs": [
+        {
+          "name": "region",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "clanIds",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "getDerivedClanState",
       "inputs": [
         {
@@ -1532,6 +1546,11 @@
                   "internalType": "uint64"
                 },
                 {
+                  "name": "missionNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
                   "name": "clanId",
                   "type": "uint32",
                   "internalType": "uint32"
@@ -1575,6 +1594,11 @@
                 },
                 {
                   "name": "commitSequence",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "missionNonce",
                   "type": "uint64",
                   "internalType": "uint64"
                 },
@@ -1684,6 +1708,11 @@
             },
             {
               "name": "commitSequence",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "missionNonce",
               "type": "uint64",
               "internalType": "uint64"
             },
@@ -2066,6 +2095,24 @@
     },
     {
       "type": "function",
+      "name": "initTreasury",
+      "inputs": [
+        {
+          "name": "tokens",
+          "type": "address[6]",
+          "internalType": "address[6]"
+        },
+        {
+          "name": "pools",
+          "type": "address[4]",
+          "internalType": "address[4]"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
       "name": "mintClan",
       "inputs": [
         {
@@ -2100,7 +2147,7 @@
       ],
       "outputs": [
         {
-          "name": "",
+          "name": "lootValue",
           "type": "uint256",
           "internalType": "uint256"
         }
@@ -2119,7 +2166,7 @@
       ],
       "outputs": [
         {
-          "name": "",
+          "name": "lootValue",
           "type": "uint256",
           "internalType": "uint256"
         }
@@ -2160,7 +2207,7 @@
       "name": "seedPools",
       "inputs": [
         {
-          "name": "",
+          "name": "cfg",
           "type": "tuple",
           "internalType": "struct PoolSeedConfig",
           "components": [
@@ -2277,7 +2324,7 @@
       ],
       "outputs": [
         {
-          "name": "results",
+          "name": "",
           "type": "tuple[]",
           "internalType": "struct OrderResult[]",
           "components": [
@@ -2311,17 +2358,17 @@
       "name": "transferBlueprint",
       "inputs": [
         {
-          "name": "",
+          "name": "fromClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "toClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "amount",
           "type": "uint256",
           "internalType": "uint256"
         }
@@ -2334,42 +2381,42 @@
       "name": "transferBundle",
       "inputs": [
         {
-          "name": "",
+          "name": "fromClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "toClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "gold",
           "type": "uint256",
           "internalType": "uint256"
         },
         {
-          "name": "",
+          "name": "blueprint",
           "type": "uint256",
           "internalType": "uint256"
         },
         {
-          "name": "",
+          "name": "wood",
           "type": "uint256",
           "internalType": "uint256"
         },
         {
-          "name": "",
+          "name": "iron",
           "type": "uint256",
           "internalType": "uint256"
         },
         {
-          "name": "",
+          "name": "wheat",
           "type": "uint256",
           "internalType": "uint256"
         },
         {
-          "name": "",
+          "name": "fish",
           "type": "uint256",
           "internalType": "uint256"
         }
@@ -2382,17 +2429,17 @@
       "name": "transferGold",
       "inputs": [
         {
-          "name": "",
+          "name": "fromClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "toClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "amount",
           "type": "uint256",
           "internalType": "uint256"
         }
@@ -2405,22 +2452,22 @@
       "name": "transferVaultResource",
       "inputs": [
         {
-          "name": "",
+          "name": "fromClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "toClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "resource",
           "type": "uint8",
           "internalType": "enum ResourceType"
         },
         {
-          "name": "",
+          "name": "amount",
           "type": "uint256",
           "internalType": "uint256"
         }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -57,8 +57,9 @@ contract ClanWorld is IClanWorld {
     mapping(uint32 => Mission) private _missions; // keyed by clansmanId
     mapping(uint32 => WheatPlot[2]) private _wheatPlots; // [0]=west [1]=east
     mapping(uint64 => ScheduledMarketAction[]) private _scheduledMarketActions; // keyed by tick
-    mapping(uint32 => uint32[]) private _incomingDefenders; // targetClanId => clansmanIds
-    mapping(uint32 => uint32) private _clanDefendingBase; // clansmanId => targetClanId
+    mapping(uint8 => uint32[]) private _defendingClansByRegion; // home region => unique defending clanIds
+    mapping(uint8 => mapping(uint32 => uint256)) private _defenderCountByRegionClan; // region => clanId => clansmen count
+    mapping(uint32 => uint8) private _clansmanDefendingRegion; // clansmanId => defended home region
     mapping(uint64 => bytes32) private _tickSeeds; // tick => seed
 
     uint32 private _nextClanId;
@@ -299,11 +300,7 @@ contract ClanWorld is IClanWorld {
         if (cs.state == ClansmanState.DEAD) {
             if (m.active) {
                 if (m.action == ActionType.DefendBase) {
-                    uint32 oldTarget = _clanDefendingBase[cs.clansmanId];
-                    if (oldTarget != 0) {
-                        _removeDefender(oldTarget, cs.clansmanId);
-                        _clanDefendingBase[cs.clansmanId] = 0;
-                    }
+                    _clearDefender(cs.clansmanId);
                 }
                 m.active = false; // silent invalidation; dead clansman gets no MissionCompleted
             }
@@ -311,6 +308,7 @@ contract ClanWorld is IClanWorld {
         }
 
         if (!m.active) return; // no active mission — nothing to settle
+        if (m.action == ActionType.DefendBase) return; // persistent defender mission
 
         bytes32 tickSeed;
         for (uint64 tick = fromTick; tick < toTick; tick++) {
@@ -442,12 +440,7 @@ contract ClanWorld is IClanWorld {
             // NOOP — worker stays ACTING (continuous), no transition needed
             // Wait mission is effectively persistent until interrupted
         } else if (action == ActionType.DefendBase) {
-            // Register defender at arrival (not at submission) per v4.3 — ensures only arrived clansmen counted.
-            // Guard: only register once (this branch executes every ACTING tick; idempotent via _clanDefendingBase check).
-            if (_clanDefendingBase[cs.clansmanId] != m.targetClanId) {
-                _incomingDefenders[m.targetClanId].push(cs.clansmanId);
-                _clanDefendingBase[cs.clansmanId] = m.targetClanId;
-            }
+            // Persistent mission. Registration happens atomically at order submission.
         } else if (
             action == ActionType.BuildWall || action == ActionType.UpgradeBase || action == ActionType.UpgradeMonument
         ) {
@@ -1045,6 +1038,26 @@ contract ClanWorld is IClanWorld {
             result.status = StatusCode.ERR_CLANSMAN_DEAD;
             return result;
         }
+
+        if (order.action == ActionType.DefendBase) {
+            StatusCode defendErr = _validateDefendBaseOrder(clan, order, order.gotoRegion);
+            if (defendErr != StatusCode.OK) {
+                result.status = defendErr;
+                return result;
+            }
+
+            Mission storage currentM = _missions[order.clansmanId];
+            if (
+                currentM.active && currentM.action == ActionType.DefendBase && currentM.targetRegion == order.gotoRegion
+                    && currentM.targetClanId == order.targetClanId
+            ) {
+                result.status = StatusCode.OK;
+                result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
+                result.missionNonce = currentM.nonce;
+                return result;
+            }
+        }
+
         // Cooldown check
         if (block.timestamp < cs.cooldownEndsAtTs) {
             result.status = StatusCode.ERR_COOLDOWN_ACTIVE;
@@ -1057,8 +1070,9 @@ contract ClanWorld is IClanWorld {
         ctx.fromRegion = cs.currentRegion;
         ctx.gotoRegion = order.gotoRegion;
 
-        // NOOP bypass: treat 0 as "stay here"
-        ctx.isNoop = (ctx.gotoRegion == ClanWorldConstants.REGION_NOOP || ctx.gotoRegion == ctx.fromRegion);
+        // NOOP bypass: treat 0 as "stay here"; DefendBase requires explicit home region.
+        ctx.isNoop = order.action != ActionType.DefendBase
+            && (ctx.gotoRegion == ClanWorldConstants.REGION_NOOP || ctx.gotoRegion == ctx.fromRegion);
         if (ctx.isNoop) {
             ctx.gotoRegion = ctx.fromRegion;
         }
@@ -1081,8 +1095,8 @@ contract ClanWorld is IClanWorld {
         ctx.wasActive = existingM.active;
         ctx.oldNonce = existingM.nonce;
 
-        // Compute travel
-        ctx.travelTicks = _travelTicks(ctx.fromRegion, ctx.gotoRegion);
+        // Compute travel. DefendBase snaps to the home base immediately.
+        ctx.travelTicks = order.action == ActionType.DefendBase ? 0 : _travelTicks(ctx.fromRegion, ctx.gotoRegion);
         ctx.arrivalTick = _addTicksClamped(_world.currentTick, uint64(ctx.travelTicks));
 
         // New nonce
@@ -1104,15 +1118,7 @@ contract ClanWorld is IClanWorld {
         // Start cooldown
         cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
 
-        // DefendBase: deregister old assignment immediately (clansman is being re-tasked).
-        // Registration at the target base happens at arrival in _resolveAction (v4.3 — arrived defenders only).
-        {
-            uint32 oldTarget = _clanDefendingBase[cs.clansmanId];
-            if (oldTarget != 0) {
-                _removeDefender(oldTarget, cs.clansmanId);
-                _clanDefendingBase[cs.clansmanId] = 0;
-            }
-        }
+        _clearDefender(cs.clansmanId);
 
         // v4.2 §8 L758: "executes at heartbeat closing tick T" where T = arrivalTick.
         // executeAtTick = arrivalTick (not arrivalTick+1).
@@ -1120,12 +1126,8 @@ contract ClanWorld is IClanWorld {
             _enqueueScheduledMarketAction(clanId, order, cs.clansmanId, ctx.arrivalTick, ctx.newNonce);
         }
 
-        // DefendBase zero-travel: register synchronously so getActiveDefenders() has no drop window.
-        // When travelTicks == 0 the clansman is already at the target base — no travel window to wait out.
-        // The _resolveAction guard (clanDefendingBase != targetClanId) will be false next tick, preventing double-register.
-        if (order.action == ActionType.DefendBase && ctx.travelTicks == 0) {
-            _incomingDefenders[order.targetClanId].push(cs.clansmanId);
-            _clanDefendingBase[cs.clansmanId] = order.targetClanId;
+        if (order.action == ActionType.DefendBase) {
+            _registerDefender(ctx.gotoRegion, clanId, cs.clansmanId);
         }
 
         if (ctx.wasActive) {
@@ -1157,7 +1159,9 @@ contract ClanWorld is IClanWorld {
         m.clansmanId = cs.clansmanId;
         m.submittedAtTick = _world.currentTick;
         m.executesAtTick = ctx.arrivalTick;
-        m.settlesAtTick = _addTicksClamped(ctx.arrivalTick, getActionDuration(order.action));
+        m.settlesAtTick = order.action == ActionType.DefendBase
+            ? type(uint64).max
+            : _addTicksClamped(ctx.arrivalTick, getActionDuration(order.action));
         m.startRegion = ctx.fromRegion;
         m.targetRegion = ctx.gotoRegion;
         m.action = order.action;
@@ -1205,15 +1209,38 @@ contract ClanWorld is IClanWorld {
         );
     }
 
-    function _removeDefender(uint32 targetClanId, uint32 clansmanId) internal {
-        uint32[] storage defenders = _incomingDefenders[targetClanId];
-        for (uint256 i = 0; i < defenders.length; i++) {
-            if (defenders[i] == clansmanId) {
-                defenders[i] = defenders[defenders.length - 1];
-                defenders.pop();
-                break;
+    function _registerDefender(uint8 region, uint32 clanId, uint32 clansmanId) internal {
+        if (_clansmanDefendingRegion[clansmanId] == region) return;
+        _clearDefender(clansmanId);
+
+        if (_defenderCountByRegionClan[region][clanId] == 0) {
+            _defendingClansByRegion[region].push(clanId);
+        }
+        _defenderCountByRegionClan[region][clanId]++;
+        _clansmanDefendingRegion[clansmanId] = region;
+    }
+
+    function _clearDefender(uint32 clansmanId) internal {
+        uint8 region = _clansmanDefendingRegion[clansmanId];
+        if (region == 0) return;
+
+        uint32 clanId = _clansmen[clansmanId].clanId;
+        uint256 count = _defenderCountByRegionClan[region][clanId];
+        if (count > 1) {
+            _defenderCountByRegionClan[region][clanId] = count - 1;
+        } else {
+            delete _defenderCountByRegionClan[region][clanId];
+            uint32[] storage clans = _defendingClansByRegion[region];
+            for (uint256 i = 0; i < clans.length; i++) {
+                if (clans[i] == clanId) {
+                    clans[i] = clans[clans.length - 1];
+                    clans.pop();
+                    break;
+                }
             }
         }
+
+        delete _clansmanDefendingRegion[clansmanId];
     }
 
     // =========================================================================
@@ -1509,17 +1536,8 @@ contract ClanWorld is IClanWorld {
             }
         }
 
-        // DefendBase: targetClanId must be valid and gotoRegion must match target's baseRegion
         if (action == ActionType.DefendBase) {
-            if (order.targetClanId == 0 || _clans[order.targetClanId].clanId == 0) {
-                return StatusCode.ERR_INVALID_TARGET;
-            }
-            if (_clans[order.targetClanId].clanState == ClanState.DEAD) {
-                return StatusCode.ERR_NOT_DEFENDABLE;
-            }
-            if (gotoRegion != _clans[order.targetClanId].baseRegion) {
-                return StatusCode.ERR_NOT_AT_TARGET_BASE;
-            }
+            return _validateDefendBaseOrder(clan, order, gotoRegion);
         }
 
         // MarketBuy/MarketSell: must target Unicorn Town
@@ -1548,6 +1566,16 @@ contract ClanWorld is IClanWorld {
         }
 
         cs; // suppress unused warning
+        return StatusCode.OK;
+    }
+
+    function _validateDefendBaseOrder(Clan storage clan, ClanOrder calldata order, uint8 gotoRegion)
+        internal
+        view
+        returns (StatusCode)
+    {
+        if (gotoRegion != clan.baseRegion) return StatusCode.ERR_INVALID_REGION;
+        if (order.targetClanId != 0 && order.targetClanId != clan.clanId) return StatusCode.ERR_INVALID_TARGET;
         return StatusCode.OK;
     }
 
@@ -1713,7 +1741,11 @@ contract ClanWorld is IClanWorld {
     }
 
     function getActiveDefenders(uint32 targetClanId) external view override returns (uint32[] memory) {
-        return _incomingDefenders[targetClanId];
+        return _defendingClansByRegion[_clans[targetClanId].baseRegion];
+    }
+
+    function getDefendingClans(uint8 region) external view override returns (uint32[] memory) {
+        return _defendingClansByRegion[region];
     }
 
     // =========================================================================
@@ -1849,12 +1881,12 @@ contract ClanWorld is IClanWorld {
             clansmen[i] = ClansmanFullView({clansman: dcs, activeMission: m});
         }
 
-        // Find if any of this clan's clansmen is defending a base
+        // Find if any of this clan's clansmen is defending a home region.
         uint32 thisClanDefendingBaseId = 0;
         for (uint256 i = 0; i < csIds.length; i++) {
-            uint32 target = _clanDefendingBase[csIds[i]];
-            if (target != 0) {
-                thisClanDefendingBaseId = target;
+            uint8 region = _clansmanDefendingRegion[csIds[i]];
+            if (region != 0) {
+                thisClanDefendingBaseId = region;
                 break;
             }
         }
@@ -1864,7 +1896,7 @@ contract ClanWorld is IClanWorld {
             clansmen: clansmen,
             westPlot: _wheatPlots[clanId][0],
             eastPlot: _wheatPlots[clanId][1],
-            incomingDefenderIds: _incomingDefenders[clanId],
+            incomingDefenderIds: _defendingClansByRegion[clan.baseRegion],
             thisClanDefendingBaseId: thisClanDefendingBaseId
         });
     }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1740,8 +1740,32 @@ contract ClanWorld is IClanWorld {
         return _scheduledMarketActions[tick];
     }
 
-    function getActiveDefenders(uint32 targetClanId) external view override returns (uint32[] memory) {
-        return _defendingClansByRegion[_clans[targetClanId].baseRegion];
+    function getActiveDefenders(uint32 targetClanId) external view override returns (uint32[] memory clansmanIds) {
+        uint32[] storage defendingClans = _defendingClansByRegion[_clans[targetClanId].baseRegion];
+        uint256 count = 0;
+
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            uint32[] storage clanClansmen = _clanClansmanIds[defendingClans[i]];
+            for (uint256 j = 0; j < clanClansmen.length; j++) {
+                Mission storage mission = _missions[clanClansmen[j]];
+                if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId) {
+                    count++;
+                }
+            }
+        }
+
+        clansmanIds = new uint32[](count);
+        uint256 out = 0;
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            uint32[] storage clanClansmen = _clanClansmanIds[defendingClans[i]];
+            for (uint256 j = 0; j < clanClansmen.length; j++) {
+                uint32 clansmanId = clanClansmen[j];
+                Mission storage mission = _missions[clansmanId];
+                if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId) {
+                    clansmanIds[out++] = clansmanId;
+                }
+            }
+        }
     }
 
     function getDefendingClans(uint8 region) external view override returns (uint32[] memory) {

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -236,6 +236,10 @@ contract ClanWorldStub is IClanWorld {
         return new uint32[](0);
     }
 
+    function getDefendingClans(uint8) external pure override returns (uint32[] memory) {
+        return new uint32[](0);
+    }
+
     // -------------------------------------------------------------------------
     // Derived read getters
     // -------------------------------------------------------------------------

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -716,7 +716,7 @@ interface IClanWorld is IClanWorldEvents {
 
     function getScheduledMarketActionsForTick(uint64 tick) external view returns (ScheduledMarketAction[] memory);
 
-    function getActiveDefenders(uint32 targetClanId) external view returns (uint32[] memory clanIds);
+    function getActiveDefenders(uint32 targetClanId) external view returns (uint32[] memory clansmanIds);
 
     function getDefendingClans(uint8 region) external view returns (uint32[] memory clanIds);
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -427,8 +427,8 @@ struct ClanFullView {
     ClansmanFullView[] clansmen;
     WheatPlot westPlot;
     WheatPlot eastPlot;
-    uint32[] incomingDefenderIds; // workers from other clans defending us
-    uint32 thisClanDefendingBaseId; // 0 if none
+    uint32[] incomingDefenderIds; // legacy UI field; clanIds defending this clan's home region
+    uint32 thisClanDefendingBaseId; // defended home region, or 0 if none
 }
 
 struct PoolReserves {
@@ -716,7 +716,9 @@ interface IClanWorld is IClanWorldEvents {
 
     function getScheduledMarketActionsForTick(uint64 tick) external view returns (ScheduledMarketAction[] memory);
 
-    function getActiveDefenders(uint32 targetClanId) external view returns (uint32[] memory clansmanIds);
+    function getActiveDefenders(uint32 targetClanId) external view returns (uint32[] memory clanIds);
+
+    function getDefendingClans(uint8 region) external view returns (uint32[] memory clanIds);
 
     // -------------------------------------------------------------------------
     // Derived read getters (read-only simulation forward to current tick)

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -1101,9 +1101,9 @@ contract ClanWorldTest is Test {
         vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
         _advanceTick();
 
-        uint32[] memory defs = world.getActiveDefenders(clanId);
+        uint32[] memory defs = world.getDefendingClans(baseRegion);
         assertEq(defs.length, 1, "one defender registered");
-        assertEq(defs[0], csId, "csId is the defender");
+        assertEq(defs[0], clanId, "clanId is the defender");
 
         // Second DefendBase to same target: zero-travel re-task — the regression case.
         vm.prank(elder);
@@ -1111,9 +1111,9 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r2[0].status), uint8(StatusCode.OK), "re-task DefendBase OK");
 
         // Defender must NOT be dropped — fix must register synchronously.
-        defs = world.getActiveDefenders(clanId);
+        defs = world.getDefendingClans(baseRegion);
         assertEq(defs.length, 1, "defender count must not drop after re-task");
-        assertEq(defs[0], csId, "csId must still be defending after re-task");
+        assertEq(defs[0], clanId, "clanId must still be defending after re-task");
     }
 
     // =========================================================================

--- a/packages/contracts/test/DefendBase.t.sol
+++ b/packages/contracts/test/DefendBase.t.sol
@@ -182,6 +182,28 @@ contract DefendBaseTest is Test {
         _assertContains(defenders, seventhClanId);
     }
 
+    function test_getActiveDefenders_keepsTargetSpecificClansmanSemantics() public {
+        uint32 firstClanId = _mintClan();
+        uint8 sharedHome = world.getClan(firstClanId).baseRegion;
+        uint32 seventhClanId;
+        for (uint256 i = 0; i < 6; i++) {
+            seventhClanId = _mintClan();
+        }
+        assertEq(world.getClan(seventhClanId).baseRegion, sharedHome, "test setup shared home");
+
+        uint32 firstCsId = _firstCs(firstClanId);
+        uint32 seventhCsId = _firstCs(seventhClanId);
+        _submit(firstClanId, _defendOrder(firstCsId, sharedHome, firstClanId));
+        _submit(seventhClanId, _defendOrder(seventhCsId, sharedHome, seventhClanId));
+
+        uint32[] memory regionDefenders = world.getDefendingClans(sharedHome);
+        assertEq(regionDefenders.length, 2, "region index includes both defending clans");
+
+        uint32[] memory targetDefenders = world.getActiveDefenders(firstClanId);
+        assertEq(targetDefenders.length, 1, "target-specific getter excludes same-region defenders");
+        assertEq(targetDefenders[0], firstCsId, "returns target-specific clansman id");
+    }
+
     function test_nonDefendBaseMissionOverwritesDefendBase_dropsDefenderIndex() public {
         uint32 clanId = _mintClan();
         Clan memory clan = world.getClan(clanId);

--- a/packages/contracts/test/DefendBase.t.sol
+++ b/packages/contracts/test/DefendBase.t.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {
+    ClanWorldConstants,
+    ClansmanState,
+    ActionType,
+    StatusCode,
+    Clan,
+    Clansman,
+    Mission,
+    ClanOrder,
+    OrderResult
+} from "../src/IClanWorld.sol";
+
+contract DefendBaseTest is Test {
+    ClanWorld world;
+    address elder = address(0xA1);
+
+    function setUp() public {
+        world = new ClanWorld();
+    }
+
+    function _mintClan() internal returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
+    }
+
+    function _firstCs(uint32 clanId) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _defendOrder(uint32 csId, uint8 region, uint32 targetClanId) internal pure returns (ClanOrder[] memory) {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: region,
+            action: ActionType.DefendBase,
+            targetClanId: targetClanId,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        return orders;
+    }
+
+    function _waitOrder(uint32 csId, uint8 region) internal pure returns (ClanOrder[] memory) {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: region,
+            action: ActionType.Wait,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        return orders;
+    }
+
+    function _submit(uint32 clanId, ClanOrder[] memory orders) internal returns (OrderResult[] memory) {
+        vm.prank(elder);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _warpCooldown() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS);
+    }
+
+    function _otherRegion(uint8 homeRegion) internal pure returns (uint8) {
+        return homeRegion == ClanWorldConstants.REGION_FOREST
+            ? ClanWorldConstants.REGION_MOUNTAINS
+            : ClanWorldConstants.REGION_FOREST;
+    }
+
+    function _assertContains(uint32[] memory values, uint32 needle) internal pure {
+        for (uint256 i = 0; i < values.length; i++) {
+            if (values[i] == needle) return;
+        }
+        revert("missing expected clanId");
+    }
+
+    function test_submitDefendBaseAtHome_succeedsImmediatePersistent() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+        uint64 submittedAtTick = world.getWorldState().currentTick;
+
+        OrderResult[] memory results = _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "defend_base status");
+        assertEq(results[0].missionNonce, 1, "first nonce");
+
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(uint8(cs.state), uint8(ClansmanState.ACTING), "defender acts immediately");
+        assertEq(cs.currentRegion, clan.baseRegion, "defender is at home");
+
+        Mission memory mission = world.getActiveMission(csId);
+        assertTrue(mission.active, "mission stays active");
+        assertEq(uint8(mission.action), uint8(ActionType.DefendBase), "mission action");
+        assertEq(mission.startTick, submittedAtTick, "start tick");
+        assertEq(mission.arrivalTick, submittedAtTick, "arrival tick");
+        assertEq(mission.actionStartTick, submittedAtTick, "action tick");
+
+        uint32[] memory defenders = world.getDefendingClans(clan.baseRegion);
+        assertEq(defenders.length, 1, "one defending clan");
+        assertEq(defenders[0], clanId, "defending clan id");
+
+        _warpCooldown();
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+        world.settleClan(clanId);
+
+        assertTrue(world.getActiveMission(csId).active, "defend_base does not settle complete");
+        assertEq(uint8(world.getClansman(csId).state), uint8(ClansmanState.ACTING), "still acting");
+    }
+
+    function test_submitDefendBaseAtNonHome_failsInvalidRegion() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory results = _submit(clanId, _defendOrder(csId, _otherRegion(clan.baseRegion), 0));
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.ERR_INVALID_REGION), "non-home defend rejected");
+        assertEq(world.getDefendingClans(clan.baseRegion).length, 0, "no defender registered");
+    }
+
+    function test_resubmitSameDefendBase_isNoopNonceUnchanged() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory first = _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+        uint64 cooldown = world.getClansman(csId).cooldownEndsAtTs;
+
+        OrderResult[] memory second = _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first status");
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "same-target no-op status");
+        assertEq(second[0].missionNonce, first[0].missionNonce, "nonce unchanged");
+        assertEq(world.getClansman(csId).lastMissionNonce, first[0].missionNonce, "stored nonce unchanged");
+        assertEq(world.getClansman(csId).cooldownEndsAtTs, cooldown, "cooldown unchanged");
+        assertEq(world.getDefendingClans(clan.baseRegion).length, 1, "no duplicate defender");
+    }
+
+    function test_resubmitDifferentDefendBaseTarget_isRealRetaskNoDuplicate() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory first = _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+        _warpCooldown();
+
+        OrderResult[] memory second = _submit(clanId, _defendOrder(csId, clan.baseRegion, clanId));
+
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "changed target accepted");
+        assertEq(second[0].missionNonce, first[0].missionNonce + 1, "nonce increments");
+        assertEq(world.getActiveMission(csId).targetClanId, clanId, "target changed");
+        uint32[] memory defenders = world.getDefendingClans(clan.baseRegion);
+        assertEq(defenders.length, 1, "old defender index entry replaced");
+        assertEq(defenders[0], clanId, "defender remains registered once");
+    }
+
+    function test_getDefendingClans_returnsAllCurrentlyDefendingClans() public {
+        uint32 firstClanId = _mintClan();
+        uint8 sharedHome = world.getClan(firstClanId).baseRegion;
+        uint32 seventhClanId;
+        for (uint256 i = 0; i < 6; i++) {
+            seventhClanId = _mintClan();
+        }
+        assertEq(world.getClan(seventhClanId).baseRegion, sharedHome, "test setup shared home");
+
+        _submit(firstClanId, _defendOrder(_firstCs(firstClanId), sharedHome, 0));
+        _submit(seventhClanId, _defendOrder(_firstCs(seventhClanId), sharedHome, 0));
+
+        uint32[] memory defenders = world.getDefendingClans(sharedHome);
+        assertEq(defenders.length, 2, "two defending clans");
+        _assertContains(defenders, firstClanId);
+        _assertContains(defenders, seventhClanId);
+    }
+
+    function test_nonDefendBaseMissionOverwritesDefendBase_dropsDefenderIndex() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+
+        _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+        assertEq(world.getDefendingClans(clan.baseRegion).length, 1, "defender registered");
+
+        _warpCooldown();
+        OrderResult[] memory results = _submit(clanId, _waitOrder(csId, clan.baseRegion));
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "wait retask accepted");
+        assertEq(world.getDefendingClans(clan.baseRegion).length, 0, "defender dropped");
+        assertEq(uint8(world.getActiveMission(csId).action), uint8(ActionType.Wait), "mission overwritten");
+    }
+}


### PR DESCRIPTION
Adds DefendBase ActionType with atomic same-target re-task semantics. New index getDefendingClans(region) for Phase 9 consumption. Closes #165.

Base: dev-phase-3-mission-core (Phase 3 stacked PR shape).