### PR TITLE
feat(contracts): Phase 6.5 — market failure semantics (Closes #218)

### DIFF
--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1217,9 +1217,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             ctx.newNonce = cs.lastMissionNonce + 1;
             cs.lastMissionNonce = ctx.newNonce;
 
-            _executeImmediateMarket(clanId, order, cs.clansmanId);
+            StatusCode marketStatus = _executeImmediateMarket(clanId, order, cs.clansmanId);
 
-            cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
+            if (marketStatus == StatusCode.OK) {
+                cs.state = ClansmanState.WAITING;
+                cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
+            }
             _clearDefender(cs.clansmanId);
 
             result.status = StatusCode.OK;
@@ -1419,16 +1422,17 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             if (sma.action == ActionType.MarketSell) {
                 try this._executeMarketSellExternal(
                     tick, sma.clanId, sma.clansmanId, sma.marketToken, sma.marketAmount, sma.commitSequence
+                ) returns (
+                    StatusCode marketStatus
                 ) {
-                // success
-                }
-                catch {
-                    _emitMarketActionFailed(
+                    marketStatus;
+                } catch {
+                    _handleMarketFailure(
                         sma.clanId,
                         sma.clansmanId,
                         sma.action,
                         MarketExecutionMode.Scheduled,
-                        StatusCode.ERR_INVALID_ACTION,
+                        StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                         tick
                     );
                 }
@@ -1441,16 +1445,17 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                     sma.marketAmount,
                     sma.maxGoldIn,
                     sma.commitSequence
+                ) returns (
+                    StatusCode marketStatus
                 ) {
-                // success
-                }
-                catch {
-                    _emitMarketActionFailed(
+                    marketStatus;
+                } catch {
+                    _handleMarketFailure(
                         sma.clanId,
                         sma.clansmanId,
                         sma.action,
                         MarketExecutionMode.Scheduled,
-                        StatusCode.ERR_INVALID_ACTION,
+                        StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                         tick
                     );
                 }
@@ -1479,10 +1484,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clansmanId,
         address token,
         uint256 amount,
-        uint64
-    ) external {
+        uint64 commitSequence
+    ) external returns (StatusCode) {
         require(msg.sender == address(this), "ClanWorld: internal only");
-        _executeMarketSell(closedTick, clanId, clansmanId, token, amount);
+        return _executeMarketSell(closedTick, clanId, clansmanId, token, amount, commitSequence);
     }
 
     /// @dev External wrapper for _executeMarketBuy — enables try/catch from heartbeat loop.
@@ -1493,10 +1498,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         address token,
         uint256 amountOut,
         uint256 maxGoldIn,
-        uint64
-    ) external {
+        uint64 commitSequence
+    ) external returns (StatusCode) {
         require(msg.sender == address(this), "ClanWorld: internal only");
-        _executeMarketBuy(closedTick, clanId, clansmanId, token, amountOut, maxGoldIn);
+        return _executeMarketBuy(closedTick, clanId, clansmanId, token, amountOut, maxGoldIn, commitSequence);
     }
 
     /// @dev Map a resource token address to its pool address.
@@ -1583,17 +1588,62 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return false;
     }
 
