### PR TITLE
feat(contracts): Phase 8.3 — monument upgrades (Closes #221)

### DIFF
--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -66,6 +66,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     mapping(uint32 => uint8) private _pendingWallUpgradesByClan; // clanId => queued, unsettled wall upgrades
     mapping(uint32 => BaseUpgradeReservation) private _baseUpgradeReservations; // clansmanId => reserved upgrade
     mapping(uint32 => uint8) private _pendingBaseUpgradesByClan; // clanId => queued, unsettled base upgrades
+    mapping(uint32 => MonumentUpgradeReservation) private _monumentUpgradeReservations; // clansmanId => reserved upgrade
+    mapping(uint32 => uint8) private _pendingMonumentUpgradesByClan; // clanId => queued, unsettled monument upgrades
 
     uint32 private _nextClanId;
     uint32 private _nextClansmanId;
@@ -91,14 +93,26 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint256 wheatCost;
     }
 
+    struct MonumentUpgradeReservation {
+        bool active;
+        uint32 clanId;
+        uint64 missionNonce;
+        uint256 woodCost;
+        uint256 ironCost;
+        uint256 wheatCost;
+        uint256 blueprintCost;
+    }
+
     // =========================================================================
     // CONSTANTS — Wheat harvest rate (not in IClanWorld constants)
     // =========================================================================
 
     uint64 private constant DEPOSIT_DURATION_TICKS = 1;
     uint64 private constant UPGRADE_WALL_DURATION_TICKS = 2;
+    uint64 private constant UPGRADE_MONUMENT_DURATION_TICKS = 4;
     uint8 private constant WALL_MAX_LEVEL = 5;
     uint8 private constant BASE_MAX_LEVEL = 5;
+    uint8 private constant MONUMENT_MAX_LEVEL = 10;
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
@@ -337,6 +351,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                     _clearDefender(cs.clansmanId);
                 } else if (m.action == ActionType.UpgradeWall) {
                     _refundWallUpgradeReservation(cs.clansmanId);
+                } else if (m.action == ActionType.UpgradeBase) {
+                    _refundBaseUpgradeReservation(cs.clansmanId);
+                } else if (m.action == ActionType.UpgradeMonument) {
+                    _refundMonumentUpgradeReservation(cs.clansmanId);
                 }
                 m.active = false; // silent invalidation; dead clansman gets no MissionCompleted
             }
@@ -749,7 +767,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         } else if (action == ActionType.UpgradeBase) {
             success = _settleBaseUpgrade(clan, cs.clansmanId, m.nonce, clanId, tick);
         } else if (action == ActionType.UpgradeMonument) {
-            success = _tryUpgradeMonument(clan, clanId, tick);
+            success = _settleMonumentUpgrade(clan, cs.clansmanId, m.nonce, clanId, tick);
         }
 
         if (!success) {
@@ -834,57 +852,27 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return true;
     }
 
