### PR TITLE
feat(contracts): Phase 3 — mission assignment + lazy settlement core

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1,11 +1,6 @@
 {
   "abi": [
     {
-      "type": "constructor",
-      "inputs": [],
-      "stateMutability": "nonpayable"
-    },
-    {
       "type": "function",
       "name": "finalizeSeason",
       "inputs": [],
@@ -105,7 +100,7 @@
           ]
         }
       ],
-      "stateMutability": "pure"
+      "stateMutability": "view"
     },
     {
       "type": "function",
@@ -119,7 +114,7 @@
       ],
       "outputs": [
         {
-          "name": "",
+          "name": "clansmanIds",
           "type": "uint32[]",
           "internalType": "uint32[]"
         }
@@ -319,26 +314,26 @@
       "name": "getBanditTargetPreview",
       "inputs": [
         {
-          "name": "",
+          "name": "banditId",
           "type": "uint32",
           "internalType": "uint32"
         }
       ],
       "outputs": [
         {
-          "name": "",
+          "name": "previewClanId",
           "type": "uint32",
           "internalType": "uint32"
         }
       ],
-      "stateMutability": "pure"
+      "stateMutability": "view"
     },
     {
       "type": "function",
       "name": "getBanditTroop",
       "inputs": [
         {
-          "name": "",
+          "name": "banditId",
           "type": "uint32",
           "internalType": "uint32"
         }
@@ -412,7 +407,7 @@
           ]
         }
       ],
