### PR TITLE
feat(contracts): Phase 8.2 — base upgrades (Closes #220)

### DIFF
--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -64,6 +64,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     mapping(uint64 => bytes32) private _tickSeeds; // tick => seed
     mapping(uint32 => WallUpgradeReservation) private _wallUpgradeReservations; // clansmanId => reserved upgrade
     mapping(uint32 => uint8) private _pendingWallUpgradesByClan; // clanId => queued, unsettled wall upgrades
+    mapping(uint32 => BaseUpgradeReservation) private _baseUpgradeReservations; // clansmanId => reserved upgrade
+    mapping(uint32 => uint8) private _pendingBaseUpgradesByClan; // clanId => queued, unsettled base upgrades
 
     uint32 private _nextClanId;
     uint32 private _nextClansmanId;
@@ -80,6 +82,15 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint256 ironCost;
     }
 
+    struct BaseUpgradeReservation {
+        bool active;
+        uint32 clanId;
+        uint64 missionNonce;
+        uint256 woodCost;
+        uint256 ironCost;
+        uint256 wheatCost;
+    }
+
     // =========================================================================
     // CONSTANTS — Wheat harvest rate (not in IClanWorld constants)
     // =========================================================================
@@ -87,6 +98,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint64 private constant DEPOSIT_DURATION_TICKS = 1;
     uint64 private constant UPGRADE_WALL_DURATION_TICKS = 2;
     uint8 private constant WALL_MAX_LEVEL = 5;
+    uint8 private constant BASE_MAX_LEVEL = 5;
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
@@ -735,7 +747,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         } else if (action == ActionType.UpgradeWall) {
             success = _settleWallUpgrade(clan, cs.clansmanId, m.nonce, clanId, tick);
         } else if (action == ActionType.UpgradeBase) {
-            success = _tryUpgradeBase(clan, clanId, tick);
+            success = _settleBaseUpgrade(clan, cs.clansmanId, m.nonce, clanId, tick);
         } else if (action == ActionType.UpgradeMonument) {
             success = _tryUpgradeMonument(clan, clanId, tick);
         }
@@ -801,40 +813,24 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return true;
     }
 
