### PR TITLE
feat(contracts): Phase 9.5 — defender reward split (Closes #208)

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -296,6 +296,31 @@
               "name": "strength",
               "type": "uint32",
               "internalType": "uint32"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryGold",
+              "type": "uint256",
+              "internalType": "uint256"
             }
           ]
         }
@@ -366,6 +391,31 @@
               "name": "strength",
               "type": "uint32",
               "internalType": "uint32"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryGold",
+              "type": "uint256",
+              "internalType": "uint256"
             }
           ]
         }
@@ -3102,6 +3152,85 @@
           "type": "uint64",
           "indexed": false,
           "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "LootDistributed",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clanIdsRewarded",
+          "type": "uint32[]",
+          "indexed": false,
+          "internalType": "uint32[]"
+        },
+        {
+          "name": "perClanWood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "perClanWheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "perClanFish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "perClanIron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "perClanGold",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "burnedWood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "burnedWheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "burnedFish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "burnedIron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "burnedGold",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
         }
       ],
       "anonymous": false

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -81,6 +81,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     // =========================================================================
 
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
+    uint256 private constant RESOURCE_UNIT = 1e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
     uint256 internal constant DOMAIN_BANDIT_SPAWN = uint256(keccak256("clanworld.bandit.spawn.v1"));
@@ -914,7 +915,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             state: BanditState.Spawned,
             targetClanId: 0,
             tickEnteredState: _world.currentTick,
-            strength: strength
+            strength: strength,
+            carryWood: 0,
+            carryIron: 0,
+            carryWheat: 0,
+            carryFish: 0,
+            carryGold: 0
         });
         _banditsByRegion[region].push(id);
         _activeBanditCount += 1;
@@ -1109,11 +1115,108 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         if (defeated) {
             emit BanditDefeated(banditId, targetClanId, closedTick);
+            _distributeBanditLootToDefendingClans(banditId, targetClanId);
             _transitionBanditState(banditId, BanditState.Defeated);
         } else {
             _transitionBanditState(banditId, BanditState.Escaped);
             emit BanditEscaped(banditId, closedTick);
         }
