### PR TITLE
feat(contracts): Phase 6.6 — market events surface (Closes #219)

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1698,11 +1698,6 @@
               "name": "missionNonce",
               "type": "uint64",
               "internalType": "uint64"
-            },
-            {
-              "name": "marketMode",
-              "type": "uint8",
-              "internalType": "enum MarketExecutionMode"
             }
           ]
         }
@@ -2447,6 +2442,11 @@
               "name": "missionNonce",
               "type": "uint64",
               "internalType": "uint64"
+            },
+            {
+              "name": "marketMode",
+              "type": "uint8",
+              "internalType": "enum MarketExecutionMode"
             }
           ]
         }
@@ -3070,22 +3070,22 @@
           "internalType": "uint32"
         },
         {
-          "name": "clansmanId",
+          "name": "csId",
           "type": "uint32",
-          "indexed": true,
+          "indexed": false,
           "internalType": "uint32"
         },
         {
-          "name": "tokenIn",
-          "type": "address",
+          "name": "action",
+          "type": "uint8",
           "indexed": false,
-          "internalType": "address"
+          "internalType": "enum ActionType"
         },
         {
-          "name": "tokenOut",
-          "type": "address",
+          "name": "resourceIn",
+          "type": "uint8",
           "indexed": false,
-          "internalType": "address"
+          "internalType": "uint8"
         },
         {
           "name": "amountIn",
@@ -3094,13 +3094,19 @@
           "internalType": "uint256"
         },
         {
+          "name": "resourceOut",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
           "name": "amountOut",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
         },
         {
-          "name": "atTick",
+          "name": "tick",
           "type": "uint64",
           "indexed": false,
           "internalType": "uint64"
@@ -3168,9 +3174,9 @@
           "internalType": "uint32"
         },
         {
-          "name": "clansmanId",
+          "name": "csId",
           "type": "uint32",
-          "indexed": true,
+          "indexed": false,
           "internalType": "uint32"
         },
         {
@@ -3180,10 +3186,22 @@
           "internalType": "enum ActionType"
         },
         {
+          "name": "mode",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum MarketExecutionMode"
+        },
+        {
           "name": "reason",
           "type": "uint8",
           "indexed": false,
           "internalType": "enum StatusCode"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
         }
       ],
       "anonymous": false
@@ -3587,40 +3605,28 @@
       "name": "ScheduledMarketActionExecuted",
       "inputs": [
         {
-          "name": "executeAtTick",
-          "type": "uint64",
-          "indexed": true,
-          "internalType": "uint64"
-        },
-        {
-          "name": "commitSequence",
-          "type": "uint64",
-          "indexed": true,
-          "internalType": "uint64"
-        },
-        {
           "name": "clanId",
           "type": "uint32",
           "indexed": true,
           "internalType": "uint32"
         },
         {
-          "name": "clansmanId",
+          "name": "csId",
           "type": "uint32",
           "indexed": false,
           "internalType": "uint32"
         },
         {
-          "name": "tokenIn",
-          "type": "address",
+          "name": "action",
+          "type": "uint8",
           "indexed": false,
-          "internalType": "address"
+          "internalType": "enum ActionType"
         },
         {
-          "name": "tokenOut",
-          "type": "address",
+          "name": "resourceIn",
+          "type": "uint8",
           "indexed": false,
-          "internalType": "address"
+          "internalType": "uint8"
         },
         {
           "name": "amountIn",
@@ -3629,10 +3635,22 @@
           "internalType": "uint256"
         },
         {
+          "name": "resourceOut",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
           "name": "amountOut",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
+        },
+        {
+          "name": "settledAtTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
         }
       ],
       "anonymous": false

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -96,8 +96,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _world.nextHeartbeatAtTick = 1; // first heartbeat will open tick 1
         // First winter: last WINTER_DURATION_TICKS of first TICKS_PER_WINTER_CYCLE cycle
         // i.e. ticks [100, 110)
-        _world.winterStartsAtTick =
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
+        _world.winterStartsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
         _world.winterEndsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE; // = 110
         _world.winterActive = false;
         _treasury.treasuryOwner = msg.sender;