-    function _tryUpgradeBase(Clan storage clan, uint32 clanId, uint64 tick) internal returns (bool) {
-        uint8 nextLevel = clan.baseLevel + 1;
-        if (nextLevel > 5) return false;
-
-        uint256 woodCost;
-        uint256 ironCost;
-        uint256 wheatCost;
-
-        if (nextLevel == 2) {
-            woodCost = 40e18;
-            ironCost = 0;
-            wheatCost = 20e18;
-        } else if (nextLevel == 3) {
-            woodCost = 60e18;
-            ironCost = 5e18;
-            wheatCost = 30e18;
-        } else if (nextLevel == 4) {
-            woodCost = 80e18;
-            ironCost = 10e18;
-            wheatCost = 40e18;
-        } else {
-            woodCost = 100e18;
-            ironCost = 15e18;
-            wheatCost = 50e18;
+    function _settleBaseUpgrade(Clan storage clan, uint32 clansmanId, uint64 missionNonce, uint32 clanId, uint64 tick)
+        internal
+        returns (bool)
+    {
+        BaseUpgradeReservation storage reservation = _baseUpgradeReservations[clansmanId];
+        if (!reservation.active || reservation.clanId != clanId || reservation.missionNonce != missionNonce) {
+            return false;
         }
 
-        if (clan.vaultWood < woodCost || clan.vaultIron < ironCost || clan.vaultWheat < wheatCost) return false;
+        _clearBaseUpgradeReservation(clansmanId);
+        if (clan.baseLevel >= BASE_MAX_LEVEL) return false;
 
-        clan.vaultWood -= woodCost;
-        clan.vaultIron -= ironCost;
-        clan.vaultWheat -= wheatCost;
         uint8 old = clan.baseLevel;
-        clan.baseLevel = nextLevel;
-        emit BaseLevelChanged(clanId, old, nextLevel, tick);
+        clan.baseLevel = old + 1;
+        emit BaseLevelChanged(clanId, old, clan.baseLevel, tick);
+        // Phase 8 event ABI uses uint32; season tick horizons are far below this cap.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        emit BaseUpgraded(clanId, clan.baseLevel, uint32(tick));
         return true;
     }
 
@@ -1258,9 +1254,15 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (ctx.wasActive && existingM.action == ActionType.UpgradeWall) {
             _refundWallUpgradeReservation(order.clansmanId);
         }
+        if (ctx.wasActive && existingM.action == ActionType.UpgradeBase) {
+            _refundBaseUpgradeReservation(order.clansmanId);
+        }
 
         if (order.action == ActionType.UpgradeWall) {
             _reserveWallUpgrade(clan, clanId, order.clansmanId, ctx.newNonce);
+        }
+        if (order.action == ActionType.UpgradeBase) {
+            _reserveBaseUpgrade(clan, clanId, order.clansmanId, ctx.newNonce);
         }
 
         // Install mission via helper to keep stack shallow
@@ -1672,6 +1674,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (action == ActionType.UpgradeWall) {
             return _validateUpgradeWallOrder(clan, cs.clansmanId);
         }
+        if (action == ActionType.UpgradeBase) {
+            return _validateUpgradeBaseOrder(clan, cs.clansmanId);
+        }
 
         // ChopWood: must go to Forest
         if (action == ActionType.ChopWood) {
@@ -1791,6 +1796,73 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         delete _wallUpgradeReservations[clansmanId];
     }
 
+    function _validateUpgradeBaseOrder(Clan storage clan, uint32 clansmanId) internal view returns (StatusCode) {
+        uint8 pendingUpgrades = _pendingBaseUpgradesByClan[clan.clanId];
+        uint256 availableWood = clan.vaultWood;
+        uint256 availableIron = clan.vaultIron;
+        uint256 availableWheat = clan.vaultWheat;
+
+        BaseUpgradeReservation storage existing = _baseUpgradeReservations[clansmanId];
+        if (existing.active && existing.clanId == clan.clanId) {
+            pendingUpgrades -= 1;
+            availableWood += existing.woodCost;
+            availableIron += existing.ironCost;
+            availableWheat += existing.wheatCost;
+        }
+
+        uint8 plannedCurrentLevel = clan.baseLevel + pendingUpgrades;
+        if (plannedCurrentLevel >= BASE_MAX_LEVEL) return StatusCode.ERR_INVALID_ACTION;
+
+        (uint256 woodCost, uint256 ironCost, uint256 wheatCost) = _baseUpgradeCost(plannedCurrentLevel);
+        if (availableWood < woodCost || availableIron < ironCost || availableWheat < wheatCost) {
+            return StatusCode.ERR_MISSING_RESOURCES;
+        }
+
+        return StatusCode.OK;
+    }
+
+    function _reserveBaseUpgrade(Clan storage clan, uint32 clanId, uint32 clansmanId, uint64 missionNonce) internal {
+        uint8 plannedCurrentLevel = clan.baseLevel + _pendingBaseUpgradesByClan[clanId];
+        (uint256 woodCost, uint256 ironCost, uint256 wheatCost) = _baseUpgradeCost(plannedCurrentLevel);
+
+        clan.vaultWood -= woodCost;
+        clan.vaultIron -= ironCost;
+        clan.vaultWheat -= wheatCost;
+        _pendingBaseUpgradesByClan[clanId] += 1;
+
+        _baseUpgradeReservations[clansmanId] = BaseUpgradeReservation({
+            active: true,
+            clanId: clanId,
+            missionNonce: missionNonce,
+            woodCost: woodCost,
+            ironCost: ironCost,
+            wheatCost: wheatCost
+        });
+    }
+
+    function _refundBaseUpgradeReservation(uint32 clansmanId) internal {
+        BaseUpgradeReservation storage reservation = _baseUpgradeReservations[clansmanId];
+        if (!reservation.active) return;
+
+        Clan storage clan = _clans[reservation.clanId];
+        clan.vaultWood += reservation.woodCost;
+        clan.vaultIron += reservation.ironCost;
+        clan.vaultWheat += reservation.wheatCost;
+        _clearBaseUpgradeReservation(clansmanId);
+    }
+
+    function _clearBaseUpgradeReservation(uint32 clansmanId) internal {
+        BaseUpgradeReservation storage reservation = _baseUpgradeReservations[clansmanId];
+        if (!reservation.active) return;
+
+        uint32 clanId = reservation.clanId;
+        if (_pendingBaseUpgradesByClan[clanId] > 0) {
+            _pendingBaseUpgradesByClan[clanId] -= 1;
+        }
+
+        delete _baseUpgradeReservations[clansmanId];
+    }
+
     function _validateDefendBaseOrder(Clan storage clan, ClanOrder calldata order, uint8 gotoRegion)
         internal
         view
@@ -1907,6 +1979,15 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return _wallUpgradeCost(currentLevel);
     }
 
+    function getBaseUpgradeCost(uint8 currentLevel)
+        public
+        pure
+        override
+        returns (uint256 wood, uint256 iron, uint256 wheat)
+    {
+        return _baseUpgradeCost(currentLevel);
+    }
+
     function _wallUpgradeCost(uint8 currentLevel) internal pure returns (uint256 wood, uint256 iron) {
         if (currentLevel == 0) return (20e18, 0);
         if (currentLevel == 1) return (35e18, 0);
@@ -1914,6 +1995,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (currentLevel == 3) return (40e18, 10e18);
         if (currentLevel == 4) return (50e18, 15e18);
         return (0, 0);
+    }
+
+    function _baseUpgradeCost(uint8 currentLevel) internal pure returns (uint256 wood, uint256 iron, uint256 wheat) {
+        if (currentLevel == 1) return (40e18, 0, 20e18);
+        if (currentLevel == 2) return (60e18, 5e18, 30e18);
+        if (currentLevel == 3) return (80e18, 10e18, 40e18);
+        if (currentLevel == 4) return (100e18, 15e18, 50e18);
+        return (0, 0, 0);
     }
 
     function getActionDuration(ActionType action) public pure override returns (uint64) {
@@ -1928,13 +2017,13 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             return DEPOSIT_DURATION_TICKS;
         }
 
-        if (action == ActionType.UpgradeWall) {
+        if (action == ActionType.UpgradeWall || action == ActionType.UpgradeBase) {
             return UPGRADE_WALL_DURATION_TICKS;
         }
 
         if (
-            action == ActionType.BuildWall || action == ActionType.UpgradeBase || action == ActionType.UpgradeMonument
-                || action == ActionType.MarketBuy || action == ActionType.MarketSell
+            action == ActionType.BuildWall || action == ActionType.UpgradeMonument || action == ActionType.MarketBuy
+                || action == ActionType.MarketSell
         ) {
             return 1;
         }

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -216,6 +216,19 @@ contract ClanWorldStub is IClanWorld {
         return (0, 0);
     }
 
+    function getBaseUpgradeCost(uint8 currentLevel)
+        external
+        pure
+        override
+        returns (uint256 wood, uint256 iron, uint256 wheat)
+    {
+        if (currentLevel == 1) return (40e18, 0, 20e18);
+        if (currentLevel == 2) return (60e18, 5e18, 30e18);
+        if (currentLevel == 3) return (80e18, 10e18, 40e18);
+        if (currentLevel == 4) return (100e18, 15e18, 50e18);
+        return (0, 0, 0);
+    }
+
     function getActionDuration(ActionType) external pure override returns (uint64) {
         return 0;
     }

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -547,6 +547,7 @@ interface IClanWorldEvents {
     event WallLevelChanged(uint32 indexed clanId, uint8 oldLevel, uint8 newLevel, uint64 atTick);
     event WallUpgraded(uint32 indexed clanId, uint8 newLevel, uint32 settledAtTick);
     event BaseLevelChanged(uint32 indexed clanId, uint8 oldLevel, uint8 newLevel, uint64 atTick);
+    event BaseUpgraded(uint32 indexed clanId, uint8 newLevel, uint32 settledAtTick);
     event MonumentLevelChanged(uint32 indexed clanId, uint8 oldLevel, uint8 newLevel, uint64 atTick);
 
     // ----- market -----
@@ -715,6 +716,8 @@ interface IClanWorld is IClanWorldEvents {
         returns (uint64 submitted, uint64 executes, uint64 settles);
 
     function getWallUpgradeCost(uint8 currentLevel) external pure returns (uint256 wood, uint256 iron);
+
+    function getBaseUpgradeCost(uint8 currentLevel) external pure returns (uint256 wood, uint256 iron, uint256 wheat);
 
     function getActionDuration(ActionType action) external pure returns (uint64);
 

--- a/packages/contracts/test/BaseUpgrades.t.sol
+++ b/packages/contracts/test/BaseUpgrades.t.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {
+    IClanWorldEvents,
+    ClanWorldConstants,
+    Clan,
+    ClanOrder,
+    OrderResult,
+    StatusCode,
+    ActionType
+} from "../src/IClanWorld.sol";
+
+contract BaseUpgradeHarness is ClanWorld {
+    function setVault(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        _clans[clanId].vaultWood = wood;
+        _clans[clanId].vaultIron = iron;
+        _clans[clanId].vaultWheat = wheat;
+        _clans[clanId].vaultFish = fish;
+    }
+}
+
+contract BaseUpgradesTest is Test {
+    BaseUpgradeHarness world;
+    address elder = address(0xA1);
+    address elder2 = address(0xA2);
+
+    function setUp() public {
+        world = new BaseUpgradeHarness();
+    }
+
+    function _mintClan(address owner) internal returns (uint32 clanId) {
+        vm.prank(owner);
+        (clanId,) = world.mintClan(owner);
+    }
+
+    function _firstCs(uint32 clanId) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _csAt(uint32 clanId, uint256 index) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[index].clansman.clansman.clansmanId;
+    }
+
+    function _submitOrder(address owner, uint32 clanId, uint32 csId, ActionType action)
+        internal
+        returns (OrderResult[] memory)
+    {
+        Clan memory clan = world.getClan(clanId);
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: clan.baseRegion,
+            action: action,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(owner);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _submitUpgradeBatch(address owner, uint32 clanId, uint256 count) internal returns (OrderResult[] memory) {
+        Clan memory clan = world.getClan(clanId);
+        ClanOrder[] memory orders = new ClanOrder[](count);
+        for (uint256 i = 0; i < count; i++) {
+            orders[i] = ClanOrder({
+                clansmanId: _csAt(clanId, i),
+                gotoRegion: clan.baseRegion,
+                action: ActionType.UpgradeBase,
+                targetClanId: 0,
+                marketToken: address(0),
+                marketAmount: 0,
+                maxGoldIn: 0
+            });
+        }
+        vm.prank(owner);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _advanceTick() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+    }
+
+    function _advanceTicks(uint256 count) internal {
+        for (uint256 i = 0; i < count; i++) {
+            _advanceTick();
+        }
+    }
+
+    function test_getBaseUpgradeCost_matchesSpecTable() public view {
+        (uint256 wood, uint256 iron, uint256 wheat) = world.getBaseUpgradeCost(1);
+        assertEq(wood, 40e18, "level 2 wood");
+        assertEq(iron, 0, "level 2 iron");
+        assertEq(wheat, 20e18, "level 2 wheat");
+
+        (wood, iron, wheat) = world.getBaseUpgradeCost(3);
+        assertEq(wood, 80e18, "level 4 wood");
+        assertEq(iron, 10e18, "level 4 iron");
+        assertEq(wheat, 40e18, "level 4 wheat");
+
+        (wood, iron, wheat) = world.getBaseUpgradeCost(4);
+        assertEq(wood, 100e18, "level 5 wood");
+        assertEq(iron, 15e18, "level 5 iron");
+        assertEq(wheat, 50e18, "level 5 wheat");
+    }
+
+    function test_upgradeBase_deductsAtQueueAndSettlesLevel() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 csId = _firstCs(clanId);
+        world.setVault(clanId, 100e18, 100e18, 100e18, 100e18);
+
+        (uint256 woodCost, uint256 ironCost, uint256 wheatCost) = world.getBaseUpgradeCost(1);
+        OrderResult[] memory result = _submitOrder(elder, clanId, csId, ActionType.UpgradeBase);
+
+        assertEq(uint8(result[0].status), uint8(StatusCode.OK), "queue status");
+        assertEq(world.getClan(clanId).vaultWood, 100e18 - woodCost, "wood deducted at queue");
+        assertEq(world.getClan(clanId).vaultIron, 100e18 - ironCost, "iron deducted at queue");
+        assertEq(world.getClan(clanId).vaultWheat, 100e18 - wheatCost, "wheat deducted at queue");
+        assertEq(world.getClan(clanId).baseLevel, 1, "base level waits for settle");
+
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeBase));
+        vm.expectEmit(true, false, false, true, address(world));
+        emit IClanWorldEvents.BaseUpgraded(clanId, 2, 2);
+        _advanceTick();
+
+        assertEq(world.getClan(clanId).baseLevel, 2, "base level after settle");
+    }
+
+    function test_upgradeBase_rejectsInsufficientVaultAtQueueTime() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 csId = _firstCs(clanId);
+        world.setVault(clanId, 0, 100e18, 0, 100e18);
+
+        OrderResult[] memory result = _submitOrder(elder, clanId, csId, ActionType.UpgradeBase);
+
+        assertEq(uint8(result[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "missing resources");
+        assertFalse(world.getActiveMission(csId).active, "no mission queued");
+        assertEq(world.getClan(clanId).baseLevel, 1, "base unchanged");
+    }
+
+    function test_upgradeBase_rejectsAboveMaxLevel() public {
+        uint32 clanId = _mintClan(elder);
+        world.setVault(clanId, 300e18, 100e18, 200e18, 100e18);
+
+        OrderResult[] memory firstFour = _submitUpgradeBatch(elder, clanId, 4);
+        for (uint256 i = 0; i < 4; i++) {
+            assertEq(uint8(firstFour[i].status), uint8(StatusCode.OK), "first batch status");
+        }
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeBase) + 1);
+        assertEq(world.getClan(clanId).baseLevel, 5, "max base level");
+
+        _advanceTicks(3);
+        uint32 csId = _firstCs(clanId);
+        OrderResult[] memory fifth = _submitOrder(elder, clanId, csId, ActionType.UpgradeBase);
+        assertEq(uint8(fifth[0].status), uint8(StatusCode.ERR_INVALID_ACTION), "max level rejects");
+        assertEq(world.getClan(clanId).baseLevel, 5, "base remains max");
+    }
+
+    function test_upgradeBase_twoClansDoNotInterfere() public {
+        uint32 clanA = _mintClan(elder);
+        vm.prank(elder2);
+        (uint32 clanB,) = world.mintClan(elder2);
+        world.setVault(clanA, 100e18, 100e18, 100e18, 100e18);
+        world.setVault(clanB, 100e18, 100e18, 100e18, 100e18);
+
+        OrderResult[] memory result = _submitOrder(elder, clanA, _firstCs(clanA), ActionType.UpgradeBase);
+        assertEq(uint8(result[0].status), uint8(StatusCode.OK), "queue status");
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeBase) + 1);
+
+        assertEq(world.getClan(clanA).baseLevel, 2, "clan A base");
+        assertEq(world.getClan(clanB).baseLevel, 1, "clan B base");
+    }
+}