-      "stateMutability": "pure"
+      "stateMutability": "view"
     },
     {
       "type": "function",
@@ -1077,6 +1072,25 @@
     },
     {
       "type": "function",
+      "name": "getDefendingClans",
+      "inputs": [
+        {
+          "name": "region",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "clanIds",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "getDerivedClanState",
       "inputs": [
         {
@@ -1532,6 +1546,11 @@
                   "internalType": "uint64"
                 },
                 {
+                  "name": "missionNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
                   "name": "clanId",
                   "type": "uint32",
                   "internalType": "uint32"
@@ -1575,6 +1594,11 @@
                 },
                 {
                   "name": "commitSequence",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "missionNonce",
                   "type": "uint64",
                   "internalType": "uint64"
                 },
@@ -1684,6 +1708,11 @@
             },
             {
               "name": "commitSequence",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "missionNonce",
               "type": "uint64",
               "internalType": "uint64"
             },
@@ -2066,6 +2095,24 @@
     },
     {
       "type": "function",
+      "name": "initTreasury",
+      "inputs": [
+        {
+          "name": "tokens",
+          "type": "address[6]",
+          "internalType": "address[6]"
+        },
+        {
+          "name": "pools",
+          "type": "address[4]",
+          "internalType": "address[4]"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
       "name": "mintClan",
       "inputs": [
         {
@@ -2100,7 +2147,7 @@
       ],
       "outputs": [
         {
-          "name": "",
+          "name": "lootValue",
           "type": "uint256",
           "internalType": "uint256"
         }
@@ -2119,7 +2166,7 @@
       ],
       "outputs": [
         {
-          "name": "",
+          "name": "lootValue",
           "type": "uint256",
           "internalType": "uint256"
         }
@@ -2160,7 +2207,7 @@
       "name": "seedPools",
       "inputs": [
         {
-          "name": "",
+          "name": "cfg",
           "type": "tuple",
           "internalType": "struct PoolSeedConfig",
           "components": [
@@ -2277,7 +2324,7 @@
       ],
       "outputs": [
         {
-          "name": "results",
+          "name": "",
           "type": "tuple[]",
           "internalType": "struct OrderResult[]",
           "components": [
@@ -2311,17 +2358,17 @@
       "name": "transferBlueprint",
       "inputs": [
         {
-          "name": "",
+          "name": "fromClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "toClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "amount",
           "type": "uint256",
           "internalType": "uint256"
         }
@@ -2334,42 +2381,42 @@
       "name": "transferBundle",
       "inputs": [
         {
-          "name": "",
+          "name": "fromClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "toClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "gold",
           "type": "uint256",
           "internalType": "uint256"
         },
         {
-          "name": "",
+          "name": "blueprint",
           "type": "uint256",
           "internalType": "uint256"
         },
         {
-          "name": "",
+          "name": "wood",
           "type": "uint256",
           "internalType": "uint256"
         },
         {
-          "name": "",
+          "name": "iron",
           "type": "uint256",
           "internalType": "uint256"
         },
         {
-          "name": "",
+          "name": "wheat",
           "type": "uint256",
           "internalType": "uint256"
         },
         {
-          "name": "",
+          "name": "fish",
           "type": "uint256",
           "internalType": "uint256"
         }
@@ -2382,17 +2429,17 @@
       "name": "transferGold",
       "inputs": [
         {
-          "name": "",
+          "name": "fromClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "toClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "amount",
           "type": "uint256",
           "internalType": "uint256"
         }
@@ -2405,22 +2452,22 @@
       "name": "transferVaultResource",
       "inputs": [
         {
-          "name": "",
+          "name": "fromClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "toClanId",
           "type": "uint32",
           "internalType": "uint32"
         },
         {
-          "name": "",
+          "name": "resource",
           "type": "uint8",
           "internalType": "enum ResourceType"
         },
         {
-          "name": "",
+          "name": "amount",
           "type": "uint256",
           "internalType": "uint256"
         }

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -153,6 +153,21 @@
               "internalType": "uint64"
             },
             {
+              "name": "submittedAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "executesAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "settlesAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
               "name": "clansmanId",
               "type": "uint32",
               "internalType": "uint32"
@@ -221,6 +236,83 @@
         }
       ],
       "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMissionTiming",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "submitted",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "executes",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "settles",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getActionDuration",
+      "inputs": [
+        {
+          "name": "action",
+          "type": "uint8",
+          "internalType": "enum ActionType"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getTravelTicks",
+      "inputs": [
+        {
+          "name": "fromRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "toRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
     },
     {
       "type": "function",
@@ -651,6 +743,21 @@
                           "internalType": "uint64"
                         },
                         {
+                          "name": "submittedAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "executesAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "settlesAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
                           "name": "clansmanId",
                           "type": "uint32",
                           "internalType": "uint32"
@@ -741,6 +848,21 @@
                     },
                     {
                       "name": "nonce",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "submittedAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "executesAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "settlesAtTick",
                       "type": "uint64",
                       "internalType": "uint64"
                     },
@@ -1171,6 +1293,21 @@
                 },
                 {
                   "name": "nonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "submittedAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "executesAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "settlesAtTick",
                   "type": "uint64",
                   "internalType": "uint64"
                 },

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -57,8 +57,9 @@ contract ClanWorld is IClanWorld {
     mapping(uint32 => Mission) private _missions; // keyed by clansmanId
     mapping(uint32 => WheatPlot[2]) private _wheatPlots; // [0]=west [1]=east
     mapping(uint64 => ScheduledMarketAction[]) private _scheduledMarketActions; // keyed by tick
-    mapping(uint32 => uint32[]) private _incomingDefenders; // targetClanId => clansmanIds
-    mapping(uint32 => uint32) private _clanDefendingBase; // clansmanId => targetClanId
+    mapping(uint8 => uint32[]) private _defendingClansByRegion; // home region => unique defending clanIds
+    mapping(uint8 => mapping(uint32 => uint256)) private _defenderCountByRegionClan; // region => clanId => clansmen count
+    mapping(uint32 => uint8) private _clansmanDefendingRegion; // clansmanId => defended home region
     mapping(uint64 => bytes32) private _tickSeeds; // tick => seed
 
     uint32 private _nextClanId;
@@ -299,11 +300,7 @@ contract ClanWorld is IClanWorld {
         if (cs.state == ClansmanState.DEAD) {
             if (m.active) {
                 if (m.action == ActionType.DefendBase) {
-                    uint32 oldTarget = _clanDefendingBase[cs.clansmanId];
-                    if (oldTarget != 0) {
-                        _removeDefender(oldTarget, cs.clansmanId);
-                        _clanDefendingBase[cs.clansmanId] = 0;
-                    }
+                    _clearDefender(cs.clansmanId);
                 }
                 m.active = false; // silent invalidation; dead clansman gets no MissionCompleted
             }
@@ -311,6 +308,7 @@ contract ClanWorld is IClanWorld {
         }
 
         if (!m.active) return; // no active mission — nothing to settle
+        if (m.action == ActionType.DefendBase) return; // persistent defender mission
 
         bytes32 tickSeed;
         for (uint64 tick = fromTick; tick < toTick; tick++) {
@@ -442,12 +440,7 @@ contract ClanWorld is IClanWorld {
             // NOOP — worker stays ACTING (continuous), no transition needed
             // Wait mission is effectively persistent until interrupted
         } else if (action == ActionType.DefendBase) {
-            // Register defender at arrival (not at submission) per v4.3 — ensures only arrived clansmen counted.
-            // Guard: only register once (this branch executes every ACTING tick; idempotent via _clanDefendingBase check).
-            if (_clanDefendingBase[cs.clansmanId] != m.targetClanId) {
-                _incomingDefenders[m.targetClanId].push(cs.clansmanId);
-                _clanDefendingBase[cs.clansmanId] = m.targetClanId;
-            }
+            // Persistent mission. Registration happens atomically at order submission.
         } else if (
             action == ActionType.BuildWall || action == ActionType.UpgradeBase || action == ActionType.UpgradeMonument
         ) {
@@ -1045,6 +1038,26 @@ contract ClanWorld is IClanWorld {
             result.status = StatusCode.ERR_CLANSMAN_DEAD;
             return result;
         }
+
+        if (order.action == ActionType.DefendBase) {
+            StatusCode defendErr = _validateDefendBaseOrder(clan, order, order.gotoRegion);
+            if (defendErr != StatusCode.OK) {
+                result.status = defendErr;
+                return result;
+            }
+
+            Mission storage currentM = _missions[order.clansmanId];
+            if (
+                currentM.active && currentM.action == ActionType.DefendBase && currentM.targetRegion == order.gotoRegion
+                    && currentM.targetClanId == order.targetClanId
+            ) {
+                result.status = StatusCode.OK;
+                result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
+                result.missionNonce = currentM.nonce;
+                return result;
+            }
+        }
+
         // Cooldown check
         if (block.timestamp < cs.cooldownEndsAtTs) {
             result.status = StatusCode.ERR_COOLDOWN_ACTIVE;
@@ -1057,8 +1070,9 @@ contract ClanWorld is IClanWorld {
         ctx.fromRegion = cs.currentRegion;
         ctx.gotoRegion = order.gotoRegion;
 
-        // NOOP bypass: treat 0 as "stay here"
-        ctx.isNoop = (ctx.gotoRegion == ClanWorldConstants.REGION_NOOP || ctx.gotoRegion == ctx.fromRegion);
+        // NOOP bypass: treat 0 as "stay here"; DefendBase requires explicit home region.
+        ctx.isNoop = order.action != ActionType.DefendBase
+            && (ctx.gotoRegion == ClanWorldConstants.REGION_NOOP || ctx.gotoRegion == ctx.fromRegion);
         if (ctx.isNoop) {
             ctx.gotoRegion = ctx.fromRegion;
         }
@@ -1081,8 +1095,8 @@ contract ClanWorld is IClanWorld {
         ctx.wasActive = existingM.active;
         ctx.oldNonce = existingM.nonce;
 
-        // Compute travel
-        ctx.travelTicks = _travelTicks(ctx.fromRegion, ctx.gotoRegion);
+        // Compute travel. DefendBase snaps to the home base immediately.
+        ctx.travelTicks = order.action == ActionType.DefendBase ? 0 : _travelTicks(ctx.fromRegion, ctx.gotoRegion);
         ctx.arrivalTick = _addTicksClamped(_world.currentTick, uint64(ctx.travelTicks));
 
         // New nonce
@@ -1104,15 +1118,7 @@ contract ClanWorld is IClanWorld {
         // Start cooldown
         cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
 
-        // DefendBase: deregister old assignment immediately (clansman is being re-tasked).
-        // Registration at the target base happens at arrival in _resolveAction (v4.3 — arrived defenders only).
-        {
-            uint32 oldTarget = _clanDefendingBase[cs.clansmanId];
-            if (oldTarget != 0) {
-                _removeDefender(oldTarget, cs.clansmanId);
-                _clanDefendingBase[cs.clansmanId] = 0;
-            }
-        }
+        _clearDefender(cs.clansmanId);
 
         // v4.2 §8 L758: "executes at heartbeat closing tick T" where T = arrivalTick.
         // executeAtTick = arrivalTick (not arrivalTick+1).
@@ -1120,12 +1126,8 @@ contract ClanWorld is IClanWorld {
             _enqueueScheduledMarketAction(clanId, order, cs.clansmanId, ctx.arrivalTick, ctx.newNonce);
         }
 
-        // DefendBase zero-travel: register synchronously so getActiveDefenders() has no drop window.
-        // When travelTicks == 0 the clansman is already at the target base — no travel window to wait out.
-        // The _resolveAction guard (clanDefendingBase != targetClanId) will be false next tick, preventing double-register.
-        if (order.action == ActionType.DefendBase && ctx.travelTicks == 0) {
-            _incomingDefenders[order.targetClanId].push(cs.clansmanId);
-            _clanDefendingBase[cs.clansmanId] = order.targetClanId;
+        if (order.action == ActionType.DefendBase) {
+            _registerDefender(ctx.gotoRegion, clanId, cs.clansmanId);
         }
 
         if (ctx.wasActive) {
@@ -1157,7 +1159,9 @@ contract ClanWorld is IClanWorld {
         m.clansmanId = cs.clansmanId;
         m.submittedAtTick = _world.currentTick;
         m.executesAtTick = ctx.arrivalTick;
-        m.settlesAtTick = _addTicksClamped(ctx.arrivalTick, getActionDuration(order.action));
+        m.settlesAtTick = order.action == ActionType.DefendBase
+            ? type(uint64).max
+            : _addTicksClamped(ctx.arrivalTick, getActionDuration(order.action));
         m.startRegion = ctx.fromRegion;
         m.targetRegion = ctx.gotoRegion;
         m.action = order.action;
@@ -1205,15 +1209,38 @@ contract ClanWorld is IClanWorld {
         );
     }
 
-    function _removeDefender(uint32 targetClanId, uint32 clansmanId) internal {
-        uint32[] storage defenders = _incomingDefenders[targetClanId];
-        for (uint256 i = 0; i < defenders.length; i++) {
-            if (defenders[i] == clansmanId) {
-                defenders[i] = defenders[defenders.length - 1];
-                defenders.pop();
-                break;
+    function _registerDefender(uint8 region, uint32 clanId, uint32 clansmanId) internal {
+        if (_clansmanDefendingRegion[clansmanId] == region) return;
+        _clearDefender(clansmanId);
+
+        if (_defenderCountByRegionClan[region][clanId] == 0) {
+            _defendingClansByRegion[region].push(clanId);
+        }
+        _defenderCountByRegionClan[region][clanId]++;
+        _clansmanDefendingRegion[clansmanId] = region;
+    }
+
+    function _clearDefender(uint32 clansmanId) internal {
+        uint8 region = _clansmanDefendingRegion[clansmanId];
+        if (region == 0) return;
+
+        uint32 clanId = _clansmen[clansmanId].clanId;
+        uint256 count = _defenderCountByRegionClan[region][clanId];
+        if (count > 1) {
+            _defenderCountByRegionClan[region][clanId] = count - 1;
+        } else {
+            delete _defenderCountByRegionClan[region][clanId];
+            uint32[] storage clans = _defendingClansByRegion[region];
+            for (uint256 i = 0; i < clans.length; i++) {
+                if (clans[i] == clanId) {
+                    clans[i] = clans[clans.length - 1];
+                    clans.pop();
+                    break;
+                }
             }
         }
+
+        delete _clansmanDefendingRegion[clansmanId];
     }
 
     // =========================================================================
@@ -1509,17 +1536,8 @@ contract ClanWorld is IClanWorld {
             }
         }
 
-        // DefendBase: targetClanId must be valid and gotoRegion must match target's baseRegion
         if (action == ActionType.DefendBase) {
-            if (order.targetClanId == 0 || _clans[order.targetClanId].clanId == 0) {
-                return StatusCode.ERR_INVALID_TARGET;
-            }
-            if (_clans[order.targetClanId].clanState == ClanState.DEAD) {
-                return StatusCode.ERR_NOT_DEFENDABLE;
-            }
-            if (gotoRegion != _clans[order.targetClanId].baseRegion) {
-                return StatusCode.ERR_NOT_AT_TARGET_BASE;
-            }
+            return _validateDefendBaseOrder(clan, order, gotoRegion);
         }
 
         // MarketBuy/MarketSell: must target Unicorn Town
@@ -1548,6 +1566,16 @@ contract ClanWorld is IClanWorld {
         }
 
         cs; // suppress unused warning
+        return StatusCode.OK;
+    }
+
+    function _validateDefendBaseOrder(Clan storage clan, ClanOrder calldata order, uint8 gotoRegion)
+        internal
+        view
+        returns (StatusCode)
+    {
+        if (gotoRegion != clan.baseRegion) return StatusCode.ERR_INVALID_REGION;
+        if (order.targetClanId != 0 && order.targetClanId != clan.clanId) return StatusCode.ERR_INVALID_TARGET;
         return StatusCode.OK;
     }
 
@@ -1712,8 +1740,36 @@ contract ClanWorld is IClanWorld {
         return _scheduledMarketActions[tick];
     }
 
-    function getActiveDefenders(uint32 targetClanId) external view override returns (uint32[] memory) {
-        return _incomingDefenders[targetClanId];
+    function getActiveDefenders(uint32 targetClanId) external view override returns (uint32[] memory clansmanIds) {
+        uint32[] storage defendingClans = _defendingClansByRegion[_clans[targetClanId].baseRegion];
+        uint256 count = 0;
+
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            uint32[] storage clanClansmen = _clanClansmanIds[defendingClans[i]];
+            for (uint256 j = 0; j < clanClansmen.length; j++) {
+                Mission storage mission = _missions[clanClansmen[j]];
+                if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId) {
+                    count++;
+                }
+            }
+        }
+
+        clansmanIds = new uint32[](count);
+        uint256 out = 0;
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            uint32[] storage clanClansmen = _clanClansmanIds[defendingClans[i]];
+            for (uint256 j = 0; j < clanClansmen.length; j++) {
+                uint32 clansmanId = clanClansmen[j];
+                Mission storage mission = _missions[clansmanId];
+                if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId) {
+                    clansmanIds[out++] = clansmanId;
+                }
+            }
+        }
+    }
+
+    function getDefendingClans(uint8 region) external view override returns (uint32[] memory) {
+        return _defendingClansByRegion[region];
     }
 
     // =========================================================================
@@ -1849,12 +1905,12 @@ contract ClanWorld is IClanWorld {
             clansmen[i] = ClansmanFullView({clansman: dcs, activeMission: m});
         }
 
-        // Find if any of this clan's clansmen is defending a base
+        // Find if any of this clan's clansmen is defending a home region.
         uint32 thisClanDefendingBaseId = 0;
         for (uint256 i = 0; i < csIds.length; i++) {
-            uint32 target = _clanDefendingBase[csIds[i]];
-            if (target != 0) {
-                thisClanDefendingBaseId = target;
+            uint8 region = _clansmanDefendingRegion[csIds[i]];
+            if (region != 0) {
+                thisClanDefendingBaseId = region;
                 break;
             }
         }
@@ -1864,7 +1920,7 @@ contract ClanWorld is IClanWorld {
             clansmen: clansmen,
             westPlot: _wheatPlots[clanId][0],
             eastPlot: _wheatPlots[clanId][1],
-            incomingDefenderIds: _incomingDefenders[clanId],
+            incomingDefenderIds: _defendingClansByRegion[clan.baseRegion],
             thisClanDefendingBaseId: thisClanDefendingBaseId
         });
     }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -53,7 +53,7 @@ contract ClanWorld is IClanWorld {
     TreasuryState private _treasury;
 
     mapping(uint32 => Clan) private _clans;
-    mapping(uint32 => Clansman) private _clansmen;
+    mapping(uint32 => Clansman) internal _clansmen;
     mapping(uint32 => Mission) private _missions; // keyed by clansmanId
     mapping(uint32 => WheatPlot[2]) private _wheatPlots; // [0]=west [1]=east
     mapping(uint64 => ScheduledMarketAction[]) private _scheduledMarketActions; // keyed by tick
@@ -805,9 +805,10 @@ contract ClanWorld is IClanWorld {
         return true;
     }
 
-    /// @dev Complete a mission: set worker to WAITING, mark mission inactive, emit event.
+    /// @dev Complete a mission: set worker to WAITING, set cooldown, mark mission inactive, emit event.
     function _completeMission(Clansman storage cs, Mission storage m) internal {
         cs.state = ClansmanState.WAITING;
+        cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
         m.active = false;
         emit MissionCompleted(_clans[cs.clanId].clanId, cs.clansmanId, m.nonce, m.action);
     }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -308,7 +308,6 @@ contract ClanWorld is IClanWorld {
         }
 
         if (!m.active) return; // no active mission — nothing to settle
-        if (m.action == ActionType.DefendBase) return; // persistent defender mission
 
         bytes32 tickSeed;
         for (uint64 tick = fromTick; tick < toTick; tick++) {
@@ -319,11 +318,20 @@ contract ClanWorld is IClanWorld {
                 cs.state = ClansmanState.ACTING;
                 cs.currentRegion = m.targetRegion;
                 emit WorkerArrived(clanId, cs.clansmanId, m.targetRegion, tick);
+
+                if (m.action == ActionType.DefendBase) {
+                    _registerDefender(m.targetRegion, clanId, cs.clansmanId);
+                }
             }
 
-            // Path 3: ACTING at/past actionStartTick → resolve
-            if (cs.state == ClansmanState.ACTING && tick >= m.actionStartTick) {
+            if (m.action == ActionType.DefendBase) continue; // persistent defender mission
+
+            // Path 3: ACTING at/past settlesAtTick → resolve
+            if (cs.state == ClansmanState.ACTING && tick >= m.settlesAtTick) {
                 _resolveAction(clan, cs, m, clanId, tick, tickSeed);
+                if (m.active && getActionDuration(m.action) > 0) {
+                    _completeMission(cs, m);
+                }
             }
 
             // If mission completed during this tick, stop iterating
@@ -1018,6 +1026,7 @@ contract ClanWorld is IClanWorld {
         uint8 travelTicks;
         uint64 arrivalTick;
         uint64 newNonce;
+        uint32 targetClanId;
         bool wasActive;
         uint64 oldNonce;
     }
@@ -1046,10 +1055,11 @@ contract ClanWorld is IClanWorld {
                 return result;
             }
 
+            uint32 defendTargetClanId = order.targetClanId == 0 ? clanId : order.targetClanId;
             Mission storage currentM = _missions[order.clansmanId];
             if (
                 currentM.active && currentM.action == ActionType.DefendBase && currentM.targetRegion == order.gotoRegion
-                    && currentM.targetClanId == order.targetClanId
+                    && currentM.targetClanId == defendTargetClanId
             ) {
                 result.status = StatusCode.OK;
                 result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
@@ -1069,6 +1079,8 @@ contract ClanWorld is IClanWorld {
         OrderCtx memory ctx;
         ctx.fromRegion = cs.currentRegion;
         ctx.gotoRegion = order.gotoRegion;
+        ctx.targetClanId =
+            order.action == ActionType.DefendBase && order.targetClanId == 0 ? clanId : order.targetClanId;
 
         // NOOP bypass: treat 0 as "stay here"; DefendBase requires explicit home region.
         ctx.isNoop = order.action != ActionType.DefendBase
@@ -1095,8 +1107,8 @@ contract ClanWorld is IClanWorld {
         ctx.wasActive = existingM.active;
         ctx.oldNonce = existingM.nonce;
 
-        // Compute travel. DefendBase snaps to the home base immediately.
-        ctx.travelTicks = order.action == ActionType.DefendBase ? 0 : _travelTicks(ctx.fromRegion, ctx.gotoRegion);
+        // Compute travel from the clansman's current region to the order target.
+        ctx.travelTicks = _travelTicks(ctx.fromRegion, ctx.gotoRegion);
         ctx.arrivalTick = _addTicksClamped(_world.currentTick, uint64(ctx.travelTicks));
 
         // New nonce
@@ -1126,7 +1138,7 @@ contract ClanWorld is IClanWorld {
             _enqueueScheduledMarketAction(clanId, order, cs.clansmanId, ctx.arrivalTick, ctx.newNonce);
         }
 
-        if (order.action == ActionType.DefendBase) {
+        if (order.action == ActionType.DefendBase && ctx.travelTicks == 0) {
             _registerDefender(ctx.gotoRegion, clanId, cs.clansmanId);
         }
 
@@ -1172,7 +1184,7 @@ contract ClanWorld is IClanWorld {
         m.marketMode = (order.action == ActionType.MarketBuy || order.action == ActionType.MarketSell)
             ? MarketExecutionMode.Scheduled
             : MarketExecutionMode.None;
-        m.targetClanId = order.targetClanId;
+        m.targetClanId = ctx.targetClanId;
         m.marketToken = order.marketToken;
         m.marketAmount = order.marketAmount;
         m.maxGoldIn = order.maxGoldIn;

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -275,6 +275,11 @@ contract ClanWorld is IClanWorld {
         return _distMatrix(fromRegion, toRegion);
     }
 
+    function _addTicksClamped(uint64 tick, uint64 delta) private pure returns (uint64) {
+        if (type(uint64).max - tick < delta) return type(uint64).max;
+        return tick + delta;
+    }
+
     // =========================================================================
     // INTERNAL SETTLEMENT
     // =========================================================================
@@ -1078,7 +1083,7 @@ contract ClanWorld is IClanWorld {
 
         // Compute travel
         ctx.travelTicks = _travelTicks(ctx.fromRegion, ctx.gotoRegion);
-        ctx.arrivalTick = _world.currentTick + uint64(ctx.travelTicks);
+        ctx.arrivalTick = _addTicksClamped(_world.currentTick, uint64(ctx.travelTicks));
 
         // New nonce
         ctx.newNonce = cs.lastMissionNonce + 1;
@@ -1150,6 +1155,9 @@ contract ClanWorld is IClanWorld {
         m.active = true;
         m.nonce = ctx.newNonce;
         m.clansmanId = cs.clansmanId;
+        m.submittedAtTick = _world.currentTick;
+        m.executesAtTick = ctx.arrivalTick;
+        m.settlesAtTick = _addTicksClamped(ctx.arrivalTick, getActionDuration(order.action));
         m.startRegion = ctx.fromRegion;
         m.targetRegion = ctx.gotoRegion;
         m.action = order.action;
@@ -1630,6 +1638,42 @@ contract ClanWorld is IClanWorld {
 
     function getActiveMission(uint32 clansmanId) external view override returns (Mission memory) {
         return _missions[clansmanId];
+    }
+
+    function getMissionTiming(uint32 clanId, uint32 clansmanId)
+        external
+        view
+        override
+        returns (uint64 submitted, uint64 executes, uint64 settles)
+    {
+        Mission memory m = _missions[clansmanId];
+        if (!m.active || _clansmen[clansmanId].clanId != clanId) {
+            return (0, 0, 0);
+        }
+        return (m.submittedAtTick, m.executesAtTick, m.settlesAtTick);
+    }
+
+    function getActionDuration(ActionType action) public pure override returns (uint64) {
+        if (
+            action == ActionType.ChopWood || action == ActionType.MineIron || action == ActionType.FishDocks
+                || action == ActionType.FishDeepSea || action == ActionType.HarvestWheat
+        ) {
+            return 4;
+        }
+
+        if (
+            action == ActionType.DepositResources || action == ActionType.BuildWall || action == ActionType.UpgradeBase
+                || action == ActionType.UpgradeMonument || action == ActionType.MarketBuy
+                || action == ActionType.MarketSell
+        ) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    function getTravelTicks(uint8 fromRegion, uint8 toRegion) external pure override returns (uint64) {
+        return uint64(_travelTicks(fromRegion, toRegion));
     }
 
     function getBanditTroop(uint32) external pure override returns (BanditTroop memory) {

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -279,6 +279,55 @@ contract ClanWorld is IClanWorld {
     // INTERNAL SETTLEMENT
     // =========================================================================
 
+    /// @dev Settle a single clansman's mission for the tick range [fromTick, toTick).
+    ///      Handles all 6 mission lifecycle paths. Called from _settleClan and settleClansman.
+    function _settleMissionForClansman(
+        Clan storage clan,
+        Clansman storage cs,
+        uint32 clanId,
+        uint64 fromTick,
+        uint64 toTick
+    ) internal {
+        Mission storage m = _missions[cs.clansmanId];
+
+        // Path 6: dead clansman — invalidate active mission if any
+        if (cs.state == ClansmanState.DEAD) {
+            if (m.active) {
+                if (m.action == ActionType.DefendBase) {
+                    uint32 oldTarget = _clanDefendingBase[cs.clansmanId];
+                    if (oldTarget != 0) {
+                        _removeDefender(oldTarget, cs.clansmanId);
+                        _clanDefendingBase[cs.clansmanId] = 0;
+                    }
+                }
+                m.active = false; // silent invalidation; dead clansman gets no MissionCompleted
+            }
+            return;
+        }
+
+        if (!m.active) return; // no active mission — nothing to settle
+
+        bytes32 tickSeed;
+        for (uint64 tick = fromTick; tick < toTick; tick++) {
+            tickSeed = _tickSeeds[tick];
+
+            // Path 1 → Path 2 transition: TRAVELING → ACTING at arrivalTick
+            if (cs.state == ClansmanState.TRAVELING && tick >= m.arrivalTick) {
+                cs.state = ClansmanState.ACTING;
+                cs.currentRegion = m.targetRegion;
+                emit WorkerArrived(clanId, cs.clansmanId, m.targetRegion, tick);
+            }
+
+            // Path 3: ACTING at/past actionStartTick → resolve
+            if (cs.state == ClansmanState.ACTING && tick >= m.actionStartTick) {
+                _resolveAction(clan, cs, m, clanId, tick, tickSeed);
+            }
+
+            // If mission completed during this tick, stop iterating
+            if (!m.active) break;
+        }
+    }
+
     /// @dev Lazy settlement of a clan forward to currentTick.
     ///      Mutates storage. Called before order submission and by public settleClan().
     function _settleClan(uint32 clanId) internal {
@@ -313,27 +362,10 @@ contract ClanWorld is IClanWorld {
                 }
             }
 
-            // 3. Advance each clansman
-            bytes32 tickSeed = _tickSeeds[tick];
+            // 3. Advance each clansman (single-tick range: [tick, tick+1))
             for (uint256 i = 0; i < clansmanIds.length; i++) {
-                uint32 csId = clansmanIds[i];
-                Clansman storage cs = _clansmen[csId];
-                if (cs.state == ClansmanState.DEAD) continue;
-
-                Mission storage m = _missions[csId];
-                if (!m.active) continue;
-
-                // Travel advancement: if still traveling and this tick >= arrivalTick, arrive
-                if (cs.state == ClansmanState.TRAVELING && tick >= m.arrivalTick) {
-                    cs.state = ClansmanState.ACTING;
-                    cs.currentRegion = m.targetRegion;
-                    emit WorkerArrived(clanId, csId, m.targetRegion, tick);
-                }
-
-                // Action resolution: if acting and this tick >= actionStartTick
-                if (cs.state == ClansmanState.ACTING && tick >= m.actionStartTick) {
-                    _resolveAction(clan, cs, m, clanId, tick, tickSeed);
-                }
+                Clansman storage cs = _clansmen[clansmanIds[i]];
+                _settleMissionForClansman(clan, cs, clanId, tick, tick + 1);
             }
         }
 
@@ -841,6 +873,16 @@ contract ClanWorld is IClanWorld {
     /// @notice Public settlement trigger — lazily settle a clan.
     function settleClan(uint32 clanId) external override {
         _settleClan(clanId);
+    }
+
+    /// @notice Lazily settle a single clansman's mission to current tick. Idempotent.
+    ///         Internally settles the entire clan (including upkeep) to guarantee
+    ///         correct ordering and prevent double-settlement. Callers may call this
+    ///         or settleClan interchangeably; both are safe and idempotent.
+    function settleClansman(uint32 csId) external override {
+        Clansman storage cs = _clansmen[csId];
+        if (cs.clansmanId == 0) return;
+        _settleClan(cs.clanId);
     }
 
     /// @notice Finalize season. Phase 1 stub.

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -236,6 +236,10 @@ contract ClanWorldStub is IClanWorld {
         return new uint32[](0);
     }
 
+    function getDefendingClans(uint8) external pure override returns (uint32[] memory) {
+        return new uint32[](0);
+    }
+
     // -------------------------------------------------------------------------
     // Derived read getters
     // -------------------------------------------------------------------------

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -170,6 +170,9 @@ contract ClanWorldStub is IClanWorld {
         return Mission({
             active: false,
             nonce: 0,
+            submittedAtTick: 0,
+            executesAtTick: 0,
+            settlesAtTick: 0,
             clansmanId: 0,
             startRegion: 0,
             targetRegion: 0,
@@ -184,6 +187,23 @@ contract ClanWorldStub is IClanWorld {
             marketAmount: 0,
             maxGoldIn: 0
         });
+    }
+
+    function getMissionTiming(uint32, uint32)
+        external
+        pure
+        override
+        returns (uint64 submitted, uint64 executes, uint64 settles)
+    {
+        return (0, 0, 0);
+    }
+
+    function getActionDuration(ActionType) external pure override returns (uint64) {
+        return 0;
+    }
+
+    function getTravelTicks(uint8, uint8) external pure override returns (uint64) {
+        return 0;
     }
 
     function getBanditTroop(uint32) external pure override returns (BanditTroop memory) {

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -76,6 +76,8 @@ contract ClanWorldStub is IClanWorld {
 
     function settleClan(uint32) external override {}
 
+    function settleClansman(uint32) external override {}
+
     function finalizeSeason() external override {}
 
     // -------------------------------------------------------------------------

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -273,6 +273,9 @@ struct Mission {
     bool active;
 
     uint64 nonce;
+    uint64 submittedAtTick;
+    uint64 executesAtTick;
+    uint64 settlesAtTick;
     uint32 clansmanId;
 
     uint8 startRegion;
@@ -697,6 +700,15 @@ interface IClanWorld is IClanWorldEvents {
     function getClansman(uint32 clansmanId) external view returns (Clansman memory);
 
     function getActiveMission(uint32 clansmanId) external view returns (Mission memory);
+
+    function getMissionTiming(uint32 clanId, uint32 clansmanId)
+        external
+        view
+        returns (uint64 submitted, uint64 executes, uint64 settles);
+
+    function getActionDuration(ActionType action) external pure returns (uint64);
+
+    function getTravelTicks(uint8 fromRegion, uint8 toRegion) external pure returns (uint64);
 
     function getBanditTroop(uint32 banditId) external view returns (BanditTroop memory);
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -427,8 +427,8 @@ struct ClanFullView {
     ClansmanFullView[] clansmen;
     WheatPlot westPlot;
     WheatPlot eastPlot;
-    uint32[] incomingDefenderIds; // workers from other clans defending us
-    uint32 thisClanDefendingBaseId; // 0 if none
+    uint32[] incomingDefenderIds; // legacy UI field; clanIds defending this clan's home region
+    uint32 thisClanDefendingBaseId; // defended home region, or 0 if none
 }
 
 struct PoolReserves {
@@ -717,6 +717,8 @@ interface IClanWorld is IClanWorldEvents {
     function getScheduledMarketActionsForTick(uint64 tick) external view returns (ScheduledMarketAction[] memory);
 
     function getActiveDefenders(uint32 targetClanId) external view returns (uint32[] memory clansmanIds);
+
+    function getDefendingClans(uint8 region) external view returns (uint32[] memory clanIds);
 
     // -------------------------------------------------------------------------
     // Derived read getters (read-only simulation forward to current tick)

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -634,6 +634,9 @@ interface IClanWorld is IClanWorldEvents {
     /// @notice Lazily settle a clan forward to current tick. Idempotent.
     function settleClan(uint32 clanId) external;
 
+    /// @notice Lazily settle a single clansman's mission to current tick. Idempotent.
+    function settleClansman(uint32 csId) external;
+
     /// @notice Finalize the current season. Permissionless after seasonEndTick.
     function finalizeSeason() external;
 

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -1414,6 +1414,361 @@ contract ClanWorldTest is Test {
         assertEq(m.nonce, 2, "3.E7: active mission nonce must be 2");
     }
 
+    // =========================================================================
+    // Phase 3.2 Lazy Settlement Engine Tests
+    // =========================================================================
+
+    // Helper: harness-based setup for Path 6 and other tests needing killClansman
+    function _setupHarness() internal returns (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) {
+        harness = new ClanWorldTestHarness();
+        vm.prank(elder);
+        (clanId,) = harness.mintClan(elder);
+        csId = harness.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    // Helper: submit an order on a harness-based world
+    function _submitOrderHarness(
+        ClanWorldTestHarness harness,
+        uint32 clanId,
+        uint32 csId,
+        uint8 gotoRegion,
+        ActionType action
+    ) internal returns (OrderResult[] memory) {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: gotoRegion,
+            action: action,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        return harness.submitClanOrders(clanId, orders);
+    }
+
+    // Helper: advance tick on a harness-based world
+    function _advanceTickHarness(ClanWorldTestHarness harness) internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        harness.heartbeat();
+    }
+
+    // -------------------------------------------------------------------------
+    // test_lazySettle_path1_noopBeforeArrival
+    // Path 1: TRAVELING, currentTick < arrivalTick → no-op
+    // -------------------------------------------------------------------------
+
+    function test_lazySettle_path1_noopBeforeArrival() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        uint8 homeRegion = v.clan.clan.baseRegion; // Forest (region 1) for first clan
+
+        // Travel from Forest(1) to Mountains(2) is 1 tick — clansman starts TRAVELING
+        (uint8 travelTicks,) = world.quoteTravel(homeRegion, ClanWorldConstants.REGION_MOUNTAINS);
+        assertGt(travelTicks, 0, "path1: need travel > 0 ticks");
+
+        OrderResult[] memory r = _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK));
+
+        // Clansman should be TRAVELING before arrival
+        Clansman memory csNow = world.getClansman(csId);
+        assertEq(uint8(csNow.state), uint8(ClansmanState.TRAVELING), "path1: should be TRAVELING after submission");
+        assertTrue(world.getActiveMission(csId).active, "path1: mission should be active");
+
+        // Call settleClansman without advancing any ticks (same tick as submission)
+        world.settleClansman(csId);
+
+        // State must be unchanged — still TRAVELING, no iron
+        Clansman memory csAfter = world.getClansman(csId);
+        assertEq(uint8(csAfter.state), uint8(ClansmanState.TRAVELING), "path1: must still be TRAVELING (no ticks passed)");
+        assertEq(csAfter.carryIron, 0, "path1: no iron gathered (haven't arrived)");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_lazySettle_path2_arrivalTransition
+    // Path 2: TRAVELING → ACTING at arrivalTick
+    // -------------------------------------------------------------------------
+
+    function test_lazySettle_path2_arrivalTransition() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        uint8 homeRegion = v.clan.clan.baseRegion;
+
+        // Travel Forest(1) → Mountains(2) = 1 tick
+        (uint8 travelTicks,) = world.quoteTravel(homeRegion, ClanWorldConstants.REGION_MOUNTAINS);
+        assertGt(travelTicks, 0, "path2: need travel > 0 ticks");
+
+        _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+
+        // arrivalTick = currentTick + travelTicks. Settlement processes [lastSettledTick, currentTick).
+        // To include arrivalTick in the settled range we need currentTick > arrivalTick,
+        // i.e. currentTick >= arrivalTick + 1, so advance travelTicks + 1 ticks.
+        for (uint256 i = 0; i < uint256(travelTicks) + 1; i++) {
+            _advanceTick();
+        }
+
+        // Call settleClansman on-demand
+        world.settleClansman(csId);
+
+        // Clansman should have transitioned to ACTING at the target region
+        Clansman memory csAfter = world.getClansman(csId);
+        assertEq(uint8(csAfter.state), uint8(ClansmanState.ACTING), "path2: must be ACTING after arrival");
+        assertEq(csAfter.currentRegion, ClanWorldConstants.REGION_MOUNTAINS, "path2: currentRegion must be Mountains");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_lazySettle_path3_settleOnCompletion
+    // Path 3: ACTING + tick >= actionStartTick → resolves action
+    // -------------------------------------------------------------------------
+
+    function test_lazySettle_path3_settleOnCompletion() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        uint8 homeRegion = v.clan.clan.baseRegion;
+
+        (uint8 travelTicks,) = world.quoteTravel(homeRegion, ClanWorldConstants.REGION_MOUNTAINS);
+        _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+
+        // Advance travelTicks + 1 action tick
+        for (uint256 i = 0; i < uint256(travelTicks) + 1; i++) {
+            _advanceTick();
+        }
+
+        // settleClan triggers the full settlement path
+        world.settleClan(clanId);
+
+        // Clansman should have mined some iron
+        Clansman memory csAfter = world.getClansman(csId);
+        assertGt(csAfter.carryIron, 0, "path3: clansman should have gathered iron after action resolved");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_lazySettle_path4_missionOverwrite
+    // Path 4: mission overwrite mid-flight — old mission gone, new mission executes
+    // -------------------------------------------------------------------------
+
+    function test_lazySettle_path4_missionOverwrite() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        uint8 homeRegion = v.clan.clan.baseRegion;
+
+        // Submit mission 1: FishDocks to EastDocks (region 7) — from Forest homebase, that's
+        // 4 ticks of travel (Forest→Mountains→UnicornTown→EastFarms→EastDocks), ensuring the
+        // clansman is still TRAVELING when interrupted after just 1 tick.
+        (uint8 travelTicks1,) = world.quoteTravel(homeRegion, ClanWorldConstants.REGION_EAST_DOCKS);
+        assertGt(travelTicks1, 1, "path4: first mission needs > 1 tick travel so it stays TRAVELING after 1 tick");
+
+        OrderResult[] memory r1 = _submitOrder(clanId, csId, ClanWorldConstants.REGION_EAST_DOCKS, ActionType.FishDocks);
+        assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "path4: first order must succeed");
+        uint64 nonce1 = r1[0].missionNonce;
+        assertEq(nonce1, 1, "path4: first nonce must be 1");
+
+        // Advance only 1 tick — first mission still TRAVELING (arrivalTick is 4 ticks away)
+        // Wait for cooldown and advance 1 tick, then interrupt
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
+        _advanceTick();
+
+        // Confirm clansman is still TRAVELING (hasn't reached EastDocks yet)
+        assertEq(uint8(world.getClansman(csId).state), uint8(ClansmanState.TRAVELING), "path4: must still be TRAVELING before interrupt");
+
+        // Overwrite with MineIron to Mountains
+        OrderResult[] memory r2 = _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+        assertEq(uint8(r2[0].status), uint8(StatusCode.OK), "path4: interrupt order must succeed");
+        uint64 nonce2 = r2[0].missionNonce;
+        assertEq(nonce2, 2, "path4: second nonce must be 2");
+
+        // Active mission must now be MineIron (nonce 2)
+        Mission memory m = world.getActiveMission(csId);
+        assertTrue(m.active, "path4: mission must be active");
+        assertEq(m.nonce, 2, "path4: active mission nonce must be 2");
+        assertEq(uint8(m.action), uint8(ActionType.MineIron), "path4: active mission action must be MineIron");
+
+        // Advance until new mission resolves (from current position after 1 tick)
+        // clansman was re-tasked from its current region; compute remaining travel
+        uint8 csRegionNow = world.getClansman(csId).currentRegion;
+        (uint8 travelToMountains,) = world.quoteTravel(csRegionNow, ClanWorldConstants.REGION_MOUNTAINS);
+        for (uint256 i = 0; i < uint256(travelToMountains) + 1; i++) {
+            _advanceTick();
+        }
+        world.settleClan(clanId);
+
+        // Must have iron (new mission executed), must have NO fish (old mission never arrived)
+        Clansman memory csAfter = world.getClansman(csId);
+        assertGt(csAfter.carryIron, 0, "path4: new mission (MineIron) should have executed");
+        assertEq(csAfter.carryFish, 0, "path4: old mission (FishDocks) must not have executed (clansman never arrived)");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_lazySettle_path5_defendBaseNeverSettles
+    // Path 5: DefendBase → clansman stays ACTING indefinitely, mission stays active
+    // -------------------------------------------------------------------------
+
+    function test_lazySettle_path5_defendBaseNeverSettles() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        uint8 baseRegion = v.clan.clan.baseRegion;
+
+        // Submit DefendBase to own clan's base (zero travel)
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: baseRegion,
+            action: ActionType.DefendBase,
+            targetClanId: clanId,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        OrderResult[] memory r = world.submitClanOrders(clanId, orders);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "path5: DefendBase order must succeed");
+
+        // Advance 5 ticks and settle
+        for (uint256 i = 0; i < 5; i++) {
+            _advanceTick();
+        }
+        world.settleClan(clanId);
+
+        // Clansman must still be ACTING (DefendBase never completes the mission)
+        Clansman memory csAfter = world.getClansman(csId);
+        assertEq(uint8(csAfter.state), uint8(ClansmanState.ACTING), "path5: DefendBase clansman must stay ACTING");
+        assertTrue(world.getActiveMission(csId).active, "path5: DefendBase mission must stay active");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_lazySettle_path6_deadClansmanMidMission
+    // Path 6: dead clansman mid-mission → mission invalidated
+    // -------------------------------------------------------------------------
+
+    function test_lazySettle_path6_deadClansmanMidMission() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClanFullView(clanId).clan.clan.baseRegion;
+
+        // Submit ChopWood to a region that requires travel (so clansman is TRAVELING)
+        // From Forest homebase, go to Mountains (1 tick travel)
+        (uint8 travelTicks,) = harness.quoteTravel(homeRegion, ClanWorldConstants.REGION_MOUNTAINS);
+        assertGt(travelTicks, 0, "path6: need travel > 0 so clansman is TRAVELING when killed");
+
+        OrderResult[] memory r = _submitOrderHarness(harness, clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "path6: order must succeed");
+        assertTrue(harness.getActiveMission(csId).active, "path6: mission must be active before kill");
+
+        // Kill clansman while it's mid-mission (TRAVELING)
+        harness.killClansman(csId);
+        assertEq(uint8(harness.getClansman(csId).state), uint8(ClansmanState.DEAD), "path6: clansman must be DEAD");
+
+        // Settle the clan — should trigger path 6 handling
+        _advanceTickHarness(harness);
+        harness.settleClan(clanId);
+
+        // Mission must be invalidated (active = false)
+        Mission memory m = harness.getActiveMission(csId);
+        assertFalse(m.active, "path6: mission must be inactive after clansman died");
+
+        // Clansman must still be DEAD (no resurrection)
+        assertEq(uint8(harness.getClansman(csId).state), uint8(ClansmanState.DEAD), "path6: clansman must remain DEAD");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_lazySettle_path6_deadDefender_cleanedFromRegistry
+    // Path 6 + DefendBase: dead defending clansman must be removed from registry
+    // -------------------------------------------------------------------------
+
+    function test_lazySettle_path6_deadDefender_cleanedFromRegistry() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 baseRegion = harness.getClanFullView(clanId).clan.clan.baseRegion;
+
+        // Submit DefendBase to own base (zero travel → immediately registered)
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: baseRegion,
+            action: ActionType.DefendBase,
+            targetClanId: clanId,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        OrderResult[] memory r = harness.submitClanOrders(clanId, orders);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "path6-defender: DefendBase order must succeed");
+
+        // Confirm clansman is registered as a defender
+        uint32[] memory defs = harness.getActiveDefenders(clanId);
+        assertEq(defs.length, 1, "path6-defender: should have 1 defender before kill");
+
+        // Kill the clansman
+        harness.killClansman(csId);
+        assertEq(uint8(harness.getClansman(csId).state), uint8(ClansmanState.DEAD), "path6-defender: clansman must be DEAD");
+
+        // Settle the clan — triggers Path 6, should remove from registry
+        _advanceTickHarness(harness);
+        harness.settleClan(clanId);
+
+        // Defender must be removed from registry
+        uint32[] memory defsAfter = harness.getActiveDefenders(clanId);
+        assertEq(defsAfter.length, 0, "path6-defender: dead defender must be removed from registry");
+
+        // Mission must be inactive
+        assertFalse(harness.getActiveMission(csId).active, "path6-defender: mission must be inactive");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_lazySettle_settleClansman_onDemand
+    // settleClansman settles a single clansman without settleClan
+    // -------------------------------------------------------------------------
+
+    function test_lazySettle_settleClansman_onDemand() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        uint8 homeRegion = v.clan.clan.baseRegion;
+
+        // Submit MineIron — requires travel to Mountains
+        (uint8 travelTicks,) = world.quoteTravel(homeRegion, ClanWorldConstants.REGION_MOUNTAINS);
+        _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+
+        // Advance past travel + 1 action tick WITHOUT calling settleClan
+        for (uint256 i = 0; i < uint256(travelTicks) + 1; i++) {
+            _advanceTick();
+        }
+
+        // Verify: raw storage not yet updated (settleClan not called)
+        assertEq(world.getClansman(csId).carryIron, 0, "onDemand: carryIron must be 0 before settleClansman");
+
+        // Call settleClansman on-demand — only this clansman's mission should resolve
+        world.settleClansman(csId);
+
+        // Verify: clansman now has iron (settled on demand)
+        assertGt(world.getClansman(csId).carryIron, 0, "onDemand: carryIron must be > 0 after settleClansman");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_lazySettle_settleClansman_noopIfUpToDate
+    // settleClansman is a no-op when clan is already settled
+    // -------------------------------------------------------------------------
+
+    function test_lazySettle_settleClansman_noopIfUpToDate() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+
+        // No ticks advanced — clan is already up to date
+        // settleClansman must not revert and must leave state unchanged
+        world.settleClansman(csId);
+
+        Clansman memory csAfter = world.getClansman(csId);
+        assertEq(uint8(csAfter.state), uint8(ClansmanState.WAITING), "noop: state must be unchanged");
+        assertEq(csAfter.carryIron, 0, "noop: carryIron must be 0");
+        assertEq(csAfter.carryWood, 0, "noop: carryWood must be 0");
+    }
+
     // -------------------------------------------------------------------------
     // 3.E8: Partial batch — mixed results across 4 orders
     // -------------------------------------------------------------------------

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -343,8 +343,8 @@ contract ClanWorldTest is Test {
             assertEq(uint8(csTraveling.state), uint8(ClansmanState.TRAVELING), "should be TRAVELING before arrival");
         }
 
-        // Advance past travel ticks + 1 action tick
-        uint256 ticksToAdvance = uint256(travelTicks) + 1;
+        // Advance until the arrival tick and four-tick action duration have both closed.
+        uint256 ticksToAdvance = uint256(travelTicks) + world.getActionDuration(ActionType.MineIron) + 1;
         for (uint256 i = 0; i < ticksToAdvance; i++) {
             _advanceTick();
         }
@@ -375,8 +375,8 @@ contract ClanWorldTest is Test {
         (uint8 travelToMountains,) = world.quoteTravel(homeRegion, targetRegion);
         _submitOrder(clanId, cs0, targetRegion, ActionType.MineIron);
 
-        // Advance past travel + 1 action tick to gather some iron
-        for (uint256 i = 0; i < uint256(travelToMountains) + 1; i++) {
+        // Advance through travel and the four-tick mining duration.
+        for (uint256 i = 0; i < uint256(travelToMountains) + world.getActionDuration(ActionType.MineIron) + 1; i++) {
             _advanceTick();
         }
         world.settleClan(clanId);
@@ -390,9 +390,9 @@ contract ClanWorldTest is Test {
         vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
         _submitOrder(clanId, cs0, homeRegion, ActionType.DepositResources);
 
-        // Advance travel back to homebase + 1 action tick
+        // Advance travel back to homebase + deposit duration.
         (uint8 travelBack,) = world.quoteTravel(targetRegion, homeRegion);
-        for (uint256 i = 0; i < uint256(travelBack) + 1; i++) {
+        for (uint256 i = 0; i < uint256(travelBack) + world.getActionDuration(ActionType.DepositResources) + 1; i++) {
             _advanceTick();
         }
         world.settleClan(clanId);
@@ -838,7 +838,11 @@ contract ClanWorldTest is Test {
         uint256 overflowCount = totalQueuedForTickTwo - cap;
         ScheduledMarketAction[] memory mergedQueue = world.getScheduledMarketActionsForTick(nextTick);
         assertEq(mergedQueue.length, overflowCount + 1, "overflow should merge with native next-tick action");
-        assertEq(mergedQueue[mergedQueue.length - 1].commitSequence, nativeSeq, "native action must stay after older overflow");
+        assertEq(
+            mergedQueue[mergedQueue.length - 1].commitSequence,
+            nativeSeq,
+            "native action must stay after older overflow"
+        );
         for (uint256 i = 1; i < mergedQueue.length; i++) {
             assertGt(mergedQueue[i].commitSequence, mergedQueue[i - 1].commitSequence, "merged queue must be FIFO");
         }
@@ -1240,8 +1244,8 @@ contract ClanWorldTest is Test {
         // Wait for submit-time cooldown to expire (warp only; no ticks yet)
         vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
 
-        // Advance 1 tick — clansman is already at homebase (NOOP), actionStartTick=currentTick,
-        // so the next closed tick resolves the deposit (empty carry → _completeMission).
+        // Advance until the one-tick deposit duration has closed.
+        _advanceTick();
         _advanceTick();
 
         // Settle the clan — mission completes, clansman back to WAITING with new cooldown
@@ -1378,9 +1382,7 @@ contract ClanWorldTest is Test {
 
         // FishDocks to Forest (not WestDocks or EastDocks) → ERR_INVALID_REGION
         OrderResult[] memory r2 = _submitOrder(clanId, cs2, ClanWorldConstants.REGION_FOREST, ActionType.FishDocks);
-        assertEq(
-            uint8(r2[0].status), uint8(StatusCode.ERR_INVALID_REGION), "3.E6: FishDocks to Forest must be invalid"
-        );
+        assertEq(uint8(r2[0].status), uint8(StatusCode.ERR_INVALID_REGION), "3.E6: FishDocks to Forest must be invalid");
     }
 
     // -------------------------------------------------------------------------
@@ -1482,7 +1484,9 @@ contract ClanWorldTest is Test {
 
         // State must be unchanged — still TRAVELING, no iron
         Clansman memory csAfter = world.getClansman(csId);
-        assertEq(uint8(csAfter.state), uint8(ClansmanState.TRAVELING), "path1: must still be TRAVELING (no ticks passed)");
+        assertEq(
+            uint8(csAfter.state), uint8(ClansmanState.TRAVELING), "path1: must still be TRAVELING (no ticks passed)"
+        );
         assertEq(csAfter.carryIron, 0, "path1: no iron gathered (haven't arrived)");
     }
 
@@ -1521,7 +1525,7 @@ contract ClanWorldTest is Test {
 
     // -------------------------------------------------------------------------
     // test_lazySettle_path3_settleOnCompletion
-    // Path 3: ACTING + tick >= actionStartTick → resolves action
+    // Path 3: ACTING + tick >= settlesAtTick → resolves action
     // -------------------------------------------------------------------------
 
     function test_lazySettle_path3_settleOnCompletion() public {
@@ -1533,8 +1537,8 @@ contract ClanWorldTest is Test {
         (uint8 travelTicks,) = world.quoteTravel(homeRegion, ClanWorldConstants.REGION_MOUNTAINS);
         _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
 
-        // Advance travelTicks + 1 action tick
-        for (uint256 i = 0; i < uint256(travelTicks) + 1; i++) {
+        // Advance through travel and the four-tick mining duration.
+        for (uint256 i = 0; i < uint256(travelTicks) + world.getActionDuration(ActionType.MineIron) + 1; i++) {
             _advanceTick();
         }
 
@@ -1574,7 +1578,11 @@ contract ClanWorldTest is Test {
         _advanceTick();
 
         // Confirm clansman is still TRAVELING (hasn't reached EastDocks yet)
-        assertEq(uint8(world.getClansman(csId).state), uint8(ClansmanState.TRAVELING), "path4: must still be TRAVELING before interrupt");
+        assertEq(
+            uint8(world.getClansman(csId).state),
+            uint8(ClansmanState.TRAVELING),
+            "path4: must still be TRAVELING before interrupt"
+        );
 
         // Overwrite with MineIron to Mountains
         OrderResult[] memory r2 = _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
@@ -1592,7 +1600,7 @@ contract ClanWorldTest is Test {
         // clansman was re-tasked from its current region; compute remaining travel
         uint8 csRegionNow = world.getClansman(csId).currentRegion;
         (uint8 travelToMountains,) = world.quoteTravel(csRegionNow, ClanWorldConstants.REGION_MOUNTAINS);
-        for (uint256 i = 0; i < uint256(travelToMountains) + 1; i++) {
+        for (uint256 i = 0; i < uint256(travelToMountains) + world.getActionDuration(ActionType.MineIron) + 1; i++) {
             _advanceTick();
         }
         world.settleClan(clanId);
@@ -1655,7 +1663,8 @@ contract ClanWorldTest is Test {
         (uint8 travelTicks,) = harness.quoteTravel(homeRegion, ClanWorldConstants.REGION_MOUNTAINS);
         assertGt(travelTicks, 0, "path6: need travel > 0 so clansman is TRAVELING when killed");
 
-        OrderResult[] memory r = _submitOrderHarness(harness, clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+        OrderResult[] memory r =
+            _submitOrderHarness(harness, clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "path6: order must succeed");
         assertTrue(harness.getActiveMission(csId).active, "path6: mission must be active before kill");
 
@@ -1705,7 +1714,9 @@ contract ClanWorldTest is Test {
 
         // Kill the clansman
         harness.killClansman(csId);
-        assertEq(uint8(harness.getClansman(csId).state), uint8(ClansmanState.DEAD), "path6-defender: clansman must be DEAD");
+        assertEq(
+            uint8(harness.getClansman(csId).state), uint8(ClansmanState.DEAD), "path6-defender: clansman must be DEAD"
+        );
 
         // Settle the clan — triggers Path 6, should remove from registry
         _advanceTickHarness(harness);
@@ -1734,8 +1745,8 @@ contract ClanWorldTest is Test {
         (uint8 travelTicks,) = world.quoteTravel(homeRegion, ClanWorldConstants.REGION_MOUNTAINS);
         _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
 
-        // Advance past travel + 1 action tick WITHOUT calling settleClan
-        for (uint256 i = 0; i < uint256(travelTicks) + 1; i++) {
+        // Advance through travel and the four-tick mining duration WITHOUT calling settleClan.
+        for (uint256 i = 0; i < uint256(travelTicks) + world.getActionDuration(ActionType.MineIron) + 1; i++) {
             _advanceTick();
         }
 
@@ -1839,9 +1850,7 @@ contract ClanWorldTest is Test {
         );
         assertEq(uint8(results[2].status), uint8(StatusCode.OK), "3.E8: order[2] must be OK");
         assertEq(
-            uint8(results[3].status),
-            uint8(StatusCode.ERR_INVALID_REGION),
-            "3.E8: order[3] must be ERR_INVALID_REGION"
+            uint8(results[3].status), uint8(StatusCode.ERR_INVALID_REGION), "3.E8: order[3] must be ERR_INVALID_REGION"
         );
     }
 }

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -43,6 +43,13 @@ import {
     RegionOccupant
 } from "../src/IClanWorld.sol";
 
+/// @dev Test harness that exposes internal state manipulation for unit tests.
+contract ClanWorldTestHarness is ClanWorld {
+    function killClansman(uint32 csId) external {
+        _clansmen[csId].state = ClansmanState.DEAD;
+    }
+}
+
 contract ClanWorldTest is Test {
     ClanWorld world;
     address elder = address(0xA1);
@@ -1107,5 +1114,379 @@ contract ClanWorldTest is Test {
         defs = world.getActiveDefenders(clanId);
         assertEq(defs.length, 1, "defender count must not drop after re-task");
         assertEq(defs[0], csId, "csId must still be defending after re-task");
+    }
+
+    // =========================================================================
+    // Phase 3.1 Order Submission Tests (3.E1–3.E8)
+    // =========================================================================
+
+    // -------------------------------------------------------------------------
+    // 3.E1: Valid order returns OK with correct nonce and cooldown set
+    // -------------------------------------------------------------------------
+
+    function test_phase3E1_validOrder_returnsOkNonceCooldown() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+
+        OrderResult[] memory r = _submitOrder(clanId, csId, ClanWorldConstants.REGION_FOREST, ActionType.ChopWood);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "3.E1: status must be OK");
+        assertEq(r[0].missionNonce, 1, "3.E1: first nonce must be 1");
+        assertEq(
+            r[0].cooldownEndsAtTs,
+            block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS,
+            "3.E1: cooldownEndsAtTs must equal block.timestamp + COOLDOWN"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // 3.E2: ERR_INVALID_CLANSMAN — clansmanId belongs to a different clan
+    // -------------------------------------------------------------------------
+
+    function test_phase3E2_invalidClansman_wrongClan() public {
+        // Clan 1 (elder)
+        uint32 clanId1 = _mintClan();
+        // Clan 2 (elder2)
+        vm.prank(elder2);
+        (uint32 clanId2,) = world.mintClan(elder2);
+
+        // Get a clansmanId from clan2
+        uint32 cs2Id = world.getClanFullView(clanId2).clansmen[0].clansman.clansman.clansmanId;
+
+        // Submit an order for clan1 using clan2's clansmanId
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: cs2Id,
+            gotoRegion: ClanWorldConstants.REGION_FOREST,
+            action: ActionType.ChopWood,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        OrderResult[] memory r = world.submitClanOrders(clanId1, orders);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_INVALID_CLANSMAN), "3.E2: cross-clan csId must be invalid");
+    }
+
+    // -------------------------------------------------------------------------
+    // 3.E3: ERR_CLANSMAN_DEAD — dead clansman is rejected
+    // -------------------------------------------------------------------------
+
+    function test_phase3E3_deadClansman_rejectsOrder() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+
+        vm.prank(elder);
+        (uint32 clanId,) = harness.mintClan(elder);
+
+        uint32 csId = harness.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+
+        harness.killClansman(csId);
+
+        assertEq(uint8(harness.getClansman(csId).state), uint8(ClansmanState.DEAD), "3.E3: clansman must be DEAD");
+
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_FOREST,
+            action: ActionType.ChopWood,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        OrderResult[] memory r = harness.submitClanOrders(clanId, orders);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_CLANSMAN_DEAD), "3.E3: dead clansman must be rejected");
+    }
+
+    // -------------------------------------------------------------------------
+    // 3.E4: ERR_COOLDOWN_ACTIVE — submit-time cooldown enforced
+    // -------------------------------------------------------------------------
+
+    function test_phase3E4_cooldownActive_blocksImmediateReorder() public {
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        // First order succeeds
+        OrderResult[] memory r1 = _submitOrder(clanId, csId, ClanWorldConstants.REGION_FOREST, ActionType.ChopWood);
+        assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "3.E4: first order must succeed");
+        uint64 expectedCooldown = r1[0].cooldownEndsAtTs;
+
+        // Immediate re-order hits cooldown
+        OrderResult[] memory r2 = _submitOrder(clanId, csId, ClanWorldConstants.REGION_FOREST, ActionType.ChopWood);
+        assertEq(uint8(r2[0].status), uint8(StatusCode.ERR_COOLDOWN_ACTIVE), "3.E4: must return ERR_COOLDOWN_ACTIVE");
+        assertEq(r2[0].cooldownEndsAtTs, expectedCooldown, "3.E4: cooldownEndsAtTs must match first order cooldown");
+    }
+
+    // -------------------------------------------------------------------------
+    // 3.E5: Cooldown from heartbeat-resolved mission — can't re-order immediately after natural completion
+    // -------------------------------------------------------------------------
+
+    function test_phase3E5_heartbeatResolvedMission_setsCooldown() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        uint8 homeRegion = v.clan.clan.baseRegion;
+
+        // Send clansman to homebase to DepositResources (empty carry → completes in 1 tick).
+        // This is the cleanest single-tick completion: _doDeposit with empty carry calls _completeMission immediately.
+        OrderResult[] memory r = _submitOrder(clanId, csId, homeRegion, ActionType.DepositResources);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "3.E5: order must succeed");
+
+        // Wait for submit-time cooldown to expire (warp only; no ticks yet)
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
+
+        // Advance 1 tick — clansman is already at homebase (NOOP), actionStartTick=currentTick,
+        // so the next closed tick resolves the deposit (empty carry → _completeMission).
+        _advanceTick();
+
+        // Settle the clan — mission completes, clansman back to WAITING with new cooldown
+        world.settleClan(clanId);
+
+        // Verify clansman is now WAITING
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "3.E5: clansman must be WAITING after completion");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "3.E5: heartbeat-resolved completion must set future cooldown");
+
+        // Attempt to re-order without advancing time — must hit cooldown
+        OrderResult[] memory r2 = _submitOrder(clanId, csId, homeRegion, ActionType.Wait);
+        assertEq(
+            uint8(r2[0].status),
+            uint8(StatusCode.ERR_COOLDOWN_ACTIVE),
+            "3.E5: must be ERR_COOLDOWN_ACTIVE after heartbeat resolution"
+        );
+
+        // Warp past cooldown and try again — should succeed
+        // Note: the cooldown check uses strict less-than (`block.timestamp < cs.cooldownEndsAtTs`),
+        // so `timestamp == cooldownEndsAtTs` is already expired (boundary is inclusive).
+        // The +1 warp here is conservative; test_phase3E5b_cooldown_exactBoundary verifies the exact boundary.
+        vm.warp(cs.cooldownEndsAtTs + 1);
+        OrderResult[] memory r3 = _submitOrder(clanId, csId, homeRegion, ActionType.Wait);
+        assertEq(uint8(r3[0].status), uint8(StatusCode.OK), "3.E5: after cooldown expires must succeed");
+    }
+
+    // -------------------------------------------------------------------------
+    // 3.E5b: Cooldown exact boundary — at exactly cooldownEndsAtTs, order is accepted
+    // (contract uses strict `<`, so `timestamp == cooldownEndsAtTs` passes)
+    // -------------------------------------------------------------------------
+
+    function test_phase3E5b_cooldown_exactBoundary() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        uint8 homeRegion = v.clan.clan.baseRegion;
+
+        // Submit first order — sets cooldown
+        OrderResult[] memory r1 = _submitOrder(clanId, csId, homeRegion, ActionType.Wait);
+        assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "3.E5b: first order must succeed");
+        uint64 cooldownEndsAt = r1[0].cooldownEndsAtTs;
+        assertGt(cooldownEndsAt, 0, "3.E5b: cooldown must be set");
+
+        // Warp to exactly cooldownEndsAtTs (not +1) — the strict-less-than guard means
+        // `block.timestamp < cooldownEndsAtTs` is false, so cooldown is considered expired.
+        vm.warp(cooldownEndsAt);
+
+        // Order must be accepted at the exact boundary
+        OrderResult[] memory r2 = _submitOrder(clanId, csId, homeRegion, ActionType.Wait);
+        assertEq(
+            uint8(r2[0].status),
+            uint8(StatusCode.OK),
+            "3.E5b: order at exact cooldownEndsAtTs must succeed (boundary inclusive)"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // 3.phase3: DefendBase does not call _completeMission — cooldown must not slide
+    // -------------------------------------------------------------------------
+
+    function test_phase3_defendBase_noCompletionCooldownSlide() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        uint8 baseRegion = v.clan.clan.baseRegion;
+
+        // Submit DefendBase to own clan — same region → zero travel → instant ACTING
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: baseRegion,
+            action: ActionType.DefendBase,
+            targetClanId: clanId,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        OrderResult[] memory r = world.submitClanOrders(clanId, orders);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "DefendBase order must succeed");
+
+        // Wait for submit-time cooldown to expire before settling
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
+        _advanceTick();
+        world.settleClan(clanId);
+
+        // Record cooldown after initial settlement
+        uint64 cooldownAfterSubmit = world.getClansman(csId).cooldownEndsAtTs;
+
+        // Run 3 more settle ticks — each calls _resolveAction for DefendBase
+        // DefendBase does NOT call _completeMission, so cooldown must stay flat
+        for (uint256 i = 0; i < 3; i++) {
+            _advanceTick();
+            world.settleClan(clanId);
+            uint64 cooldownNow = world.getClansman(csId).cooldownEndsAtTs;
+            assertEq(
+                cooldownNow,
+                cooldownAfterSubmit,
+                "DefendBase must not slide cooldown: _completeMission must not be called per tick"
+            );
+        }
+
+        // Clansman must still be ACTING (continuous defender, not returned to WAITING)
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(
+            uint8(cs.state),
+            uint8(ClansmanState.ACTING),
+            "DefendBase clansman must remain ACTING after 3 settlement ticks"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // 3.E6: ERR_INVALID_REGION — wrong region for action type
+    // -------------------------------------------------------------------------
+
+    function test_phase3E6_invalidRegion_wrongActionForRegion() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+
+        uint32 cs0 = v.clansmen[0].clansman.clansman.clansmanId;
+        uint32 cs1 = v.clansmen[1].clansman.clansman.clansmanId;
+        uint32 cs2 = v.clansmen[2].clansman.clansman.clansmanId;
+
+        // ChopWood to Mountains (not Forest) → ERR_INVALID_REGION
+        OrderResult[] memory r0 = _submitOrder(clanId, cs0, ClanWorldConstants.REGION_MOUNTAINS, ActionType.ChopWood);
+        assertEq(
+            uint8(r0[0].status), uint8(StatusCode.ERR_INVALID_REGION), "3.E6: ChopWood to Mountains must be invalid"
+        );
+
+        // MineIron to Forest (not Mountains) → ERR_INVALID_REGION
+        OrderResult[] memory r1 = _submitOrder(clanId, cs1, ClanWorldConstants.REGION_FOREST, ActionType.MineIron);
+        assertEq(uint8(r1[0].status), uint8(StatusCode.ERR_INVALID_REGION), "3.E6: MineIron to Forest must be invalid");
+
+        // FishDocks to Forest (not WestDocks or EastDocks) → ERR_INVALID_REGION
+        OrderResult[] memory r2 = _submitOrder(clanId, cs2, ClanWorldConstants.REGION_FOREST, ActionType.FishDocks);
+        assertEq(
+            uint8(r2[0].status), uint8(StatusCode.ERR_INVALID_REGION), "3.E6: FishDocks to Forest must be invalid"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // 3.E7: Mission overwrite — nonce increments, MissionInterrupted emitted
+    // -------------------------------------------------------------------------
+
+    function test_phase3E7_missionOverwrite_nonceIncrements_interruptedEmitted() public {
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        // Submit first mission → nonce 1
+        OrderResult[] memory r1 = _submitOrder(clanId, csId, ClanWorldConstants.REGION_FOREST, ActionType.ChopWood);
+        assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "3.E7: first order must succeed");
+        assertEq(r1[0].missionNonce, 1, "3.E7: first mission nonce must be 1");
+
+        // Wait for cooldown
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
+
+        // Expect MissionInterrupted(clanId, csId, oldNonce=1, newNonce=2) before second submit
+        vm.expectEmit(true, true, false, true);
+        emit IClanWorldEvents.MissionInterrupted(clanId, csId, 1, 2);
+
+        // Submit second mission → interrupts first, nonce 2
+        OrderResult[] memory r2 = _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+        assertEq(uint8(r2[0].status), uint8(StatusCode.OK), "3.E7: interrupt order must succeed");
+        assertEq(r2[0].missionNonce, 2, "3.E7: second mission nonce must be 2");
+
+        // Active mission must have nonce 2
+        Mission memory m = world.getActiveMission(csId);
+        assertTrue(m.active, "3.E7: mission must be active");
+        assertEq(m.nonce, 2, "3.E7: active mission nonce must be 2");
+    }
+
+    // -------------------------------------------------------------------------
+    // 3.E8: Partial batch — mixed results across 4 orders
+    // -------------------------------------------------------------------------
+
+    function test_phase3E8_partialBatch_mixedResults() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+
+        uint32 cs0 = v.clansmen[0].clansman.clansman.clansmanId;
+        uint32 cs1 = v.clansmen[1].clansman.clansman.clansmanId;
+        uint32 cs2 = v.clansmen[2].clansman.clansman.clansmanId;
+
+        ClanOrder[] memory orders = new ClanOrder[](4);
+
+        // Order 0: valid — cs0 ChopWood to Forest
+        orders[0] = ClanOrder({
+            clansmanId: cs0,
+            gotoRegion: ClanWorldConstants.REGION_FOREST,
+            action: ActionType.ChopWood,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+
+        // Order 1: invalid clansmanId 9999
+        orders[1] = ClanOrder({
+            clansmanId: 9999,
+            gotoRegion: ClanWorldConstants.REGION_FOREST,
+            action: ActionType.ChopWood,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+
+        // Order 2: valid — cs1 Wait at homebase (NOOP)
+        orders[2] = ClanOrder({
+            clansmanId: cs1,
+            gotoRegion: ClanWorldConstants.REGION_NOOP,
+            action: ActionType.Wait,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+
+        // Order 3: invalid — cs2 ChopWood to Mountains (wrong region for ChopWood)
+        orders[3] = ClanOrder({
+            clansmanId: cs2,
+            gotoRegion: ClanWorldConstants.REGION_MOUNTAINS,
+            action: ActionType.ChopWood,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+
+        assertEq(results.length, 4, "3.E8: must return 4 results");
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "3.E8: order[0] must be OK");
+        assertEq(
+            uint8(results[1].status),
+            uint8(StatusCode.ERR_INVALID_CLANSMAN),
+            "3.E8: order[1] must be ERR_INVALID_CLANSMAN"
+        );
+        assertEq(uint8(results[2].status), uint8(StatusCode.OK), "3.E8: order[2] must be OK");
+        assertEq(
+            uint8(results[3].status),
+            uint8(StatusCode.ERR_INVALID_REGION),
+            "3.E8: order[3] must be ERR_INVALID_REGION"
+        );
     }
 }

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -1101,9 +1101,9 @@ contract ClanWorldTest is Test {
         vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
         _advanceTick();
 
-        uint32[] memory defs = world.getActiveDefenders(clanId);
+        uint32[] memory defs = world.getDefendingClans(baseRegion);
         assertEq(defs.length, 1, "one defender registered");
-        assertEq(defs[0], csId, "csId is the defender");
+        assertEq(defs[0], clanId, "clanId is the defender");
 
         // Second DefendBase to same target: zero-travel re-task — the regression case.
         vm.prank(elder);
@@ -1111,9 +1111,9 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r2[0].status), uint8(StatusCode.OK), "re-task DefendBase OK");
 
         // Defender must NOT be dropped — fix must register synchronously.
-        defs = world.getActiveDefenders(clanId);
+        defs = world.getDefendingClans(baseRegion);
         assertEq(defs.length, 1, "defender count must not drop after re-task");
-        assertEq(defs[0], csId, "csId must still be defending after re-task");
+        assertEq(defs[0], clanId, "clanId must still be defending after re-task");
     }
 
     // =========================================================================

--- a/packages/contracts/test/DefendBase.t.sol
+++ b/packages/contracts/test/DefendBase.t.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {
+    ClanWorldConstants,
+    ClansmanState,
+    ActionType,
+    StatusCode,
+    Clan,
+    Clansman,
+    Mission,
+    ClanOrder,
+    OrderResult
+} from "../src/IClanWorld.sol";
+
+contract DefendBaseTest is Test {
+    ClanWorld world;
+    address elder = address(0xA1);
+
+    function setUp() public {
+        world = new ClanWorld();
+    }
+
+    function _mintClan() internal returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
+    }
+
+    function _firstCs(uint32 clanId) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _defendOrder(uint32 csId, uint8 region, uint32 targetClanId) internal pure returns (ClanOrder[] memory) {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: region,
+            action: ActionType.DefendBase,
+            targetClanId: targetClanId,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        return orders;
+    }
+
+    function _waitOrder(uint32 csId, uint8 region) internal pure returns (ClanOrder[] memory) {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: region,
+            action: ActionType.Wait,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        return orders;
+    }
+
+    function _submit(uint32 clanId, ClanOrder[] memory orders) internal returns (OrderResult[] memory) {
+        vm.prank(elder);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _warpCooldown() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS);
+    }
+
+    function _otherRegion(uint8 homeRegion) internal pure returns (uint8) {
+        return homeRegion == ClanWorldConstants.REGION_FOREST
+            ? ClanWorldConstants.REGION_MOUNTAINS
+            : ClanWorldConstants.REGION_FOREST;
+    }
+
+    function _assertContains(uint32[] memory values, uint32 needle) internal pure {
+        for (uint256 i = 0; i < values.length; i++) {
+            if (values[i] == needle) return;
+        }
+        revert("missing expected clanId");
+    }
+
+    function test_submitDefendBaseAtHome_succeedsImmediatePersistent() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+        uint64 submittedAtTick = world.getWorldState().currentTick;
+
+        OrderResult[] memory results = _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "defend_base status");
+        assertEq(results[0].missionNonce, 1, "first nonce");
+
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(uint8(cs.state), uint8(ClansmanState.ACTING), "defender acts immediately");
+        assertEq(cs.currentRegion, clan.baseRegion, "defender is at home");
+
+        Mission memory mission = world.getActiveMission(csId);
+        assertTrue(mission.active, "mission stays active");
+        assertEq(uint8(mission.action), uint8(ActionType.DefendBase), "mission action");
+        assertEq(mission.startTick, submittedAtTick, "start tick");
+        assertEq(mission.arrivalTick, submittedAtTick, "arrival tick");
+        assertEq(mission.actionStartTick, submittedAtTick, "action tick");
+
+        uint32[] memory defenders = world.getDefendingClans(clan.baseRegion);
+        assertEq(defenders.length, 1, "one defending clan");
+        assertEq(defenders[0], clanId, "defending clan id");
+
+        _warpCooldown();
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+        world.settleClan(clanId);
+
+        assertTrue(world.getActiveMission(csId).active, "defend_base does not settle complete");
+        assertEq(uint8(world.getClansman(csId).state), uint8(ClansmanState.ACTING), "still acting");
+    }
+
+    function test_submitDefendBaseAtNonHome_failsInvalidRegion() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory results = _submit(clanId, _defendOrder(csId, _otherRegion(clan.baseRegion), 0));
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.ERR_INVALID_REGION), "non-home defend rejected");
+        assertEq(world.getDefendingClans(clan.baseRegion).length, 0, "no defender registered");
+    }
+
+    function test_resubmitSameDefendBase_isNoopNonceUnchanged() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory first = _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+        uint64 cooldown = world.getClansman(csId).cooldownEndsAtTs;
+
+        OrderResult[] memory second = _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first status");
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "same-target no-op status");
+        assertEq(second[0].missionNonce, first[0].missionNonce, "nonce unchanged");
+        assertEq(world.getClansman(csId).lastMissionNonce, first[0].missionNonce, "stored nonce unchanged");
+        assertEq(world.getClansman(csId).cooldownEndsAtTs, cooldown, "cooldown unchanged");
+        assertEq(world.getDefendingClans(clan.baseRegion).length, 1, "no duplicate defender");
+    }
+
+    function test_resubmitDifferentDefendBaseTarget_isRealRetaskNoDuplicate() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory first = _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+        _warpCooldown();
+
+        OrderResult[] memory second = _submit(clanId, _defendOrder(csId, clan.baseRegion, clanId));
+
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "changed target accepted");
+        assertEq(second[0].missionNonce, first[0].missionNonce + 1, "nonce increments");
+        assertEq(world.getActiveMission(csId).targetClanId, clanId, "target changed");
+        uint32[] memory defenders = world.getDefendingClans(clan.baseRegion);
+        assertEq(defenders.length, 1, "old defender index entry replaced");
+        assertEq(defenders[0], clanId, "defender remains registered once");
+    }
+
+    function test_getDefendingClans_returnsAllCurrentlyDefendingClans() public {
+        uint32 firstClanId = _mintClan();
+        uint8 sharedHome = world.getClan(firstClanId).baseRegion;
+        uint32 seventhClanId;
+        for (uint256 i = 0; i < 6; i++) {
+            seventhClanId = _mintClan();
+        }
+        assertEq(world.getClan(seventhClanId).baseRegion, sharedHome, "test setup shared home");
+
+        _submit(firstClanId, _defendOrder(_firstCs(firstClanId), sharedHome, 0));
+        _submit(seventhClanId, _defendOrder(_firstCs(seventhClanId), sharedHome, 0));
+
+        uint32[] memory defenders = world.getDefendingClans(sharedHome);
+        assertEq(defenders.length, 2, "two defending clans");
+        _assertContains(defenders, firstClanId);
+        _assertContains(defenders, seventhClanId);
+    }
+
+    function test_getActiveDefenders_keepsTargetSpecificClansmanSemantics() public {
+        uint32 firstClanId = _mintClan();
+        uint8 sharedHome = world.getClan(firstClanId).baseRegion;
+        uint32 seventhClanId;
+        for (uint256 i = 0; i < 6; i++) {
+            seventhClanId = _mintClan();
+        }
+        assertEq(world.getClan(seventhClanId).baseRegion, sharedHome, "test setup shared home");
+
+        uint32 firstCsId = _firstCs(firstClanId);
+        uint32 seventhCsId = _firstCs(seventhClanId);
+        _submit(firstClanId, _defendOrder(firstCsId, sharedHome, firstClanId));
+        _submit(seventhClanId, _defendOrder(seventhCsId, sharedHome, seventhClanId));
+
+        uint32[] memory regionDefenders = world.getDefendingClans(sharedHome);
+        assertEq(regionDefenders.length, 2, "region index includes both defending clans");
+
+        uint32[] memory targetDefenders = world.getActiveDefenders(firstClanId);
+        assertEq(targetDefenders.length, 1, "target-specific getter excludes same-region defenders");
+        assertEq(targetDefenders[0], firstCsId, "returns target-specific clansman id");
+    }
+
+    function test_nonDefendBaseMissionOverwritesDefendBase_dropsDefenderIndex() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+
+        _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+        assertEq(world.getDefendingClans(clan.baseRegion).length, 1, "defender registered");
+
+        _warpCooldown();
+        OrderResult[] memory results = _submit(clanId, _waitOrder(csId, clan.baseRegion));
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "wait retask accepted");
+        assertEq(world.getDefendingClans(clan.baseRegion).length, 0, "defender dropped");
+        assertEq(uint8(world.getActiveMission(csId).action), uint8(ActionType.Wait), "mission overwritten");
+    }
+}

--- a/packages/contracts/test/DefendBase.t.sol
+++ b/packages/contracts/test/DefendBase.t.sol
@@ -69,6 +69,17 @@ contract DefendBaseTest is Test {
         vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS);
     }
 
+    function _advanceTick() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+    }
+
+    function _advanceUntilCurrentTick(uint64 targetTick) internal {
+        while (world.getWorldState().currentTick < targetTick) {
+            _advanceTick();
+        }
+    }
+
     function _otherRegion(uint8 homeRegion) internal pure returns (uint8) {
         return homeRegion == ClanWorldConstants.REGION_FOREST
             ? ClanWorldConstants.REGION_MOUNTAINS
@@ -100,6 +111,7 @@ contract DefendBaseTest is Test {
         Mission memory mission = world.getActiveMission(csId);
         assertTrue(mission.active, "mission stays active");
         assertEq(uint8(mission.action), uint8(ActionType.DefendBase), "mission action");
+        assertEq(mission.targetClanId, clanId, "zero target normalizes to self");
         assertEq(mission.startTick, submittedAtTick, "start tick");
         assertEq(mission.arrivalTick, submittedAtTick, "arrival tick");
         assertEq(mission.actionStartTick, submittedAtTick, "action tick");
@@ -115,6 +127,47 @@ contract DefendBaseTest is Test {
 
         assertTrue(world.getActiveMission(csId).active, "defend_base does not settle complete");
         assertEq(uint8(world.getClansman(csId).state), uint8(ClansmanState.ACTING), "still acting");
+    }
+
+    function test_submitDefendBaseFromNonHome_travelsBeforeRegisteringDefender() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+        uint8 awayRegion = _otherRegion(clan.baseRegion);
+
+        OrderResult[] memory move = _submit(clanId, _waitOrder(csId, awayRegion));
+        assertEq(uint8(move[0].status), uint8(StatusCode.OK), "move away accepted");
+
+        Mission memory moveMission = world.getActiveMission(csId);
+        _advanceUntilCurrentTick(moveMission.executesAtTick + 1);
+        world.settleClan(clanId);
+        assertEq(world.getClansman(csId).currentRegion, awayRegion, "test setup: clansman is away");
+
+        _warpCooldown();
+        OrderResult[] memory defend = _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+
+        assertEq(uint8(defend[0].status), uint8(StatusCode.OK), "defend accepted");
+
+        Mission memory defendMission = world.getActiveMission(csId);
+        uint64 expectedTravel = world.getTravelTicks(awayRegion, clan.baseRegion);
+        assertEq(defendMission.executesAtTick, defendMission.submittedAtTick + expectedTravel, "normal travel");
+        assertEq(uint8(world.getClansman(csId).state), uint8(ClansmanState.TRAVELING), "travels home first");
+        assertEq(world.getDefendingClans(clan.baseRegion).length, 0, "not registered before arrival");
+        assertEq(world.getActiveDefenders(clanId).length, 0, "no active defender before arrival");
+
+        _advanceUntilCurrentTick(defendMission.executesAtTick + 1);
+        world.settleClan(clanId);
+
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(uint8(cs.state), uint8(ClansmanState.ACTING), "defender acts after arrival");
+        assertEq(cs.currentRegion, clan.baseRegion, "defender arrived home");
+
+        uint32[] memory defendingClans = world.getDefendingClans(clan.baseRegion);
+        assertEq(defendingClans.length, 1, "registered after arrival");
+        assertEq(defendingClans[0], clanId, "defending clan id");
+        uint32[] memory activeDefenders = world.getActiveDefenders(clanId);
+        assertEq(activeDefenders.length, 1, "active defender after arrival");
+        assertEq(activeDefenders[0], csId, "active defender id");
     }
 
     function test_submitDefendBaseAtNonHome_failsInvalidRegion() public {
@@ -146,22 +199,35 @@ contract DefendBaseTest is Test {
         assertEq(world.getDefendingClans(clan.baseRegion).length, 1, "no duplicate defender");
     }
 
-    function test_resubmitDifferentDefendBaseTarget_isRealRetaskNoDuplicate() public {
+    function test_resubmitExplicitSelfAfterDefaultDefendBase_isNoopNonceUnchanged() public {
         uint32 clanId = _mintClan();
         Clan memory clan = world.getClan(clanId);
         uint32 csId = _firstCs(clanId);
 
         OrderResult[] memory first = _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
-        _warpCooldown();
-
         OrderResult[] memory second = _submit(clanId, _defendOrder(csId, clan.baseRegion, clanId));
 
-        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "changed target accepted");
-        assertEq(second[0].missionNonce, first[0].missionNonce + 1, "nonce increments");
-        assertEq(world.getActiveMission(csId).targetClanId, clanId, "target changed");
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "explicit self is same target");
+        assertEq(second[0].missionNonce, first[0].missionNonce, "nonce unchanged");
+        assertEq(world.getActiveMission(csId).targetClanId, clanId, "target normalized");
         uint32[] memory defenders = world.getDefendingClans(clan.baseRegion);
-        assertEq(defenders.length, 1, "old defender index entry replaced");
+        assertEq(defenders.length, 1, "no duplicate defender");
         assertEq(defenders[0], clanId, "defender remains registered once");
+    }
+
+    function test_defendBaseZeroTargetAppearsInActiveDefenders() public {
+        uint32 clanId = _mintClan();
+        Clan memory clan = world.getClan(clanId);
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory results = _submit(clanId, _defendOrder(csId, clan.baseRegion, 0));
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "defend accepted");
+        assertEq(world.getActiveMission(csId).targetClanId, clanId, "stored target is self");
+
+        uint32[] memory activeDefenders = world.getActiveDefenders(clanId);
+        assertEq(activeDefenders.length, 1, "default self-defense is target visible");
+        assertEq(activeDefenders[0], csId, "active defender id");
     }
 
     function test_getDefendingClans_returnsAllCurrentlyDefendingClans() public {

--- a/packages/contracts/test/MissionTiming.t.sol
+++ b/packages/contracts/test/MissionTiming.t.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {
+    ClanWorldConstants,
+    ActionType,
+    StatusCode,
+    ClanFullView,
+    ClanOrder,
+    OrderResult,
+    Mission
+} from "../src/IClanWorld.sol";
+
+contract MissionTimingTest is Test {
+    ClanWorld world;
+    address elder = address(0xA1);
+
+    function setUp() public {
+        world = new ClanWorld();
+    }
+
+    function _advanceTick() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+    }
+
+    function _mintClan() internal returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
+    }
+
+    function _firstCs(uint32 clanId) internal view returns (uint32) {
+        ClanFullView memory view_ = world.getClanFullView(clanId);
+        return view_.clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _submitOrder(uint32 clanId, uint32 csId, uint8 gotoRegion, ActionType action)
+        internal
+        returns (OrderResult[] memory)
+    {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: gotoRegion,
+            action: action,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function test_submitStoresSubmittedExecutesAndSettlesTicks() public {
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+        uint64 submittedAt = world.getWorldState().currentTick;
+        uint64 travel = world.getTravelTicks(ClanWorldConstants.REGION_FOREST, ClanWorldConstants.REGION_MOUNTAINS);
+        uint64 duration = world.getActionDuration(ActionType.MineIron);
+
+        OrderResult[] memory results =
+            _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "order should be accepted");
+
+        Mission memory mission = world.getActiveMission(csId);
+        assertEq(mission.submittedAtTick, submittedAt, "submitted tick");
+        assertEq(mission.executesAtTick, submittedAt + travel, "executes tick");
+        assertEq(mission.settlesAtTick, submittedAt + travel + duration, "settles tick");
+
+        assertEq(mission.startTick, mission.submittedAtTick, "legacy start tick mirrors submitted");
+        assertEq(mission.actionStartTick, mission.executesAtTick, "legacy action start mirrors executes");
+
+        (uint64 submitted, uint64 executes, uint64 settles) = world.getMissionTiming(clanId, csId);
+        assertEq(submitted, mission.submittedAtTick, "getter submitted");
+        assertEq(executes, mission.executesAtTick, "getter executes");
+        assertEq(settles, mission.settlesAtTick, "getter settles");
+    }
+
+    function test_getActionDuration_eachActionType() public view {
+        assertEq(world.getActionDuration(ActionType.None), 0, "none");
+        assertEq(world.getActionDuration(ActionType.ChopWood), 4, "chop wood");
+        assertEq(world.getActionDuration(ActionType.MineIron), 4, "mine iron");
+        assertEq(world.getActionDuration(ActionType.FishDocks), 4, "fish docks");
+        assertEq(world.getActionDuration(ActionType.FishDeepSea), 4, "fish deep sea");
+        assertEq(world.getActionDuration(ActionType.HarvestWheat), 4, "harvest wheat");
+        assertEq(world.getActionDuration(ActionType.DepositResources), 1, "deposit");
+        assertEq(world.getActionDuration(ActionType.BuildWall), 1, "build wall");
+        assertEq(world.getActionDuration(ActionType.UpgradeBase), 1, "upgrade base");
+        assertEq(world.getActionDuration(ActionType.UpgradeMonument), 1, "upgrade monument");
+        assertEq(world.getActionDuration(ActionType.DefendBase), 0, "defend base");
+        assertEq(world.getActionDuration(ActionType.MarketBuy), 1, "market buy");
+        assertEq(world.getActionDuration(ActionType.MarketSell), 1, "market sell");
+        assertEq(world.getActionDuration(ActionType.Wait), 0, "wait");
+    }
+
+    function test_getTravelTicks_adjacentAndDistantMatchTable() public view {
+        assertEq(
+            world.getTravelTicks(ClanWorldConstants.REGION_FOREST, ClanWorldConstants.REGION_MOUNTAINS), 1, "adjacent"
+        );
+        assertEq(
+            world.getTravelTicks(ClanWorldConstants.REGION_FOREST, ClanWorldConstants.REGION_EAST_DOCKS), 4, "distant"
+        );
+        assertEq(
+            world.getTravelTicks(ClanWorldConstants.REGION_FOREST, ClanWorldConstants.REGION_FOREST), 0, "same region"
+        );
+    }
+
+    function test_missionOverwriteResetsSubmittedAtTick() public {
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory first = _submitOrder(clanId, csId, ClanWorldConstants.REGION_NOOP, ActionType.Wait);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first wait");
+        uint64 firstSubmitted = world.getActiveMission(csId).submittedAtTick;
+
+        _advanceTick();
+
+        OrderResult[] memory second = _submitOrder(clanId, csId, ClanWorldConstants.REGION_NOOP, ActionType.Wait);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "second wait");
+        uint64 secondSubmitted = world.getActiveMission(csId).submittedAtTick;
+
+        assertEq(firstSubmitted, 0, "first submit starts at tick 0");
+        assertEq(secondSubmitted, world.getWorldState().currentTick, "second submit uses current tick");
+        assertGt(secondSubmitted, firstSubmitted, "countdown restarts");
+    }
+
+    function test_getMissionTimingReturnsZerosForNonExistentMission() public view {
+        (uint64 submitted, uint64 executes, uint64 settles) = world.getMissionTiming(123, 456);
+
+        assertEq(submitted, 0, "submitted");
+        assertEq(executes, 0, "executes");
+        assertEq(settles, 0, "settles");
+    }
+}

--- a/packages/contracts/test/MissionTiming.t.sol
+++ b/packages/contracts/test/MissionTiming.t.sol
@@ -6,8 +6,10 @@ import {ClanWorld} from "../src/ClanWorld.sol";
 import {
     ClanWorldConstants,
     ActionType,
+    ClansmanState,
     StatusCode,
     ClanFullView,
+    Clansman,
     ClanOrder,
     OrderResult,
     Mission
@@ -24,6 +26,12 @@ contract MissionTimingTest is Test {
     function _advanceTick() internal {
         vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
         world.heartbeat();
+    }
+
+    function _advanceUntilCurrentTick(uint64 targetTick) internal {
+        while (world.getWorldState().currentTick < targetTick) {
+            _advanceTick();
+        }
     }
 
     function _mintClan() internal returns (uint32 clanId) {
@@ -78,6 +86,36 @@ contract MissionTimingTest is Test {
         assertEq(submitted, mission.submittedAtTick, "getter submitted");
         assertEq(executes, mission.executesAtTick, "getter executes");
         assertEq(settles, mission.settlesAtTick, "getter settles");
+    }
+
+    function test_settlementWaitsUntilSettlesAtTickForGatherMission() public {
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory results =
+            _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "order should be accepted");
+
+        Mission memory mission = world.getActiveMission(csId);
+        assertEq(mission.settlesAtTick, mission.executesAtTick + 4, "four tick action duration");
+
+        _advanceUntilCurrentTick(mission.executesAtTick + 1);
+        world.settleClan(clanId);
+
+        Clansman memory arrived = world.getClansman(csId);
+        assertEq(uint8(arrived.state), uint8(ClansmanState.ACTING), "arrived and action started");
+        assertEq(arrived.currentRegion, ClanWorldConstants.REGION_MOUNTAINS, "arrived at target");
+        assertEq(arrived.carryIron, 0, "no iron before settlesAtTick");
+        assertTrue(world.getActiveMission(csId).active, "mission remains active before settlesAtTick");
+
+        _advanceUntilCurrentTick(mission.settlesAtTick + 1);
+        world.settleClan(clanId);
+
+        Clansman memory settled = world.getClansman(csId);
+        assertGt(settled.carryIron, 0, "iron granted at settlesAtTick");
+        assertEq(uint8(settled.state), uint8(ClansmanState.WAITING), "mission completed");
+        assertFalse(world.getActiveMission(csId).active, "mission inactive after settlement");
+        assertGt(settled.cooldownEndsAtTs, block.timestamp, "cooldown starts on settlement");
     }
 
     function test_getActionDuration_eachActionType() public view {


### PR DESCRIPTION
**Phase 3 release PR** — bundles all 4 Phase 3 sub-issues for cohesive review.

## Sub-issues bundled

| PR | Issue | Title |
|---|---|---|
| #176 | #162 | Phase 3.1 — implement order submission |
| #179 | #163 | Phase 3.2 — lazy settlement engine |
| #177 | #164 | Phase 3.3 — mission timing rules |
| #178 | #165 | Phase 3.4 — defend_base mission |

## Diff summary
- 7 files changed, 1580 insertions, 114 deletions
- contracts/src/ClanWorld.sol: +291 (core engine, settlement paths, DefendBase handling)
- contracts/src/IClanWorld.sol: +21 (new fns: getMissionTiming, getActionDuration, getTravelTicks, getDefendingClans, getActiveDefenders)
- contracts/test/ClanWorld.t.sol: +744 (Phase 3.E1-3.E8 spec + per-feature regression tests)
- contracts/test/DefendBase.t.sol: NEW +222 (defender registry + atomic re-task semantics)
- contracts/test/MissionTiming.t.sol: NEW +138 (timing field invariants)
- contracts/abi/IClanWorld.json: regenerated

## Review history
- Each sub-issue reviewed by codex orch-r1
- 1 fix-round on #178 (legacy getActiveDefenders semantic restore)
- All sub-issues merged with tests green; phase branch tip 62ebbcb

## Tests
59/59 forge tests passing on phase-3 tip.