@@ -1334,14 +1333,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         });
         _scheduledMarketActions[executeAtTick].push(sma);
         emit ScheduledMarketActionCommitted(
-            executeAtTick,
-            sma.commitSequence,
-            clanId,
-            clansmanId,
-            m.action,
-            m.marketToken,
-            m.marketAmount,
-            m.maxGoldIn
+            executeAtTick, sma.commitSequence, clanId, clansmanId, m.action, m.marketToken, m.marketAmount, m.maxGoldIn
         );
     }
 
@@ -1397,7 +1389,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // Validate clansman still belongs to the clan
             Clansman storage cs = _clansmen[sma.clansmanId];
             if (cs.clanId != sma.clanId || cs.state == ClansmanState.DEAD) {
-                emit MarketActionFailed(sma.clanId, sma.clansmanId, sma.action, StatusCode.ERR_INVALID_CLANSMAN);
+                _emitMarketActionFailed(
+                    sma.clanId,
+                    sma.clansmanId,
+                    sma.action,
+                    MarketExecutionMode.Scheduled,
+                    StatusCode.ERR_INVALID_CLANSMAN,
+                    tick
+                );
                 continue;
             }
 
@@ -1406,7 +1405,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // cannot use m.active as a validity signal here — check action type and nonce.
             Mission storage m = _missions[sma.clansmanId];
             if (m.action != sma.action || m.nonce != sma.missionNonce) {
-                emit MarketActionFailed(sma.clanId, sma.clansmanId, sma.action, StatusCode.ERR_INVALID_ACTION);
+                _emitMarketActionFailed(
+                    sma.clanId,
+                    sma.clansmanId,
+                    sma.action,
+                    MarketExecutionMode.Scheduled,
+                    StatusCode.ERR_INVALID_ACTION,
+                    tick
+                );
                 continue;
             }
 
@@ -1417,7 +1423,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 // success
                 }
                 catch {
-                    emit MarketActionFailed(sma.clanId, sma.clansmanId, sma.action, StatusCode.ERR_INVALID_ACTION);
+                    _emitMarketActionFailed(
+                        sma.clanId,
+                        sma.clansmanId,
+                        sma.action,
+                        MarketExecutionMode.Scheduled,
+                        StatusCode.ERR_INVALID_ACTION,
+                        tick
+                    );
                 }
             } else if (sma.action == ActionType.MarketBuy) {
                 try this._executeMarketBuyExternal(
@@ -1432,7 +1445,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 // success
                 }
                 catch {
-                    emit MarketActionFailed(sma.clanId, sma.clansmanId, sma.action, StatusCode.ERR_INVALID_ACTION);
+                    _emitMarketActionFailed(
+                        sma.clanId,
+                        sma.clansmanId,
+                        sma.action,
+                        MarketExecutionMode.Scheduled,
+                        StatusCode.ERR_INVALID_ACTION,
+                        tick
+                    );
                 }
             }
         }
@@ -1459,10 +1479,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clansmanId,
         address token,
         uint256 amount,
-        uint64 commitSequence
+        uint64
     ) external {
         require(msg.sender == address(this), "ClanWorld: internal only");
-        _executeMarketSell(closedTick, clanId, clansmanId, token, amount, commitSequence);
+        _executeMarketSell(closedTick, clanId, clansmanId, token, amount);
     }
 
     /// @dev External wrapper for _executeMarketBuy — enables try/catch from heartbeat loop.
@@ -1473,10 +1493,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         address token,
         uint256 amountOut,
         uint256 maxGoldIn,
-        uint64 commitSequence
+        uint64
     ) external {
         require(msg.sender == address(this), "ClanWorld: internal only");
-        _executeMarketBuy(closedTick, clanId, clansmanId, token, amountOut, maxGoldIn, commitSequence);
+        _executeMarketBuy(closedTick, clanId, clansmanId, token, amountOut, maxGoldIn);
     }
 
     /// @dev Map a resource token address to its pool address.
@@ -1486,6 +1506,27 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (token == _treasury.wheatToken) return _treasury.wheatGoldPool;
         if (token == _treasury.fishToken) return _treasury.fishGoldPool;
         return address(0);