--- a/packages/contracts/test/MissionTiming.t.sol
+++ b/packages/contracts/test/MissionTiming.t.sol
@@ -127,7 +127,7 @@ contract MissionTimingTest is Test {
         assertEq(world.getActionDuration(ActionType.HarvestWheat), 4, "harvest wheat");
         assertEq(world.getActionDuration(ActionType.DepositResources), 1, "deposit");
         assertEq(world.getActionDuration(ActionType.BuildWall), 1, "build wall");
-        assertEq(world.getActionDuration(ActionType.UpgradeBase), 1, "upgrade base");
+        assertEq(world.getActionDuration(ActionType.UpgradeBase), 2, "upgrade base");
         assertEq(world.getActionDuration(ActionType.UpgradeMonument), 1, "upgrade monument");
         assertEq(world.getActionDuration(ActionType.DefendBase), 0, "defend base");
         assertEq(world.getActionDuration(ActionType.MarketBuy), 1, "market buy");


### PR DESCRIPTION
## Summary
- Implements Phase 8.2 base upgrade queue/settle flow to mirror Phase 8.1 wall upgrades.
- Adds queue-time vault reservations/refunds, `BaseUpgraded`, `getBaseUpgradeCost`, max level 5, and 2-tick duration.
- Leaves `ActionType.UpgradeBase` in its existing parent-branch enum slot; it was already present before this issue branch.

## Cost Table
Chosen from `docs/planning/clanworld_v4_spec.md` because v4.2 records `baseLevel` but does not list costs.

| Upgrade To | Cost |
| --- | --- |
| Level 2 | 40 wood + 20 wheat |
| Level 3 | 60 wood + 5 iron + 30 wheat |
| Level 4 | 80 wood + 10 iron + 40 wheat |
| Level 5 | 100 wood + 15 iron + 50 wheat |

## Tests
- `~/.foundry/bin/forge test --match-path 'test/{BaseUpgrades,WallUpgrades,MissionTiming}.t.sol'`\n- `~/.foundry/bin/forge test`\n\nCloses #220