-    function _executeImmediateMarket(uint32 clanId, ClanOrder calldata order, uint32 clansmanId) internal {
-        if (order.action == ActionType.MarketSell) {
-            _executeImmediateMarketSell(clanId, clansmanId, order.marketToken, order.marketAmount);
-        } else {
-            _executeImmediateMarketBuy(clanId, clansmanId, order.marketToken, order.marketAmount, order.maxGoldIn);
+    function _handleMarketFailure(
+        uint32 clanId,
+        uint32 clansmanId,
+        ActionType action,
+        MarketExecutionMode mode,
+        StatusCode reason,
+        uint64 tick
+    ) internal returns (StatusCode) {
+        Clansman storage cs = _clansmen[clansmanId];
+        if (cs.clansmanId != 0 && cs.state != ClansmanState.DEAD) {
+            cs.state = ClansmanState.WAITING;
+            cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
         }
+        _emitMarketActionFailed(clanId, clansmanId, action, mode, reason, tick);
+        return reason;
     }
 
-    function _executeImmediateMarketSell(uint32 clanId, uint32 clansmanId, address token, uint256 amount) internal {
+    function _remainingCarryForToken(Clansman storage cs, address token) internal view returns (uint256) {
+        uint256 carried;
+        uint256 cap;
+        if (token == _treasury.woodToken) {
+            carried = cs.carryWood;
+            cap = ClanWorldConstants.WOOD_CAP;
+        } else if (token == _treasury.ironToken) {
+            carried = cs.carryIron;
+            cap = ClanWorldConstants.IRON_CAP;
+        } else if (token == _treasury.wheatToken) {
+            carried = cs.carryWheat;
+            cap = ClanWorldConstants.WHEAT_CAP;
+        } else if (token == _treasury.fishToken) {
+            carried = cs.carryFish;
+            cap = ClanWorldConstants.FISH_CAP;
+        } else {
+            return 0;
+        }
+
+        if (carried >= cap) return 0;
+        return cap - carried;
+    }
+
+    function _executeImmediateMarket(uint32 clanId, ClanOrder calldata order, uint32 clansmanId)
+        internal
+        returns (StatusCode)
+    {
+        if (order.action == ActionType.MarketSell) {
+            return _executeImmediateMarketSell(clanId, clansmanId, order.marketToken, order.marketAmount);
+        }
+        return _executeImmediateMarketBuy(clanId, clansmanId, order.marketToken, order.marketAmount, order.maxGoldIn);
+    }
+
+    function _executeImmediateMarketSell(uint32 clanId, uint32 clansmanId, address token, uint256 amount)
+        internal
+        returns (StatusCode)
+    {
         if (!_treasury.poolsSeeded) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1601,11 +1651,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 _world.currentTick
             );
-            return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1613,12 +1662,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 _world.currentTick
             );
-            return;
         }
 
         Clan storage clan = _clans[clanId];
         if (!_hasVaultBalance(clan, token, amount)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1626,7 +1674,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MISSING_RESOURCES,
                 _world.currentTick
             );
-            return;
         }
 
         try StubPool(poolAddr).swapExactInForOut(amount, 1) returns (uint256 goldOut) {
@@ -1642,13 +1689,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 goldOut,
                 _world.currentTick
             );
+            return StatusCode.OK;
         } catch {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
                 MarketExecutionMode.Immediate,
-                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                 _world.currentTick
             );
         }
@@ -1660,9 +1708,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         address token,
         uint256 amountOut,
         uint256 maxGoldIn
-    ) internal {
+    ) internal returns (StatusCode) {
         if (!_treasury.poolsSeeded) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1670,11 +1718,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 _world.currentTick
             );
-            return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1682,38 +1729,47 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 _world.currentTick
             );
-            return;
+        }
+
+        Clansman storage cs = _clansmen[clansmanId];
+        if (amountOut > _remainingCarryForToken(cs, token)) {
+            return _handleMarketFailure(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_CARRY_FULL,
+                _world.currentTick
+            );
         }
 
         uint256 goldIn;
         try StubPool(poolAddr).getAmountInForExactOut(amountOut) returns (uint256 quotedGoldIn) {
             goldIn = quotedGoldIn;
         } catch {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
                 MarketExecutionMode.Immediate,
-                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                 _world.currentTick
             );
-            return;
         }
 
         Clan storage clan = _clans[clanId];
         if (goldIn > maxGoldIn) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
                 MarketExecutionMode.Immediate,
-                StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+                StatusCode.ERR_MAX_GOLD_IN_EXCEEDED,
                 _world.currentTick
             );
-            return;
         }
         if (clan.goldBalance < goldIn) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1721,7 +1777,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_NOT_ENOUGH_GOLD,
                 _world.currentTick
             );
-            return;
         }
 
         try StubPool(poolAddr).swapExactOutForInWithMaxIn(amountOut, maxGoldIn) returns (uint256 actualGoldIn) {
@@ -1737,24 +1792,30 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 amountOut,
                 _world.currentTick
             );
