### PR TITLE
feat(contracts): Phase 9.1 bandit troop state machine

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -9,6 +9,25 @@
     },
     {
       "type": "function",
+      "name": "getActionDuration",
+      "inputs": [
+        {
+          "name": "action",
+          "type": "uint8",
+          "internalType": "enum ActionType"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
       "name": "getActiveBanditView",
       "inputs": [],
       "outputs": [
@@ -234,80 +253,54 @@
     },
     {
       "type": "function",
-      "name": "getMissionTiming",
+      "name": "getBandit",
       "inputs": [
         {
-          "name": "clanId",
-          "type": "uint32",
-          "internalType": "uint32"
-        },
-        {
-          "name": "clansmanId",
+          "name": "banditId",
           "type": "uint32",
           "internalType": "uint32"
         }
       ],
       "outputs": [
         {
-          "name": "submitted",
-          "type": "uint64",
-          "internalType": "uint64"
-        },
-        {
-          "name": "executes",
-          "type": "uint64",
-          "internalType": "uint64"
-        },
-        {
-          "name": "settles",
-          "type": "uint64",
-          "internalType": "uint64"
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct BanditTroop",
+          "components": [
+            {
+              "name": "id",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "region",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum BanditState"
+            },
+            {
+              "name": "targetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "tickEnteredState",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "strength",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ]
         }
       ],
       "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "getActionDuration",
-      "inputs": [
-        {
-          "name": "action",
-          "type": "uint8",
-          "internalType": "enum ActionType"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint64",
-          "internalType": "uint64"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "getTravelTicks",
-      "inputs": [
-        {
-          "name": "fromRegion",
-          "type": "uint8",
-          "internalType": "uint8"
-        },
-        {
-          "name": "toRegion",
-          "type": "uint8",
-          "internalType": "uint8"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint64",
-          "internalType": "uint64"
-        }
-      ],
-      "stateMutability": "pure"
     },
     {
       "type": "function",
@@ -345,9 +338,14 @@
           "internalType": "struct BanditTroop",
           "components": [
             {
-              "name": "banditId",
+              "name": "id",
               "type": "uint32",
               "internalType": "uint32"
+            },
+            {
+              "name": "region",
+              "type": "uint8",
+              "internalType": "uint8"
             },
             {
               "name": "state",
@@ -355,56 +353,40 @@
               "internalType": "enum BanditState"
             },
             {
-              "name": "currentRegion",
-              "type": "uint8",
-              "internalType": "uint8"
+              "name": "targetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
             },
             {
-              "name": "attackAttemptsMade",
-              "type": "uint8",
-              "internalType": "uint8"
-            },
-            {
-              "name": "stateEnteredTick",
+              "name": "tickEnteredState",
               "type": "uint64",
               "internalType": "uint64"
             },
             {
-              "name": "nextActionTick",
-              "type": "uint64",
-              "internalType": "uint64"
-            },
-            {
-              "name": "tier",
-              "type": "uint8",
-              "internalType": "uint8"
-            },
-            {
-              "name": "attackPower",
-              "type": "uint16",
-              "internalType": "uint16"
-            },
-            {
-              "name": "carryWood",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "carryIron",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "carryWheat",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "carryFish",
-              "type": "uint256",
-              "internalType": "uint256"
+              "name": "strength",
+              "type": "uint32",
+              "internalType": "uint32"
             }
           ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getBanditsInRegion",
+      "inputs": [
+        {
+          "name": "region",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
         }
       ],
       "stateMutability": "view"
@@ -1641,6 +1623,40 @@
     },
     {
       "type": "function",
+      "name": "getMissionTiming",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "submitted",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "executes",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "settles",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "getRegionPopulation",
       "inputs": [
         {
@@ -1750,6 +1766,30 @@
         }
       ],
       "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getTravelTicks",
+      "inputs": [
+        {
+          "name": "fromRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "toRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
     },
     {
       "type": "function",
@@ -2263,6 +2303,19 @@
       "inputs": [
         {
           "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "settleClansman",
+      "inputs": [
+        {
+          "name": "csId",
           "type": "uint32",
           "internalType": "uint32"
         }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -60,10 +60,13 @@ contract ClanWorld is IClanWorld {
     mapping(uint8 => uint32[]) private _defendingClansByRegion; // home region => unique defending clanIds
     mapping(uint8 => mapping(uint32 => uint256)) private _defenderCountByRegionClan; // region => clanId => clansmen count
     mapping(uint32 => uint8) private _clansmanDefendingRegion; // clansmanId => defended home region
+    mapping(uint32 => BanditTroop) internal _bandits;
+    mapping(uint8 => uint32[]) internal _banditsByRegion; // region => bandit IDs
     mapping(uint64 => bytes32) private _tickSeeds; // tick => seed
 
     uint32 private _nextClanId;
     uint32 private _nextClansmanId;
+    uint32 internal _nextBanditId;
     uint32[] private _allClanIds;
 
     // per-clan clansman list: clanId => clansmanId[]
@@ -89,6 +92,7 @@ contract ClanWorld is IClanWorld {
         _treasury.treasuryOwner = msg.sender;
         _nextClanId = 1;
         _nextClansmanId = 1;
+        _nextBanditId = 1;
     }
 
     // =========================================================================
@@ -849,6 +853,118 @@ contract ClanWorld is IClanWorld {
         cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
         m.active = false;
         emit MissionCompleted(_clans[cs.clanId].clanId, cs.clansmanId, m.nonce, m.action);
+    }
+
+    // =========================================================================
+    // BANDIT STATE MACHINE
+    // =========================================================================
+
+    function _spawnBandit(uint8 region, uint32 strength) internal returns (uint32 id) {
+        require(
+            region >= ClanWorldConstants.REGION_FOREST && region <= ClanWorldConstants.REGION_DEEP_SEA,
+            "ClanWorld: invalid bandit region"
+        );
+        require(strength > 0, "ClanWorld: invalid bandit strength");
+
+        id = _nextBanditId++;
+        _bandits[id] = BanditTroop({
+            id: id,
+            region: region,
+            state: BanditState.Spawned,
+            targetClanId: 0,
+            tickEnteredState: _world.currentTick,
+            strength: strength
+        });
+        _banditsByRegion[region].push(id);
+
+        if (_world.activeBanditId == ClanWorldConstants.BANDIT_ID_NULL) {
+            _world.activeBanditId = id;
+        }
+
+        emit BanditSpawned(id, region, 0, _banditStrengthForLegacyEvent(strength));
+    }
+
+    function _transitionBanditToAttacking(uint32 id, uint32 targetClanId) internal {
+        require(targetClanId != ClanWorldConstants.CLAN_ID_NULL, "ClanWorld: invalid bandit target");
+        _bandits[id].targetClanId = targetClanId;
+        _transitionBanditState(id, BanditState.Attacking);
+    }
+
+    function _transitionBanditState(uint32 id, BanditState newState) internal {
+        BanditTroop storage bandit = _bandits[id];
+        require(bandit.id != ClanWorldConstants.BANDIT_ID_NULL, "ClanWorld: bandit not found");
+
+        BanditState oldState = bandit.state;
+        require(_isValidBanditTransition(bandit, newState), "ClanWorld: invalid bandit transition");
+
+        if (newState == BanditState.Defeated) {
+            emit BanditStateChanged(id, oldState, newState, bandit.region, _world.currentTick);
+            _deleteBandit(id);
+            return;
+        }
+
+        bandit.state = newState;
+        bandit.tickEnteredState = _world.currentTick;
+        if (newState != BanditState.Attacking) {
+            bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
+        }
+
+        emit BanditStateChanged(id, oldState, newState, bandit.region, _world.currentTick);
+    }
+
+    function _isValidBanditTransition(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
+        if (bandit.state == BanditState.Spawned) return _canBanditLeaveSpawned(bandit, newState);
+        if (bandit.state == BanditState.Camped) return _canBanditLeaveCamped(bandit, newState);
+        if (bandit.state == BanditState.Attacking) return _canBanditLeaveAttacking(newState);
+        if (bandit.state == BanditState.Escaped) return _canBanditLeaveEscaped(newState);
+        if (bandit.state == BanditState.Resting) return _canBanditLeaveResting(bandit, newState);
+        return false;
+    }
+
+    function _canBanditLeaveSpawned(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
+        return newState == BanditState.Camped && _world.currentTick >= bandit.tickEnteredState + 1;
+    }
+
+    function _canBanditLeaveCamped(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
+        return newState == BanditState.Attacking && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
+            && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
+    }
+
+    function _canBanditLeaveAttacking(BanditState newState) internal pure returns (bool) {
+        return newState == BanditState.Defeated || newState == BanditState.Escaped;
+    }
+
+    function _canBanditLeaveEscaped(BanditState newState) internal pure returns (bool) {
+        return newState == BanditState.Resting;
+    }
+
+    function _canBanditLeaveResting(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
+        return newState == BanditState.Camped
+            && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS;
+    }
+
+    function _deleteBandit(uint32 id) internal {
+        BanditTroop storage bandit = _bandits[id];
+        uint8 region = bandit.region;
+        uint32[] storage regionBandits = _banditsByRegion[region];
+        for (uint256 i = 0; i < regionBandits.length; i++) {
+            if (regionBandits[i] == id) {
+                regionBandits[i] = regionBandits[regionBandits.length - 1];
+                regionBandits.pop();
+                break;
+            }
+        }
+
+        delete _bandits[id];
+        if (_world.activeBanditId == id) {
+            _world.activeBanditId = ClanWorldConstants.BANDIT_ID_NULL;
+        }
+    }
+
+    function _banditStrengthForLegacyEvent(uint32 strength) internal pure returns (uint16) {
+        if (strength > type(uint16).max) return type(uint16).max;
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint16(strength);
     }
 
     // =========================================================================
@@ -1716,21 +1832,16 @@ contract ClanWorld is IClanWorld {
         return uint64(_travelTicks(fromRegion, toRegion));
     }
 
-    function getBanditTroop(uint32) external pure override returns (BanditTroop memory) {
-        return BanditTroop({
-            banditId: 0,
-            state: BanditState.NONE,
-            currentRegion: 0,
-            attackAttemptsMade: 0,
-            stateEnteredTick: 0,
-            nextActionTick: 0,
-            tier: 0,
-            attackPower: 0,
-            carryWood: 0,
-            carryIron: 0,
-            carryWheat: 0,
-            carryFish: 0
-        });
+    function getBandit(uint32 banditId) public view override returns (BanditTroop memory) {
+        return _bandits[banditId];
+    }
+
+    function getBanditTroop(uint32 banditId) external view override returns (BanditTroop memory) {
+        return _bandits[banditId];
+    }
+
+    function getBanditsInRegion(uint8 region) external view override returns (uint32[] memory) {
+        return _banditsByRegion[region];
     }
 
     function getWheatPlots(uint32 clanId)
@@ -1815,8 +1926,8 @@ contract ClanWorld is IClanWorld {
         });
     }
 
-    function getBanditTargetPreview(uint32) external pure override returns (uint32) {
-        return 0; // Phase 3
+    function getBanditTargetPreview(uint32 banditId) external view override returns (uint32) {
+        return _bandits[banditId].targetClanId;
     }
 
     function quoteTravel(uint8 srcRegion, uint8 dstRegion)
@@ -1960,23 +2071,33 @@ contract ClanWorld is IClanWorld {
         pr.spotPriceGoldPerResource = rA > 0 ? (rB * 1e18) / rA : 0;
     }
 
-    function getActiveBanditView() external pure override returns (ActiveBanditView memory) {
+    function getActiveBanditView() external view override returns (ActiveBanditView memory) {
+        BanditTroop memory bandit = _bandits[_world.activeBanditId];
+        uint64 nextActionTick = 0;
+        if (bandit.id != ClanWorldConstants.BANDIT_ID_NULL) {
+            if (bandit.state == BanditState.Camped) {
+                nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
+            } else if (bandit.state == BanditState.Resting) {
+                nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS;
+            }
+        }
+
         return ActiveBanditView({
-            exists: false,
-            banditId: 0,
-            state: BanditState.NONE,
-            currentRegion: 0,
+            exists: bandit.id != ClanWorldConstants.BANDIT_ID_NULL,
+            banditId: bandit.id,
+            state: bandit.state,
+            currentRegion: bandit.region,
             attackAttemptsMade: 0,
             maxAttemptsRemaining: 0,
-            stateEnteredTick: 0,
-            nextActionTick: 0,
+            stateEnteredTick: bandit.tickEnteredState,
+            nextActionTick: nextActionTick,
             tier: 0,
-            attackPower: 0,
+            attackPower: _banditStrengthForLegacyEvent(bandit.strength),
             carryWood: 0,
             carryIron: 0,
             carryWheat: 0,
             carryFish: 0,
-            projectedTargetClanId: 0,
+            projectedTargetClanId: bandit.targetClanId,
             projectedTargetLootValue: 0
         });
     }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -893,6 +893,7 @@ contract ClanWorld is IClanWorld {
     function _transitionBanditState(uint32 id, BanditState newState) internal {
         BanditTroop storage bandit = _bandits[id];
         require(bandit.id != ClanWorldConstants.BANDIT_ID_NULL, "ClanWorld: bandit not found");
+        require(newState != BanditState.None, "ClanWorld: invalid bandit transition");
 
         BanditState oldState = bandit.state;
         require(_isValidBanditTransition(bandit, newState), "ClanWorld: invalid bandit transition");
@@ -1833,11 +1834,18 @@ contract ClanWorld is IClanWorld {
     }
 
     function getBandit(uint32 banditId) public view override returns (BanditTroop memory) {
-        return _bandits[banditId];
+        BanditTroop memory bandit = _bandits[banditId];
+        if (bandit.id == ClanWorldConstants.BANDIT_ID_NULL || bandit.state == BanditState.None) {
+            return
+                BanditTroop({
+                    id: 0, region: 0, state: BanditState.None, targetClanId: 0, tickEnteredState: 0, strength: 0
+                });
+        }
+        return bandit;
     }
 
     function getBanditTroop(uint32 banditId) external view override returns (BanditTroop memory) {
-        return _bandits[banditId];
+        return getBandit(banditId);
     }
 
     function getBanditsInRegion(uint8 region) external view override returns (uint32[] memory) {
@@ -2074,7 +2082,8 @@ contract ClanWorld is IClanWorld {
     function getActiveBanditView() external view override returns (ActiveBanditView memory) {
         BanditTroop memory bandit = _bandits[_world.activeBanditId];
         uint64 nextActionTick = 0;
-        if (bandit.id != ClanWorldConstants.BANDIT_ID_NULL) {
+        bool exists = bandit.id != ClanWorldConstants.BANDIT_ID_NULL && bandit.state != BanditState.None;
+        if (exists) {
             if (bandit.state == BanditState.Camped) {
                 nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
             } else if (bandit.state == BanditState.Resting) {
@@ -2083,7 +2092,7 @@ contract ClanWorld is IClanWorld {
         }
 
         return ActiveBanditView({
-            exists: bandit.id != ClanWorldConstants.BANDIT_ID_NULL,
+            exists: exists,
             banditId: bandit.id,
             state: bandit.state,
             currentRegion: bandit.region,

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -206,21 +206,19 @@ contract ClanWorldStub is IClanWorld {
         return 0;
     }
 
-    function getBanditTroop(uint32) external pure override returns (BanditTroop memory) {
-        return BanditTroop({
-            banditId: 0,
-            state: BanditState.NONE,
-            currentRegion: 0,
-            attackAttemptsMade: 0,
-            stateEnteredTick: 0,
-            nextActionTick: 0,
-            tier: 0,
-            attackPower: 0,
-            carryWood: 0,
-            carryIron: 0,
-            carryWheat: 0,
-            carryFish: 0
-        });
+    function getBandit(uint32) public pure override returns (BanditTroop memory) {
+        return
+            BanditTroop({
+                id: 0, region: 0, state: BanditState.Spawned, targetClanId: 0, tickEnteredState: 0, strength: 0
+            });
+    }
+
+    function getBanditTroop(uint32 banditId) external pure override returns (BanditTroop memory) {
+        return getBandit(banditId);
+    }
+
+    function getBanditsInRegion(uint8) external pure override returns (uint32[] memory) {
+        return new uint32[](0);
     }
 
     function getWheatPlots(uint32) external pure override returns (WheatPlot memory west, WheatPlot memory east) {
@@ -330,7 +328,7 @@ contract ClanWorldStub is IClanWorld {
         return ActiveBanditView({
             exists: false,
             banditId: 0,
-            state: BanditState.NONE,
+            state: BanditState.Spawned,
             currentRegion: 0,
             attackAttemptsMade: 0,
             maxAttemptsRemaining: 0,

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -208,9 +208,7 @@ contract ClanWorldStub is IClanWorld {
 
     function getBandit(uint32) public pure override returns (BanditTroop memory) {
         return
-            BanditTroop({
-                id: 0, region: 0, state: BanditState.Spawned, targetClanId: 0, tickEnteredState: 0, strength: 0
-            });
+            BanditTroop({id: 0, region: 0, state: BanditState.None, targetClanId: 0, tickEnteredState: 0, strength: 0});
     }
 
     function getBanditTroop(uint32 banditId) external pure override returns (BanditTroop memory) {
@@ -328,7 +326,7 @@ contract ClanWorldStub is IClanWorld {
         return ActiveBanditView({
             exists: false,
             banditId: 0,
-            state: BanditState.Spawned,
+            state: BanditState.None,
             currentRegion: 0,
             attackAttemptsMade: 0,
             maxAttemptsRemaining: 0,

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -104,12 +104,12 @@ enum ClansmanState {
 }
 
 enum BanditState {
-    NONE,
-    CAMPING,
-    RESTING,
-    ATTACKING,
-    DEFEATED,
-    ESCAPED
+    Spawned,
+    Camped,
+    Resting,
+    Attacking,
+    Defeated,
+    Escaped
 }
 
 enum WheatPlotState {
@@ -296,21 +296,12 @@ struct Mission {
 }
 
 struct BanditTroop {
-    uint32 banditId;
+    uint32 id;
+    uint8 region;
     BanditState state;
-
-    uint8 currentRegion;
-    uint8 attackAttemptsMade;
-    uint64 stateEnteredTick;
-    uint64 nextActionTick;
-
-    uint8 tier;
-    uint16 attackPower; // derived from tier; tier is canonical (v4.3 §G)
-
-    uint256 carryWood;
-    uint256 carryIron;
-    uint256 carryWheat;
-    uint256 carryFish;
+    uint32 targetClanId; // 0 if not attacking
+    uint64 tickEnteredState;
+    uint32 strength; // hp / combat power
 }
 
 struct ScheduledMarketAction {
@@ -710,7 +701,11 @@ interface IClanWorld is IClanWorldEvents {
 
     function getTravelTicks(uint8 fromRegion, uint8 toRegion) external pure returns (uint64);
 
+    function getBandit(uint32 banditId) external view returns (BanditTroop memory);
+
     function getBanditTroop(uint32 banditId) external view returns (BanditTroop memory);
+
+    function getBanditsInRegion(uint8 region) external view returns (uint32[] memory);
 
     function getWheatPlots(uint32 clanId) external view returns (WheatPlot memory west, WheatPlot memory east);
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -104,6 +104,7 @@ enum ClansmanState {
 }
 
 enum BanditState {
+    None,
     Spawned,
     Camped,
     Resting,

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -69,6 +69,19 @@ contract BanditTest is Test {
         assertEq(state.activeBanditId, id, "active bandit");
     }
 
+    function test_getBanditMissingIdReturnsNoneState() public view {
+        BanditTroop memory bandit = world.getBandit(999);
+
+        assertEq(bandit.id, 0, "missing id");
+        assertEq(uint8(bandit.state), uint8(BanditState.None), "missing state");
+    }
+
+    function test_defaultBanditTroopStateIsNone() public pure {
+        BanditTroop memory bandit;
+
+        assertEq(uint8(bandit.state), uint8(BanditState.None), "default state");
+    }
+
     function test_spawnedToCampedTransitionSucceedsAfterNextHeartbeat() public {
         uint32 id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
 
@@ -100,6 +113,7 @@ contract BanditTest is Test {
         BanditTroop memory deletedBandit = world.getBandit(id);
         assertEq(deletedBandit.id, 0, "deleted id");
         assertEq(deletedBandit.region, 0, "deleted region");
+        assertEq(uint8(deletedBandit.state), uint8(BanditState.None), "deleted state");
         assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, 0, "removed from region");
         assertEq(world.getWorldState().activeBanditId, 0, "active bandit cleared");
     }
@@ -137,6 +151,9 @@ contract BanditTest is Test {
 
         vm.expectRevert("ClanWorld: invalid bandit transition");
         world.transitionBandit(id, BanditState.Attacking);
+
+        vm.expectRevert("ClanWorld: invalid bandit transition");
+        world.transitionBandit(id, BanditState.None);
     }
 
     function test_getBanditsInRegionReturnsListAndUpdatesAfterDelete() public {

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {ClanWorldConstants, BanditState, BanditTroop, WorldState} from "../src/IClanWorld.sol";
+
+contract BanditHarness is ClanWorld {
+    function spawnBandit(uint8 region, uint32 strength) external returns (uint32) {
+        return _spawnBandit(region, strength);
+    }
+
+    function transitionBandit(uint32 id, BanditState newState) external {
+        _transitionBanditState(id, newState);
+    }
+
+    function transitionBanditToAttacking(uint32 id, uint32 targetClanId) external {
+        _transitionBanditToAttacking(id, targetClanId);
+    }
+}
+
+contract BanditTest is Test {
+    BanditHarness world;
+
+    function setUp() public {
+        world = new BanditHarness();
+    }
+
+    function _advanceTick() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+    }
+
+    function _advanceTicks(uint64 ticks) internal {
+        for (uint64 i = 0; i < ticks; i++) {
+            _advanceTick();
+        }
+    }
+
+    function _spawnAndCamp() internal returns (uint32 id) {
+        id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        _advanceTick();
+        world.transitionBandit(id, BanditState.Camped);
+    }
+
+    function _spawnCampAndAttack(uint32 targetClanId) internal returns (uint32 id) {
+        id = _spawnAndCamp();
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        world.transitionBanditToAttacking(id, targetClanId);
+    }
+
+    function test_spawnBandit_recordsSpawnedTroopAndRegionIndex() public {
+        uint32 id = world.spawnBandit(ClanWorldConstants.REGION_MOUNTAINS, 250);
+
+        assertEq(id, 1, "first bandit id");
+        BanditTroop memory bandit = world.getBandit(id);
+        assertEq(bandit.id, id, "bandit id");
+        assertEq(bandit.region, ClanWorldConstants.REGION_MOUNTAINS, "region");
+        assertEq(uint8(bandit.state), uint8(BanditState.Spawned), "state");
+        assertEq(bandit.targetClanId, 0, "no target while spawned");
+        assertEq(bandit.tickEnteredState, world.getWorldState().currentTick, "entered tick");
+        assertEq(bandit.strength, 250, "strength");
+
+        uint32[] memory regionBandits = world.getBanditsInRegion(ClanWorldConstants.REGION_MOUNTAINS);
+        assertEq(regionBandits.length, 1, "region index length");
+        assertEq(regionBandits[0], id, "region index id");
+
+        WorldState memory state = world.getWorldState();
+        assertEq(state.activeBanditId, id, "active bandit");
+    }
+
+    function test_spawnedToCampedTransitionSucceedsAfterNextHeartbeat() public {
+        uint32 id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+
+        _advanceTick();
+        world.transitionBandit(id, BanditState.Camped);
+
+        BanditTroop memory bandit = world.getBandit(id);
+        assertEq(uint8(bandit.state), uint8(BanditState.Camped), "state");
+        assertEq(bandit.tickEnteredState, world.getWorldState().currentTick, "entered camp tick");
+    }
+
+    function test_campedToAttackingTransitionSucceedsWithTargetAfterCampDuration() public {
+        uint32 id = _spawnAndCamp();
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+
+        world.transitionBanditToAttacking(id, 77);
+
+        BanditTroop memory bandit = world.getBandit(id);
+        assertEq(uint8(bandit.state), uint8(BanditState.Attacking), "state");
+        assertEq(bandit.targetClanId, 77, "target");
+        assertEq(bandit.tickEnteredState, world.getWorldState().currentTick, "entered attack tick");
+    }
+
+    function test_attackingToDefeatedDeletesBanditAndRegionIndex() public {
+        uint32 id = _spawnCampAndAttack(77);
+
+        world.transitionBandit(id, BanditState.Defeated);
+
+        BanditTroop memory deletedBandit = world.getBandit(id);
+        assertEq(deletedBandit.id, 0, "deleted id");
+        assertEq(deletedBandit.region, 0, "deleted region");
+        assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, 0, "removed from region");
+        assertEq(world.getWorldState().activeBanditId, 0, "active bandit cleared");
+    }
+
+    function test_attackingToEscapedRestingCampedCycleWorks() public {
+        uint32 id = _spawnCampAndAttack(77);
+
+        world.transitionBandit(id, BanditState.Escaped);
+        BanditTroop memory escaped = world.getBandit(id);
+        assertEq(uint8(escaped.state), uint8(BanditState.Escaped), "escaped");
+        assertEq(escaped.targetClanId, 0, "target cleared on escape");
+
+        world.transitionBandit(id, BanditState.Resting);
+        BanditTroop memory resting = world.getBandit(id);
+        assertEq(uint8(resting.state), uint8(BanditState.Resting), "resting");
+        assertEq(resting.tickEnteredState, world.getWorldState().currentTick, "resting tick");
+
+        _advanceTicks(ClanWorldConstants.BANDIT_REST_TICKS);
+        world.transitionBandit(id, BanditState.Camped);
+
+        BanditTroop memory camped = world.getBandit(id);
+        assertEq(uint8(camped.state), uint8(BanditState.Camped), "camped again");
+        assertEq(camped.targetClanId, 0, "target remains clear");
+    }
+
+    function test_invalidTransitionsRevert() public {
+        uint32 id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+
+        vm.expectRevert("ClanWorld: invalid bandit transition");
+        world.transitionBandit(id, BanditState.Defeated);
+
+        _advanceTick();
+        world.transitionBandit(id, BanditState.Camped);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+
+        vm.expectRevert("ClanWorld: invalid bandit transition");
+        world.transitionBandit(id, BanditState.Attacking);
+    }
+
+    function test_getBanditsInRegionReturnsListAndUpdatesAfterDelete() public {
+        uint32 id1 = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        uint32 id2 = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 200);
+        uint32 id3 = world.spawnBandit(ClanWorldConstants.REGION_MOUNTAINS, 300);
+
+        uint32[] memory forestBandits = world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST);
+        assertEq(forestBandits.length, 2, "forest count");
+        assertEq(forestBandits[0], id1, "first forest bandit");
+        assertEq(forestBandits[1], id2, "second forest bandit");
+
+        uint32[] memory mountainBandits = world.getBanditsInRegion(ClanWorldConstants.REGION_MOUNTAINS);
+        assertEq(mountainBandits.length, 1, "mountain count");
+        assertEq(mountainBandits[0], id3, "mountain bandit");
+
+        _advanceTick();
+        world.transitionBandit(id1, BanditState.Camped);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        world.transitionBanditToAttacking(id1, 77);
+        world.transitionBandit(id1, BanditState.Defeated);
+
+        forestBandits = world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST);
+        assertEq(forestBandits.length, 1, "forest count after delete");
+        assertEq(forestBandits[0], id2, "remaining forest bandit");
+    }
+}

--- a/packages/contracts/test/ClanWorldStub.t.sol
+++ b/packages/contracts/test/ClanWorldStub.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
 import {ClanWorldStub} from "../src/ClanWorldStub.sol";
+import {BanditState, BanditTroop} from "../src/IClanWorld.sol";
 import {MinimalERC20} from "../src/MinimalERC20.sol";
 import {StubPool} from "../src/StubPool.sol";
 
@@ -32,5 +33,12 @@ contract ClanWorldStubTest is Test {
     function test_getWorldSnapshot_returns_current_tick() public {
         stub.heartbeat();
         assertEq(stub.getWorldSnapshot().currentTick, 2);
+    }
+
+    function test_getBanditMissingIdReturnsNoneState() public view {
+        BanditTroop memory bandit = stub.getBandit(999);
+
+        assertEq(bandit.id, 0, "missing id");
+        assertEq(uint8(bandit.state), uint8(BanditState.None), "missing state");
     }
 }


### PR DESCRIPTION
## Summary
- Implements the Phase 9.1 bandit troop state machine storage and six-state transition validation.
- Adds bandit spawn/delete bookkeeping and region-index getters.
- Refreshes the checked-in IClanWorld ABI for the new bandit getter surface.

Closes #186

## Validation
- cd packages/contracts && PATH="$HOME/.foundry/bin:$PATH" forge build
- cd packages/contracts && PATH="$HOME/.foundry/bin:$PATH" forge test --match-contract Bandit
- cd packages/contracts && PATH="$HOME/.foundry/bin:$PATH" forge test