+    }
+
+    /// @dev Map a market token address to the canonical uint8 resource id used by market events.
+    function _marketResourceForToken(address token) internal view returns (uint8) {
+        if (token == _treasury.woodToken) return uint8(ResourceType.Wood);
+        if (token == _treasury.ironToken) return uint8(ResourceType.Iron);
+        if (token == _treasury.wheatToken) return uint8(ResourceType.Wheat);
+        if (token == _treasury.fishToken) return uint8(ResourceType.Fish);
+        if (token == _treasury.goldToken) return ClanWorldConstants.RESOURCE_GOLD;
+        revert("ClanWorld: invalid market resource");
+    }
+
+    function _emitMarketActionFailed(
+        uint32 clanId,
+        uint32 clansmanId,
+        ActionType action,
+        MarketExecutionMode mode,
+        StatusCode reason,
+        uint64 tick
+    ) internal {
+        emit MarketActionFailed(clanId, clansmanId, action, mode, reason, tick);
     }
 
     /// @dev Add an amount of a resource token to the clan vault.
@@ -1552,18 +1593,39 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     function _executeImmediateMarketSell(uint32 clanId, uint32 clansmanId, address token, uint256 amount) internal {
         if (!_treasury.poolsSeeded) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                _world.currentTick
+            );
             return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                _world.currentTick
+            );
             return;
         }
 
         Clan storage clan = _clans[clanId];
         if (!_hasVaultBalance(clan, token, amount)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MISSING_RESOURCES);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MISSING_RESOURCES,
+                _world.currentTick
+            );
             return;
         }
 
@@ -1571,10 +1633,24 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             _deductFromVault(clan, token, amount);
             clan.goldBalance += goldOut;
             emit ImmediateMarketActionExecuted(
-                clanId, clansmanId, token, _treasury.goldToken, amount, goldOut, _world.currentTick
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                _marketResourceForToken(token),
+                amount,
+                ClanWorldConstants.RESOURCE_GOLD,
+                goldOut,
+                _world.currentTick
             );
         } catch {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_INVALID_ACTION);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                _world.currentTick
+            );
         }
     }
 
@@ -1586,12 +1662,26 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint256 maxGoldIn
     ) internal {
         if (!_treasury.poolsSeeded) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                _world.currentTick
+            );
             return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                _world.currentTick
+            );
             return;
         }
 
@@ -1599,19 +1689,38 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         try StubPool(poolAddr).getAmountInForExactOut(amountOut) returns (uint256 quotedGoldIn) {
             goldIn = quotedGoldIn;
         } catch {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_INVALID_ACTION);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                _world.currentTick
+            );
             return;
         }
 
         Clan storage clan = _clans[clanId];
         if (goldIn > maxGoldIn) {
-            emit MarketActionFailed(
-                clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+                _world.currentTick
             );
             return;
         }
         if (clan.goldBalance < goldIn) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_NOT_ENOUGH_GOLD);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_NOT_ENOUGH_GOLD,
+                _world.currentTick
+            );
             return;
         }
 
@@ -1619,35 +1728,65 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             clan.goldBalance -= actualGoldIn;
             _addToVault(clan, token, amountOut);
             emit ImmediateMarketActionExecuted(
-                clanId, clansmanId, _treasury.goldToken, token, actualGoldIn, amountOut, _world.currentTick
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                ClanWorldConstants.RESOURCE_GOLD,
+                actualGoldIn,
+                _marketResourceForToken(token),
+                amountOut,
+                _world.currentTick
             );
         } catch {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_INVALID_ACTION);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_INVALID_ACTION,
+                _world.currentTick
+            );
         }
     }
 
     /// @dev Execute a scheduled market sell: deduct resource from vault, credit gold.
-    function _executeMarketSell(
-        uint64 closedTick,
-        uint32 clanId,
-        uint32 clansmanId,
-        address token,
-        uint256 amount,
-        uint64 commitSequence
-    ) internal {
+    function _executeMarketSell(uint64 closedTick, uint32 clanId, uint32 clansmanId, address token, uint256 amount)
+        internal
+    {
         if (!_treasury.poolsSeeded) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                closedTick
+            );
             return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                closedTick
+            );
             return;
         }
 
         Clan storage clan = _clans[clanId];
         if (!_deductFromVault(clan, token, amount)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MISSING_RESOURCES);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MISSING_RESOURCES,
+                closedTick
+            );
             return;
         }
 
