### PR TITLE
feat(contracts): Phase 8.1 — wall upgrades (Closes #197)

### DIFF
--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -63,6 +63,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     mapping(uint8 => mapping(uint32 => uint256)) private _defenderCountByRegionClan; // region => clanId => clansmen count
     mapping(uint32 => uint8) private _clansmanDefendingRegion; // clansmanId => defended home region
     mapping(uint64 => bytes32) private _tickSeeds; // tick => seed
+    mapping(uint32 => WallUpgradeReservation) private _wallUpgradeReservations; // clansmanId => reserved upgrade
+    mapping(uint32 => uint8) private _pendingWallUpgradesByClan; // clanId => queued, unsettled wall upgrades
 
     uint32 private _nextClanId;
     uint32 private _nextClansmanId;
@@ -71,11 +73,21 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     // per-clan clansman list: clanId => clansmanId[]
     mapping(uint32 => uint32[]) private _clanClansmanIds;
 
+    struct WallUpgradeReservation {
+        bool active;
+        uint32 clanId;
+        uint64 missionNonce;
+        uint256 woodCost;
+        uint256 ironCost;
+    }
+
     // =========================================================================
     // CONSTANTS — Wheat harvest rate (not in IClanWorld constants)
     // =========================================================================
 
     uint64 private constant DEPOSIT_DURATION_TICKS = 1;
+    uint64 private constant UPGRADE_WALL_DURATION_TICKS = 2;
+    uint8 private constant WALL_MAX_LEVEL = 5;
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     uint256 private constant DOMAIN_GATHER = uint256(keccak256("clanworld.gather.v1"));
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
@@ -313,6 +325,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             if (m.active) {
                 if (m.action == ActionType.DefendBase) {
                     _clearDefender(cs.clansmanId);
+                } else if (m.action == ActionType.UpgradeWall) {
+                    _refundWallUpgradeReservation(cs.clansmanId);
                 }
                 m.active = false; // silent invalidation; dead clansman gets no MissionCompleted
             }
@@ -463,8 +477,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // Persistent mission. Registration happens atomically at order submission.
         } else if (
             action == ActionType.BuildWall || action == ActionType.UpgradeBase || action == ActionType.UpgradeMonument
+                || action == ActionType.UpgradeWall
         ) {
-            // Phase 1 stub: check homebase, check resources; if ok, stub success
             _doBuilding(clan, cs, m, clanId, tick, action);
         } else if (action == ActionType.MarketBuy || action == ActionType.MarketSell) {
             // Scheduled market actions: already enqueued at submitClanOrders time.
@@ -719,6 +733,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         bool success = false;
         if (action == ActionType.BuildWall) {
             success = _tryBuildWall(clan, clanId, tick);
+        } else if (action == ActionType.UpgradeWall) {
+            success = _settleWallUpgrade(clan, cs.clansmanId, m.nonce, clanId, tick);
         } else if (action == ActionType.UpgradeBase) {
             success = _tryUpgradeBase(clan, clanId, tick);
         } else if (action == ActionType.UpgradeMonument) {
@@ -762,6 +778,27 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint8 old = clan.wallLevel;
         clan.wallLevel = nextLevel;
         emit WallLevelChanged(clanId, old, nextLevel, tick);
+        return true;
+    }
+
+    function _settleWallUpgrade(Clan storage clan, uint32 clansmanId, uint64 missionNonce, uint32 clanId, uint64 tick)
+        internal
+        returns (bool)
+    {
+        WallUpgradeReservation storage reservation = _wallUpgradeReservations[clansmanId];
+        if (!reservation.active || reservation.clanId != clanId || reservation.missionNonce != missionNonce) {
+            return false;
+        }
+
+        _clearWallUpgradeReservation(clansmanId);
+        if (clan.wallLevel >= WALL_MAX_LEVEL) return false;
+
+        uint8 old = clan.wallLevel;
+        clan.wallLevel = old + 1;
+        emit WallLevelChanged(clanId, old, clan.wallLevel, tick);
+        // Phase 8 event ABI uses uint32; season tick horizons are far below this cap.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        emit WallUpgraded(clanId, clan.wallLevel, uint32(tick));
         return true;
     }
 
@@ -1219,6 +1256,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         ctx.newNonce = cs.lastMissionNonce + 1;
         cs.lastMissionNonce = ctx.newNonce;
 
+        if (ctx.wasActive && existingM.action == ActionType.UpgradeWall) {
+            _refundWallUpgradeReservation(order.clansmanId);
+        }
+
+        if (order.action == ActionType.UpgradeWall) {
+            _reserveWallUpgrade(clan, clanId, order.clansmanId, ctx.newNonce);
+        }
+
         // Install mission via helper to keep stack shallow
         _installMission(existingM, order, cs, ctx);
 
@@ -1617,10 +1662,16 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             if (gotoRegion != clan.baseRegion) return StatusCode.ERR_INVALID_REGION;
         }
 