+            return StatusCode.OK;
         } catch {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
                 MarketExecutionMode.Immediate,
-                StatusCode.ERR_INVALID_ACTION,
+                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                 _world.currentTick
             );
         }
     }
 
     /// @dev Execute a scheduled market sell: deduct resource from vault, credit gold.
-    function _executeMarketSell(uint64 closedTick, uint32 clanId, uint32 clansmanId, address token, uint256 amount)
-        internal
-    {
+    function _executeMarketSell(
+        uint64 closedTick,
+        uint32 clanId,
+        uint32 clansmanId,
+        address token,
+        uint256 amount,
+        uint64
+    ) internal returns (StatusCode) {
         if (!_treasury.poolsSeeded) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1762,11 +1823,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 closedTick
             );
-            return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1774,12 +1834,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 closedTick
             );
-            return;
         }
 
         Clan storage clan = _clans[clanId];
         if (!_deductFromVault(clan, token, amount)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1787,7 +1846,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MISSING_RESOURCES,
                 closedTick
             );
-            return;
         }
 
         uint256 goldOut = StubPool(poolAddr).sellResource(amount);
@@ -1803,6 +1861,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             goldOut,
             closedTick
         );
+        return StatusCode.OK;
     }
 
     /// @dev Execute a scheduled market buy: deduct gold from purse, credit resource to vault.
@@ -1812,10 +1871,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clansmanId,
         address token,
         uint256 amountOut,
-        uint256 maxGoldIn
-    ) internal {
+        uint256 maxGoldIn,
+        uint64
+    ) internal returns (StatusCode) {
         if (!_treasury.poolsSeeded) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1823,11 +1883,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 closedTick
             );
-            return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1835,40 +1894,48 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 closedTick
             );
-            return;
         }
 
-        // Quote gold cost without updating reserves
+        Clansman storage cs = _clansmen[clansmanId];
+        if (amountOut > _remainingCarryForToken(cs, token)) {
+            return _handleMarketFailure(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_CARRY_FULL,
+                closedTick
+            );
+        }
+
         uint256 goldIn;
         try StubPool(poolAddr).quoteBuy(amountOut) returns (uint256 quotedGoldIn) {
             goldIn = quotedGoldIn;
         } catch {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
                 MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                 closedTick
             );
-            return;
         }
 
         Clan storage clan = _clans[clanId];
 
         if (goldIn > maxGoldIn) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
                 MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+                StatusCode.ERR_MAX_GOLD_IN_EXCEEDED,
                 closedTick
             );
-            return;
         }
         if (clan.goldBalance < goldIn) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1876,11 +1943,22 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_NOT_ENOUGH_GOLD,
                 closedTick
             );
-            return;
         }
 
-        // Execute — use return value to guard against any future pool divergence
-        uint256 actualGoldIn = StubPool(poolAddr).buyResource(amountOut);
+        uint256 actualGoldIn;
+        try StubPool(poolAddr).swapExactOutForInWithMaxIn(amountOut, maxGoldIn) returns (uint256 spentGold) {
+            actualGoldIn = spentGold;
+        } catch {
+            return _handleMarketFailure(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
+                closedTick
+            );
+        }
+
         clan.goldBalance -= actualGoldIn;
         _addToVault(clan, token, amountOut);
 
@@ -1894,6 +1972,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             amountOut,
             closedTick
         );