@@ -1655,7 +1794,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         clan.goldBalance += goldOut;
 
         emit ScheduledMarketActionExecuted(
-            closedTick, commitSequence, clanId, clansmanId, token, _treasury.goldToken, amount, goldOut
+            clanId,
+            clansmanId,
+            ActionType.MarketSell,
+            _marketResourceForToken(token),
+            amount,
+            ClanWorldConstants.RESOURCE_GOLD,
+            goldOut,
+            closedTick
         );
     }
 
@@ -1666,32 +1812,70 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clansmanId,
         address token,
         uint256 amountOut,
-        uint256 maxGoldIn,
-        uint64 commitSequence
+        uint256 maxGoldIn
     ) internal {
         if (!_treasury.poolsSeeded) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                closedTick
+            );
             return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                closedTick
+            );
             return;
         }
 
         // Quote gold cost without updating reserves
-        uint256 goldIn = StubPool(poolAddr).quoteBuy(amountOut);
+        uint256 goldIn;
+        try StubPool(poolAddr).quoteBuy(amountOut) returns (uint256 quotedGoldIn) {
+            goldIn = quotedGoldIn;
+        } catch {
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                closedTick
+            );
+            return;
+        }
 
         Clan storage clan = _clans[clanId];
 
         if (goldIn > maxGoldIn) {
-            emit MarketActionFailed(
-                clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+                closedTick
             );
             return;
         }
         if (clan.goldBalance < goldIn) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_NOT_ENOUGH_GOLD);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_NOT_ENOUGH_GOLD,
+                closedTick
+            );
             return;
         }
 