-        // BuildWall / UpgradeBase / UpgradeMonument: must go to homebase
-        if (action == ActionType.BuildWall || action == ActionType.UpgradeBase || action == ActionType.UpgradeMonument)
-        {
+        // BuildWall / UpgradeWall / UpgradeBase / UpgradeMonument: must go to homebase
+        if (
+            action == ActionType.BuildWall || action == ActionType.UpgradeWall || action == ActionType.UpgradeBase
+                || action == ActionType.UpgradeMonument
+        ) {
             if (gotoRegion != clan.baseRegion) return StatusCode.ERR_NOT_AT_HOMEBASE;
+        }
+
+        if (action == ActionType.UpgradeWall) {
+            return _validateUpgradeWallOrder(clan, cs.clansmanId);
         }
 
         // ChopWood: must go to Forest
@@ -1683,6 +1734,62 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         cs; // suppress unused warning
         return StatusCode.OK;
+    }
+
+    function _validateUpgradeWallOrder(Clan storage clan, uint32 clansmanId) internal view returns (StatusCode) {
+        uint8 pendingUpgrades = _pendingWallUpgradesByClan[clan.clanId];
+        uint256 availableWood = clan.vaultWood;
+        uint256 availableIron = clan.vaultIron;
+
+        WallUpgradeReservation storage existing = _wallUpgradeReservations[clansmanId];
+        if (existing.active && existing.clanId == clan.clanId) {
+            pendingUpgrades -= 1;
+            availableWood += existing.woodCost;
+            availableIron += existing.ironCost;
+        }
+
+        uint8 plannedCurrentLevel = clan.wallLevel + pendingUpgrades;
+        if (plannedCurrentLevel >= WALL_MAX_LEVEL) return StatusCode.ERR_INVALID_ACTION;
+
+        (uint256 woodCost, uint256 ironCost) = _wallUpgradeCost(plannedCurrentLevel);
+        if (availableWood < woodCost || availableIron < ironCost) return StatusCode.ERR_MISSING_RESOURCES;
+
+        return StatusCode.OK;
+    }
+
+    function _reserveWallUpgrade(Clan storage clan, uint32 clanId, uint32 clansmanId, uint64 missionNonce) internal {
+        uint8 plannedCurrentLevel = clan.wallLevel + _pendingWallUpgradesByClan[clanId];
+        (uint256 woodCost, uint256 ironCost) = _wallUpgradeCost(plannedCurrentLevel);
+
+        clan.vaultWood -= woodCost;
+        clan.vaultIron -= ironCost;
+        _pendingWallUpgradesByClan[clanId] += 1;
+
+        _wallUpgradeReservations[clansmanId] = WallUpgradeReservation({
+            active: true, clanId: clanId, missionNonce: missionNonce, woodCost: woodCost, ironCost: ironCost
+        });
+    }
+
+    function _refundWallUpgradeReservation(uint32 clansmanId) internal {
+        WallUpgradeReservation storage reservation = _wallUpgradeReservations[clansmanId];
+        if (!reservation.active) return;
+
+        Clan storage clan = _clans[reservation.clanId];
+        clan.vaultWood += reservation.woodCost;
+        clan.vaultIron += reservation.ironCost;
+        _clearWallUpgradeReservation(clansmanId);
+    }
+
+    function _clearWallUpgradeReservation(uint32 clansmanId) internal {
+        WallUpgradeReservation storage reservation = _wallUpgradeReservations[clansmanId];
+        if (!reservation.active) return;
+
+        uint32 clanId = reservation.clanId;
+        if (_pendingWallUpgradesByClan[clanId] > 0) {
+            _pendingWallUpgradesByClan[clanId] -= 1;
+        }
+
+        delete _wallUpgradeReservations[clansmanId];
     }
 
     function _validateDefendBaseOrder(Clan storage clan, ClanOrder calldata order, uint8 gotoRegion)
