### PR TITLE
feat(contracts): Phase 7.5 — restrict dead clans from OTC (Closes #227)

### DIFF
--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1773,10 +1773,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     {
         Clan storage fromClan = _clans[fromClanId];
         require(fromClan.clanId != 0, "ClanWorld: clan not found");
+        require(fromClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
         require(_clans[toClanId].clanId != 0, "ClanWorld: target clan not found");
-        require(_clans[toClanId].clanState == ClanState.ACTIVE, "ClanWorld: target clan dead");
+        require(_clans[toClanId].clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         require(expiryTick <= type(uint64).max, "ClanWorld: expiry overflow");
         if (fromClan.goldBalance < amount) revert("ERR_NOT_ENOUGH_GOLD");
 
@@ -1802,8 +1802,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         Clan storage fromClan = _clans[proposal.from];
         Clan storage toClan = _clans[proposal.to];
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
-        require(toClan.clanState == ClanState.ACTIVE, "ClanWorld: target clan dead");
+        require(fromClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
+        require(toClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         require(toClan.owner == msg.sender, "ClanWorld: not clan owner");
         if (fromClan.goldBalance < proposal.amount) revert("ERR_NOT_ENOUGH_GOLD");
 
@@ -1822,7 +1822,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         Clan storage fromClan = _clans[proposal.from];
         require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
 
         proposal.cancelled = true;
         emit GoldTransferCancelled(proposalId);
@@ -1839,10 +1838,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     ) external override nonReentrant returns (uint256 proposalId) {
         Clan storage fromClan = _clans[fromClanId];
         require(fromClan.clanId != 0, "ClanWorld: clan not found");
+        require(fromClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
         require(_clans[toClanId].clanId != 0, "ClanWorld: target clan not found");
-        require(_clans[toClanId].clanState == ClanState.ACTIVE, "ClanWorld: target clan dead");
+        require(_clans[toClanId].clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         if (!_hasVaultResources(fromClan, woodAmt, wheatAmt, fishAmt, ironAmt)) {
             revert("ERR_NOT_ENOUGH_RESOURCES");
         }
@@ -1872,8 +1871,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         Clan storage fromClan = _clans[proposal.from];
         Clan storage toClan = _clans[proposal.to];
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
-        require(toClan.clanState == ClanState.ACTIVE, "ClanWorld: target clan dead");
+        require(fromClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
+        require(toClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         require(toClan.owner == msg.sender, "ClanWorld: not clan owner");
         if (!_hasVaultResources(fromClan, proposal.wood, proposal.wheat, proposal.fish, proposal.iron)) {
             revert("ERR_NOT_ENOUGH_RESOURCES");
@@ -1909,7 +1908,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         Clan storage fromClan = _clans[proposal.from];
         require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
 
         proposal.cancelled = true;
         emit VaultTransferCancelled(proposalId);
@@ -1931,10 +1929,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     {
         Clan storage fromClan = _clans[fromClanId];
         require(fromClan.clanId != 0, "ClanWorld: clan not found");
+        require(fromClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
         require(_clans[toClanId].clanId != 0, "ClanWorld: target clan not found");
-        require(_clans[toClanId].clanState == ClanState.ACTIVE, "ClanWorld: target clan dead");
+        require(_clans[toClanId].clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         if (fromClan.blueprintBalance < amount) revert("ERR_NOT_ENOUGH_BLUEPRINT");
 
         proposalId = _nextOtcProposalId++;
@@ -1954,8 +1952,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         Clan storage fromClan = _clans[proposal.from];
         Clan storage toClan = _clans[proposal.to];
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
-        require(toClan.clanState == ClanState.ACTIVE, "ClanWorld: target clan dead");
+        require(fromClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
+        require(toClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         require(toClan.owner == msg.sender, "ClanWorld: not clan owner");
         if (fromClan.blueprintBalance < proposal.amount) revert("ERR_NOT_ENOUGH_BLUEPRINT");
 
@@ -1974,7 +1972,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         Clan storage fromClan = _clans[proposal.from];
         require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
 
         proposal.cancelled = true;
         emit BlueprintTransferCancelled(proposalId);
@@ -1993,10 +1990,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     ) external override nonReentrant returns (uint256 proposalId) {
         Clan storage fromClan = _clans[fromClanId];
         require(fromClan.clanId != 0, "ClanWorld: clan not found");
+        require(fromClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
         require(_clans[toClanId].clanId != 0, "ClanWorld: target clan not found");
-        require(_clans[toClanId].clanState == ClanState.ACTIVE, "ClanWorld: target clan dead");
+        require(_clans[toClanId].clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         require(!_isEmptyBundledTransfer(gold, wood, wheat, fish, iron, blueprint), "ClanWorld: empty bundled transfer");
         _requireBundledTransferBalance(fromClan, gold, wood, wheat, fish, iron, blueprint);
 
@@ -2029,8 +2026,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         Clan storage fromClan = _clans[proposal.from];
         Clan storage toClan = _clans[proposal.to];
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
-        require(toClan.clanState == ClanState.ACTIVE, "ClanWorld: target clan dead");
+        require(fromClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
+        require(toClan.clanState != ClanState.DEAD, "ERR_CLAN_DEAD");
         require(toClan.owner == msg.sender, "ClanWorld: not clan owner");
         _requireBundledTransferBalance(
             fromClan, proposal.gold, proposal.wood, proposal.wheat, proposal.fish, proposal.iron, proposal.blueprint
@@ -2072,7 +2069,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         Clan storage fromClan = _clans[proposal.from];
         require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
-        require(fromClan.clanState == ClanState.ACTIVE, "ClanWorld: clan dead");
 
         proposal.cancelled = true;
         emit BundledTransferCancelled(proposalId);

--- a/packages/contracts/test/DeadClanOtc.t.sol
+++ b/packages/contracts/test/DeadClanOtc.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {Clan, ClanState} from "../src/IClanWorld.sol";
+
+contract DeadClanOtcHarness is ClanWorld {
+    function setClanState(uint32 clanId, ClanState state) external {
+        _clans[clanId].clanState = state;
+    }
+
+    function setVault(uint32 clanId, uint256 wood, uint256 wheat, uint256 fish, uint256 iron) external {
+        _clans[clanId].vaultWood = wood;
+        _clans[clanId].vaultWheat = wheat;
+        _clans[clanId].vaultFish = fish;
+        _clans[clanId].vaultIron = iron;
+    }
+
+    function setBlueprintBalance(uint32 clanId, uint256 amount) external {
+        _clans[clanId].blueprintBalance = amount;
+    }
+}
+
+contract DeadClanOtcTest is Test {
+    DeadClanOtcHarness world;
+    address elderA = address(0xA1);
+    address elderB = address(0xA2);
+    address elderC = address(0xA3);
+
+    function setUp() public {
+        world = new DeadClanOtcHarness();
+    }
+
+    function test_aliveClansCanProposeAndAcceptAllOtcTypes() public {
+        (uint32 clanA, uint32 clanB,) = _mintThreeClans();
+        _fundOtcBalances(clanA);
+
+        uint256 goldProposal = _proposeGold(elderA, clanA, clanB, 1e18);
+        uint256 vaultProposal = _proposeVault(elderA, clanA, clanB, 1e18);
+        uint256 blueprintProposal = _proposeBlueprint(elderA, clanA, clanB, 1e18);
+        uint256 bundledProposal = _proposeBundled(elderA, clanA, clanB, 1e18);
+
+        vm.prank(elderB);
+        world.acceptGoldTransfer(goldProposal);
+        vm.prank(elderB);
+        world.acceptVaultTransfer(vaultProposal);
+        vm.prank(elderB);
+        world.acceptBlueprintTransfer(blueprintProposal);
+        vm.prank(elderB);
+        world.acceptBundledTransfer(bundledProposal);
+
+        Clan memory fromAfter = world.getClan(clanA);
+        Clan memory toAfter = world.getClan(clanB);
+        assertEq(fromAfter.goldBalance, 1e18, "from gold debited");
+        assertEq(toAfter.goldBalance, 5e18, "to gold credited");
+        assertEq(fromAfter.vaultWood, 8e18, "from wood debited");
+        assertEq(toAfter.vaultWood, 22e18, "to wood credited");
+        assertEq(fromAfter.blueprintBalance, 0, "from blueprint debited");
+        assertEq(toAfter.blueprintBalance, 2e18, "to blueprint credited");
+    }
+
+    function test_deadProposerCannotProposeAnyOtcType() public {
+        (uint32 clanA, uint32 clanB,) = _mintThreeClans();
+        _fundOtcBalances(clanA);
+        world.setClanState(clanA, ClanState.DEAD);
+
+        vm.expectRevert("ERR_CLAN_DEAD");
+        _proposeGold(elderA, clanA, clanB, 1e18);
+        vm.expectRevert("ERR_CLAN_DEAD");
+        _proposeVault(elderA, clanA, clanB, 1e18);
+        vm.expectRevert("ERR_CLAN_DEAD");
+        _proposeBlueprint(elderA, clanA, clanB, 1e18);
+        vm.expectRevert("ERR_CLAN_DEAD");
+        _proposeBundled(elderA, clanA, clanB, 1e18);
+    }
+
+    function test_deadProposerAfterProposeCannotBeAccepted() public {
+        (uint32 clanA, uint32 clanB,) = _mintThreeClans();
+        _fundOtcBalances(clanA);
+        uint256 goldProposal = _proposeGold(elderA, clanA, clanB, 1e18);
+        uint256 vaultProposal = _proposeVault(elderA, clanA, clanB, 1e18);
+        uint256 blueprintProposal = _proposeBlueprint(elderA, clanA, clanB, 1e18);
+        uint256 bundledProposal = _proposeBundled(elderA, clanA, clanB, 1e18);
+
+        world.setClanState(clanA, ClanState.DEAD);
+
+        vm.expectRevert("ERR_CLAN_DEAD");
+        vm.prank(elderB);
+        world.acceptGoldTransfer(goldProposal);
+        vm.expectRevert("ERR_CLAN_DEAD");
+        vm.prank(elderB);
+        world.acceptVaultTransfer(vaultProposal);
+        vm.expectRevert("ERR_CLAN_DEAD");
+        vm.prank(elderB);
+        world.acceptBlueprintTransfer(blueprintProposal);
+        vm.expectRevert("ERR_CLAN_DEAD");
+        vm.prank(elderB);
+        world.acceptBundledTransfer(bundledProposal);
+    }
+
+    function test_deadTargetCannotAcceptAnyOtcType() public {
+        (uint32 clanA, uint32 clanB,) = _mintThreeClans();
+        _fundOtcBalances(clanA);
+        uint256 goldProposal = _proposeGold(elderA, clanA, clanB, 1e18);
+        uint256 vaultProposal = _proposeVault(elderA, clanA, clanB, 1e18);
+        uint256 blueprintProposal = _proposeBlueprint(elderA, clanA, clanB, 1e18);
+        uint256 bundledProposal = _proposeBundled(elderA, clanA, clanB, 1e18);
+
+        world.setClanState(clanB, ClanState.DEAD);
+
+        vm.expectRevert("ERR_CLAN_DEAD");
+        vm.prank(elderB);
+        world.acceptGoldTransfer(goldProposal);
+        vm.expectRevert("ERR_CLAN_DEAD");
+        vm.prank(elderB);
+        world.acceptVaultTransfer(vaultProposal);
+        vm.expectRevert("ERR_CLAN_DEAD");
+        vm.prank(elderB);
+        world.acceptBlueprintTransfer(blueprintProposal);
+        vm.expectRevert("ERR_CLAN_DEAD");
+        vm.prank(elderB);
+        world.acceptBundledTransfer(bundledProposal);
+    }
+
+    function test_deadProposerCanCancelExistingProposals() public {
+        (uint32 clanA, uint32 clanB,) = _mintThreeClans();
+        _fundOtcBalances(clanA);
+        uint256 goldProposal = _proposeGold(elderA, clanA, clanB, 1e18);
+        uint256 vaultProposal = _proposeVault(elderA, clanA, clanB, 1e18);
+        uint256 blueprintProposal = _proposeBlueprint(elderA, clanA, clanB, 1e18);
+        uint256 bundledProposal = _proposeBundled(elderA, clanA, clanB, 1e18);
+
+        world.setClanState(clanA, ClanState.DEAD);
+
+        vm.prank(elderA);
+        world.cancelGoldTransfer(goldProposal);
+        vm.prank(elderA);
+        world.cancelVaultTransfer(vaultProposal);
+        vm.prank(elderA);
+        world.cancelBlueprintTransfer(blueprintProposal);
+        vm.prank(elderA);
+        world.cancelBundledTransfer(bundledProposal);
+
+        assertTrue(world.getOtcGoldProposal(goldProposal).cancelled, "gold cancelled");
+        assertTrue(world.getOtcVaultTransferProposal(vaultProposal).cancelled, "vault cancelled");
+        assertTrue(world.getOtcBlueprintTransferProposal(blueprintProposal).cancelled, "blueprint cancelled");
+        assertTrue(world.getOtcBundledTransferProposal(bundledProposal).cancelled, "bundled cancelled");
+    }
+
+    function test_unrelatedClanDeathDoesNotBlockOtherClanOtc() public {
+        (uint32 clanA, uint32 clanB, uint32 clanC) = _mintThreeClans();
+        world.setClanState(clanA, ClanState.DEAD);
+
+        uint256 clanCBefore = world.getClan(clanC).goldBalance;
+        uint256 proposalId = _proposeGold(elderB, clanB, clanC, 1e18);
+
+        vm.prank(elderC);
+        world.acceptGoldTransfer(proposalId);
+
+        assertEq(world.getClan(clanC).goldBalance, clanCBefore + 1e18, "alive clans trade");
+    }
+
+    function _mintThreeClans() internal returns (uint32 clanA, uint32 clanB, uint32 clanC) {
+        vm.prank(elderA);
+        (clanA,) = world.mintClan(elderA);
+        vm.prank(elderB);
+        (clanB,) = world.mintClan(elderB);
+        vm.prank(elderC);
+        (clanC,) = world.mintClan(elderC);
+    }
+
+    function _fundOtcBalances(uint32 clanId) internal {
+        world.setVault(clanId, 10e18, 10e18, 10e18, 10e18);
+        world.setBlueprintBalance(clanId, 2e18);
+    }
+
+    function _proposeGold(address elder, uint32 fromClanId, uint32 toClanId, uint256 amount)
+        internal
+        returns (uint256 proposalId)
+    {
+        vm.prank(elder);
+        proposalId = world.proposeGoldTransfer(fromClanId, toClanId, amount, 10);
+    }
+
+    function _proposeVault(address elder, uint32 fromClanId, uint32 toClanId, uint256 amount)
+        internal
+        returns (uint256 proposalId)
+    {
+        vm.prank(elder);
+        proposalId = world.proposeVaultTransfer(fromClanId, toClanId, amount, amount, amount, amount, 10);
+    }
+
+    function _proposeBlueprint(address elder, uint32 fromClanId, uint32 toClanId, uint256 amount)
+        internal
+        returns (uint256 proposalId)
+    {
+        vm.prank(elder);
+        proposalId = world.proposeBlueprintTransfer(fromClanId, toClanId, amount, 10);
+    }
+
+    function _proposeBundled(address elder, uint32 fromClanId, uint32 toClanId, uint256 amount)
+        internal
+        returns (uint256 proposalId)
+    {
+        vm.prank(elder);
+        proposalId =
+            world.proposeBundledTransfer(fromClanId, toClanId, amount, amount, amount, amount, amount, amount, 10);
+    }
+}


### PR DESCRIPTION
Closes #227

## Summary
- Wires `ClanState.DEAD` into gold, vault, blueprint, and bundled OTC propose/accept paths.
- Uses the phase parent `StatusCode.ERR_CLAN_DEAD` enum addition as the shared revert reason (`ERR_CLAN_DEAD`); no new interface enum change was needed on this branch.
- Leaves cancel permissive so a dead proposer can still cancel an existing proposal.

## Semantics
- Propose-time checks reject dead proposers, and keep dead target clans from receiving new OTC proposals.
- Accept-time checks re-read both proposer and acceptor clan state, so if either clan dies after proposal creation the accept reverts and the proposal is effectively unacceptible.
- Cancel only requires the original proposer owner, preserving cleanup for pre-existing proposals.

## Validation
- `PATH="$HOME/.foundry/bin:$PATH" forge test` — 135 passed, 0 failed.
- `git diff --check`
