### PR TITLE
feat(contracts): Phase 8.4 — score / rank getters (Closes #222)

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2175,6 +2175,53 @@
     },
     {
       "type": "function",
+      "name": "getClanScore",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "score",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "monumentReachedAtTick",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "monumentLevel",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRankings",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "clanIdsRanked",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
+        },
+        {
+          "name": "scores",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "quoteTravel",
       "inputs": [
         {

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -68,6 +68,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     mapping(uint32 => uint8) private _pendingBaseUpgradesByClan; // clanId => queued, unsettled base upgrades
     mapping(uint32 => MonumentUpgradeReservation) private _monumentUpgradeReservations; // clansmanId => reserved upgrade
     mapping(uint32 => uint8) private _pendingMonumentUpgradesByClan; // clanId => queued, unsettled monument upgrades
+    mapping(uint32 => mapping(uint8 => uint64)) private _monumentLevelReachedAt; // clanId => level => first reached tick
 
     uint32 private _nextClanId;
     uint32 private _nextClansmanId;
@@ -113,6 +114,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint8 private constant WALL_MAX_LEVEL = 5;
     uint8 private constant BASE_MAX_LEVEL = 5;
     uint8 private constant MONUMENT_MAX_LEVEL = 10;
+    uint256 public constant MAX_CLAN_SCAN_FOR_RANKING = 24;
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
@@ -869,11 +871,19 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         uint8 old = clan.monumentLevel;
         clan.monumentLevel = old + 1;
+        recordMonumentReachTick(clanId, clan.monumentLevel, tick);
         emit MonumentLevelChanged(clanId, old, clan.monumentLevel, tick);
         // Phase 8 event ABI uses uint32; season tick horizons are far below this cap.
         // forge-lint: disable-next-line(unsafe-typecast)
         emit MonumentUpgraded(clanId, clan.monumentLevel, uint32(tick));
         return true;
+    }
+
+    function recordMonumentReachTick(uint32 clanId, uint8 newLevel, uint64 tick) internal {
+        if (newLevel == 0) return;
+        if (_monumentLevelReachedAt[clanId][newLevel] == 0) {
+            _monumentLevelReachedAt[clanId][newLevel] = tick;
+        }
     }
 
     /// @dev Complete a mission: set worker to WAITING, set cooldown, mark mission inactive, emit event.
@@ -2266,9 +2276,107 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return _lootValueRaw(_clans[clanId]);
     }
 
+    /// @notice Score preview used by season-end ranking.
+    /// @dev Formula packs three descending priorities into one uint256:
+    ///      (monumentLevel << 248) | ((type(uint64).max - monumentReachedAtTick) << 184)
+    ///      | (min(committedVaultLootValue, 2^176 - 1) << 8) | wallLevel.
+    ///      Monument level dominates; for the same level, the earlier first-reached tick wins;
+    ///      for the same level and tick, committed vault loot value wins; wall level is the final
+    ///      score tiebreaker before getRankings falls back to clanId ascending for exact ties.
+    ///      The loot component matches quoteLootValueSettled's current committed-vault basis and
+    ///      does not simulate pending lazy settlement until derived settlement getters are fixed in #230.
+    function getClanScore(uint32 clanId)
+        external
+        view
+        override
+        returns (uint256 score, uint64 monumentReachedAtTick, uint8 monumentLevel)
+    {
+        return _getClanScore(clanId);
+    }
+
+    /// @notice Return live clan rankings sorted by score descending, with clanId ascending for exact ties.
+    /// @dev Scans at most MAX_CLAN_SCAN_FOR_RANKING clan ids to keep gas bounded. The current mint cap is 12,
+    ///      so the 24-clan scan cap covers all live clans plus headroom for Phase 11.
+    function getRankings() external view override returns (uint32[] memory clanIdsRanked, uint256[] memory scores) {
+        uint256 scanCount = _allClanIds.length;
+        if (scanCount > MAX_CLAN_SCAN_FOR_RANKING) {
+            scanCount = MAX_CLAN_SCAN_FOR_RANKING;
+        }
+
+        uint32[] memory tempClanIds = new uint32[](scanCount);
+        uint256[] memory tempScores = new uint256[](scanCount);
+        uint256 liveCount;
+
+        for (uint256 i = 0; i < scanCount; i++) {
+            uint32 clanId = _allClanIds[i];
+            if (_clans[clanId].clanState != ClanState.ACTIVE) continue;
+
+            (uint256 score,,) = _getClanScore(clanId);
+            tempClanIds[liveCount] = clanId;
+            tempScores[liveCount] = score;
+            liveCount++;
+        }
+
+        for (uint256 i = 1; i < liveCount; i++) {
+            uint32 keyClanId = tempClanIds[i];
+            uint256 keyScore = tempScores[i];
+            uint256 j = i;
+            while (j > 0 && _rankingComesAfter(tempClanIds[j - 1], tempScores[j - 1], keyClanId, keyScore)) {
+                tempClanIds[j] = tempClanIds[j - 1];
+                tempScores[j] = tempScores[j - 1];
+                j--;
+            }
+            tempClanIds[j] = keyClanId;
+            tempScores[j] = keyScore;
+        }
+
+        clanIdsRanked = new uint32[](liveCount);
+        scores = new uint256[](liveCount);
+        for (uint256 i = 0; i < liveCount; i++) {
+            clanIdsRanked[i] = tempClanIds[i];
+            scores[i] = tempScores[i];
+        }
+    }
+
     /// @dev Compute loot value per v4 spec §6.9: wood=1, wheat=1, fish=2, iron=4 points.
     function _lootValueRaw(Clan memory clan) internal pure returns (uint256) {
         return clan.vaultWood + clan.vaultWheat + clan.vaultFish * 2 + clan.vaultIron * 4;
+    }
+
+    function _getClanScore(uint32 clanId)
+        internal
+        view
+        returns (uint256 score, uint64 monumentReachedAtTick, uint8 monumentLevel)
+    {
+        Clan memory clan = _clans[clanId];
+        monumentLevel = clan.monumentLevel;
+        if (monumentLevel > 0) {
+            monumentReachedAtTick = _monumentLevelReachedAt[clanId][monumentLevel];
+        }
+
+        uint256 lootValue = _lootValueRaw(clan);
+        uint256 maxLootComponent = (uint256(1) << 176) - 1;
+        if (lootValue > maxLootComponent) {
+            lootValue = maxLootComponent;
+        }
+
+        uint256 timeComponent;
+        if (monumentLevel > 0) {
+            timeComponent = uint256(type(uint64).max) - uint256(monumentReachedAtTick);
+        }
+
+        score = (uint256(monumentLevel) << 248) | (timeComponent << 184) | (lootValue << 8) | clan.wallLevel;
+    }
+
+    function _rankingComesAfter(uint32 leftClanId, uint256 leftScore, uint32 rightClanId, uint256 rightScore)
+        internal
+        pure
+        returns (bool)
+    {
+        if (leftScore != rightScore) {
+            return leftScore < rightScore;
+        }
+        return leftClanId > rightClanId;
     }
 
     // =========================================================================

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -321,6 +321,14 @@ contract ClanWorldStub is IClanWorld {
         return 0;
     }
 
+    function getClanScore(uint32) external pure override returns (uint256, uint64, uint8) {
+        return (0, 0, 0);
+    }
+
+    function getRankings() external pure override returns (uint32[] memory, uint256[] memory) {
+        return (new uint32[](0), new uint256[](0));
+    }
+
     // -------------------------------------------------------------------------
     // UI indexer aggregator getters
     // -------------------------------------------------------------------------

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -760,6 +760,19 @@ interface IClanWorld is IClanWorldEvents {
 
     function quoteLootValueSettled(uint32 clanId) external view returns (uint256 lootValue);
 
+    /// @notice Ranking score preview for a clan.
+    /// @dev Score is ordered by monument level, then earliest first-reached tick for that level,
+    ///      then committed vault loot value, then wall level. The loot component matches
+    ///      quoteLootValueSettled's current committed-vault basis and does not simulate pending
+    ///      lazy settlement.
+    function getClanScore(uint32 clanId)
+        external
+        view
+        returns (uint256 score, uint64 monumentReachedAtTick, uint8 monumentLevel);
+
+    /// @notice Live clans sorted by score descending, with clanId ascending for exact ties.
+    function getRankings() external view returns (uint32[] memory clanIdsRanked, uint256[] memory scores);
+
     // -------------------------------------------------------------------------
     // UI indexer aggregator getters (v4.4 additions)
     //

--- a/packages/contracts/test/RankGetters.t.sol
+++ b/packages/contracts/test/RankGetters.t.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {ClanWorldConstants, Clan, ClanOrder, OrderResult, StatusCode, ActionType} from "../src/IClanWorld.sol";
+
+contract RankGetterHarness is ClanWorld {
+    function setVault(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        _clans[clanId].vaultWood = wood;
+        _clans[clanId].vaultIron = iron;
+        _clans[clanId].vaultWheat = wheat;
+        _clans[clanId].vaultFish = fish;
+    }
+
+    function setWallLevel(uint32 clanId, uint8 wallLevel) external {
+        _clans[clanId].wallLevel = wallLevel;
+    }
+}
+
+contract RankGettersTest is Test {
+    RankGetterHarness world;
+    address elderA = address(0xA1);
+    address elderB = address(0xA2);
+    address elderC = address(0xA3);
+
+    function setUp() public {
+        world = new RankGetterHarness();
+    }
+
+    function _mintClan(address owner) internal returns (uint32 clanId) {
+        vm.prank(owner);
+        (clanId,) = world.mintClan(owner);
+    }
+
+    function _csAt(uint32 clanId, uint256 index) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[index].clansman.clansman.clansmanId;
+    }
+
+    function _submitUpgradeBatch(address owner, uint32 clanId, uint256 count) internal returns (OrderResult[] memory) {
+        Clan memory clan = world.getClan(clanId);
+        ClanOrder[] memory orders = new ClanOrder[](count);
+        for (uint256 i = 0; i < count; i++) {
+            orders[i] = ClanOrder({
+                clansmanId: _csAt(clanId, i),
+                gotoRegion: clan.baseRegion,
+                action: ActionType.UpgradeMonument,
+                targetClanId: 0,
+                marketToken: address(0),
+                marketAmount: 0,
+                maxGoldIn: 0
+            });
+        }
+
+        vm.prank(owner);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _advanceTick() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+    }
+
+    function _advanceTicks(uint256 count) internal {
+        for (uint256 i = 0; i < count; i++) {
+            _advanceTick();
+        }
+    }
+
+    function _assertAllOk(OrderResult[] memory results) internal pure {
+        for (uint256 i = 0; i < results.length; i++) {
+            assertEq(uint8(results[i].status), uint8(StatusCode.OK), "upgrade queued");
+        }
+    }
+
+    function _expectedScore(uint8 level, uint64 reachedAtTick, uint256 lootValue) internal pure returns (uint256) {
+        return _expectedScore(level, reachedAtTick, lootValue, 0);
+    }
+
+    function _expectedScore(uint8 level, uint64 reachedAtTick, uint256 lootValue, uint8 wallLevel)
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 maxLootComponent = (uint256(1) << 176) - 1;
+        if (lootValue > maxLootComponent) {
+            lootValue = maxLootComponent;
+        }
+
+        uint256 timeComponent;
+        if (level > 0) {
+            timeComponent = uint256(type(uint64).max) - uint256(reachedAtTick);
+        }
+
+        return (uint256(level) << 248) | (timeComponent << 184) | (lootValue << 8) | wallLevel;
+    }
+
+    function test_getClanScoreAndRankings_sortByLevelThenEarliestReachTick() public {
+        uint32 clanA = _mintClan(elderA);
+        uint32 clanB = _mintClan(elderB);
+        uint32 clanC = _mintClan(elderC);
+
+        world.setVault(clanA, 300e18, 100e18, 300e18, 0);
+        world.setVault(clanB, 300e18, 100e18, 300e18, 0);
+        world.setVault(clanC, 300e18, 100e18, 300e18, 0);
+
+        _assertAllOk(_submitUpgradeBatch(elderA, clanA, 2));
+        _assertAllOk(_submitUpgradeBatch(elderB, clanB, 1));
+
+        _advanceTick();
+        _assertAllOk(_submitUpgradeBatch(elderC, clanC, 1));
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeMonument) + 1);
+
+        (uint256 scoreA, uint64 reachedA, uint8 levelA) = world.getClanScore(clanA);
+        (uint256 scoreB, uint64 reachedB, uint8 levelB) = world.getClanScore(clanB);
+        (uint256 scoreC, uint64 reachedC, uint8 levelC) = world.getClanScore(clanC);
+
+        assertEq(levelA, 2, "A level");
+        assertEq(levelB, 1, "B level");
+        assertEq(levelC, 1, "C level");
+        assertEq(reachedA, 4, "A reached level 2");
+        assertEq(reachedB, 4, "B reached level 1");
+        assertEq(reachedC, 5, "C reached level 1");
+        assertEq(scoreA, _expectedScore(levelA, reachedA, world.quoteLootValueRaw(clanA)), "A score");
+        assertEq(scoreB, _expectedScore(levelB, reachedB, world.quoteLootValueRaw(clanB)), "B score");
+        assertEq(scoreC, _expectedScore(levelC, reachedC, world.quoteLootValueRaw(clanC)), "C score");
+        assertGt(scoreA, scoreB, "higher monument level wins");
+        assertGt(scoreB, scoreC, "earlier reach tick wins");
+
+        (uint32[] memory ranked, uint256[] memory scores) = world.getRankings();
+        assertEq(ranked.length, 3, "ranked count");
+        assertEq(scores.length, 3, "score count");
+        assertEq(ranked[0], clanA, "rank 1");
+        assertEq(ranked[1], clanB, "rank 2");
+        assertEq(ranked[2], clanC, "rank 3");
+        assertEq(scores[0], scoreA, "rank 1 score");
+        assertEq(scores[1], scoreB, "rank 2 score");
+        assertEq(scores[2], scoreC, "rank 3 score");
+    }
+
+    function test_getRankings_breaksExactScoreTiesByClanId() public {
+        uint32 clanA = _mintClan(elderA);
+        uint32 clanB = _mintClan(elderB);
+        uint32 clanC = _mintClan(elderC);
+
+        world.setVault(clanA, 100e18, 0, 100e18, 0);
+        world.setVault(clanB, 100e18, 0, 100e18, 0);
+        world.setVault(clanC, 100e18, 0, 100e18, 0);
+
+        _assertAllOk(_submitUpgradeBatch(elderA, clanA, 1));
+        _assertAllOk(_submitUpgradeBatch(elderB, clanB, 1));
+        _assertAllOk(_submitUpgradeBatch(elderC, clanC, 1));
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeMonument) + 1);
+
+        (uint256 scoreA,,) = world.getClanScore(clanA);
+        (uint256 scoreB,,) = world.getClanScore(clanB);
+        (uint256 scoreC,,) = world.getClanScore(clanC);
+        assertEq(scoreA, scoreB, "A/B exact tie");
+        assertEq(scoreB, scoreC, "B/C exact tie");
+
+        (uint32[] memory ranked, uint256[] memory scores) = world.getRankings();
+        assertEq(ranked.length, 3, "ranked count");
+        assertEq(ranked[0], clanA, "lowest clanId first");
+        assertEq(ranked[1], clanB, "middle clanId second");
+        assertEq(ranked[2], clanC, "highest clanId third");
+        assertEq(scores[0], scoreA, "A score");
+        assertEq(scores[1], scoreB, "B score");
+        assertEq(scores[2], scoreC, "C score");
+    }
+
+    function test_getRankings_usesWallLevelAfterLootBeforeClanId() public {
+        uint32 clanA = _mintClan(elderA);
+        uint32 clanB = _mintClan(elderB);
+        uint32 clanC = _mintClan(elderC);
+
+        world.setVault(clanA, 100e18, 0, 100e18, 0);
+        world.setVault(clanB, 100e18, 0, 100e18, 0);
+        world.setVault(clanC, 100e18, 0, 100e18, 0);
+        world.setWallLevel(clanA, 1);
+        world.setWallLevel(clanB, 2);
+
+        _assertAllOk(_submitUpgradeBatch(elderA, clanA, 1));
+        _assertAllOk(_submitUpgradeBatch(elderB, clanB, 1));
+        _assertAllOk(_submitUpgradeBatch(elderC, clanC, 1));
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeMonument) + 1);
+
+        (uint256 scoreA, uint64 reachedA, uint8 levelA) = world.getClanScore(clanA);
+        (uint256 scoreB, uint64 reachedB, uint8 levelB) = world.getClanScore(clanB);
+        (uint256 scoreC, uint64 reachedC, uint8 levelC) = world.getClanScore(clanC);
+        assertEq(scoreA, _expectedScore(levelA, reachedA, world.quoteLootValueRaw(clanA), 1), "A score");
+        assertEq(scoreB, _expectedScore(levelB, reachedB, world.quoteLootValueRaw(clanB), 2), "B score");
+        assertEq(scoreC, _expectedScore(levelC, reachedC, world.quoteLootValueRaw(clanC), 0), "C score");
+
+        (uint32[] memory ranked,) = world.getRankings();
+        assertEq(ranked[0], clanB, "highest wall wins after loot");
+        assertEq(ranked[1], clanA, "next wall second");
+        assertEq(ranked[2], clanC, "zero wall third");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds committed monument-level reach tick tracking during monument upgrade settlement.
- Adds `getClanScore` and `getRankings` to the contract/interface/stub ABI surface.
- Adds rank getter tests for level priority, earlier reach tick, wall-level fallback, and exact tie clanId order.

## Scoring Formula
`score = (monumentLevel << 248) | ((type(uint64).max - monumentReachedAtTick) << 184) | (min(committedVaultLootValue, 2^176 - 1) << 8) | wallLevel`

Priority order is: highest monument level, earliest tick reaching that current monument level, highest committed vault loot value, highest wall level. The loot component matches the current committed-vault basis of `quoteLootValueSettled`; it does not simulate pending lazy settlement until #230 is fixed.

## Stable Sort Guarantees
`getRankings()` sorts live clans by score descending. Exact score ties fall back to clanId ascending, so same level/time/loot/wall remains deterministic.

## Scan Cap
Ranking scans at most `MAX_CLAN_SCAN_FOR_RANKING = 24` clan ids. Current mint cap is 12 clans, so this covers the live game cap with 2x headroom.

## Validation
- `PATH="$HOME/.foundry/bin:$PATH" forge test --match-path test/RankGetters.t.sol`
- `PATH="$HOME/.foundry/bin:$PATH" forge test` (114 passed)
- `codex review --uncommitted` CLEAN after addressing the wall-level tiebreaker finding
- `git diff --check`

Closes #222