-    function _tryUpgradeMonument(Clan storage clan, uint32 clanId, uint64 tick) internal returns (bool) {
-        uint8 nextLevel = clan.monumentLevel + 1;
-        if (nextLevel > 10) return false;
-
-        uint256 woodCost;
-        uint256 wheatCost;
-        uint256 ironCost;
-        uint256 blueprintCost;
-
-        if (nextLevel == 1) {
-            woodCost = 30e18;
-            wheatCost = 20e18;
-        } else if (nextLevel == 2) {
-            woodCost = 50e18;
-            wheatCost = 30e18;
-        } else if (nextLevel == 3) {
-            woodCost = 70e18;
-            wheatCost = 40e18;
-            ironCost = 5e18;
-        } else if (nextLevel == 4) {
-            woodCost = 90e18;
-            wheatCost = 50e18;
-            ironCost = 10e18;
-        } else if (nextLevel == 5) {
-            woodCost = 120e18;
-            wheatCost = 60e18;
-            ironCost = 15e18;
-        } else if (nextLevel == 6) {
-            woodCost = 150e18;
-            wheatCost = 80e18;
-            ironCost = 20e18;
-        } else if (nextLevel <= 10) {
-            woodCost = 200e18;
-            wheatCost = 100e18;
-            ironCost = 25e18;
-            blueprintCost = 1e18;
+    function _settleMonumentUpgrade(
+        Clan storage clan,
+        uint32 clansmanId,
+        uint64 missionNonce,
+        uint32 clanId,
+        uint64 tick
+    ) internal returns (bool) {
+        MonumentUpgradeReservation storage reservation = _monumentUpgradeReservations[clansmanId];
+        if (!reservation.active || reservation.clanId != clanId || reservation.missionNonce != missionNonce) {
+            return false;
         }
 
-        if (
-            clan.vaultWood < woodCost || clan.vaultWheat < wheatCost || clan.vaultIron < ironCost
-                || clan.blueprintBalance < blueprintCost
-        ) return false;
-
-        clan.vaultWood -= woodCost;
-        clan.vaultWheat -= wheatCost;
-        clan.vaultIron -= ironCost;
-        clan.blueprintBalance -= blueprintCost;
+        _clearMonumentUpgradeReservation(clansmanId);
+        if (clan.monumentLevel >= MONUMENT_MAX_LEVEL) return false;
 
         uint8 old = clan.monumentLevel;
-        clan.monumentLevel = nextLevel;
-        emit MonumentLevelChanged(clanId, old, nextLevel, tick);
+        clan.monumentLevel = old + 1;
+        emit MonumentLevelChanged(clanId, old, clan.monumentLevel, tick);
+        // Phase 8 event ABI uses uint32; season tick horizons are far below this cap.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        emit MonumentUpgraded(clanId, clan.monumentLevel, uint32(tick));
         return true;
     }
 
@@ -1257,12 +1245,18 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (ctx.wasActive && existingM.action == ActionType.UpgradeBase) {
             _refundBaseUpgradeReservation(order.clansmanId);
         }
+        if (ctx.wasActive && existingM.action == ActionType.UpgradeMonument) {
+            _refundMonumentUpgradeReservation(order.clansmanId);
+        }
 
         if (order.action == ActionType.UpgradeWall) {
             _reserveWallUpgrade(clan, clanId, order.clansmanId, ctx.newNonce);
         }
         if (order.action == ActionType.UpgradeBase) {
             _reserveBaseUpgrade(clan, clanId, order.clansmanId, ctx.newNonce);
+        }
+        if (order.action == ActionType.UpgradeMonument) {
+            _reserveMonumentUpgrade(clan, clanId, order.clansmanId, ctx.newNonce);
         }
 
         // Install mission via helper to keep stack shallow
@@ -1677,6 +1671,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (action == ActionType.UpgradeBase) {
             return _validateUpgradeBaseOrder(clan, cs.clansmanId);
         }
+        if (action == ActionType.UpgradeMonument) {
+            return _validateUpgradeMonumentOrder(clan, cs.clansmanId);
+        }
 
         // ChopWood: must go to Forest
         if (action == ActionType.ChopWood) {
@@ -1863,6 +1860,85 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         delete _baseUpgradeReservations[clansmanId];
     }
 
+    function _validateUpgradeMonumentOrder(Clan storage clan, uint32 clansmanId) internal view returns (StatusCode) {
+        uint8 pendingUpgrades = _pendingMonumentUpgradesByClan[clan.clanId];
+        uint256 availableWood = clan.vaultWood;
+        uint256 availableIron = clan.vaultIron;
+        uint256 availableWheat = clan.vaultWheat;
+        uint256 availableBlueprint = clan.blueprintBalance;
+
+        MonumentUpgradeReservation storage existing = _monumentUpgradeReservations[clansmanId];
+        if (existing.active && existing.clanId == clan.clanId) {
+            pendingUpgrades -= 1;
+            availableWood += existing.woodCost;
+            availableIron += existing.ironCost;
+            availableWheat += existing.wheatCost;
+            availableBlueprint += existing.blueprintCost;
+        }
+
+        uint8 plannedCurrentLevel = clan.monumentLevel + pendingUpgrades;
+        if (plannedCurrentLevel >= MONUMENT_MAX_LEVEL) return StatusCode.ERR_INVALID_ACTION;
+
+        (uint256 woodCost, uint256 ironCost, uint256 wheatCost, uint256 blueprintCost) =
+            _monumentUpgradeCost(plannedCurrentLevel);
+        if (
+            availableWood < woodCost || availableIron < ironCost || availableWheat < wheatCost
+                || availableBlueprint < blueprintCost
+        ) {
+            return StatusCode.ERR_MISSING_RESOURCES;
+        }
+
+        return StatusCode.OK;
+    }
+
+    function _reserveMonumentUpgrade(Clan storage clan, uint32 clanId, uint32 clansmanId, uint64 missionNonce)
+        internal
+    {
+        uint8 plannedCurrentLevel = clan.monumentLevel + _pendingMonumentUpgradesByClan[clanId];
+        (uint256 woodCost, uint256 ironCost, uint256 wheatCost, uint256 blueprintCost) =
+            _monumentUpgradeCost(plannedCurrentLevel);
+
+        clan.vaultWood -= woodCost;
+        clan.vaultIron -= ironCost;
+        clan.vaultWheat -= wheatCost;
+        clan.blueprintBalance -= blueprintCost;
+        _pendingMonumentUpgradesByClan[clanId] += 1;
+
+        _monumentUpgradeReservations[clansmanId] = MonumentUpgradeReservation({
+            active: true,
+            clanId: clanId,
+            missionNonce: missionNonce,
+            woodCost: woodCost,
+            ironCost: ironCost,
+            wheatCost: wheatCost,
+            blueprintCost: blueprintCost
+        });
+    }
+
+    function _refundMonumentUpgradeReservation(uint32 clansmanId) internal {
+        MonumentUpgradeReservation storage reservation = _monumentUpgradeReservations[clansmanId];
+        if (!reservation.active) return;
+
+        Clan storage clan = _clans[reservation.clanId];
+        clan.vaultWood += reservation.woodCost;
+        clan.vaultIron += reservation.ironCost;
+        clan.vaultWheat += reservation.wheatCost;
+        clan.blueprintBalance += reservation.blueprintCost;
+        _clearMonumentUpgradeReservation(clansmanId);
+    }
+
+    function _clearMonumentUpgradeReservation(uint32 clansmanId) internal {
+        MonumentUpgradeReservation storage reservation = _monumentUpgradeReservations[clansmanId];
+        if (!reservation.active) return;
+
+        uint32 clanId = reservation.clanId;
+        if (_pendingMonumentUpgradesByClan[clanId] > 0) {
+            _pendingMonumentUpgradesByClan[clanId] -= 1;
+        }
+
+        delete _monumentUpgradeReservations[clansmanId];
+    }
+
     function _validateDefendBaseOrder(Clan storage clan, ClanOrder calldata order, uint8 gotoRegion)
         internal
         view
@@ -1988,6 +2064,15 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return _baseUpgradeCost(currentLevel);
     }
 
+    function getMonumentUpgradeCost(uint8 currentLevel)
+        public
+        pure
+        override
+        returns (uint256 wood, uint256 iron, uint256 wheat, uint256 blueprint)
+    {
+        return _monumentUpgradeCost(currentLevel);
+    }
+
     function _wallUpgradeCost(uint8 currentLevel) internal pure returns (uint256 wood, uint256 iron) {
         if (currentLevel == 0) return (20e18, 0);
         if (currentLevel == 1) return (35e18, 0);
@@ -2003,6 +2088,21 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (currentLevel == 3) return (80e18, 10e18, 40e18);
         if (currentLevel == 4) return (100e18, 15e18, 50e18);
         return (0, 0, 0);
+    }
+
+    function _monumentUpgradeCost(uint8 currentLevel)
+        internal
+        pure
+        returns (uint256 wood, uint256 iron, uint256 wheat, uint256 blueprint)
+    {
+        if (currentLevel == 0) return (30e18, 0, 20e18, 0);
+        if (currentLevel == 1) return (50e18, 0, 30e18, 0);
+        if (currentLevel == 2) return (70e18, 5e18, 40e18, 0);
+        if (currentLevel == 3) return (90e18, 10e18, 50e18, 0);
+        if (currentLevel == 4) return (120e18, 15e18, 60e18, 0);
+        if (currentLevel == 5) return (150e18, 20e18, 80e18, 0);
+        if (currentLevel >= 6 && currentLevel < MONUMENT_MAX_LEVEL) return (200e18, 25e18, 100e18, 1e18);
+        return (0, 0, 0, 0);
     }
 
     function getActionDuration(ActionType action) public pure override returns (uint64) {
@@ -2021,10 +2121,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             return UPGRADE_WALL_DURATION_TICKS;
         }
 
-        if (
-            action == ActionType.BuildWall || action == ActionType.UpgradeMonument || action == ActionType.MarketBuy
-                || action == ActionType.MarketSell
-        ) {
+        if (action == ActionType.UpgradeMonument) {
+            return UPGRADE_MONUMENT_DURATION_TICKS;
+        }
+
+        if (action == ActionType.BuildWall || action == ActionType.MarketBuy || action == ActionType.MarketSell) {
             return 1;
         }
 

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -229,6 +229,22 @@ contract ClanWorldStub is IClanWorld {
         return (0, 0, 0);
     }
 
+    function getMonumentUpgradeCost(uint8 currentLevel)
+        external
+        pure
+        override
+        returns (uint256 wood, uint256 iron, uint256 wheat, uint256 blueprint)
+    {
+        if (currentLevel == 0) return (30e18, 0, 20e18, 0);
+        if (currentLevel == 1) return (50e18, 0, 30e18, 0);
+        if (currentLevel == 2) return (70e18, 5e18, 40e18, 0);
+        if (currentLevel == 3) return (90e18, 10e18, 50e18, 0);
+        if (currentLevel == 4) return (120e18, 15e18, 60e18, 0);
+        if (currentLevel == 5) return (150e18, 20e18, 80e18, 0);
+        if (currentLevel >= 6 && currentLevel < 10) return (200e18, 25e18, 100e18, 1e18);
+        return (0, 0, 0, 0);
+    }
+
     function getActionDuration(ActionType) external pure override returns (uint64) {
         return 0;
     }

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -549,6 +549,7 @@ interface IClanWorldEvents {
     event BaseLevelChanged(uint32 indexed clanId, uint8 oldLevel, uint8 newLevel, uint64 atTick);
     event BaseUpgraded(uint32 indexed clanId, uint8 newLevel, uint32 settledAtTick);
     event MonumentLevelChanged(uint32 indexed clanId, uint8 oldLevel, uint8 newLevel, uint64 atTick);
+    event MonumentUpgraded(uint32 indexed clanId, uint8 newLevel, uint32 settledAtTick);
 
     // ----- market -----
     event ImmediateMarketActionExecuted(
@@ -718,6 +719,11 @@ interface IClanWorld is IClanWorldEvents {
     function getWallUpgradeCost(uint8 currentLevel) external pure returns (uint256 wood, uint256 iron);
 
     function getBaseUpgradeCost(uint8 currentLevel) external pure returns (uint256 wood, uint256 iron, uint256 wheat);
+
+    function getMonumentUpgradeCost(uint8 currentLevel)
+        external
+        pure
+        returns (uint256 wood, uint256 iron, uint256 wheat, uint256 blueprint);
 
     function getActionDuration(ActionType action) external pure returns (uint64);
 

--- a/packages/contracts/test/MissionTiming.t.sol
+++ b/packages/contracts/test/MissionTiming.t.sol
@@ -128,7 +128,7 @@ contract MissionTimingTest is Test {
         assertEq(world.getActionDuration(ActionType.DepositResources), 1, "deposit");
         assertEq(world.getActionDuration(ActionType.BuildWall), 1, "build wall");
         assertEq(world.getActionDuration(ActionType.UpgradeBase), 2, "upgrade base");
-        assertEq(world.getActionDuration(ActionType.UpgradeMonument), 1, "upgrade monument");
+        assertEq(world.getActionDuration(ActionType.UpgradeMonument), 4, "upgrade monument");
         assertEq(world.getActionDuration(ActionType.DefendBase), 0, "defend base");
         assertEq(world.getActionDuration(ActionType.MarketBuy), 1, "market buy");
         assertEq(world.getActionDuration(ActionType.MarketSell), 1, "market sell");

--- a/packages/contracts/test/MonumentUpgrades.t.sol
+++ b/packages/contracts/test/MonumentUpgrades.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {
+    IClanWorldEvents,
+    ClanWorldConstants,
+    Clan,
+    ClanOrder,
+    OrderResult,
+    StatusCode,
+    ActionType
+} from "../src/IClanWorld.sol";
+
+contract MonumentUpgradeHarness is ClanWorld {
+    function setVault(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        _clans[clanId].vaultWood = wood;
+        _clans[clanId].vaultIron = iron;
+        _clans[clanId].vaultWheat = wheat;
+        _clans[clanId].vaultFish = fish;
+    }
+
+    function setBlueprint(uint32 clanId, uint256 blueprint) external {
+        _clans[clanId].blueprintBalance = blueprint;
+    }
+
+    function setMonumentLevel(uint32 clanId, uint8 level) external {
+        _clans[clanId].monumentLevel = level;
+    }
+}
+
+contract MonumentUpgradesTest is Test {
+    MonumentUpgradeHarness world;
+    address elder = address(0xA1);
+    address elder2 = address(0xA2);
+
+    function setUp() public {
+        world = new MonumentUpgradeHarness();
+    }
+
+    function _mintClan(address owner) internal returns (uint32 clanId) {
+        vm.prank(owner);
+        (clanId,) = world.mintClan(owner);
+    }
+
+    function _firstCs(uint32 clanId) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _csAt(uint32 clanId, uint256 index) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[index].clansman.clansman.clansmanId;
+    }
+
+    function _submitOrder(address owner, uint32 clanId, uint32 csId, ActionType action)
+        internal
+        returns (OrderResult[] memory)
+    {
+        Clan memory clan = world.getClan(clanId);
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: clan.baseRegion,
+            action: action,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        vm.prank(owner);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _submitUpgradeBatch(address owner, uint32 clanId, uint256 count) internal returns (OrderResult[] memory) {
+        Clan memory clan = world.getClan(clanId);
+        ClanOrder[] memory orders = new ClanOrder[](count);
+        for (uint256 i = 0; i < count; i++) {
+            orders[i] = ClanOrder({
+                clansmanId: _csAt(clanId, i),
+                gotoRegion: clan.baseRegion,
+                action: ActionType.UpgradeMonument,
+                targetClanId: 0,
+                marketToken: address(0),
+                marketAmount: 0,
+                maxGoldIn: 0
+            });
+        }
+        vm.prank(owner);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _advanceTick() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+    }
+
+    function _advanceTicks(uint256 count) internal {
+        for (uint256 i = 0; i < count; i++) {
+            _advanceTick();
+        }
+    }
+
+    function test_getMonumentUpgradeCost_matchesPhaseTable() public view {
+        (uint256 wood, uint256 iron, uint256 wheat, uint256 blueprint) = world.getMonumentUpgradeCost(0);
+        assertEq(wood, 30e18, "level 1 wood");
+        assertEq(iron, 0, "level 1 iron");
+        assertEq(wheat, 20e18, "level 1 wheat");
+        assertEq(blueprint, 0, "level 1 blueprint");
+
+        (wood, iron, wheat, blueprint) = world.getMonumentUpgradeCost(5);
+        assertEq(wood, 150e18, "level 6 wood");
+        assertEq(iron, 20e18, "level 6 iron");
+        assertEq(wheat, 80e18, "level 6 wheat");
+        assertEq(blueprint, 0, "level 6 blueprint");
+
+        (wood, iron, wheat, blueprint) = world.getMonumentUpgradeCost(6);
+        assertEq(wood, 200e18, "level 7 wood");
+        assertEq(iron, 25e18, "level 7 iron");
+        assertEq(wheat, 100e18, "level 7 wheat");
+        assertEq(blueprint, 1e18, "level 7 blueprint");
+    }
+
+    function test_upgradeMonument_deductsAtQueueAndSettlesLevel() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 csId = _firstCs(clanId);
+        world.setVault(clanId, 100e18, 100e18, 100e18, 100e18);
+        world.setBlueprint(clanId, 5e18);
+
+        (uint256 woodCost, uint256 ironCost, uint256 wheatCost, uint256 blueprintCost) = world.getMonumentUpgradeCost(0);
+        OrderResult[] memory result = _submitOrder(elder, clanId, csId, ActionType.UpgradeMonument);
+
+        assertEq(uint8(result[0].status), uint8(StatusCode.OK), "queue status");
+        assertEq(world.getClan(clanId).vaultWood, 100e18 - woodCost, "wood deducted at queue");
+        assertEq(world.getClan(clanId).vaultIron, 100e18 - ironCost, "iron deducted at queue");
+        assertEq(world.getClan(clanId).vaultWheat, 100e18 - wheatCost, "wheat deducted at queue");
+        assertEq(world.getClan(clanId).blueprintBalance, 5e18 - blueprintCost, "blueprint deducted at queue");
+        assertEq(world.getClan(clanId).monumentLevel, 0, "monument level waits for settle");
+
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeMonument));
+        vm.expectEmit(true, false, false, true, address(world));
+        emit IClanWorldEvents.MonumentUpgraded(clanId, 1, 4);
+        _advanceTick();
+
+        assertEq(world.getClanFullView(clanId).clan.clan.monumentLevel, 1, "monument level after settle");
+    }
+
+    function test_upgradeMonument_rejectsInsufficientVaultAtQueueTime() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 csId = _firstCs(clanId);
+        world.setVault(clanId, 0, 100e18, 0, 100e18);
+
+        OrderResult[] memory result = _submitOrder(elder, clanId, csId, ActionType.UpgradeMonument);
+
+        assertEq(uint8(result[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "missing resources");
+        assertFalse(world.getActiveMission(csId).active, "no mission queued");
+        assertEq(world.getClan(clanId).monumentLevel, 0, "monument unchanged");
+    }
+
+    function test_upgradeMonument_requiresBlueprintForLateLevel() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 csId = _firstCs(clanId);
+        world.setMonumentLevel(clanId, 6);
+        world.setVault(clanId, 300e18, 100e18, 200e18, 100e18);
+
+        OrderResult[] memory result = _submitOrder(elder, clanId, csId, ActionType.UpgradeMonument);
+
+        assertEq(uint8(result[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "missing blueprint");
+        assertFalse(world.getActiveMission(csId).active, "no mission queued");
+        assertEq(world.getClan(clanId).monumentLevel, 6, "monument unchanged");
+    }
+
+    function test_upgradeMonument_rejectsAboveMaxLevel() public {
+        uint32 clanId = _mintClan(elder);
+        world.setVault(clanId, 2_000e18, 500e18, 1_000e18, 100e18);
+        world.setBlueprint(clanId, 4e18);
+
+        uint256 remaining = 10;
+        while (remaining > 0) {
+            uint256 batchSize = remaining > 4 ? 4 : remaining;
+            OrderResult[] memory batch = _submitUpgradeBatch(elder, clanId, batchSize);
+            for (uint256 i = 0; i < batchSize; i++) {
+                assertEq(uint8(batch[i].status), uint8(StatusCode.OK), "batch status");
+            }
+            _advanceTicks(world.getActionDuration(ActionType.UpgradeMonument) + 1);
+            _advanceTicks(3);
+            remaining -= batchSize;
+        }
+        assertEq(world.getClan(clanId).monumentLevel, 10, "max monument level");
+
+        uint32 csId = _firstCs(clanId);
+        OrderResult[] memory eleventh = _submitOrder(elder, clanId, csId, ActionType.UpgradeMonument);
+        assertEq(uint8(eleventh[0].status), uint8(StatusCode.ERR_INVALID_ACTION), "max level rejects");
+        assertEq(world.getClan(clanId).monumentLevel, 10, "monument remains max");
+    }
+
+    function test_upgradeMonument_twoClansDoNotInterfere() public {
+        uint32 clanA = _mintClan(elder);
+        vm.prank(elder2);
+        (uint32 clanB,) = world.mintClan(elder2);
+        world.setVault(clanA, 100e18, 100e18, 100e18, 100e18);
+        world.setVault(clanB, 100e18, 100e18, 100e18, 100e18);
+
+        OrderResult[] memory result = _submitOrder(elder, clanA, _firstCs(clanA), ActionType.UpgradeMonument);
+        assertEq(uint8(result[0].status), uint8(StatusCode.OK), "queue status");
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeMonument) + 1);
+
+        assertEq(world.getClan(clanA).monumentLevel, 1, "clan A monument");
+        assertEq(world.getClan(clanB).monumentLevel, 0, "clan B monument");
+    }
+}


### PR DESCRIPTION
## Summary
- Implements Phase 8.3 monument upgrades using the Phase 8.1/8.2 queue-time reservation pattern.
- Adds `MonumentUpgraded(uint32 indexed clanId, uint8 newLevel, uint32 settledAtTick)` and `getMonumentUpgradeCost`.
- Keeps `monumentLevel` readable through existing clan/full-view getters.

Closes #221

## Cost Table
| Current level | New level | Wood | Iron | Wheat | Blueprint |
|---:|---:|---:|---:|---:|---:|
| 0 | 1 | 30e18 | 0 | 20e18 | 0 |
| 1 | 2 | 50e18 | 0 | 30e18 | 0 |
| 2 | 3 | 70e18 | 5e18 | 40e18 | 0 |
| 3 | 4 | 90e18 | 10e18 | 50e18 | 0 |
| 4 | 5 | 120e18 | 15e18 | 60e18 | 0 |
| 5 | 6 | 150e18 | 20e18 | 80e18 | 0 |
| 6-9 | 7-10 | 200e18 | 25e18 | 100e18 | 1e18 |

## Phase 8.3 Decisions
- Action duration: `UpgradeMonument` is `4` ticks, slower than wall/base (`2`).
- Max level: `10`, matching `docs/planning/clanworld_v4_spec.md` §9.2.
- Blueprint gating: enabled now because `Clan.blueprintBalance` and blueprint token plumbing already exist; levels `7-10` require `1e18` Blueprint Fragment per spec §9.3.
- Action enum: `UpgradeMonument` already existed in the enum on the phase branch, so this PR wires the existing action instead of adding a duplicate/reordering ABI values.

## Validation
- `PATH="$HOME/.foundry/bin:$PATH" forge test --match-contract MonumentUpgradesTest`
- `PATH="$HOME/.foundry/bin:$PATH" forge test`