@@ -1701,7 +1885,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _addToVault(clan, token, amountOut);
 
         emit ScheduledMarketActionExecuted(
-            closedTick, commitSequence, clanId, clansmanId, _treasury.goldToken, token, actualGoldIn, amountOut
+            clanId,
+            clansmanId,
+            ActionType.MarketBuy,
+            ClanWorldConstants.RESOURCE_GOLD,
+            actualGoldIn,
+            _marketResourceForToken(token),
+            amountOut,
+            closedTick
         );
     }
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -84,6 +84,10 @@ library ClanWorldConstants {
     uint8 internal constant REGION_EAST_DOCKS = 7;
     uint8 internal constant REGION_DEEP_SEA = 8;
 
+    // Market event resource ids. ResourceType covers the four vault resources;
+    // gold is the quote asset emitted as resource id 4.
+    uint8 internal constant RESOURCE_GOLD = 4;
+
     // Sentinels
     uint32 internal constant CLAN_ID_NULL = 0; // valid clan IDs start at 1
     uint32 internal constant BANDIT_ID_NULL = 0;
@@ -178,7 +182,8 @@ enum StatusCode {
     ERR_NO_ACTIVE_BANDIT,
     ERR_SEASON_ENDED,
     ERR_NOT_ENOUGH_GOLD,
-    ERR_CARRY_FULL
+    ERR_CARRY_FULL,
+    ERR_MARKET_INSUFFICIENT_LIQUIDITY
 }
 
 // =============================================================================
@@ -190,8 +195,8 @@ struct WorldState {
     uint64 seasonStartTick;
     uint64 seasonEndTick;
     bool seasonFinalized;
-    uint64 currentSeasonNumber;   // 1-indexed; incremented each time seasonEndTick is crossed
-    uint64 nextHeartbeatAtTick;   // estimated tick that will be opened by the next heartbeat (for off-chain UI)
+    uint64 currentSeasonNumber; // 1-indexed; incremented each time seasonEndTick is crossed
+    uint64 nextHeartbeatAtTick; // estimated tick that will be opened by the next heartbeat (for off-chain UI)
 
     uint64 nextHeartbeatAtTs;
     uint64 nextBanditSpawnEligibleTick;
@@ -551,22 +556,26 @@ interface IClanWorldEvents {
     // ----- market -----
     event ImmediateMarketActionExecuted(
         uint32 indexed clanId,
-        uint32 indexed clansmanId,
-        address tokenIn,
-        address tokenOut,
+        uint32 csId,
+        ActionType action,
+        uint8 resourceIn,
         uint256 amountIn,
+        uint8 resourceOut,
         uint256 amountOut,
-        uint64 atTick
+        uint64 tick
     );
     event ScheduledMarketActionExecuted(
-        uint64 indexed executeAtTick,
-        uint64 indexed commitSequence,
         uint32 indexed clanId,
-        uint32 clansmanId,
-        address tokenIn,
-        address tokenOut,
+        uint32 csId,
+        ActionType action,
+        uint8 resourceIn,
         uint256 amountIn,
-        uint256 amountOut
+        uint8 resourceOut,
+        uint256 amountOut,
+        uint64 settledAtTick
+    );
+    event MarketActionFailed(
+        uint32 indexed clanId, uint32 csId, ActionType action, MarketExecutionMode mode, StatusCode reason, uint64 tick
     );
     event ScheduledMarketActionCommitted(
         uint64 indexed executeAtTick,
@@ -578,7 +587,6 @@ interface IClanWorldEvents {
         uint256 marketAmount,
         uint256 maxGoldIn
     );
-    event MarketActionFailed(uint32 indexed clanId, uint32 indexed clansmanId, ActionType action, StatusCode reason);
     event ResourceMinted(uint8 indexed resourceType, address indexed to, uint256 amount);
     event ResourceBurned(uint8 indexed resourceType, address indexed from, uint256 amount);
 

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -741,11 +741,10 @@ contract ClanWorldTest is Test {
         return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
     }
 
-    function _setupHarnessClanAt(
-        ClansmanState state,
-        uint8 region,
-        uint64 cooldownEndsAtTs
-    ) internal returns (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) {
+    function _setupHarnessClanAt(ClansmanState state, uint8 region, uint64 cooldownEndsAtTs)
+        internal
+        returns (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId)
+    {
         harness = new ClanWorldTestHarness();
         world = harness;
         woodAddr = _setupMarket();
@@ -759,9 +758,19 @@ contract ClanWorldTest is Test {
             _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
 
         Clan memory beforeClan = world.getClan(clanId);
+        uint256 expectedGoldOut = woodPool.getAmountOutForExactIn(5e18);
 
-        vm.expectEmit(true, true, false, false);
-        emit IClanWorldEvents.ImmediateMarketActionExecuted(clanId, csId, woodAddr, address(goldToken), 5e18, 0, 0);
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.ImmediateMarketActionExecuted(
+            clanId,
+            csId,
+            ActionType.MarketSell,
+            uint8(ResourceType.Wood),
+            5e18,
+            ClanWorldConstants.RESOURCE_GOLD,
+            expectedGoldOut,
+            world.getWorldState().currentTick
+        );
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 5e18, 0);
 
         Clan memory afterClan = world.getClan(clanId);
@@ -838,7 +847,19 @@ contract ClanWorldTest is Test {
             _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
 
         Clan memory beforeClan = world.getClan(clanId);
+        uint256 expectedGoldIn = woodPool.getAmountInForExactOut(1e18);
 
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.ImmediateMarketActionExecuted(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            ClanWorldConstants.RESOURCE_GOLD,
+            expectedGoldIn,
+            uint8(ResourceType.Wood),
+            1e18,
+            world.getWorldState().currentTick
+        );
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 2e18);
 
         Clan memory afterClan = world.getClan(clanId);
@@ -855,8 +876,15 @@ contract ClanWorldTest is Test {
 
         Clan memory beforeClan = world.getClan(clanId);
 
-        vm.expectEmit(true, true, false, true);
-        emit IClanWorldEvents.MarketActionFailed(clanId, csId, ActionType.MarketBuy, StatusCode.ERR_INVALID_ACTION);
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Immediate,
+            StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+            world.getWorldState().currentTick
+        );
         OrderResult[] memory r = _submitMarketOrder(
             clanId, csId, ActionType.MarketBuy, woodAddr, world.INITIAL_RESOURCE_POOL_SEED() + 1, type(uint256).max
         );
@@ -865,7 +893,9 @@ contract ClanWorldTest is Test {
         Clansman memory cs = world.getClansman(csId);
 
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
-        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed immediate action stays immediate");
+        assertEq(
+            uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed immediate action stays immediate"
+        );
         assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
         assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
@@ -878,9 +908,14 @@ contract ClanWorldTest is Test {
 
         Clan memory beforeClan = world.getClan(clanId);
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit IClanWorldEvents.MarketActionFailed(
-            clanId, csId, ActionType.MarketBuy, StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Immediate,
+            StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+            world.getWorldState().currentTick
         );
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 0);
 
@@ -914,13 +949,26 @@ contract ClanWorldTest is Test {
         // Find out which tick the action fires
         Mission memory m = world.getActiveMission(csId);
         uint64 executeAtTick = m.settlesAtTick;
+        uint256 expectedGoldOut = woodPool.getAmountOutForExactIn(5e18);
 
-        // Advance ticks until heartbeat closes executeAtTick
+        // Advance ticks until the heartbeat before executeAtTick
         uint64 curTick = world.getWorldState().currentTick;
-        uint256 ticksNeeded = uint256(executeAtTick - curTick) + 1;
-        for (uint256 i = 0; i < ticksNeeded; i++) {
+        for (uint256 i = 0; i < uint256(executeAtTick - curTick); i++) {
             _advanceTick();
         }
+
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.ScheduledMarketActionExecuted(
+            clanId,
+            csId,
+            ActionType.MarketSell,
+            uint8(ResourceType.Wood),
+            5e18,
+            ClanWorldConstants.RESOURCE_GOLD,
+            expectedGoldOut,
+            executeAtTick
+        );
+        _advanceTick();
 
         // Settle clan to apply any mission resolution
         world.settleClan(clanId);
@@ -992,9 +1040,14 @@ contract ClanWorldTest is Test {
 
         // Now the next heartbeat will close executeAtTick — that's when MarketActionFailed fires
         // Place expectEmit right before the final heartbeat
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit IClanWorldEvents.MarketActionFailed(
-            clanId, csId, ActionType.MarketBuy, StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Scheduled,
+            StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+            executeAtTick
         );
         _advanceTick();
 
@@ -1048,8 +1101,12 @@ contract ClanWorldTest is Test {
         uint64 newExecuteAtTick = newMission.settlesAtTick;
         assertGt(newMission.nonce, oldMission.nonce, "replacement should bump nonce");
 
-        assertEq(world.getScheduledMarketActionsForTick(oldExecuteAtTick).length, 0, "old mission not queued before settle");
-        assertEq(world.getScheduledMarketActionsForTick(newExecuteAtTick).length, 0, "new mission not queued before settle");
+        assertEq(
+            world.getScheduledMarketActionsForTick(oldExecuteAtTick).length, 0, "old mission not queued before settle"
+        );
+        assertEq(
+            world.getScheduledMarketActionsForTick(newExecuteAtTick).length, 0, "new mission not queued before settle"
+        );
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 
@@ -1095,7 +1152,7 @@ contract ClanWorldTest is Test {
 
         uint64 executeAtTick = 3;
         bytes32 executedSig =
-            keccak256("ScheduledMarketActionExecuted(uint64,uint64,uint32,uint32,address,address,uint256,uint256)");
+            keccak256("ScheduledMarketActionExecuted(uint32,uint32,uint8,uint8,uint256,uint8,uint256,uint64)");
 
         _advanceTick(); // close tick 1
         _advanceTick(); // close tick 2
@@ -1109,7 +1166,9 @@ contract ClanWorldTest is Test {
             if (logs[i].emitter != address(world) || logs[i].topics.length == 0 || logs[i].topics[0] != executedSig) {
                 continue;
             }
-            if (uint64(uint256(logs[i].topics[1])) != executeAtTick) continue;
+            (,,,,,, uint64 settledAtTick) =
+                abi.decode(logs[i].data, (uint32, ActionType, uint8, uint256, uint8, uint256, uint64));
+            if (settledAtTick != executeAtTick) continue;
             executedCount++;
         }
 
@@ -1134,7 +1193,7 @@ contract ClanWorldTest is Test {
                 action: ActionType.MarketSell,
                 targetClanId: 0,
                 marketToken: woodAddr,
-                marketAmount: 2e18,
+                marketAmount: uint256(i + 1) * 1e18,
                 maxGoldIn: 0
             });
         }
@@ -1147,7 +1206,7 @@ contract ClanWorldTest is Test {
         Mission memory m = world.getActiveMission(orders[0].clansmanId);
         uint64 executeAtTick = m.settlesAtTick;
         bytes32 executedSig =
-            keccak256("ScheduledMarketActionExecuted(uint64,uint64,uint32,uint32,address,address,uint256,uint256)");
+            keccak256("ScheduledMarketActionExecuted(uint32,uint32,uint8,uint8,uint256,uint8,uint256,uint64)");
 
         while (world.getWorldState().currentTick < executeAtTick) {
             _advanceTick();
@@ -1157,18 +1216,18 @@ contract ClanWorldTest is Test {
         _advanceTick();
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        uint64 previousSeq;
         uint256 executedCount;
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].emitter != address(world) || logs[i].topics.length == 0 || logs[i].topics[0] != executedSig) {
                 continue;
             }
-            if (uint64(uint256(logs[i].topics[1])) != executeAtTick) continue;
+            (,, uint8 resourceIn, uint256 amountIn,,, uint64 settledAtTick) =
+                abi.decode(logs[i].data, (uint32, ActionType, uint8, uint256, uint8, uint256, uint64));
+            if (settledAtTick != executeAtTick) continue;
 
-            uint64 seq = uint64(uint256(logs[i].topics[2]));
-            if (executedCount > 0) assertGt(seq, previousSeq, "execution should be FIFO");
-            assertEq(uint32(uint256(logs[i].topics[3])), clanId, "same clan should execute");
-            previousSeq = seq;
+            assertEq(uint32(uint256(logs[i].topics[1])), clanId, "same clan should execute");
+            assertEq(resourceIn, uint8(ResourceType.Wood), "sell should input wood");
+            assertEq(amountIn, uint256(executedCount + 1) * 1e18, "execution should be FIFO");
             executedCount++;
         }
 
@@ -1224,13 +1283,38 @@ contract ClanWorldTest is Test {
         uint64 maxTick = m1.settlesAtTick > m2.settlesAtTick ? m1.settlesAtTick : m2.settlesAtTick;
         uint64 curTick = world.getWorldState().currentTick;
         uint256 ticksNeeded = uint256(maxTick - curTick) + 1;
+        bytes32 scheduledSig =
+            keccak256("ScheduledMarketActionExecuted(uint32,uint32,uint8,uint8,uint256,uint8,uint256,uint64)");
+        vm.recordLogs();
         for (uint256 i = 0; i < ticksNeeded; i++) {
             _advanceTick();
+        }
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bool sawClan1SellEvent;
+        bool sawClan2BuyEvent;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != address(world) || logs[i].topics.length == 0 || logs[i].topics[0] != scheduledSig) {
+                continue;
+            }
+
+            uint32 eventClanId = uint32(uint256(logs[i].topics[1]));
+            (uint32 eventCsId, ActionType eventAction,,,,,) =
+                abi.decode(logs[i].data, (uint32, ActionType, uint8, uint256, uint8, uint256, uint64));
+
+            if (eventClanId == clanId1 && eventCsId == csId1 && eventAction == ActionType.MarketSell) {
+                sawClan1SellEvent = true;
+            }
+            if (eventClanId == clanId2 && eventCsId == csId2 && eventAction == ActionType.MarketBuy) {
+                sawClan2BuyEvent = true;
+            }
         }
 
         world.settleClan(clanId1);
         world.settleClan(clanId2);
 
+        assertTrue(sawClan1SellEvent, "sell event should carry clan1 id");
+        assertTrue(sawClan2BuyEvent, "buy event should carry clan2 id");
         // Clan1 sold wood → gold should increase
         assertGt(world.getClan(clanId1).goldBalance, 3e18, "clan1 should have more gold after sell");
         // Clan2 bought wood → vault wood should increase beyond starter 20e18


### PR DESCRIPTION
## Summary
- Replaced the already-present market event names with the canonical Phase 6.6 signatures.
- Added `RESOURCE_GOLD = 4` for gold-side market event resource ids and `ERR_MARKET_INSUFFICIENT_LIQUIDITY` for liquidity failures.
- Threaded `MarketExecutionMode` and tick through immediate and scheduled market failures, and regenerated `packages/contracts/abi/IClanWorld.json`.

## Deduplication audit
- `ImmediateMarketActionExecuted` already existed from 6.3 with address token payloads; updated in place.
- `ScheduledMarketActionExecuted` already existed from 6.4 with execution tick / commit sequence / address payloads; updated in place.
- `MarketActionFailed` already existed with only action and reason; updated in place.
- `ScheduledMarketActionCommitted` was left as-is; no duplicate market event names were added.

## Tests
- `~/.foundry/bin/forge test` (110 passed)

Closes #219