### PR TITLE
feat(contracts): Phase 4 — heartbeat + world progression

### DIFF
--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -6,6 +6,14 @@ export default defineSchema({
     tick: v.number(),
     tickEpochStartedAt: v.number(),
     tickEpochDurationMs: v.number(),
+    // Season + winter timers (Phase 4.4)
+    currentSeasonNumber: v.optional(v.number()),
+    seasonStartTick: v.optional(v.number()),
+    seasonEndTick: v.optional(v.number()),
+    winterActive: v.optional(v.boolean()),
+    winterStartsAtTick: v.optional(v.number()),
+    winterEndsAtTick: v.optional(v.number()),
+    nextHeartbeatAtTick: v.optional(v.number()),
     regions: v.array(
       v.object({
         id: v.string(),

--- a/packages/contracts/.gitignore
+++ b/packages/contracts/.gitignore
@@ -1,4 +1,4 @@
 out/
 cache/
 broadcast/
-lib/
+/lib/

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -86,6 +86,14 @@ contract ClanWorld is IClanWorld {
         _world.nextHeartbeatAtTs = uint64(block.timestamp);
         _world.seasonStartTick = 0;
         _world.seasonEndTick = ClanWorldConstants.SEASON_DURATION_TICKS;
+        _world.currentSeasonNumber = 1;
+        _world.nextHeartbeatAtTick = 1; // first heartbeat will open tick 1
+        // First winter: last WINTER_DURATION_TICKS of first TICKS_PER_WINTER_CYCLE cycle
+        // i.e. ticks [100, 110)
+        _world.winterStartsAtTick =
+            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
+        _world.winterEndsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE; // = 110
+        _world.winterActive = false;
         _treasury.treasuryOwner = msg.sender;
         _nextClanId = 1;
         _nextClansmanId = 1;
@@ -871,6 +879,48 @@ contract ClanWorld is IClanWorld {
         // Phase 2: execute scheduled market actions for closedTick
         _executeScheduledMarketActions(closedTick);
         // TODO Phase 3: bandit state transitions and attacks
+
+        uint64 newTick = _world.currentTick;
+
+        // update next-heartbeat tick estimate
+        _world.nextHeartbeatAtTick = newTick + 1;
+
+        // --- season boundary ---
+        if (newTick >= _world.seasonEndTick) {
+            _world.currentSeasonNumber += 1;
+            _world.seasonStartTick = _world.seasonEndTick;
+            _world.seasonEndTick = _world.seasonStartTick + ClanWorldConstants.SEASON_DURATION_TICKS;
+            // reset winter timers for new season
+            _world.winterActive = false;
+            _world.winterStartsAtTick = _world.seasonStartTick + ClanWorldConstants.TICKS_PER_WINTER_CYCLE
+                - ClanWorldConstants.WINTER_DURATION_TICKS;
+            _world.winterEndsAtTick = _world.seasonStartTick + ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
+        }
+
+        // --- winter transitions (timer only; mechanics = Phase 10) ---
+        if (
+            !_world.winterActive && newTick >= _world.winterStartsAtTick
+                && _world.winterStartsAtTick < _world.seasonEndTick
+        ) {
+            _world.winterActive = true;
+            emit WinterStarted(newTick);
+        }
+        if (_world.winterActive && newTick >= _world.winterEndsAtTick) {
+            _world.winterActive = false;
+            emit WinterEnded(newTick);
+            // schedule next winter cycle within this season
+            uint64 nextWinterStart = _world.winterEndsAtTick + ClanWorldConstants.TICKS_PER_WINTER_CYCLE
+                - ClanWorldConstants.WINTER_DURATION_TICKS;
+            uint64 nextWinterEnd = _world.winterEndsAtTick + ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
+            if (nextWinterStart < _world.seasonEndTick) {
+                _world.winterStartsAtTick = nextWinterStart;
+                _world.winterEndsAtTick = nextWinterEnd;
+            } else {
+                // no more winters this season; sentinel = seasonEndTick so guard never fires
+                _world.winterStartsAtTick = _world.seasonEndTick;
+                _world.winterEndsAtTick = _world.seasonEndTick;
+            }
+        }
 
         emit TickAdvanced(closedTick, _world.currentTick, _world.currentTickSeed);
     }
@@ -1880,6 +1930,8 @@ contract ClanWorld is IClanWorld {
             seasonStartTick: _world.seasonStartTick,
             seasonEndTick: _world.seasonEndTick,
             seasonFinalized: _world.seasonFinalized,
+            currentSeasonNumber: _world.currentSeasonNumber,
+            nextHeartbeatAtTick: _world.nextHeartbeatAtTick,
             winterActive: _world.winterActive,
             winterStartsAtTick: _world.winterStartsAtTick,
             winterEndsAtTick: _world.winterEndsAtTick,

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -38,13 +38,14 @@ import {
     RegionOccupant
 } from "./IClanWorld.sol";
 import {StubPool} from "./StubPool.sol";
+import {ReentrancyGuard} from "./util/ReentrancyGuard.sol";
 
 /// @title ClanWorld
 /// @notice Phase 1+2 real engine implementation of IClanWorld v4.
 ///         Implements: world clock, clan lifecycle, lazy settlement, resource gathering,
 ///         deposit, wheat harvest, travel, NOOP bypass, order validation, and market execution.
 ///         Phase 2 is implemented; Phase 3 (bandits, winter damage) remains stubbed.
-contract ClanWorld is IClanWorld {
+contract ClanWorld is IClanWorld, ReentrancyGuard {
     // =========================================================================
     // STORAGE
     // =========================================================================
@@ -52,7 +53,7 @@ contract ClanWorld is IClanWorld {
     WorldState private _world;
     TreasuryState private _treasury;
 
-    mapping(uint32 => Clan) private _clans;
+    mapping(uint32 => Clan) internal _clans;
     mapping(uint32 => Clansman) internal _clansmen;
     mapping(uint32 => Mission) private _missions; // keyed by clansmanId
     mapping(uint32 => WheatPlot[2]) private _wheatPlots; // [0]=west [1]=east
@@ -864,26 +865,77 @@ contract ClanWorld is IClanWorld {
     // =========================================================================
 
     /// @notice Permissionless heartbeat. Closes the current tick, advances tick counter.
-    function heartbeat() external override {
+    ///         Execution order per spec §4.2 (CEI-safe):
+    ///         CEI guard: nextHeartbeatAtTs written first to close reentrancy window.
+    ///         Seed:      closedTick seed derived and published before step 1 so
+    ///                    settlement RNG reads real entropy, not zero.
+    ///         1. Settle missions completing this tick.
+    ///         2. Execute scheduled market actions for closedTick (external calls).
+    ///         3. Eager-settle clans touched by world events (Phase 3 stub).
+    ///         4. Resolve world events (season boundary, winter transitions).
+    ///         5. Increment tick and publish (seed already written above).
+    function heartbeat() external override nonReentrant {
         require(block.timestamp >= _world.nextHeartbeatAtTs, "ClanWorld: heartbeat rate limited");
 
         uint64 closedTick = _world.currentTick;
-        bytes32 newSeed = keccak256(abi.encode(block.prevrandao, _world.currentTickSeed, closedTick));
 
-        _tickSeeds[closedTick] = newSeed;
-        _world.currentTickSeed = newSeed;
-        _world.currentTick = closedTick + 1;
-
+        // CEI: update rate-limit guard before any external calls
         _world.nextHeartbeatAtTs = uint64(block.timestamp) + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS;
 
-        // Phase 2: execute scheduled market actions for closedTick
+        // Derive and publish seed for closedTick before step 1 (settlement reads it for RNG)
+        bytes32 newSeed = keccak256(abi.encode(block.prevrandao, _world.currentTickSeed, closedTick));
+        _tickSeeds[closedTick] = newSeed;
+        _world.currentTickSeed = newSeed;
+
+        // Step 1: Settle missions that complete this tick (settlesAtTick == closedTick).
+        // Bounded by 12-clan cap x 4 clansmen = 48 max iterations.
+        _settleCompletingMissions(closedTick);
+
+        // Step 2: Execute scheduled market actions for closedTick (may make external calls).
         _executeScheduledMarketActions(closedTick);
-        // TODO Phase 3: bandit state transitions and attacks
 
-        uint64 newTick = _world.currentTick;
+        // Step 3: Eager-settle clans touched by world events (Phase 3 bandit — stub).
+        // TODO Phase 3: _settleClansNearBandit(closedTick);
 
-        // update next-heartbeat tick estimate
+        // Step 4: Resolve world events (season boundary, winter transitions).
+        _resolveWorldEvents(closedTick);
+
+        // Step 5: Increment tick and publish (seed already written above; complete the atomic pair).
+        uint64 newTick = closedTick + 1;
+        _world.currentTick = newTick;
         _world.nextHeartbeatAtTick = newTick + 1;
+
+        emit TickAdvanced(closedTick, newTick, newSeed);
+    }
+
+    /// @dev Settle missions that complete exactly at `tick` (settlesAtTick == tick).
+    ///      Called from heartbeat before market execution and tick increment.
+    ///      Bounded by 12-clan cap x 4 clansmen = 48 max iterations.
+    function _settleCompletingMissions(uint64 tick) internal {
+        for (uint256 i = 0; i < _allClanIds.length; i++) {
+            uint32 clanId = _allClanIds[i];
+            Clan storage clan = _clans[clanId];
+            if (clan.clanState == ClanState.DEAD) continue;
+
+            uint32[] storage csIds = _clanClansmanIds[clanId];
+            for (uint256 j = 0; j < csIds.length; j++) {
+                Clansman storage cs = _clansmen[csIds[j]];
+                if (cs.state == ClansmanState.DEAD) continue;
+
+                Mission storage m = _missions[cs.clansmanId];
+                if (!m.active) continue;
+                if (m.settlesAtTick != tick) continue; // not due this tick
+
+                // Settle this mission using the single-tick range [tick, tick+1).
+                _settleMissionForClansman(clan, cs, clanId, tick, tick + 1);
+            }
+        }
+    }
+
+    /// @dev Resolve world events for the tick that was just closed.
+    ///      Uses closedTick+1 as the equivalent of the old `newTick` for transition checks.
+    function _resolveWorldEvents(uint64 closedTick) internal {
+        uint64 newTick = closedTick + 1;
 
         // --- season boundary ---
         if (newTick >= _world.seasonEndTick) {
@@ -921,12 +973,10 @@ contract ClanWorld is IClanWorld {
                 _world.winterEndsAtTick = _world.seasonEndTick;
             }
         }
-
-        emit TickAdvanced(closedTick, _world.currentTick, _world.currentTickSeed);
     }
 
     /// @notice Public settlement trigger — lazily settle a clan.
-    function settleClan(uint32 clanId) external override {
+    function settleClan(uint32 clanId) external override nonReentrant {
         _settleClan(clanId);
     }
 
@@ -934,7 +984,7 @@ contract ClanWorld is IClanWorld {
     ///         Internally settles the entire clan (including upkeep) to guarantee
     ///         correct ordering and prevent double-settlement. Callers may call this
     ///         or settleClan interchangeably; both are safe and idempotent.
-    function settleClansman(uint32 csId) external override {
+    function settleClansman(uint32 csId) external override nonReentrant {
         Clansman storage cs = _clansmen[csId];
         if (cs.clansmanId == 0) return;
         _settleClan(cs.clanId);
@@ -950,7 +1000,7 @@ contract ClanWorld is IClanWorld {
     // =========================================================================
 
     /// @notice Mint a new clan and spawn its homebase.
-    function mintClan(address to) external override returns (uint32 clanId, uint256 iftTokenId) {
+    function mintClan(address to) external override nonReentrant returns (uint32 clanId, uint256 iftTokenId) {
         require(to != address(0), "ClanWorld: zero address");
         require(_allClanIds.length < 12, "ClanWorld: max clans");
         clanId = _nextClanId++;
@@ -1030,6 +1080,7 @@ contract ClanWorld is IClanWorld {
     function submitClanOrders(uint32 clanId, ClanOrder[] calldata orders)
         external
         override
+        nonReentrant
         returns (OrderResult[] memory results)
     {
         Clan storage clan = _clans[clanId];
@@ -1646,7 +1697,7 @@ contract ClanWorld is IClanWorld {
 
     /// @notice One-time treasury initialization: register token and pool addresses.
     ///         Must be called before seedPools. Callable only once.
-    function initTreasury(address[6] calldata tokens, address[4] calldata pools) external override {
+    function initTreasury(address[6] calldata tokens, address[4] calldata pools) external override nonReentrant {
         require(!_treasury.poolsSeeded && _treasury.woodToken == address(0), "ClanWorld: treasury already init");
         require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
 
@@ -1664,7 +1715,7 @@ contract ClanWorld is IClanWorld {
     }
 
     /// @notice Owner-only. Seeds the four Unicorn Town AMM pools.
-    function seedPools(PoolSeedConfig calldata cfg) external override {
+    function seedPools(PoolSeedConfig calldata cfg) external override nonReentrant {
         require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
         require(!_treasury.poolsSeeded, "ClanWorld: pools already seeded");
         require(_treasury.woodToken != address(0), "ClanWorld: treasury not init");

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -860,12 +860,11 @@ contract ClanWorld is IClanWorld {
         require(block.timestamp >= _world.nextHeartbeatAtTs, "ClanWorld: heartbeat rate limited");
 
         uint64 closedTick = _world.currentTick;
-        _world.currentTick = closedTick + 1; // increment first
+        bytes32 newSeed = keccak256(abi.encode(block.prevrandao, _world.currentTickSeed, closedTick));
 
-        // Derive tick seed: domain-separated from block randomness; stored under NEW tick
-        bytes32 newSeed = keccak256(abi.encode(block.prevrandao, closedTick, block.timestamp));
-        _tickSeeds[_world.currentTick] = newSeed; // store under new tick
+        _tickSeeds[closedTick] = newSeed;
         _world.currentTickSeed = newSeed;
+        _world.currentTick = closedTick + 1;
 
         _world.nextHeartbeatAtTs = uint64(block.timestamp) + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS;
 

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -47,6 +47,14 @@ contract ClanWorldStub is IClanWorld {
     constructor(address[6] memory tokens, address[4] memory pools) {
         _world.currentTick = 1;
         _world.nextHeartbeatAtTs = uint64(block.timestamp);
+        _world.seasonStartTick = 0;
+        _world.seasonEndTick = ClanWorldConstants.SEASON_DURATION_TICKS;
+        _world.currentSeasonNumber = 1;
+        _world.nextHeartbeatAtTick = 1;
+        _world.winterStartsAtTick =
+            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS;
+        _world.winterEndsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
+        _world.winterActive = false;
 
         _treasury.woodToken = tokens[0];
         _treasury.ironToken = tokens[1];
@@ -70,6 +78,7 @@ contract ClanWorldStub is IClanWorld {
     function heartbeat() external override {
         uint64 closed = _world.currentTick;
         _world.currentTick += 1;
+        _world.nextHeartbeatAtTick = _world.currentTick + 1;
         _world.nextHeartbeatAtTs = uint64(block.timestamp);
         emit TickAdvanced(closed, _world.currentTick, bytes32(0));
     }
@@ -284,9 +293,11 @@ contract ClanWorldStub is IClanWorld {
             seasonStartTick: _world.seasonStartTick,
             seasonEndTick: _world.seasonEndTick,
             seasonFinalized: false,
-            winterActive: false,
-            winterStartsAtTick: 0,
-            winterEndsAtTick: 0,
+            currentSeasonNumber: _world.currentSeasonNumber,
+            nextHeartbeatAtTick: _world.nextHeartbeatAtTick,
+            winterActive: _world.winterActive,
+            winterStartsAtTick: _world.winterStartsAtTick,
+            winterEndsAtTick: _world.winterEndsAtTick,
             activeBanditId: 0,
             currentTickSeed: bytes32(0),
             leaderboard: new LeaderboardEntry[](0)

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -50,7 +50,7 @@ contract ClanWorldStub is IClanWorld {
         _world.seasonStartTick = 0;
         _world.seasonEndTick = ClanWorldConstants.SEASON_DURATION_TICKS;
         _world.currentSeasonNumber = 1;
-        _world.nextHeartbeatAtTick = 1;
+        _world.nextHeartbeatAtTick = _world.currentTick + 1;
         _world.winterStartsAtTick =
             ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS;
         _world.winterEndsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE;

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -188,6 +188,8 @@ struct WorldState {
     uint64 seasonStartTick;
     uint64 seasonEndTick;
     bool seasonFinalized;
+    uint64 currentSeasonNumber;   // 1-indexed; incremented each time seasonEndTick is crossed
+    uint64 nextHeartbeatAtTick;   // estimated tick that will be opened by the next heartbeat (for off-chain UI)
 
     uint64 nextHeartbeatAtTs;
     uint64 nextBanditSpawnEligibleTick;
@@ -408,6 +410,8 @@ struct WorldSnapshot {
     uint64 seasonStartTick;
     uint64 seasonEndTick;
     bool seasonFinalized;
+    uint64 currentSeasonNumber;
+    uint64 nextHeartbeatAtTick;
     bool winterActive;
     uint64 winterStartsAtTick;
     uint64 winterEndsAtTick;

--- a/packages/contracts/src/lib/RNG.sol
+++ b/packages/contracts/src/lib/RNG.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+/// @title ClanWorld domain-separated RNG helpers
+/// @notice Cheap deterministic randomness derived from a published per-tick seed.
+library RNG {
+    uint256 internal constant DOMAIN_MISSION_RESOLUTION = uint256(keccak256("clanworld.mission.resolve.v1"));
+    uint256 internal constant DOMAIN_BANDIT_SPAWN = uint256(keccak256("clanworld.bandit.spawn.v1"));
+    uint256 internal constant DOMAIN_MARKET_NOISE = uint256(keccak256("clanworld.market.noise.v1"));
+    uint256 internal constant DOMAIN_WEATHER = uint256(keccak256("clanworld.weather.v1"));
+    uint256 internal constant DOMAIN_FAIR_ITERATION = uint256(keccak256("clanworld.fair.iteration.v1"));
+
+    uint256 internal constant MAX_SHUFFLE_N = 64;
+
+    error ShuffleSizeTooLarge(uint256 n, uint256 max);
+
+    /// @notice Returns a uniform uint256 in [0, 2^256).
+    function rngUniform(bytes32 seed, uint256 domainSalt, uint256 nonce) internal pure returns (uint256) {
+        return uint256(keccak256(abi.encodePacked(domainSalt, seed, nonce)));
+    }
+
+    /// @notice Returns a uniform value in [0, max) using rejection sampling.
+    /// @dev Returns 0 when max is 0 so callers can handle optional random choices cheaply.
+    function rngBounded(bytes32 seed, uint256 domainSalt, uint256 nonce, uint256 max) internal pure returns (uint256) {
+        if (max == 0) {
+            return 0;
+        }
+
+        uint256 remainder;
+        unchecked {
+            // Computes 2^256 % max without trying to represent 2^256 directly.
+            remainder = (uint256(0) - max) % max;
+        }
+        uint256 maxValid = type(uint256).max - remainder;
+        uint256 attempt = 0;
+
+        while (true) {
+            uint256 value = uint256(keccak256(abi.encodePacked(domainSalt, seed, nonce, max, attempt)));
+            if (value <= maxValid) {
+                return value % max;
+            }
+
+            unchecked {
+                attempt++;
+            }
+        }
+
+        revert("RNG: unreachable");
+    }
+
+    /// @notice Returns true with 50% probability.
+    function rngBool(bytes32 seed, uint256 domainSalt, uint256 nonce) internal pure returns (bool) {
+        return rngUniform(seed, domainSalt, nonce) & 1 == 1;
+    }
+
+    /// @notice Picks an index in proportion to each weight.
+    /// @dev Returns 0 for empty arrays and zero-total arrays.
+    function rngWeightedPick(bytes32 seed, uint256 domainSalt, uint256 nonce, uint256[] memory weights)
+        internal
+        pure
+        returns (uint256 index)
+    {
+        uint256 total = 0;
+        for (uint256 i = 0; i < weights.length; i++) {
+            total += weights[i];
+        }
+
+        if (total == 0) {
+            return 0;
+        }
+
+        uint256 pick = rngBounded(seed, domainSalt, nonce, total);
+        uint256 cumulative = 0;
+        for (uint256 i = 0; i < weights.length; i++) {
+            cumulative += weights[i];
+            if (pick < cumulative) {
+                return i;
+            }
+        }
+
+        return weights.length - 1;
+    }
+
+    /// @notice Returns a Fisher-Yates permutation of [0, n).
+    /// @dev Reverts above MAX_SHUFFLE_N to keep callers away from accidental gas blowups.
+    function rngShuffle(bytes32 seed, uint256 domainSalt, uint256 nonce, uint256 n)
+        internal
+        pure
+        returns (uint8[] memory permutation)
+    {
+        if (n > MAX_SHUFFLE_N) {
+            revert ShuffleSizeTooLarge(n, MAX_SHUFFLE_N);
+        }
+
+        permutation = new uint8[](n);
+        for (uint256 i = 0; i < n; i++) {
+            // casting is safe because n is bounded by MAX_SHUFFLE_N (64).
+            // forge-lint: disable-next-line(unsafe-typecast)
+            permutation[i] = uint8(i);
+        }
+
+        for (uint256 i = n; i > 1; i--) {
+            uint256 stepNonce = uint256(keccak256(abi.encodePacked(nonce, n, i)));
+            uint256 j = rngBounded(seed, domainSalt, stepNonce, i);
+            uint8 tmp = permutation[i - 1];
+            permutation[i - 1] = permutation[j];
+            permutation[j] = tmp;
+        }
+    }
+}

--- a/packages/contracts/src/util/ReentrancyGuard.sol
+++ b/packages/contracts/src/util/ReentrancyGuard.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+abstract contract ReentrancyGuard {
+    uint256 private constant _NOT_ENTERED = 1;
+    uint256 private constant _ENTERED = 2;
+    uint256 private _reentrancyStatus;
+
+    constructor() {
+        _reentrancyStatus = _NOT_ENTERED;
+    }
+
+    modifier nonReentrant() {
+        require(_reentrancyStatus != _ENTERED, "ClanWorld: reentrant call");
+        _reentrancyStatus = _ENTERED;
+        _;
+        _reentrancyStatus = _NOT_ENTERED;
+    }
+}

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -1807,14 +1807,14 @@ contract ClanWorldTest is Test {
             _advanceTick();
         }
 
-        // Verify: raw storage not yet updated (settleClan not called)
-        assertEq(world.getClansman(csId).carryIron, 0, "onDemand: carryIron must be 0 before settleClansman");
+        // Phase 4.2: heartbeat eagerly settles missions at settlesAtTick (step 1 of heartbeat).
+        // carryIron is already > 0 after tick advancement — no manual settleClansman required.
+        assertGt(world.getClansman(csId).carryIron, 0, "onDemand: heartbeat settled mission at settlesAtTick");
 
-        // Call settleClansman on-demand — only this clansman's mission should resolve
+        // Call settleClansman on-demand — must be idempotent (no crash, no double-credit).
+        uint256 ironBefore = world.getClansman(csId).carryIron;
         world.settleClansman(csId);
-
-        // Verify: clansman now has iron (settled on demand)
-        assertGt(world.getClansman(csId).carryIron, 0, "onDemand: carryIron must be > 0 after settleClansman");
+        assertEq(world.getClansman(csId).carryIron, ironBefore, "onDemand: settleClansman is idempotent after heartbeat settle");
     }
 
     // -------------------------------------------------------------------------

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -160,19 +160,76 @@ contract ClanWorldTest is Test {
         world.heartbeat();
     }
 
+    function test_heartbeat_tickIncrementsExactlyOne() public {
+        uint64 tickBefore = world.getWorldState().currentTick;
+
+        world.heartbeat();
+
+        uint64 tickAfter = world.getWorldState().currentTick;
+        assertEq(tickAfter - tickBefore, 1, "heartbeat should advance exactly one tick");
+    }
+
     // -------------------------------------------------------------------------
     // Test 2: tick seed changes after heartbeat
     // -------------------------------------------------------------------------
 
     function test_heartbeat_seedChanges() public {
-        bytes32 seedBefore = world.getWorldState().currentTickSeed;
-        assertEq(seedBefore, bytes32(0));
+        WorldState memory beforeFirst = world.getWorldState();
+        assertEq(beforeFirst.currentTickSeed, bytes32(0));
 
-        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        bytes32 expectedFirstSeed =
+            keccak256(abi.encode(block.prevrandao, beforeFirst.currentTickSeed, beforeFirst.currentTick));
         world.heartbeat();
 
-        bytes32 seedAfter = world.getWorldState().currentTickSeed;
-        assertTrue(seedAfter != bytes32(0), "Seed should be non-zero after heartbeat");
+        WorldState memory afterFirst = world.getWorldState();
+        assertEq(afterFirst.currentTickSeed, expectedFirstSeed, "first seed should use closed tick and prior seed");
+        assertTrue(afterFirst.currentTickSeed != beforeFirst.currentTickSeed, "seed should change after heartbeat");
+
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        bytes32 expectedSecondSeed =
+            keccak256(abi.encode(block.prevrandao, afterFirst.currentTickSeed, afterFirst.currentTick));
+        world.heartbeat();
+
+        WorldState memory afterSecond = world.getWorldState();
+        assertEq(afterSecond.currentTickSeed, expectedSecondSeed, "second seed should chain from prior seed");
+        assertTrue(afterSecond.currentTickSeed != afterFirst.currentTickSeed, "next seed should differ");
+        assertTrue(
+            afterSecond.currentTickSeed != beforeFirst.currentTickSeed, "next seed should not repeat initial seed"
+        );
+    }
+
+    function test_heartbeat_permissionless() public {
+        address rando = makeAddr("rando");
+        uint64 tickBefore = world.getWorldState().currentTick;
+
+        vm.prank(rando);
+        world.heartbeat();
+
+        assertEq(world.getWorldState().currentTick, tickBefore + 1, "non-owner caller should advance heartbeat");
+    }
+
+    function test_heartbeat_sequenceFiveTicks() public {
+        bytes32[5] memory seeds;
+        uint64 previousTick = world.getWorldState().currentTick;
+
+        for (uint256 i = 0; i < 5; i++) {
+            if (i != 0) {
+                vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+            }
+
+            world.heartbeat();
+
+            WorldState memory state = world.getWorldState();
+            assertEq(state.currentTick, previousTick + 1, "each heartbeat should advance exactly one tick");
+            assertTrue(state.currentTickSeed != bytes32(0), "seed should be non-zero");
+
+            for (uint256 j = 0; j < i; j++) {
+                assertTrue(state.currentTickSeed != seeds[j], "seed sequence should not repeat");
+            }
+
+            seeds[i] = state.currentTickSeed;
+            previousTick = state.currentTick;
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -1910,4 +1910,91 @@ contract ClanWorldTest is Test {
             uint8(results[3].status), uint8(StatusCode.ERR_INVALID_REGION), "3.E8: order[3] must be ERR_INVALID_REGION"
         );
     }
+
+    // =====================================================================
+    // Phase 4.4 — season + winter timer tests
+    // =====================================================================
+
+    function test_season_initialState() public {
+        WorldState memory ws = world.getWorldState();
+        assertEq(ws.currentSeasonNumber, 1, "season starts at 1");
+        assertEq(ws.seasonStartTick, 0);
+        assertEq(ws.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS);
+        assertEq(
+            ws.winterStartsAtTick,
+            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS
+        );
+        assertFalse(ws.winterActive);
+    }
+
+    function test_winter_onset() public {
+        // winterStartsAtTick = 100; WinterStarted fires on the heartbeat that opens tick 100
+        // i.e. when closedTick=99, newTick=100 >= winterStartsAtTick=100.
+        // Advance 99 heartbeats so currentTick=99, then one more heartbeat fires WinterStarted at tick 100.
+        uint64 winterStart =
+            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
+        for (uint64 i = 0; i < winterStart - 1; i++) {
+            vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+            world.heartbeat();
+        }
+        // currentTick == 99; next heartbeat opens tick 100 and should emit WinterStarted(100)
+        vm.recordLogs();
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 winterSig = keccak256("WinterStarted(uint64)");
+        bool foundWinterStarted = false;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics.length > 0 && logs[i].topics[0] == winterSig) {
+                foundWinterStarted = true;
+                break;
+            }
+        }
+        assertTrue(foundWinterStarted, "WinterStarted event should have been emitted at tick 100");
+        assertTrue(world.getWorldState().winterActive, "winter should be active");
+        assertEq(world.getWorldState().currentTick, winterStart, "currentTick should be 100");
+    }
+
+    function test_winter_end_and_next_cycle() public {
+        // Advance past first winter end tick (= 110)
+        uint64 winterEnd = ClanWorldConstants.TICKS_PER_WINTER_CYCLE; // = 110
+        for (uint64 i = 0; i <= winterEnd; i++) {
+            vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+            world.heartbeat();
+        }
+        WorldState memory ws = world.getWorldState();
+        assertFalse(ws.winterActive, "winter should be over");
+        // next winter at [210, 220)
+        assertEq(
+            ws.winterStartsAtTick,
+            ClanWorldConstants.TICKS_PER_WINTER_CYCLE * 2 - ClanWorldConstants.WINTER_DURATION_TICKS
+        );
+    }
+
+    function test_season_transition() public {
+        // Advance SEASON_DURATION_TICKS heartbeats to cross season boundary
+        for (uint256 i = 0; i < ClanWorldConstants.SEASON_DURATION_TICKS; i++) {
+            vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+            world.heartbeat();
+        }
+        WorldState memory ws = world.getWorldState();
+        assertEq(ws.currentSeasonNumber, 2, "season number should increment");
+        assertEq(ws.seasonStartTick, ClanWorldConstants.SEASON_DURATION_TICKS);
+        assertEq(ws.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS * 2);
+        // winter reset for new season
+        uint64 expectedWinterStart = ClanWorldConstants.SEASON_DURATION_TICKS
+            + ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS;
+        assertEq(ws.winterStartsAtTick, expectedWinterStart);
+    }
+
+    function test_nextHeartbeatAtTick_tracks_tick() public {
+        WorldState memory ws0 = world.getWorldState();
+        assertEq(ws0.nextHeartbeatAtTick, 1, "before first heartbeat, next = tick 1");
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+        WorldState memory ws1 = world.getWorldState();
+        assertEq(ws1.currentTick, 1);
+        assertEq(ws1.nextHeartbeatAtTick, 2, "after tick 1, next = tick 2");
+    }
 }

--- a/packages/contracts/test/ClanWorldStub.t.sol
+++ b/packages/contracts/test/ClanWorldStub.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
 import {ClanWorldStub} from "../src/ClanWorldStub.sol";
+import {ClanWorldConstants, WorldState} from "../src/IClanWorld.sol";
 import {MinimalERC20} from "../src/MinimalERC20.sol";
 import {StubPool} from "../src/StubPool.sol";
 
@@ -32,5 +33,20 @@ contract ClanWorldStubTest is Test {
     function test_getWorldSnapshot_returns_current_tick() public {
         stub.heartbeat();
         assertEq(stub.getWorldSnapshot().currentTick, 2);
+    }
+
+    function test_initial_timer_fields_match_ClanWorld() public {
+        WorldState memory ws = stub.getWorldState();
+
+        assertEq(ws.currentSeasonNumber, 1, "season starts at 1");
+        assertEq(ws.seasonStartTick, 0);
+        assertEq(ws.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS);
+        assertEq(ws.nextHeartbeatAtTick, 1, "first heartbeat opens tick 1");
+        assertEq(
+            ws.winterStartsAtTick,
+            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS
+        );
+        assertEq(ws.winterEndsAtTick, ClanWorldConstants.TICKS_PER_WINTER_CYCLE);
+        assertFalse(ws.winterActive);
     }
 }

--- a/packages/contracts/test/ClanWorldStub.t.sol
+++ b/packages/contracts/test/ClanWorldStub.t.sol
@@ -41,7 +41,7 @@ contract ClanWorldStubTest is Test {
         assertEq(ws.currentSeasonNumber, 1, "season starts at 1");
         assertEq(ws.seasonStartTick, 0);
         assertEq(ws.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS);
-        assertEq(ws.nextHeartbeatAtTick, 1, "first heartbeat opens tick 1");
+        assertEq(ws.nextHeartbeatAtTick, ws.currentTick + 1, "next heartbeat opens currentTick + 1");
         assertEq(
             ws.winterStartsAtTick,
             ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS

--- a/packages/contracts/test/HeartbeatOrdering.t.sol
+++ b/packages/contracts/test/HeartbeatOrdering.t.sol
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {MinimalERC20} from "../src/MinimalERC20.sol";
+import {StubPool} from "../src/StubPool.sol";
+import {
+    ClanWorldConstants,
+    ClanState,
+    ClansmanState,
+    ActionType,
+    StatusCode,
+    WorldState,
+    ClanOrder,
+    OrderResult,
+    Mission,
+    Clan,
+    Clansman,
+    ClanFullView,
+    PoolSeedConfig
+} from "../src/IClanWorld.sol";
+
+/// @dev Harness to expose internal state injection for ordering tests.
+contract HeartbeatOrderingHarness is ClanWorld {
+    function setCarryWood(uint32 csId, uint256 amount) external {
+        _clansmen[csId].carryWood = amount;
+    }
+
+    function setVaultWood(uint32 clanId, uint256 amount) external {
+        _clans[clanId].vaultWood = amount;
+    }
+
+    function setClansmanRegion(uint32 csId, uint8 region) external {
+        _clansmen[csId].currentRegion = region;
+    }
+}
+
+contract HeartbeatOrderingTest is Test {
+    HeartbeatOrderingHarness world;
+    address elder = address(0xA1);
+
+    // Market infra
+    MinimalERC20 woodToken;
+    MinimalERC20 ironToken;
+    MinimalERC20 wheatToken;
+    MinimalERC20 fishToken;
+    MinimalERC20 goldToken;
+    MinimalERC20 blueprintToken;
+    StubPool woodPool;
+    StubPool ironPool;
+    StubPool wheatPool;
+    StubPool fishPool;
+
+    function setUp() public {
+        world = new HeartbeatOrderingHarness();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    function _advanceTick() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+    }
+
+    function _advanceToTick(uint64 targetTick) internal {
+        while (world.getWorldState().currentTick < targetTick) {
+            _advanceTick();
+        }
+    }
+
+    function _mintClan() internal returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
+    }
+
+    function _firstCs(uint32 clanId) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _secondCs(uint32 clanId) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[1].clansman.clansman.clansmanId;
+    }
+
+    function _submitOrder(uint32 clanId, uint32 csId, uint8 gotoRegion, ActionType action)
+        internal
+        returns (OrderResult[] memory)
+    {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: gotoRegion,
+            action: action,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _submitMarketOrder(
+        uint32 clanId,
+        uint32 csId,
+        ActionType action,
+        address token,
+        uint256 amount,
+        uint256 maxGold
+    ) internal returns (OrderResult[] memory) {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: action,
+            targetClanId: 0,
+            marketToken: token,
+            marketAmount: amount,
+            maxGoldIn: maxGold
+        });
+        vm.prank(elder);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _setupMarket() internal {
+        woodToken = new MinimalERC20("Wood", "WOOD");
+        ironToken = new MinimalERC20("Iron", "IRON");
+        wheatToken = new MinimalERC20("Wheat", "WHEAT");
+        fishToken = new MinimalERC20("Fish", "FISH");
+        goldToken = new MinimalERC20("Gold", "GOLD");
+        blueprintToken = new MinimalERC20("BPRT", "BPRT");
+
+        address wAddr = address(world);
+        woodPool = new StubPool(address(woodToken), address(goldToken), wAddr);
+        ironPool = new StubPool(address(ironToken), address(goldToken), wAddr);
+        wheatPool = new StubPool(address(wheatToken), address(goldToken), wAddr);
+        fishPool = new StubPool(address(fishToken), address(goldToken), wAddr);
+
+        address[6] memory tokens = [
+            address(woodToken),
+            address(ironToken),
+            address(wheatToken),
+            address(fishToken),
+            address(goldToken),
+            address(blueprintToken)
+        ];
+        address[4] memory pools = [address(woodPool), address(wheatPool), address(fishPool), address(ironPool)];
+        world.initTreasury(tokens, pools);
+
+        uint256 resSeed = 1000e18;
+        uint256 goldSeed = 1000e18;
+        PoolSeedConfig memory cfg = PoolSeedConfig({
+            woodSeed: resSeed,
+            wheatSeed: resSeed,
+            fishSeed: resSeed,
+            ironSeed: resSeed,
+            goldSeedForWood: goldSeed,
+            goldSeedForWheat: goldSeed,
+            goldSeedForFish: goldSeed,
+            goldSeedForIron: goldSeed
+        });
+        world.seedPools(cfg);
+    }
+
+    // -------------------------------------------------------------------------
+    // test_heartbeat_settlementBeforeMarket
+    //
+    // Proves Step 1 (settle) fires before Step 2 (market execute) within the SAME
+    // heartbeat closing tick T:
+    //   - cs0 is placed at Mountains (region 2). Deposit to homebase Forest (region 1)
+    //     = 1 tick travel. arrivalTick = T0+1, settlesAtTick = T0+2.
+    //   - cs1 at Forest submits MarketSell to UT (region 3) = 2 ticks travel.
+    //     executeAtTick = T0+2. (Same tick as cs0 settles.)
+    //   - vault starts at 0; cs0 has carry wood.
+    //   - Heartbeat at T0+2: Step 1 deposits cs0 carry wood to vault, Step 2 sells
+    //     it. Gold increases only if Step 1 ran first (vault was 0 before Step 1).
+    //   - If ordering were reversed, sell would fail (vault still 0) and gold stays flat.
+    // -------------------------------------------------------------------------
+    function test_heartbeat_settlementBeforeMarket() public {
+        _setupMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId0 = _firstCs(clanId);
+        uint32 csId1 = _secondCs(clanId);
+
+        uint64 t0 = world.getWorldState().currentTick;
+
+        // Place cs0 at Mountains (region 2). Homebase = Forest (region 1).
+        // Deposit from Mountains to Forest: travel = 1 tick.
+        world.setClansmanRegion(csId0, ClanWorldConstants.REGION_MOUNTAINS);
+
+        // cs0: submit Deposit. arrivalTick = t0+1, settlesAtTick = t0+2.
+        OrderResult[] memory r0 = _submitOrder(clanId, csId0, ClanWorldConstants.REGION_FOREST, ActionType.DepositResources);
+        assertEq(uint8(r0[0].status), uint8(StatusCode.OK), "deposit order must succeed");
+        Mission memory depositMission = world.getActiveMission(csId0);
+        assertEq(depositMission.settlesAtTick, t0 + 2, "deposit settlesAtTick must be t0+2");
+
+        // cs1: at Forest. Submit MarketSell to UT. Forest→UT = 2 ticks.
+        // executeAtTick = t0+2. Same tick as deposit settles.
+        OrderResult[] memory r1 = _submitMarketOrder(clanId, csId1, ActionType.MarketSell, address(woodToken), 5e18, 0);
+        assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "market sell order must enqueue");
+        Mission memory sellMission = world.getActiveMission(csId1);
+        assertEq(sellMission.arrivalTick, t0 + 2, "sell arrivalTick must be t0+2");
+
+        // Give cs0 carry wood. Zero vault so market sell only succeeds if step1 ran first.
+        world.setCarryWood(csId0, 10e18);
+        world.setVaultWood(clanId, 0);
+        assertEq(world.getClan(clanId).vaultWood, 0, "vault wood must be 0 before test tick");
+
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+
+        // Advance to tick t0+2. The heartbeat closing t0+2 runs:
+        //   Step 1: _settleCompletingMissions(t0+2) → deposit fires, cs0 carry 10e18 → vault
+        //   Step 2: _executeScheduledMarketActions(t0+2) → sell fires, 5e18 vault wood → gold
+        // If reversed: sell would fail (vault=0), gold unchanged.
+        _advanceToTick(t0 + 3);
+
+        uint256 goldAfter = world.getClan(clanId).goldBalance;
+        assertGt(goldAfter, goldBefore, "gold must increase: settlement ran before market sell");
+        assertEq(world.getClansman(csId0).carryWood, 0, "cs0 carry wood cleared by deposit");
+        assertFalse(world.getActiveMission(csId0).active, "deposit mission must be complete");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_heartbeat_atomicTickSeedPublish
+    //
+    // Proves Step 5: after heartbeat, currentTick increments by 1, currentTickSeed
+    // changes, and the new seed is deterministic from block.prevrandao + prior seed.
+    // -------------------------------------------------------------------------
+    function test_heartbeat_atomicTickSeedPublish() public {
+        WorldState memory before_ = world.getWorldState();
+        uint64 tickBefore = before_.currentTick;
+        bytes32 seedBefore = before_.currentTickSeed;
+
+        bytes32 expectedSeed = keccak256(abi.encode(block.prevrandao, seedBefore, tickBefore));
+        world.heartbeat();
+
+        WorldState memory after_ = world.getWorldState();
+        assertEq(after_.currentTick, tickBefore + 1, "tick must increment by 1");
+        assertNotEq(after_.currentTickSeed, seedBefore, "seed must change after heartbeat");
+        assertEq(after_.currentTickSeed, expectedSeed, "seed must match keccak(prevrandao, oldSeed, closedTick)");
+
+        // Second heartbeat chains from the new seed
+        uint64 tick2 = after_.currentTick;
+        bytes32 seed2 = after_.currentTickSeed;
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        bytes32 expectedSeed2 = keccak256(abi.encode(block.prevrandao, seed2, tick2));
+        world.heartbeat();
+
+        assertEq(world.getWorldState().currentTick, tick2 + 1, "tick must increment again");
+        assertEq(world.getWorldState().currentTickSeed, expectedSeed2, "seed must chain from prior seed");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_heartbeat_seasonTransition
+    //
+    // Proves Step 4 (world events) fires AFTER Steps 1-3:
+    //   - season boundary is crossed at SEASON_DURATION_TICKS
+    //   - currentSeasonNumber increments on the heartbeat that closes tick
+    //     SEASON_DURATION_TICKS-1 (newTick = SEASON_DURATION_TICKS >= seasonEndTick)
+    //   - no crash or revert when there are no pending missions or market actions
+    // -------------------------------------------------------------------------
+    function test_heartbeat_seasonTransition() public {
+        WorldState memory ws0 = world.getWorldState();
+        assertEq(ws0.currentSeasonNumber, 1, "season starts at 1");
+        assertEq(ws0.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS, "seasonEndTick starts at 360");
+
+        // Advance SEASON_DURATION_TICKS heartbeats to cross the boundary
+        for (uint256 i = 0; i < ClanWorldConstants.SEASON_DURATION_TICKS; i++) {
+            vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+            world.heartbeat();
+        }
+
+        WorldState memory ws1 = world.getWorldState();
+        assertEq(ws1.currentSeasonNumber, 2, "season must have incremented to 2 after Steps 1-4");
+        assertEq(ws1.currentTick, ClanWorldConstants.SEASON_DURATION_TICKS, "tick must be at season boundary");
+        assertEq(ws1.seasonStartTick, ClanWorldConstants.SEASON_DURATION_TICKS, "new seasonStartTick");
+        assertEq(ws1.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS * 2, "new seasonEndTick");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_heartbeat_noopTick
+    //
+    // Heartbeat with no pending missions and no queued market actions must:
+    //   - not revert
+    //   - increment currentTick exactly by 1
+    //   - change currentTickSeed
+    // -------------------------------------------------------------------------
+    function test_heartbeat_noopTick() public {
+        uint64 tickBefore = world.getWorldState().currentTick;
+        bytes32 seedBefore = world.getWorldState().currentTickSeed;
+
+        world.heartbeat();
+
+        assertEq(world.getWorldState().currentTick, tickBefore + 1, "tick must increment");
+        assertNotEq(world.getWorldState().currentTickSeed, seedBefore, "seed must change");
+    }
+
+    // -------------------------------------------------------------------------
+    // test_heartbeat_multipleStepsInOneTick
+    //
+    // Proves that when a mission settles at tick T AND a market action is queued at
+    // tick T, both fire in the same heartbeat without conflict.
+    //   - cs0 placed at Mountains, deposits to Forest homebase: settlesAtTick = T0+2
+    //   - cs1 sells wood to UT from Forest: executeAtTick = T0+2
+    //   Both succeed in the same heartbeat call at T0+2.
+    // -------------------------------------------------------------------------
+    function test_heartbeat_multipleStepsInOneTick() public {
+        _setupMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId0 = _firstCs(clanId);
+        uint32 csId1 = _secondCs(clanId);
+
+        uint64 t0 = world.getWorldState().currentTick;
+
+        // cs0: placed at Mountains (1 tick from Forest homebase).
+        // Deposit: arrivalTick = t0+1, settlesAtTick = t0+2.
+        world.setClansmanRegion(csId0, ClanWorldConstants.REGION_MOUNTAINS);
+        world.setCarryWood(csId0, 10e18);
+        OrderResult[] memory r0 = _submitOrder(clanId, csId0, ClanWorldConstants.REGION_FOREST, ActionType.DepositResources);
+        assertEq(uint8(r0[0].status), uint8(StatusCode.OK), "deposit must succeed");
+        assertEq(world.getActiveMission(csId0).settlesAtTick, t0 + 2, "deposit settlesAtTick must be t0+2");
+
+        // cs1: at Forest, sells wood to UT. Forest→UT = 2 ticks. executeAtTick = t0+2.
+        // Vault has 20e18 starter wood — sell always has enough.
+        OrderResult[] memory r1 = _submitMarketOrder(clanId, csId1, ActionType.MarketSell, address(woodToken), 5e18, 0);
+        assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "market sell must enqueue");
+        assertEq(world.getActiveMission(csId1).arrivalTick, t0 + 2, "sell executeAtTick must be t0+2");
+
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+
+        // Advance to tick t0+3 (the heartbeat closing t0+2 runs step1+step2 together).
+        _advanceToTick(t0 + 3);
+
+        // Both cs0 deposit (settled at T0+2) and cs1 sell (at T0+2) must have fired.
+        assertEq(world.getClansman(csId0).carryWood, 0, "deposit settled: carry cleared");
+        assertGt(world.getClan(clanId).goldBalance, goldBefore, "sell executed: gold increased");
+        assertFalse(world.getActiveMission(csId0).active, "deposit mission must be complete");
+    }
+}

--- a/packages/contracts/test/RNG.t.sol
+++ b/packages/contracts/test/RNG.t.sol
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {RNG} from "../src/lib/RNG.sol";
+
+contract RNGTest is Test {
+    bytes32 internal constant SEED = keccak256("clanworld.test.seed");
+    uint256 internal constant DOMAIN_A = uint256(keccak256("clanworld.mission.resolve.v1"));
+    uint256 internal constant DOMAIN_B = uint256(keccak256("clanworld.bandit.spawn.v1"));
+
+    function test_determinism_allHelpers() public pure {
+        uint256[] memory weights = new uint256[](4);
+        weights[0] = 1;
+        weights[1] = 3;
+        weights[2] = 0;
+        weights[3] = 6;
+
+        assertEq(RNG.rngUniform(SEED, DOMAIN_A, 7), RNG.rngUniform(SEED, DOMAIN_A, 7), "uniform deterministic");
+        assertEq(RNG.rngBounded(SEED, DOMAIN_A, 7, 10), RNG.rngBounded(SEED, DOMAIN_A, 7, 10), "bounded deterministic");
+        assertEq(RNG.rngBool(SEED, DOMAIN_A, 7), RNG.rngBool(SEED, DOMAIN_A, 7), "bool deterministic");
+        assertEq(
+            RNG.rngWeightedPick(SEED, DOMAIN_A, 7, weights),
+            RNG.rngWeightedPick(SEED, DOMAIN_A, 7, weights),
+            "weighted deterministic"
+        );
+
+        uint8[] memory first = RNG.rngShuffle(SEED, DOMAIN_A, 7, 12);
+        uint8[] memory second = RNG.rngShuffle(SEED, DOMAIN_A, 7, 12);
+        _assertSameUint8Array(first, second);
+    }
+
+    function test_domainSeparation_outputsDifferAcrossDomains() public pure {
+        uint256 uniformDiffs = 0;
+        uint256 boundedDiffs = 0;
+        uint256 boolDiffs = 0;
+        uint256 weightedDiffs = 0;
+        uint256 shuffleDiffs = 0;
+
+        uint256[] memory weights = new uint256[](10);
+        for (uint256 i = 0; i < weights.length; i++) {
+            weights[i] = 1;
+        }
+
+        for (uint256 nonce = 0; nonce < 32; nonce++) {
+            if (RNG.rngUniform(SEED, DOMAIN_A, nonce) != RNG.rngUniform(SEED, DOMAIN_B, nonce)) {
+                uniformDiffs++;
+            }
+            if (RNG.rngBounded(SEED, DOMAIN_A, nonce, 10_000) != RNG.rngBounded(SEED, DOMAIN_B, nonce, 10_000)) {
+                boundedDiffs++;
+            }
+            if (RNG.rngBool(SEED, DOMAIN_A, nonce) != RNG.rngBool(SEED, DOMAIN_B, nonce)) {
+                boolDiffs++;
+            }
+            if (RNG.rngWeightedPick(SEED, DOMAIN_A, nonce, weights) != RNG.rngWeightedPick(SEED, DOMAIN_B, nonce, weights)) {
+                weightedDiffs++;
+            }
+            if (!_sameUint8Array(RNG.rngShuffle(SEED, DOMAIN_A, nonce, 8), RNG.rngShuffle(SEED, DOMAIN_B, nonce, 8))) {
+                shuffleDiffs++;
+            }
+        }
+
+        assertGe(uniformDiffs, 30, "uniform domains should diverge");
+        assertGe(boundedDiffs, 30, "bounded domains should diverge");
+        assertGe(boolDiffs, 8, "bool domains should diverge often enough");
+        assertGe(weightedDiffs, 20, "weighted domains should diverge");
+        assertGe(shuffleDiffs, 20, "shuffle domains should diverge");
+    }
+
+    function test_rngUniform_distributionVariationAcrossNonces() public pure {
+        uint256 minValue = type(uint256).max;
+        uint256 maxValue = 0;
+
+        for (uint256 nonce = 0; nonce < 100; nonce++) {
+            uint256 value = RNG.rngUniform(SEED, DOMAIN_A, nonce);
+            if (value < minValue) {
+                minValue = value;
+            }
+            if (value > maxValue) {
+                maxValue = value;
+            }
+        }
+
+        assertGt(maxValue - minValue, type(uint256).max / 2, "uniform range should be non-trivial");
+    }
+
+    function test_rngBounded_distributionForMaxTen() public pure {
+        uint256[10] memory buckets;
+
+        for (uint256 nonce = 0; nonce < 1000; nonce++) {
+            uint256 value = RNG.rngBounded(SEED, DOMAIN_A, nonce, 10);
+            buckets[value]++;
+        }
+
+        for (uint256 i = 0; i < buckets.length; i++) {
+            assertGe(buckets[i], 50, "bucket should get enough hits");
+        }
+    }
+
+    function test_rngBounded_powerOfTwoBoundsUseFirstSample() public pure {
+        _assertPowerOfTwoBoundUsesFirstSample(uint256(1) << 200);
+        _assertPowerOfTwoBoundUsesFirstSample(uint256(1) << 255);
+    }
+
+    function test_rngBounded_distributionForMax256() public pure {
+        uint256[256] memory buckets;
+        uint256 hitBuckets = 0;
+
+        for (uint256 nonce = 0; nonce < 1000; nonce++) {
+            uint256 value = RNG.rngBounded(SEED, DOMAIN_A, nonce, 256);
+            assertLt(value, 256, "value must stay in range");
+
+            if (buckets[value] == 0) {
+                hitBuckets++;
+            }
+            buckets[value]++;
+        }
+
+        assertGe(hitBuckets, 245, "nearly every bucket should be represented");
+        for (uint256 i = 0; i < buckets.length; i++) {
+            assertLe(buckets[i], 12, "bucket should not dominate");
+        }
+    }
+
+    function test_rngBool_distribution() public pure {
+        uint256 trueCount = 0;
+
+        for (uint256 nonce = 0; nonce < 1000; nonce++) {
+            if (RNG.rngBool(SEED, DOMAIN_A, nonce)) {
+                trueCount++;
+            }
+        }
+
+        assertGe(trueCount, 400, "true count too low");
+        assertLe(trueCount, 600, "true count too high");
+    }
+
+    function test_rngWeightedPick_degenerateAndWeightedCases() public pure {
+        uint256[] memory empty = new uint256[](0);
+        assertEq(RNG.rngWeightedPick(SEED, DOMAIN_A, 0, empty), 0, "empty weights return 0");
+
+        uint256[] memory zeros = new uint256[](3);
+        assertEq(RNG.rngWeightedPick(SEED, DOMAIN_A, 0, zeros), 0, "zero-total weights return 0");
+
+        uint256[] memory single = new uint256[](1);
+        single[0] = 42;
+        for (uint256 nonce = 0; nonce < 100; nonce++) {
+            assertEq(RNG.rngWeightedPick(SEED, DOMAIN_A, nonce, single), 0, "single non-zero weight always wins");
+        }
+
+        uint256[] memory equal = new uint256[](4);
+        equal[0] = 1;
+        equal[1] = 1;
+        equal[2] = 1;
+        equal[3] = 1;
+        uint256[4] memory equalCounts;
+        for (uint256 nonce = 0; nonce < 1000; nonce++) {
+            equalCounts[RNG.rngWeightedPick(SEED, DOMAIN_A, nonce, equal)]++;
+        }
+        for (uint256 i = 0; i < equalCounts.length; i++) {
+            assertGe(equalCounts[i], 150, "equal buckets should all be represented");
+        }
+
+        uint256[] memory zeroFront = new uint256[](4);
+        zeroFront[0] = 0;
+        zeroFront[1] = 0;
+        zeroFront[2] = 7;
+        zeroFront[3] = 3;
+        uint256[4] memory zeroFrontCounts;
+        for (uint256 nonce = 0; nonce < 1000; nonce++) {
+            zeroFrontCounts[RNG.rngWeightedPick(SEED, DOMAIN_A, nonce, zeroFront)]++;
+        }
+        assertEq(zeroFrontCounts[0], 0, "zero-weight index 0 should not be picked");
+        assertEq(zeroFrontCounts[1], 0, "zero-weight index 1 should not be picked");
+        assertGe(zeroFrontCounts[2], 600, "weight 7 bucket should dominate");
+        assertLe(zeroFrontCounts[2], 800, "weight 7 bucket should stay plausible");
+        assertGe(zeroFrontCounts[3], 200, "weight 3 bucket should be represented");
+        assertLe(zeroFrontCounts[3], 400, "weight 3 bucket should stay plausible");
+    }
+
+    function test_rngShuffle_permutationAndDeterminism() public pure {
+        uint256 n = 16;
+        uint8[] memory permutation = RNG.rngShuffle(SEED, DOMAIN_A, 99, n);
+        uint8[] memory repeat = RNG.rngShuffle(SEED, DOMAIN_A, 99, n);
+
+        _assertSameUint8Array(permutation, repeat);
+        _assertPermutation(permutation, n);
+    }
+
+    function _assertPermutation(uint8[] memory permutation, uint256 n) internal pure {
+        assertEq(permutation.length, n, "length mismatch");
+
+        bool[] memory seen = new bool[](n);
+        for (uint256 i = 0; i < permutation.length; i++) {
+            uint256 value = uint256(permutation[i]);
+            assertLt(value, n, "value out of range");
+            assertFalse(seen[value], "duplicate value");
+            seen[value] = true;
+        }
+
+        for (uint256 i = 0; i < n; i++) {
+            assertTrue(seen[i], "missing value");
+        }
+    }
+
+    function _assertPowerOfTwoBoundUsesFirstSample(uint256 max) internal pure {
+        for (uint256 nonce = 0; nonce < 100; nonce++) {
+            uint256 firstSample = uint256(keccak256(abi.encodePacked(DOMAIN_A, SEED, nonce, max, uint256(0))));
+            assertEq(RNG.rngBounded(SEED, DOMAIN_A, nonce, max), firstSample & (max - 1), "should not reject");
+        }
+    }
+
+    function _assertSameUint8Array(uint8[] memory a, uint8[] memory b) internal pure {
+        assertTrue(_sameUint8Array(a, b), "arrays differ");
+    }
+
+    function _sameUint8Array(uint8[] memory a, uint8[] memory b) internal pure returns (bool) {
+        if (a.length != b.length) {
+            return false;
+        }
+
+        for (uint256 i = 0; i < a.length; i++) {
+            if (a[i] != b[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/packages/contracts/test/Reentrancy.t.sol
+++ b/packages/contracts/test/Reentrancy.t.sol
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {MinimalERC20} from "../src/MinimalERC20.sol";
+import {StubPool} from "../src/StubPool.sol";
+import {
+    IClanWorld,
+    ClanWorldConstants,
+    ActionType,
+    StatusCode,
+    ClanOrder,
+    OrderResult,
+    Mission,
+    PoolSeedConfig
+} from "../src/IClanWorld.sol";
+
+contract MockReentrantPool {
+    address public immutable TOKEN_A;
+    address public immutable TOKEN_B;
+    address public immutable ENGINE;
+
+    uint256 public reserveA;
+    uint256 public reserveB;
+    bool public sawReentrantGuard;
+    bytes public lastRevertData;
+
+    bool private _seeded;
+
+    modifier onlyEngine() {
+        require(msg.sender == ENGINE, "MockReentrantPool: only engine");
+        _;
+    }
+
+    constructor(address tokenA_, address tokenB_, address engine_) {
+        TOKEN_A = tokenA_;
+        TOKEN_B = tokenB_;
+        ENGINE = engine_;
+    }
+
+    function seed(uint256 amountA, uint256 amountB) external onlyEngine {
+        require(!_seeded, "MockReentrantPool: already seeded");
+        require(amountA > 0 && amountB > 0, "MockReentrantPool: zero seed");
+        reserveA = amountA;
+        reserveB = amountB;
+        _seeded = true;
+    }
+
+    function sellResource(uint256 amountIn) external onlyEngine returns (uint256 goldOut) {
+        _attemptHeartbeatReentry();
+
+        require(amountIn > 0, "MockReentrantPool: zero amount");
+        require(reserveA > 0 && reserveB > 0, "MockReentrantPool: not seeded");
+        goldOut = (reserveB * amountIn) / (reserveA + amountIn);
+        require(goldOut > 0, "MockReentrantPool: zero output");
+        reserveA += amountIn;
+        reserveB -= goldOut;
+    }
+
+    function quoteBuy(uint256 amountOut) external view returns (uint256 goldIn) {
+        require(amountOut > 0, "MockReentrantPool: zero amount");
+        require(amountOut < reserveA, "MockReentrantPool: insufficient resource reserve");
+        uint256 num = reserveB * amountOut;
+        uint256 denom = reserveA - amountOut;
+        goldIn = num / denom + (num % denom == 0 ? 0 : 1);
+    }
+
+    function buyResource(uint256 amountOut) external onlyEngine returns (uint256 goldIn) {
+        require(amountOut > 0, "MockReentrantPool: zero amount");
+        require(amountOut < reserveA, "MockReentrantPool: insufficient resource reserve");
+        require(reserveB > 0, "MockReentrantPool: not seeded");
+        uint256 num = reserveB * amountOut;
+        uint256 denom = reserveA - amountOut;
+        goldIn = num / denom + (num % denom == 0 ? 0 : 1);
+        reserveA -= amountOut;
+        reserveB += goldIn;
+    }
+
+    function getReserves() external view returns (uint256, uint256) {
+        return (reserveA, reserveB);
+    }
+
+    function _attemptHeartbeatReentry() internal {
+        try IClanWorld(ENGINE).heartbeat() {
+            revert("MockReentrantPool: heartbeat reentry succeeded");
+        } catch Error(string memory reason) {
+            if (keccak256(bytes(reason)) == keccak256(bytes("ClanWorld: reentrant call"))) {
+                sawReentrantGuard = true;
+            }
+        } catch (bytes memory data) {
+            lastRevertData = data;
+        }
+    }
+}
+
+contract ReentrancyTest is Test {
+    ClanWorld world;
+    address elder = address(0xA1);
+
+    MinimalERC20 woodToken;
+    MinimalERC20 ironToken;
+    MinimalERC20 wheatToken;
+    MinimalERC20 fishToken;
+    MinimalERC20 goldToken;
+    MinimalERC20 blueprintToken;
+    MockReentrantPool woodPool;
+    StubPool ironPool;
+    StubPool wheatPool;
+    StubPool fishPool;
+
+    function setUp() public {
+        world = new ClanWorld();
+    }
+
+    function test_marketPoolHeartbeatCallback_revertsWithReentrancyGuard() public {
+        _setupReentrantMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+
+        OrderResult[] memory results = _submitMarketSell(clanId, csId, address(woodToken), 5e18);
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "market sell should enqueue");
+
+        Mission memory mission = world.getActiveMission(csId);
+        uint64 currentTick = world.getWorldState().currentTick;
+        uint256 ticksNeeded = uint256(mission.actionStartTick - currentTick) + 1;
+        for (uint256 i = 0; i < ticksNeeded; i++) {
+            _advanceTick();
+        }
+
+        assertTrue(woodPool.sawReentrantGuard(), "pool callback should receive reentrant guard revert");
+        assertEq(woodPool.lastRevertData().length, 0, "callback should catch the string guard revert");
+        assertGt(world.getClan(clanId).goldBalance, goldBefore, "heartbeat should finish original market action");
+    }
+
+    function _setupReentrantMarket() internal {
+        woodToken = new MinimalERC20("Wood", "WOOD");
+        ironToken = new MinimalERC20("Iron", "IRON");
+        wheatToken = new MinimalERC20("Wheat", "WHEAT");
+        fishToken = new MinimalERC20("Fish", "FISH");
+        goldToken = new MinimalERC20("Gold", "GOLD");
+        blueprintToken = new MinimalERC20("BPRT", "BPRT");
+
+        address engine = address(world);
+        woodPool = new MockReentrantPool(address(woodToken), address(goldToken), engine);
+        ironPool = new StubPool(address(ironToken), address(goldToken), engine);
+        wheatPool = new StubPool(address(wheatToken), address(goldToken), engine);
+        fishPool = new StubPool(address(fishToken), address(goldToken), engine);
+
+        address[6] memory tokens = [
+            address(woodToken),
+            address(ironToken),
+            address(wheatToken),
+            address(fishToken),
+            address(goldToken),
+            address(blueprintToken)
+        ];
+        address[4] memory pools = [address(woodPool), address(wheatPool), address(fishPool), address(ironPool)];
+        world.initTreasury(tokens, pools);
+
+        uint256 resSeed = 1000e18;
+        uint256 goldSeed = 1000e18;
+        PoolSeedConfig memory cfg = PoolSeedConfig({
+            woodSeed: resSeed,
+            wheatSeed: resSeed,
+            fishSeed: resSeed,
+            ironSeed: resSeed,
+            goldSeedForWood: goldSeed,
+            goldSeedForWheat: goldSeed,
+            goldSeedForFish: goldSeed,
+            goldSeedForIron: goldSeed
+        });
+        world.seedPools(cfg);
+    }
+
+    function _advanceTick() internal {
+        vm.warp(world.getWorldState().nextHeartbeatAtTs);
+        world.heartbeat();
+    }
+
+    function _mintClan() internal returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
+    }
+
+    function _firstCs(uint32 clanId) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _submitMarketSell(uint32 clanId, uint32 csId, address token, uint256 amount)
+        internal
+        returns (OrderResult[] memory)
+    {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketSell,
+            targetClanId: 0,
+            marketToken: token,
+            marketAmount: amount,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        return world.submitClanOrders(clanId, orders);
+    }
+}


### PR DESCRIPTION
**Phase 4 release PR** — bundles all 4 Phase 4 sub-issues + integration round.

## Sub-issues bundled

| PR | Issue | Title |
|---|---|---|
| #173 | #166 | Phase 4.1 — permissionless heartbeat with rate limit + atomic seed publish |
| #174 | #168 | Phase 4.3 — domain-separated RNG helpers |
| #175 | #169 | Phase 4.4 — winter/season timers |
| #182 | #167 | Phase 4.2 — correct heartbeat ordering (final integration) |

## Diff summary

- 12 files changed, 1224 insertions, 30 deletions
- New library: `packages/contracts/src/lib/RNG.sol` (110 lines, 5 domain-separated helpers)
- New util: `packages/contracts/src/util/ReentrancyGuard.sol` (custom guard, no OZ dep)
- ClanWorld.sol heartbeat() refactored into 6-step orchestration with nonReentrant guard
- Tests added:
  - `HeartbeatOrdering.t.sol` — 5 step-ordering integration cases (341 lines)
  - `RNG.t.sol` — 7 cases for determinism/distribution/edge cases (230 lines)
  - `Reentrancy.t.sol` — malicious pool callback regression (209 lines)
  - `ClanWorldStub.t.sol` — stub-vs-real parity (16 lines added)

## Review history

- Each sub-issue reviewed by codex orch-r1
- Fix-rounds:
  - #174 RNG bound power-of-two threshold
  - #175 ClanWorldStub init parity
  - #178/Phase 3.4 (came in via phase-3 release)
  - #182 reentrancy guard (orch-r1 on this PR caught a cross-feature interaction)
- All sub-issues merged with tests green; phase branch tip 31787a9

## Tests

86/86 forge tests passing on phase-4 tip (includes Phase 3 inheritance via rebase).

## Closes

Issues #166, #167, #168, #169 close on merge.