### PR TITLE
feat(contracts): Phase 9.6 — blueprint reward on successful defense (Closes #209)

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2872,6 +2872,31 @@
     },
     {
       "type": "event",
+      "name": "BlueprintEarned",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
       "name": "BlueprintTransferred",
       "inputs": [
         {

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1116,6 +1116,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (defeated) {
             emit BanditDefeated(banditId, targetClanId, closedTick);
             _distributeBanditLootToDefendingClans(banditId, targetClanId);
+            targetClan.blueprintBalance += 1;
+            emit BlueprintEarned(targetClanId, banditId, closedTick);
             _transitionBanditState(banditId, BanditState.Defeated);
         } else {
             _transitionBanditState(banditId, BanditState.Escaped);

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -598,6 +598,7 @@ interface IClanWorldEvents {
     event WallDamagedByBandit(uint32 indexed clanId, uint8 newLevel, uint32 indexed banditId);
     event ClansmanKilledByBandit(uint32 indexed clanId, uint32 indexed clansmanId, uint32 indexed banditId);
     event BlueprintAwarded(uint32 indexed clanId, uint32 indexed banditId, uint256 amount);
+    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint64 tick);
     event LootDistributed(
         uint32 indexed banditId,
         uint32[] clanIdsRewarded,

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -68,6 +68,7 @@ contract BanditAttackResolutionTest is Test {
         uint64 atTick
     );
     event BanditDefeated(uint32 indexed banditId, uint32 indexed targetClanId, uint64 atTick);
+    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint64 tick);
     event LootDistributed(
         uint32 indexed banditId,
         uint32[] clanIdsRewarded,
@@ -203,6 +204,24 @@ contract BanditAttackResolutionTest is Test {
         assertEq(world.getBandit(banditId).id, 0, "defeated bandit deleted");
     }
 
+    function test_defeatedBanditAwardsBlueprintToTargetClan() public {
+        uint32 clanId = _mintClan();
+        uint32[] memory defenders = new uint32[](1);
+        defenders[0] = clanId;
+        _activateTargetDefenders(clanId, defenders, 4);
+
+        uint256 blueprintBefore = world.getClan(clanId).blueprintBalance;
+        uint32 banditId = _forceAttack(clanId, 1);
+        world.setBanditStrength(banditId, 0);
+
+        vm.expectEmit(true, true, false, true, address(world));
+        emit BlueprintEarned(clanId, banditId, world.getWorldState().currentTick);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore + 1, "target blueprint awarded");
+    }
+
     function test_defeatedBanditLootSplitsEquallyAcrossFourDefendingClans() public {
         uint32[] memory clanIds = _mintClans(4);
         _activateTargetDefenders(clanIds[0], clanIds, 1);
@@ -235,6 +254,43 @@ contract BanditAttackResolutionTest is Test {
             assertEq(clan.vaultIron, ironBefore[i] + 25e18, "iron share");
             assertEq(clan.goldBalance, goldBefore[i] + 25e18, "gold share");
         }
+    }
+
+    function test_mixedClanDefenseAwardsBlueprintOnlyToBaseOwner() public {
+        uint32[] memory clanIds = _mintClans(4);
+        _activateTargetDefenders(clanIds[0], clanIds, 1);
+
+        uint256[4] memory blueprintBefore;
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            blueprintBefore[i] = world.getClan(clanIds[i]).blueprintBalance;
+        }
+
+        uint32 banditId = _forceAttack(clanIds[0], 1);
+        world.setBanditStrength(banditId, 0);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanIds[0]).blueprintBalance, blueprintBefore[0] + 1, "base owner blueprint");
+        for (uint256 i = 1; i < clanIds.length; i++) {
+            assertEq(world.getClan(clanIds[i]).blueprintBalance, blueprintBefore[i], "helper clan no blueprint");
+        }
+    }
+
+    function test_multipleDefeatedBanditsEachAwardBlueprint() public {
+        uint32 clanId = _mintClan();
+        uint32[] memory defenders = new uint32[](1);
+        defenders[0] = clanId;
+        _activateTargetDefenders(clanId, defenders, 4);
+
+        uint256 blueprintBefore = world.getClan(clanId).blueprintBalance;
+        uint32 firstBanditId = _forceAttack(clanId, 1);
+        uint32 secondBanditId = _forceAttack(clanId, 1);
+        world.setBanditStrength(firstBanditId, 0);
+        world.setBanditStrength(secondBanditId, 0);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore + 2, "one blueprint per defeated bandit");
     }
 
     function test_defeatedBanditLootBurnsWholeTokenOverflowAcrossThreeDefendingClans() public {
@@ -309,6 +365,17 @@ contract BanditAttackResolutionTest is Test {
         assertEq(afterClan.vaultFish, beforeClan.vaultFish, "fish unchanged");
         assertEq(afterClan.vaultIron, beforeClan.vaultIron, "iron unchanged");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "gold unchanged");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
+    }
+
+    function test_escapedBanditDoesNotAwardBlueprint() public {
+        uint32 clanId = _mintClan();
+        uint256 blueprintBefore = world.getClan(clanId).blueprintBalance;
+        uint32 banditId = _forceAttack(clanId, 100);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore, "blueprint unchanged");
         assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
     }
 


### PR DESCRIPTION
## Summary
- Awards one blueprint fragment to the defended base owner clan when a bandit is defeated.
- Emits `BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint64 tick)` and refreshes the checked-in ABI.
- Adds focused coverage for single defeat, mixed-clan defense, multiple defeated bandits in one tick, and escaped bandits.

## Notes
- Blueprint ownership is base-owner-only: helper defender clans still receive 9.5 loot shares, but only the bandit's target clan gets the fragment.
- Hook order is `BanditDefeated` -> 9.5 loot distribution -> blueprint increment/event -> defeated-state transition/deletion. This preserves the existing 9.5 event order while awarding before deletion.

## Validation
- `docker run --rm -v /tmp/wt-issue-209:/repo -w /repo/packages/contracts ghcr.io/foundry-rs/foundry:latest 'forge test --match-path test/BanditAttackResolution.t.sol'`
- `docker run --rm -v /tmp/wt-issue-209:/repo -w /repo/packages/contracts ghcr.io/foundry-rs/foundry:latest 'forge test'`
- `git diff --check`

Closes #209