+    }
+
+    function _distributeBanditLootToDefendingClans(uint32 banditId, uint32 targetClanId) internal {
+        BanditTroop storage bandit = _bandits[banditId];
+        uint32[] memory rewardedClanIds = _activeDefendingClanIds(targetClanId);
+        uint256 nDefendingClans = rewardedClanIds.length;
+
+        uint256 perWood;
+        uint256 perIron;
+        uint256 perWheat;
+        uint256 perFish;
+        uint256 perGold;
+        if (nDefendingClans > 0) {
+            perWood = _perClanBanditLootShare(bandit.carryWood, nDefendingClans);
+            perIron = _perClanBanditLootShare(bandit.carryIron, nDefendingClans);
+            perWheat = _perClanBanditLootShare(bandit.carryWheat, nDefendingClans);
+            perFish = _perClanBanditLootShare(bandit.carryFish, nDefendingClans);
+            perGold = _perClanBanditLootShare(bandit.carryGold, nDefendingClans);
+
+            for (uint256 i = 0; i < rewardedClanIds.length; i++) {
+                Clan storage defenderClan = _clans[rewardedClanIds[i]];
+                defenderClan.vaultWood += perWood;
+                defenderClan.vaultIron += perIron;
+                defenderClan.vaultWheat += perWheat;
+                defenderClan.vaultFish += perFish;
+                defenderClan.goldBalance += perGold;
+            }
+        }
+
+        emit LootDistributed(
+            banditId,
+            rewardedClanIds,
+            perWood,
+            perWheat,
+            perFish,
+            perIron,
+            perGold,
+            bandit.carryWood - (perWood * nDefendingClans),
+            bandit.carryWheat - (perWheat * nDefendingClans),
+            bandit.carryFish - (perFish * nDefendingClans),
+            bandit.carryIron - (perIron * nDefendingClans),
+            bandit.carryGold - (perGold * nDefendingClans)
+        );
+    }
+
+    function _perClanBanditLootShare(uint256 loot, uint256 nDefendingClans) internal pure returns (uint256) {
+        if (nDefendingClans == 1) {
+            return loot;
+        }
+        return ((loot / RESOURCE_UNIT) / nDefendingClans) * RESOURCE_UNIT;
+    }
+
+    function _activeDefendingClanIds(uint32 targetClanId) internal view returns (uint32[] memory clanIds) {
+        uint8 targetRegion = _clans[targetClanId].baseRegion;
+        uint32[] storage defendingClans = _defendingClansByRegion[targetRegion];
+        uint256 count;
+
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            if (_clanHasActiveDefenderForTarget(defendingClans[i], targetClanId, targetRegion)) {
+                count++;
+            }
+        }
+
+        clanIds = new uint32[](count);
+        uint256 out;
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            uint32 defenderClanId = defendingClans[i];
+            if (_clanHasActiveDefenderForTarget(defenderClanId, targetClanId, targetRegion)) {
+                clanIds[out++] = defenderClanId;
+            }
+        }
+    }
+
+    function _clanHasActiveDefenderForTarget(uint32 defenderClanId, uint32 targetClanId, uint8 targetRegion)
+        internal
+        view
+        returns (bool)
+    {
+        Clan storage defenderClan = _clans[defenderClanId];
+        if (defenderClan.clanState == ClanState.DEAD || _isStarving(defenderClan)) {
+            return false;
+        }
+
+        uint32[] storage clansmanIds = _clanClansmanIds[defenderClanId];
+        for (uint256 i = 0; i < clansmanIds.length; i++) {
+            uint32 clansmanId = clansmanIds[i];
+            Clansman storage cs = _clansmen[clansmanId];
+            Mission storage mission = _missions[clansmanId];
+            if (
+                cs.state == ClansmanState.ACTING && cs.currentRegion == targetRegion && mission.active
+                    && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId
+            ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     function _totalBanditClansmanDefense(uint32 banditId, uint32 targetClanId, bytes32 tickSeed)
@@ -1794,7 +1897,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         ctx.targetClanId =
             order.action == ActionType.DefendBase && order.targetClanId == 0 ? clanId : order.targetClanId;
 
-        // NOOP bypass: treat 0 as "stay here"; DefendBase requires explicit home region.
+        // NOOP bypass: treat 0 as "stay here"; DefendBase requires the defended base region.
         ctx.isNoop = order.action != ActionType.DefendBase
             && (ctx.gotoRegion == ClanWorldConstants.REGION_NOOP || ctx.gotoRegion == ctx.fromRegion);
         if (ctx.isNoop) {
@@ -2298,8 +2401,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         view
         returns (StatusCode)
     {
-        if (gotoRegion != clan.baseRegion) return StatusCode.ERR_INVALID_REGION;
-        if (order.targetClanId != 0 && order.targetClanId != clan.clanId) return StatusCode.ERR_INVALID_TARGET;
+        uint32 targetClanId = order.targetClanId == 0 ? clan.clanId : order.targetClanId;
+        Clan storage targetClan = _clans[targetClanId];
+        if (targetClan.clanId == ClanWorldConstants.CLAN_ID_NULL || targetClan.clanState == ClanState.DEAD) {
+            return StatusCode.ERR_INVALID_TARGET;
+        }
+        if (gotoRegion != targetClan.baseRegion) return StatusCode.ERR_INVALID_REGION;
         return StatusCode.OK;
     }
 
@@ -2431,10 +2538,19 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     function getBandit(uint32 banditId) public view override returns (BanditTroop memory) {
         BanditTroop memory bandit = _bandits[banditId];
         if (bandit.id == ClanWorldConstants.BANDIT_ID_NULL || bandit.state == BanditState.None) {
-            return
-                BanditTroop({
-                    id: 0, region: 0, state: BanditState.None, targetClanId: 0, tickEnteredState: 0, strength: 0
-                });
+            return BanditTroop({
+                id: 0,
+                region: 0,
+                state: BanditState.None,
+                targetClanId: 0,
+                tickEnteredState: 0,
+                strength: 0,
+                carryWood: 0,
+                carryIron: 0,
+                carryWheat: 0,
+                carryFish: 0,
+                carryGold: 0
+            });
         }
         return bandit;
     }
@@ -2699,10 +2815,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             nextActionTick: nextActionTick,
             tier: 0,
             attackPower: _banditStrengthForLegacyEvent(bandit.strength),
-            carryWood: 0,
-            carryIron: 0,
-            carryWheat: 0,
-            carryFish: 0,
+            carryWood: bandit.carryWood,
+            carryIron: bandit.carryIron,
+            carryWheat: bandit.carryWheat,
+            carryFish: bandit.carryFish,
             projectedTargetClanId: bandit.targetClanId,
             projectedTargetLootValue: 0
         });

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -216,8 +216,19 @@ contract ClanWorldStub is IClanWorld {
     }
 
     function getBandit(uint32) public pure override returns (BanditTroop memory) {
-        return
-            BanditTroop({id: 0, region: 0, state: BanditState.None, targetClanId: 0, tickEnteredState: 0, strength: 0});
+        return BanditTroop({
+            id: 0,
+            region: 0,
+            state: BanditState.None,
+            targetClanId: 0,
+            tickEnteredState: 0,
+            strength: 0,
+            carryWood: 0,
+            carryIron: 0,
+            carryWheat: 0,
+            carryFish: 0,
+            carryGold: 0
+        });
     }
 
     function getBanditTroop(uint32 banditId) external pure override returns (BanditTroop memory) {

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -305,6 +305,11 @@ struct BanditTroop {
     uint32 targetClanId; // 0 if not attacking
     uint64 tickEnteredState;
     uint32 strength; // hp / combat power
+    uint256 carryWood;
+    uint256 carryIron;
+    uint256 carryWheat;
+    uint256 carryFish;
+    uint256 carryGold;
 }
 
 struct ScheduledMarketAction {
@@ -593,6 +598,20 @@ interface IClanWorldEvents {
     event WallDamagedByBandit(uint32 indexed clanId, uint8 newLevel, uint32 indexed banditId);
     event ClansmanKilledByBandit(uint32 indexed clanId, uint32 indexed clansmanId, uint32 indexed banditId);
     event BlueprintAwarded(uint32 indexed clanId, uint32 indexed banditId, uint256 amount);
+    event LootDistributed(
+        uint32 indexed banditId,
+        uint32[] clanIdsRewarded,
+        uint256 perClanWood,
+        uint256 perClanWheat,
+        uint256 perClanFish,
+        uint256 perClanIron,
+        uint256 perClanGold,
+        uint256 burnedWood,
+        uint256 burnedWheat,
+        uint256 burnedFish,
+        uint256 burnedIron,
+        uint256 burnedGold
+    );
     event LootDistributedToDefender(
         uint32 indexed banditId,
         uint32 indexed clanId,

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -11,6 +11,7 @@ import {
     ActionType,
     StatusCode,
     Clan,
+    Mission,
     ClanOrder,
     OrderResult
 } from "../src/IClanWorld.sol";
@@ -34,6 +35,16 @@ contract BanditAttackHarness is ClanWorld {
         _bandits[banditId].strength = strength;
     }
 
+    function setBanditCarry(uint32 banditId, uint256 wood, uint256 wheat, uint256 fish, uint256 iron, uint256 gold)
+        external
+    {
+        _bandits[banditId].carryWood = wood;
+        _bandits[banditId].carryWheat = wheat;
+        _bandits[banditId].carryFish = fish;
+        _bandits[banditId].carryIron = iron;
+        _bandits[banditId].carryGold = gold;
+    }
+
     function defenseRoll(bytes32 tickSeed, uint32 banditId, uint32 clansmanId) external pure returns (uint32) {
         return _clansmanDefenseDamageRoll(tickSeed, banditId, clansmanId);
     }
@@ -42,6 +53,35 @@ contract BanditAttackHarness is ClanWorld {
 contract BanditAttackResolutionTest is Test {
     BanditAttackHarness world;
     address elder = address(0xA1);
+
+    event BanditAttackResolved(
+        uint32 indexed banditId,
+        uint32 indexed targetClanId,
+        bool defended,
+        uint16 attackPower,
+        uint16 totalDefense,
+        uint16 wallLevelAfter,
+        uint256 stolenWood,
+        uint256 stolenIron,
+        uint256 stolenWheat,
+        uint256 stolenFish,
+        uint64 atTick
+    );
+    event BanditDefeated(uint32 indexed banditId, uint32 indexed targetClanId, uint64 atTick);
+    event LootDistributed(
+        uint32 indexed banditId,
+        uint32[] clanIdsRewarded,
+        uint256 perClanWood,
+        uint256 perClanWheat,
+        uint256 perClanFish,
+        uint256 perClanIron,
+        uint256 perClanGold,
+        uint256 burnedWood,
+        uint256 burnedWheat,
+        uint256 burnedFish,
+        uint256 burnedIron,
+        uint256 burnedGold
+    );
 
     function setUp() public {
         world = new BanditAttackHarness();
@@ -58,13 +98,21 @@ contract BanditAttackResolutionTest is Test {
 
     function _defendOrders(uint32 clanId, uint256 count) internal view returns (ClanOrder[] memory orders) {
         Clan memory clan = world.getClan(clanId);
+        return _defendTargetOrders(clanId, clanId, clan.baseRegion, count);
+    }
+
+    function _defendTargetOrders(uint32 clanId, uint32 targetClanId, uint8 targetRegion, uint256 count)
+        internal
+        view
+        returns (ClanOrder[] memory orders)
+    {
         orders = new ClanOrder[](count);
         for (uint256 i = 0; i < count; i++) {
             orders[i] = ClanOrder({
                 clansmanId: _csId(clanId, i),
-                gotoRegion: clan.baseRegion,
+                gotoRegion: targetRegion,
                 action: ActionType.DefendBase,
-                targetClanId: 0,
+                targetClanId: targetClanId,
                 marketToken: address(0),
                 marketAmount: 0,
                 maxGoldIn: 0
@@ -73,11 +121,23 @@ contract BanditAttackResolutionTest is Test {
     }
 
     function _submitDefenders(uint32 clanId, uint256 count) internal {
-        ClanOrder[] memory orders = _defendOrders(clanId, count);
+        _submitTargetDefenders(clanId, clanId, count);
+    }
+
+    function _submitTargetDefenders(uint32 defenderClanId, uint32 targetClanId, uint256 count)
+        internal
+        returns (uint64 maxExecutesAtTick)
+    {
+        Clan memory targetClan = world.getClan(targetClanId);
+        ClanOrder[] memory orders = _defendTargetOrders(defenderClanId, targetClanId, targetClan.baseRegion, count);
         vm.prank(elder);
-        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+        OrderResult[] memory results = world.submitClanOrders(defenderClanId, orders);
         for (uint256 i = 0; i < count; i++) {
             assertEq(uint8(results[i].status), uint8(StatusCode.OK), "defender order status");
+            Mission memory mission = world.getActiveMission(orders[i].clansmanId);
+            if (mission.executesAtTick > maxExecutesAtTick) {
+                maxExecutesAtTick = mission.executesAtTick;
+            }
         }
     }
 
@@ -86,9 +146,170 @@ contract BanditAttackResolutionTest is Test {
         world.heartbeat();
     }
 
+    function _advanceUntilAfter(uint64 tick) internal {
+        while (world.getWorldState().currentTick <= tick) {
+            _advanceTick();
+        }
+    }
+
+    function _activateTargetDefenders(uint32 targetClanId, uint32[] memory defenderClanIds, uint256 countEach)
+        internal
+    {
+        uint64 maxExecutesAtTick;
+        for (uint256 i = 0; i < defenderClanIds.length; i++) {
+            uint64 executesAtTick = _submitTargetDefenders(defenderClanIds[i], targetClanId, countEach);
+            if (executesAtTick > maxExecutesAtTick) {
+                maxExecutesAtTick = executesAtTick;
+            }
+        }
+
+        _advanceUntilAfter(maxExecutesAtTick);
+        for (uint256 i = 0; i < defenderClanIds.length; i++) {
+            world.settleClan(defenderClanIds[i]);
+        }
+    }
+
     function _forceAttack(uint32 clanId, uint32 strength) internal returns (uint32 banditId) {
         Clan memory clan = world.getClan(clanId);
         return world.forceAttackingBandit(clan.baseRegion, strength, clanId);
+    }
+
+    function _mintClans(uint256 count) internal returns (uint32[] memory clanIds) {
+        clanIds = new uint32[](count);
+        for (uint256 i = 0; i < count; i++) {
+            clanIds[i] = _mintClan();
+        }
+    }
+
+    function test_defeatedBanditLootSingleDefendingClanGetsFullCarry() public {
+        uint32 clanId = _mintClan();
+        uint32[] memory defenders = new uint32[](1);
+        defenders[0] = clanId;
+        _activateTargetDefenders(clanId, defenders, 4);
+
+        Clan memory beforeClan = world.getClan(clanId);
+        uint32 banditId = _forceAttack(clanId, 1);
+        world.setBanditCarry(banditId, 7e18, 11e18, 13e18, 17e18, 19e18);
+        world.setBanditStrength(banditId, 0);
+
+        _advanceTick();
+
+        Clan memory afterClan = world.getClan(clanId);
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood + 7e18, "wood full carry");
+        assertEq(afterClan.vaultWheat, beforeClan.vaultWheat + 11e18, "wheat full carry");
+        assertEq(afterClan.vaultFish, beforeClan.vaultFish + 13e18, "fish full carry");
+        assertEq(afterClan.vaultIron, beforeClan.vaultIron + 17e18, "iron full carry");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance + 19e18, "gold full carry");
+        assertEq(world.getBandit(banditId).id, 0, "defeated bandit deleted");
+    }
+
+    function test_defeatedBanditLootSplitsEquallyAcrossFourDefendingClans() public {
+        uint32[] memory clanIds = _mintClans(4);
+        _activateTargetDefenders(clanIds[0], clanIds, 1);
+
+        uint256[4] memory woodBefore;
+        uint256[4] memory wheatBefore;
+        uint256[4] memory fishBefore;
+        uint256[4] memory ironBefore;
+        uint256[4] memory goldBefore;
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            Clan memory clan = world.getClan(clanIds[i]);
+            woodBefore[i] = clan.vaultWood;
+            wheatBefore[i] = clan.vaultWheat;
+            fishBefore[i] = clan.vaultFish;
+            ironBefore[i] = clan.vaultIron;
+            goldBefore[i] = clan.goldBalance;
+        }
+
+        uint32 banditId = _forceAttack(clanIds[0], 1);
+        world.setBanditCarry(banditId, 100e18, 100e18, 100e18, 100e18, 100e18);
+        world.setBanditStrength(banditId, 0);
+
+        _advanceTick();
+
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            Clan memory clan = world.getClan(clanIds[i]);
+            assertEq(clan.vaultWood, woodBefore[i] + 25e18, "wood share");
+            assertEq(clan.vaultWheat, wheatBefore[i] + 25e18, "wheat share");
+            assertEq(clan.vaultFish, fishBefore[i] + 25e18, "fish share");
+            assertEq(clan.vaultIron, ironBefore[i] + 25e18, "iron share");
+            assertEq(clan.goldBalance, goldBefore[i] + 25e18, "gold share");
+        }
+    }
+
+    function test_defeatedBanditLootBurnsWholeTokenOverflowAcrossThreeDefendingClans() public {
+        uint32[] memory clanIds = _mintClans(3);
+        _activateTargetDefenders(clanIds[0], clanIds, 1);
+
+        uint256 woodBeforeTotal;
+        uint256 goldBeforeTotal;
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            Clan memory clan = world.getClan(clanIds[i]);
+            woodBeforeTotal += clan.vaultWood;
+            goldBeforeTotal += clan.goldBalance;
+        }
+
+        uint32 banditId = _forceAttack(clanIds[0], 1);
+        world.setBanditCarry(banditId, 100e18, 100e18, 100e18, 100e18, 100e18);
+        world.setBanditStrength(banditId, 0);
+
+        vm.expectEmit(true, true, false, false, address(world));
+        emit BanditAttackResolved(banditId, clanIds[0], true, 0, 0, 0, 0, 0, 0, 0, world.getWorldState().currentTick);
+        vm.expectEmit(true, true, false, true, address(world));
+        emit BanditDefeated(banditId, clanIds[0], world.getWorldState().currentTick);
+        vm.expectEmit(true, false, false, true, address(world));
+        emit LootDistributed(banditId, clanIds, 33e18, 33e18, 33e18, 33e18, 33e18, 1e18, 1e18, 1e18, 1e18, 1e18);
+
+        _advanceTick();
+
+        uint256 woodAfterTotal;
+        uint256 goldAfterTotal;
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            Clan memory clan = world.getClan(clanIds[i]);
+            assertEq(clan.vaultWood, 20e18 + 33e18, "wood share");
+            assertEq(clan.goldBalance, 3e18 + 33e18, "gold share");
+            woodAfterTotal += clan.vaultWood;
+            goldAfterTotal += clan.goldBalance;
+        }
+        assertEq(woodAfterTotal - woodBeforeTotal, 99e18, "wood overflow burned");
+        assertEq(goldAfterTotal - goldBeforeTotal, 99e18, "gold overflow burned");
+    }
+
+    function test_multipleDefendersFromSameClanStillReceiveOneClanShare() public {
+        uint32[] memory clanIds = _mintClans(2);
+        uint64 firstExecutesAtTick = _submitTargetDefenders(clanIds[0], clanIds[0], 3);
+        uint64 secondExecutesAtTick = _submitTargetDefenders(clanIds[1], clanIds[0], 1);
+        _advanceUntilAfter(firstExecutesAtTick > secondExecutesAtTick ? firstExecutesAtTick : secondExecutesAtTick);
+        world.settleClan(clanIds[0]);
+        world.settleClan(clanIds[1]);
+
+        uint256 targetWoodBefore = world.getClan(clanIds[0]).vaultWood;
+        uint256 helperWoodBefore = world.getClan(clanIds[1]).vaultWood;
+        uint32 banditId = _forceAttack(clanIds[0], 1);
+        world.setBanditCarry(banditId, 100e18, 100e18, 100e18, 100e18, 100e18);
+        world.setBanditStrength(banditId, 0);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanIds[0]).vaultWood, targetWoodBefore + 50e18, "target clan one share");
+        assertEq(world.getClan(clanIds[1]).vaultWood, helperWoodBefore + 50e18, "helper clan one share");
+    }
+
+    function test_escapedBanditDoesNotDistributeCarry() public {
+        uint32 clanId = _mintClan();
+        Clan memory beforeClan = world.getClan(clanId);
+        uint32 banditId = _forceAttack(clanId, 100);
+        world.setBanditCarry(banditId, 100e18, 100e18, 100e18, 100e18, 100e18);
+
+        _advanceTick();
+
+        Clan memory afterClan = world.getClan(clanId);
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "wood unchanged");
+        assertEq(afterClan.vaultWheat, beforeClan.vaultWheat, "wheat unchanged");
+        assertEq(afterClan.vaultFish, beforeClan.vaultFish, "fish unchanged");
+        assertEq(afterClan.vaultIron, beforeClan.vaultIron, "iron unchanged");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "gold unchanged");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
     }
 
     function test_twoAliveDefendersWithSufficientDefenseDefeatBanditWithoutWallChip() public {


### PR DESCRIPTION
## Summary
- Adds carried loot fields to bandit state and exposes them through getBandit/getBanditTroop plus active bandit view resource fields.
- Distributes defeated bandit carry to active defending clans after BanditDefeated and before the bandit is cleared.
- Emits aggregate LootDistributed with rewarded clan IDs, per-clan shares, and burned overflow amounts.

## Semantics
- Split is per defending clan, not per clansman: multiple active defenders from one clan still earn one clan share.
- Overflow is burned by leaving it unallocated. Multi-clan splits round down to whole 1e18 resource/gold units so 100e18 across 3 clans pays 33e18 each and burns 1e18.
- If no active defending clans are found on a defeat path, the full carry is emitted as burned and no vaults/purses are credited.

## Validation
- ~/.foundry/bin/forge test --match-path test/BanditAttackResolution.t.sol
- ~/.foundry/bin/forge test

Closes #208