+        return StatusCode.OK;
     }
 
     function _validateAction(Clan storage clan, Clansman storage cs, ClanOrder calldata order, uint8 gotoRegion)

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -183,7 +183,9 @@ enum StatusCode {
     ERR_SEASON_ENDED,
     ERR_NOT_ENOUGH_GOLD,
     ERR_CARRY_FULL,
-    ERR_MARKET_INSUFFICIENT_LIQUIDITY
+    ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+    ERR_LIQUIDITY_INSUFFICIENT,
+    ERR_MAX_GOLD_IN_EXCEEDED
 }
 
 // =============================================================================

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -85,6 +85,10 @@ contract ClanWorldTest is Test {
 
     /// @dev Deploy tokens + pools, call initTreasury + seedPools. Returns wood token address.
     function _setupMarket() internal returns (address woodAddr) {
+        return _setupMarketWithWoodSeed(world.INITIAL_RESOURCE_POOL_SEED());
+    }
+
+    function _setupMarketWithWoodSeed(uint256 woodSeed) internal returns (address woodAddr) {
         woodToken = new MinimalERC20("Wood", "WOOD");
         ironToken = new MinimalERC20("Iron", "IRON");
         wheatToken = new MinimalERC20("Wheat", "WHEAT");
@@ -115,20 +119,20 @@ contract ClanWorldTest is Test {
         uint256 goldSeed = world.INITIAL_GOLD_POOL_SEED();
         uint256 totalGoldSeed = goldSeed * 4;
 
-        woodToken.seedTreasury(address(this), resSeed);
+        woodToken.seedTreasury(address(this), woodSeed);
         wheatToken.seedTreasury(address(this), resSeed);
         fishToken.seedTreasury(address(this), resSeed);
         ironToken.seedTreasury(address(this), resSeed);
         goldToken.seedTreasury(address(this), totalGoldSeed);
 
-        woodToken.approve(address(world), resSeed);
+        woodToken.approve(address(world), woodSeed);
         wheatToken.approve(address(world), resSeed);
         fishToken.approve(address(world), resSeed);
         ironToken.approve(address(world), resSeed);
         goldToken.approve(address(world), totalGoldSeed);
 
         PoolSeedConfig memory cfg = PoolSeedConfig({
-            woodSeed: resSeed,
+            woodSeed: woodSeed,
             wheatSeed: resSeed,
             fishSeed: resSeed,
             ironSeed: resSeed,
@@ -736,6 +740,12 @@ contract ClanWorldTest is Test {
         return count;
     }
 
+    function _advanceUntilNextHeartbeatCloses(uint64 tick) internal {
+        while (world.getWorldState().currentTick < tick) {
+            _advanceTick();
+        }
+    }
+
     // Helper: get the first clansman id for a clan
     function _firstCs(uint32 clanId) internal view returns (uint32) {
         return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
@@ -745,9 +755,18 @@ contract ClanWorldTest is Test {
         internal
         returns (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId)
     {
+        return _setupHarnessClanAtWithWoodSeed(state, region, cooldownEndsAtTs, world.INITIAL_RESOURCE_POOL_SEED());
+    }
+
+    function _setupHarnessClanAtWithWoodSeed(
+        ClansmanState state,
+        uint8 region,
+        uint64 cooldownEndsAtTs,
+        uint256 woodSeed
+    ) internal returns (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) {
         harness = new ClanWorldTestHarness();
         world = harness;
-        woodAddr = _setupMarket();
+        woodAddr = _setupMarketWithWoodSeed(woodSeed);
         clanId = _mintClan();
         csId = _firstCs(clanId);
         harness.setClansmanForTest(csId, state, region, cooldownEndsAtTs);
@@ -872,7 +891,7 @@ contract ClanWorldTest is Test {
 
     function test_immediateMarket_insufficientLiquidityFailsAndConsumesCooldown() public {
         (, address woodAddr, uint32 clanId, uint32 csId) =
-            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+            _setupHarnessClanAtWithWoodSeed(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0, 5e18);
 
         Clan memory beforeClan = world.getClan(clanId);
 
@@ -882,12 +901,11 @@ contract ClanWorldTest is Test {
             csId,
             ActionType.MarketBuy,
             MarketExecutionMode.Immediate,
-            StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+            StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
             world.getWorldState().currentTick
         );
-        OrderResult[] memory r = _submitMarketOrder(
-            clanId, csId, ActionType.MarketBuy, woodAddr, world.INITIAL_RESOURCE_POOL_SEED() + 1, type(uint256).max
-        );
+        OrderResult[] memory r =
+            _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 6e18, type(uint256).max);
 
         Clan memory afterClan = world.getClan(clanId);
         Clansman memory cs = world.getClansman(csId);
@@ -899,6 +917,7 @@ contract ClanWorldTest is Test {
         assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
         assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed immediate worker waits");
         assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
     }
 
@@ -914,7 +933,7 @@ contract ClanWorldTest is Test {
             csId,
             ActionType.MarketBuy,
             MarketExecutionMode.Immediate,
-            StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+            StatusCode.ERR_MAX_GOLD_IN_EXCEEDED,
             world.getWorldState().currentTick
         );
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 0);
@@ -927,6 +946,66 @@ contract ClanWorldTest is Test {
         assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
         assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed immediate worker waits");
+        assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
+    }
+
+    function test_immediateMarketBuy_insufficientGoldFailsAndConsumesCooldown() public {
+        (, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+
+        Clan memory beforeClan = world.getClan(clanId);
+
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Immediate,
+            StatusCode.ERR_NOT_ENOUGH_GOLD,
+            world.getWorldState().currentTick
+        );
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 7e18, 10e18);
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed buy should report immediate");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed immediate worker waits");
+        assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
+    }
+
+    function test_immediateMarketBuy_carryFullFailsAndConsumesCooldown() public {
+        (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+        harness.setCarry(csId, ClanWorldConstants.WOOD_CAP, 0, 0, 0);
+
+        Clan memory beforeClan = world.getClan(clanId);
+
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Immediate,
+            StatusCode.ERR_CARRY_FULL,
+            world.getWorldState().currentTick
+        );
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 10e18);
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed buy should report immediate");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed immediate worker waits");
         assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
     }
 
@@ -1015,7 +1094,7 @@ contract ClanWorldTest is Test {
     }
 
     // -------------------------------------------------------------------------
-    // Test 13: buy_maxGoldIn — buy fails with ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+    // Test 13: buy_maxGoldIn — buy fails with ERR_MAX_GOLD_IN_EXCEEDED
     // -------------------------------------------------------------------------
 
     function test_buy_maxGoldIn() public {
@@ -1046,13 +1125,116 @@ contract ClanWorldTest is Test {
             csId,
             ActionType.MarketBuy,
             MarketExecutionMode.Scheduled,
-            StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+            StatusCode.ERR_MAX_GOLD_IN_EXCEEDED,
             executeAtTick
         );
         _advanceTick();
 
+        Clansman memory cs = world.getClansman(csId);
+
         // Verify gold balance unchanged (buy failed)
         assertEq(world.getClan(clanId).goldBalance, 3e18, "gold should be unchanged after failed buy");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed scheduled buy should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed scheduled worker waits");
+        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
+    }
+
+    function test_scheduledMarketBuy_insufficientGoldFailsAndConsumesCooldown() public {
+        address woodAddr = _setupMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 7e18, 10e18);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "buy order should be accepted");
+
+        Mission memory m = world.getActiveMission(csId);
+        uint64 executeAtTick = m.settlesAtTick;
+        Clan memory beforeClan = world.getClan(clanId);
+
+        _advanceUntilNextHeartbeatCloses(executeAtTick);
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Scheduled,
+            StatusCode.ERR_NOT_ENOUGH_GOLD,
+            executeAtTick
+        );
+        _advanceTick();
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed scheduled buy should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed scheduled worker waits");
+        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
+    }
+
+    function test_scheduledMarketBuy_carryFullFailsAndConsumesCooldown() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        address woodAddr = _setupMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+        harness.setCarry(csId, ClanWorldConstants.WOOD_CAP, 0, 0, 0);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 10e18);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "buy order should be accepted");
+
+        Mission memory m = world.getActiveMission(csId);
+        uint64 executeAtTick = m.settlesAtTick;
+        Clan memory beforeClan = world.getClan(clanId);
+
+        _advanceUntilNextHeartbeatCloses(executeAtTick);
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId, csId, ActionType.MarketBuy, MarketExecutionMode.Scheduled, StatusCode.ERR_CARRY_FULL, executeAtTick
+        );
+        _advanceTick();
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed scheduled buy should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed scheduled worker waits");
+        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
+    }
+
+    function test_scheduledMarketBuy_insufficientLiquidityFailsAndConsumesCooldown() public {
+        address woodAddr = _setupMarketWithWoodSeed(5e18);
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory r =
+            _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 6e18, type(uint256).max);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "buy order should be accepted");
+
+        Mission memory m = world.getActiveMission(csId);
+        uint64 executeAtTick = m.settlesAtTick;
+        Clan memory beforeClan = world.getClan(clanId);
+
+        _advanceUntilNextHeartbeatCloses(executeAtTick);
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Scheduled,
+            StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
+            executeAtTick
+        );
+        _advanceTick();
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed scheduled buy should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed scheduled worker waits");
+        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
     }
 
     // -------------------------------------------------------------------------