@@ -1797,6 +1904,19 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return (m.submittedAtTick, m.executesAtTick, m.settlesAtTick);
     }
 
+    function getWallUpgradeCost(uint8 currentLevel) public pure override returns (uint256 wood, uint256 iron) {
+        return _wallUpgradeCost(currentLevel);
+    }
+
+    function _wallUpgradeCost(uint8 currentLevel) internal pure returns (uint256 wood, uint256 iron) {
+        if (currentLevel == 0) return (20e18, 0);
+        if (currentLevel == 1) return (35e18, 0);
+        if (currentLevel == 2) return (30e18, 5e18);
+        if (currentLevel == 3) return (40e18, 10e18);
+        if (currentLevel == 4) return (50e18, 15e18);
+        return (0, 0);
+    }
+
     function getActionDuration(ActionType action) public pure override returns (uint64) {
         if (
             action == ActionType.ChopWood || action == ActionType.MineIron || action == ActionType.FishDocks
@@ -1807,6 +1927,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         if (action == ActionType.DepositResources) {
             return DEPOSIT_DURATION_TICKS;
+        }
+
+        if (action == ActionType.UpgradeWall) {
+            return UPGRADE_WALL_DURATION_TICKS;
         }
 
         if (

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -207,6 +207,15 @@ contract ClanWorldStub is IClanWorld {
         return (0, 0, 0);
     }
 
+    function getWallUpgradeCost(uint8 currentLevel) external pure override returns (uint256 wood, uint256 iron) {
+        if (currentLevel == 0) return (20e18, 0);
+        if (currentLevel == 1) return (35e18, 0);
+        if (currentLevel == 2) return (30e18, 5e18);
+        if (currentLevel == 3) return (40e18, 10e18);
+        if (currentLevel == 4) return (50e18, 15e18);
+        return (0, 0);
+    }
+
     function getActionDuration(ActionType) external pure override returns (uint64) {
         return 0;
     }

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -141,7 +141,8 @@ enum ActionType {
     DefendBase,
     MarketBuy,
     MarketSell,
-    Wait
+    Wait,
+    UpgradeWall
 }
 
 enum MarketExecutionMode {
@@ -543,6 +544,7 @@ interface IClanWorldEvents {
 
     // ----- building -----
     event WallLevelChanged(uint32 indexed clanId, uint8 oldLevel, uint8 newLevel, uint64 atTick);
+    event WallUpgraded(uint32 indexed clanId, uint8 newLevel, uint32 settledAtTick);
     event BaseLevelChanged(uint32 indexed clanId, uint8 oldLevel, uint8 newLevel, uint64 atTick);
     event MonumentLevelChanged(uint32 indexed clanId, uint8 oldLevel, uint8 newLevel, uint64 atTick);
 
@@ -710,6 +712,8 @@ interface IClanWorld is IClanWorldEvents {
         external
         view
         returns (uint64 submitted, uint64 executes, uint64 settles);
+
+    function getWallUpgradeCost(uint8 currentLevel) external pure returns (uint256 wood, uint256 iron);
 
     function getActionDuration(ActionType action) external pure returns (uint64);
 

--- a/packages/contracts/test/MissionTiming.t.sol
+++ b/packages/contracts/test/MissionTiming.t.sol
@@ -133,6 +133,7 @@ contract MissionTimingTest is Test {
         assertEq(world.getActionDuration(ActionType.MarketBuy), 1, "market buy");
         assertEq(world.getActionDuration(ActionType.MarketSell), 1, "market sell");
         assertEq(world.getActionDuration(ActionType.Wait), 0, "wait");
+        assertEq(world.getActionDuration(ActionType.UpgradeWall), 2, "upgrade wall");
     }
 
     function test_getTravelTicks_adjacentAndDistantMatchTable() public view {

--- a/packages/contracts/test/WallUpgrades.t.sol
+++ b/packages/contracts/test/WallUpgrades.t.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {
+    IClanWorldEvents,
+    ClanWorldConstants,
+    Clan,
+    ClanOrder,
+    OrderResult,
+    StatusCode,
+    ActionType
+} from "../src/IClanWorld.sol";
+
+contract WallUpgradeHarness is ClanWorld {
+    function setVault(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        _clans[clanId].vaultWood = wood;
+        _clans[clanId].vaultIron = iron;
+        _clans[clanId].vaultWheat = wheat;
+        _clans[clanId].vaultFish = fish;
+    }
+}
+
+contract WallUpgradesTest is Test {
+    WallUpgradeHarness world;
+    address elder = address(0xA1);
+    address elder2 = address(0xA2);
+
+    function setUp() public {
+        world = new WallUpgradeHarness();
+    }
+
+    function _mintClan(address owner) internal returns (uint32 clanId) {
+        vm.prank(owner);
+        (clanId,) = world.mintClan(owner);
+    }
+
+    function _firstCs(uint32 clanId) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _csAt(uint32 clanId, uint256 index) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[index].clansman.clansman.clansmanId;
+    }
+
+    function _submitOrder(address owner, uint32 clanId, uint32 csId, ActionType action)
+        internal
+        returns (OrderResult[] memory)
+    {
+        Clan memory clan = world.getClan(clanId);
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: clan.baseRegion,
+            action: action,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(owner);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _submitUpgradeBatch(address owner, uint32 clanId, uint256 count) internal returns (OrderResult[] memory) {
+        Clan memory clan = world.getClan(clanId);
+        ClanOrder[] memory orders = new ClanOrder[](count);
+        for (uint256 i = 0; i < count; i++) {
+            orders[i] = ClanOrder({
+                clansmanId: _csAt(clanId, i),
+                gotoRegion: clan.baseRegion,
+                action: ActionType.UpgradeWall,
+                targetClanId: 0,
+                marketToken: address(0),
+                marketAmount: 0,
+                maxGoldIn: 0
+            });
+        }
+        vm.prank(owner);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _advanceTick() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+    }
+
+    function _advanceTicks(uint256 count) internal {
+        for (uint256 i = 0; i < count; i++) {
+            _advanceTick();
+        }
+    }
+
+    function test_getWallUpgradeCost_matchesSpecTable() public view {
+        (uint256 wood, uint256 iron) = world.getWallUpgradeCost(0);
+        assertEq(wood, 20e18, "level 1 wood");
+        assertEq(iron, 0, "level 1 iron");
+
+        (wood, iron) = world.getWallUpgradeCost(2);
+        assertEq(wood, 30e18, "level 3 wood");
+        assertEq(iron, 5e18, "level 3 iron");
+
+        (wood, iron) = world.getWallUpgradeCost(4);
+        assertEq(wood, 50e18, "level 5 wood");
+        assertEq(iron, 15e18, "level 5 iron");
+    }
+
+    function test_upgradeWall_deductsAtQueueAndSettlesLevel() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 csId = _firstCs(clanId);
+        world.setVault(clanId, 100e18, 100e18, 100e18, 100e18);
+
+        (uint256 woodCost, uint256 ironCost) = world.getWallUpgradeCost(0);
+        OrderResult[] memory result = _submitOrder(elder, clanId, csId, ActionType.UpgradeWall);
+
+        assertEq(uint8(result[0].status), uint8(StatusCode.OK), "queue status");
+        assertEq(world.getClan(clanId).vaultWood, 100e18 - woodCost, "wood deducted at queue");
+        assertEq(world.getClan(clanId).vaultIron, 100e18 - ironCost, "iron deducted at queue");
+        assertEq(world.getClan(clanId).wallLevel, 0, "wall level waits for settle");
+
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeWall));
+        vm.expectEmit(true, false, false, true, address(world));
+        emit IClanWorldEvents.WallUpgraded(clanId, 1, 2);
+        _advanceTick();
+
+        assertEq(world.getClan(clanId).wallLevel, 1, "wall level after settle");
+    }
+
+    function test_upgradeWall_rejectsInsufficientVaultAtQueueTime() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 csId = _firstCs(clanId);
+        world.setVault(clanId, 0, 0, 100e18, 100e18);
+
+        OrderResult[] memory result = _submitOrder(elder, clanId, csId, ActionType.UpgradeWall);
+
+        assertEq(uint8(result[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "missing resources");
+        assertFalse(world.getActiveMission(csId).active, "no mission queued");
+        assertEq(world.getClan(clanId).wallLevel, 0, "wall unchanged");
+    }
+
+    function test_upgradeWall_rejectsAboveMaxLevel() public {
+        uint32 clanId = _mintClan(elder);
+        world.setVault(clanId, 300e18, 100e18, 100e18, 100e18);
+
+        OrderResult[] memory firstFour = _submitUpgradeBatch(elder, clanId, 4);
+        for (uint256 i = 0; i < 4; i++) {
+            assertEq(uint8(firstFour[i].status), uint8(StatusCode.OK), "first batch status");
+        }
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeWall) + 1);
+        assertEq(world.getClan(clanId).wallLevel, 4, "first four upgrades settled");
+
+        _advanceTicks(3);
+        uint32 csId = _firstCs(clanId);
+        OrderResult[] memory fifth = _submitOrder(elder, clanId, csId, ActionType.UpgradeWall);
+        assertEq(uint8(fifth[0].status), uint8(StatusCode.OK), "fifth status");
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeWall) + 1);
+        assertEq(world.getClan(clanId).wallLevel, 5, "max wall level");
+
+        _advanceTicks(3);
+        OrderResult[] memory sixth = _submitOrder(elder, clanId, csId, ActionType.UpgradeWall);
+        assertEq(uint8(sixth[0].status), uint8(StatusCode.ERR_INVALID_ACTION), "max level rejects");
+        assertEq(world.getClan(clanId).wallLevel, 5, "wall remains max");
+    }
+
+    function test_upgradeWall_twoClansDoNotInterfere() public {
+        uint32 clanA = _mintClan(elder);
+        vm.prank(elder2);
+        (uint32 clanB,) = world.mintClan(elder2);
+        world.setVault(clanA, 100e18, 100e18, 100e18, 100e18);
+        world.setVault(clanB, 100e18, 100e18, 100e18, 100e18);
+
+        OrderResult[] memory result = _submitOrder(elder, clanA, _firstCs(clanA), ActionType.UpgradeWall);
+        assertEq(uint8(result[0].status), uint8(StatusCode.OK), "queue status");
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeWall) + 1);
+
+        assertEq(world.getClan(clanA).wallLevel, 1, "clan A wall");
+        assertEq(world.getClan(clanB).wallLevel, 0, "clan B wall");
+    }
+}


### PR DESCRIPTION
Implements Phase 8.1 per issue #197. New UpgradeWall action, queue-time cost spend, settle-time level inc. Tests green: 100/100. <signed:codex>