@@ -1321,6 +1503,49 @@ contract ClanWorldTest is Test {
         assertGt(world.getClan(clanId2).vaultWood, 20e18, "clan2 should have more vault wood after buy");
         // Clan2 spent gold
         assertLt(world.getClan(clanId2).goldBalance, 3e18, "clan2 should have less gold after buy");
+    }
+
+    function test_scheduledMarketFailure_doesNotAffectAnotherClan() public {
+        address woodAddr = _setupMarket();
+
+        uint32 clanId1 = _mintClan();
+        vm.prank(elder2);
+        (uint32 clanId2,) = world.mintClan(elder2);
+
+        uint32 csId1 = _firstCs(clanId1);
+        uint32 csId2 = world.getClanFullView(clanId2).clansmen[0].clansman.clansman.clansmanId;
+
+        OrderResult[] memory buyFail = _submitMarketOrder(clanId1, csId1, ActionType.MarketBuy, woodAddr, 1e18, 0);
+        assertEq(uint8(buyFail[0].status), uint8(StatusCode.OK), "failing buy should enqueue");
+
+        ClanOrder[] memory sellOrders = new ClanOrder[](1);
+        sellOrders[0] = ClanOrder({
+            clansmanId: csId2,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketSell,
+            targetClanId: 0,
+            marketToken: woodAddr,
+            marketAmount: 5e18,
+            maxGoldIn: 0
+        });
+        vm.prank(elder2);
+        OrderResult[] memory sellOk = world.submitClanOrders(clanId2, sellOrders);
+        assertEq(uint8(sellOk[0].status), uint8(StatusCode.OK), "other clan sell should enqueue");
+
+        uint64 tick1 = world.getActiveMission(csId1).settlesAtTick;
+        uint64 tick2 = world.getActiveMission(csId2).settlesAtTick;
+        uint64 maxTick = tick1 > tick2 ? tick1 : tick2;
+        Clan memory failingBefore = world.getClan(clanId1);
+        uint256 sellerGoldBefore = world.getClan(clanId2).goldBalance;
+
+        while (world.getWorldState().currentTick <= maxTick) {
+            _advanceTick();
+        }
+
+        Clan memory failingAfter = world.getClan(clanId1);
+        assertEq(failingAfter.vaultWood, failingBefore.vaultWood, "failed buy should not credit resources");
+        assertEq(failingAfter.goldBalance, failingBefore.goldBalance, "failed buy should not debit gold");
+        assertGt(world.getClan(clanId2).goldBalance, sellerGoldBefore, "other clan sell should execute");
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Closes #218
- Adds `ERR_LIQUIDITY_INSUFFICIENT` and `ERR_MAX_GOLD_IN_EXCEEDED` to `StatusCode` while preserving the 6.6 market event surface.
- Consolidates immediate and scheduled market failures through `_handleMarketFailure`, which sets cooldown, returns the worker to `WAITING`, and emits `MarketActionFailed` with mode, reason, and tick.
- Adds buy failure coverage for insufficient gold, maxGoldIn, carry capacity, and liquidity across immediate and scheduled paths, plus a two-clan no-interference check.

## Verification
- `docker run --rm --user 1000:1000 -v /tmp/wt-issue-218/packages/contracts:/work -w /work --entrypoint sh ghcr.io/foundry-rs/foundry:latest -lc 'forge fmt src/ClanWorld.sol src/IClanWorld.sol test/ClanWorld.t.sol && forge test -vvv'`\n- Result: 116 passed, 0 failed, 0 skipped\n