### PR TITLE
fix(contracts): Phase 9 super-swarm r2 — 5 HIGH findings

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2912,6 +2912,12 @@
           "internalType": "uint32"
         },
         {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
           "name": "tick",
           "type": "uint64",
           "indexed": false,

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -82,9 +82,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     uint256 private constant RESOURCE_UNIT = 1e18;
+    uint256 internal constant BLUEPRINT_UNIT = 1e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
     uint256 internal constant DOMAIN_BANDIT_SPAWN = uint256(keccak256("clanworld.bandit.spawn.v1"));
+    uint256 internal constant DOMAIN_BANDIT_TARGET_PICK = uint256(keccak256("bandit_target_pick"));
     uint64 internal constant MIN_SPAWN_COOLDOWN_TICKS = ClanWorldConstants.BANDIT_COOLDOWN_TICKS;
     uint16 internal constant BANDIT_SPAWN_PROBABILITY_INCREMENT_BPS = 1000;
     uint16 internal constant BANDIT_SPAWN_MAX_PROBABILITY_BPS = 8000;
@@ -468,9 +470,21 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             emit ClanStarvationChanged(clan.clanId, false, tick);
         }
 
-        if (starving && _world.winterActive && clan.starvationStartsAtTick >= _world.winterStartsAtTick) {
+        if (starving && _isWinterTick(tick) && clan.starvationStartsAtTick <= tick) {
             _killNextClansmanFromStarvation(clan, tick);
         }
+    }
+
+    function _isWinterTick(uint64 tick) internal pure returns (bool) {
+        uint64 seasonOffset = tick % ClanWorldConstants.SEASON_DURATION_TICKS;
+        uint64 cycleOffset = seasonOffset % ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
+        uint64 cycleStart = seasonOffset - cycleOffset;
+        uint64 winterStart =
+            cycleStart + ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS;
+        uint64 winterEnd = cycleStart + ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
+
+        return winterStart < ClanWorldConstants.SEASON_DURATION_TICKS && seasonOffset >= winterStart
+            && seasonOffset < winterEnd;
     }
 
     function _killNextClansmanFromStarvation(Clan storage clan, uint64 tick) internal {
@@ -1088,7 +1102,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             sim.clan.starvationStartsAtTick = 0;
         }
 
-        if (starving && _world.winterActive && sim.clan.starvationStartsAtTick >= _world.winterStartsAtTick) {
+        if (starving && _isWinterTick(tick) && sim.clan.starvationStartsAtTick <= tick) {
             _simulateKillNextClansmanFromStarvation(sim);
         }
     }
@@ -1661,6 +1675,22 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 if (bandit.state == BanditState.Spawned && closedTick > bandit.tickEnteredState) {
                     _transitionBanditState(banditId, BanditState.Camped);
                 } else if (
+                    bandit.state == BanditState.Camped
+                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS
+                ) {
+                    uint32 targetClanId = _pickBanditAttackTarget(bandit);
+                    if (targetClanId == ClanWorldConstants.CLAN_ID_NULL) {
+                        _transitionBanditState(banditId, BanditState.Escaped);
+                        emit BanditEscaped(banditId, closedTick);
+                    } else {
+                        _transitionBanditToAttacking(banditId, targetClanId);
+                    }
+                } else if (
+                    bandit.state == BanditState.Escaped
+                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
+                ) {
+                    _transitionBanditState(banditId, BanditState.Resting);
+                } else if (
                     bandit.state == BanditState.Resting
                         && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
                 ) {
@@ -1668,6 +1698,40 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 }
             }
         }
+    }
+
+    function _pickBanditAttackTarget(BanditTroop storage bandit) internal view returns (uint32 targetClanId) {
+        uint32[MAX_CLANS] memory tiedClanIds;
+        uint256 tiedCount;
+        uint256 bestLootValue;
+
+        for (uint256 i = 0; i < _allClanIds.length; i++) {
+            uint32 clanId = _allClanIds[i];
+            Clan storage clan = _clans[clanId];
+            if (clan.clanState == ClanState.DEAD || clan.baseRegion != bandit.region || clan.livingClansmen == 0) {
+                continue;
+            }
+
+            uint256 lootValue = _lootValueRaw(clan);
+            if (tiedCount == 0 || lootValue > bestLootValue) {
+                bestLootValue = lootValue;
+                tiedClanIds[0] = clanId;
+                tiedCount = 1;
+            } else if (lootValue == bestLootValue) {
+                tiedClanIds[tiedCount] = clanId;
+                tiedCount++;
+            }
+        }
+
+        if (tiedCount == 0) {
+            return ClanWorldConstants.CLAN_ID_NULL;
+        }
+        if (tiedCount == 1) {
+            return tiedClanIds[0];
+        }
+
+        uint256 selected = RNG.rngBounded(_world.currentTickSeed, DOMAIN_BANDIT_TARGET_PICK, bandit.id, tiedCount);
+        return tiedClanIds[selected];
     }
 
     function _banditStrengthForLegacyEvent(uint32 strength) internal pure returns (uint16) {
@@ -1715,7 +1779,22 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         _settleClan(targetClanId);
+        if (bandit.state != BanditState.Attacking || bandit.targetClanId != targetClanId) {
+            return;
+        }
+        if (targetClan.clanState == ClanState.DEAD) {
+            _transitionBanditState(banditId, BanditState.Escaped);
+            emit BanditEscaped(banditId, closedTick);
+            return;
+        }
+
         _eagerSettleActiveDefendersForBase(targetClanId, targetClan.baseRegion);
+        if (
+            bandit.state != BanditState.Attacking || bandit.targetClanId != targetClanId
+                || targetClan.clanState == ClanState.DEAD
+        ) {
+            return;
+        }
 
         bytes32 tickSeed = _world.currentTickSeed;
         uint32 banditAttackPower = bandit.strength;
@@ -1752,8 +1831,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (defeated) {
             emit BanditDefeated(banditId, targetClanId, closedTick);
             _distributeBanditLootToDefendingClans(banditId, targetClanId);
-            targetClan.blueprintBalance += 1;
-            emit BlueprintEarned(targetClanId, banditId, closedTick);
+            targetClan.blueprintBalance += BLUEPRINT_UNIT;
+            emit BlueprintEarned(targetClanId, banditId, BLUEPRINT_UNIT, closedTick);
             _transitionBanditState(banditId, BanditState.Defeated);
         } else {
             _transitionBanditState(banditId, BanditState.Escaped);

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -601,7 +601,7 @@ interface IClanWorldEvents {
     event WallDamagedByBandit(uint32 indexed clanId, uint8 newLevel, uint32 indexed banditId);
     event ClansmanKilledByBandit(uint32 indexed clanId, uint32 indexed clansmanId, uint32 indexed banditId);
     event BlueprintAwarded(uint32 indexed clanId, uint32 indexed banditId, uint256 amount);
-    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint64 tick);
+    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint256 amount, uint64 tick);
     event LootDistributed(
         uint32 indexed banditId,
         uint32[] clanIdsRewarded,

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -44,7 +44,7 @@ contract BanditTest is Test {
 
     function _spawnCampAndAttack(uint32 targetClanId) internal returns (uint32 id) {
         id = _spawnAndCamp();
-        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS - 1);
         world.transitionBanditToAttacking(id, targetClanId);
     }
 
@@ -103,7 +103,7 @@ contract BanditTest is Test {
 
     function test_campedToAttackingTransitionSucceedsWithTargetAfterCampDuration() public {
         uint32 id = _spawnAndCamp();
-        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS - 1);
 
         world.transitionBanditToAttacking(id, 77);
 
@@ -132,7 +132,7 @@ contract BanditTest is Test {
         uint32 id3 = world.spawnBandit(ClanWorldConstants.REGION_WEST_FARMS, 300);
 
         _advanceTicks(2);
-        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS - 1);
         world.transitionBanditToAttacking(id1, 77);
         world.transitionBandit(id1, BanditState.Defeated);
 
@@ -167,7 +167,7 @@ contract BanditTest is Test {
         world.transitionBandit(id, BanditState.Defeated);
 
         _advanceTicks(2);
-        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS - 1);
 
         vm.expectRevert("ClanWorld: invalid bandit transition");
         world.transitionBandit(id, BanditState.Attacking);
@@ -191,7 +191,7 @@ contract BanditTest is Test {
         assertEq(mountainBandits[0], id3, "mountain bandit");
 
         _advanceTicks(2);
-        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS - 1);
         world.transitionBanditToAttacking(id1, 77);
         world.transitionBandit(id1, BanditState.Defeated);
 

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -12,6 +12,7 @@ import {
     ActionType,
     StatusCode,
     Clan,
+    ClanFullView,
     Mission,
     ClanOrder,
     OrderResult
@@ -32,14 +33,27 @@ contract BanditAttackHarness is ClanWorld {
         _clans[clanId].starvationStartsAtTick = tick;
     }
 
-    function setClanUpkeepState(uint32 clanId, uint64 lastSettledTick, uint256 vaultWheat, uint256 vaultFish)
-        external
-    {
+    function setClanUpkeepState(uint32 clanId, uint64 lastSettledTick, uint256 vaultWheat, uint256 vaultFish) external {
         Clan storage clan = _clans[clanId];
         clan.lastSettledTick = lastSettledTick;
         clan.vaultWheat = vaultWheat;
         clan.vaultFish = vaultFish;
         clan.starvationStartsAtTick = 0;
+    }
+
+    function setLivingClansmenForTest(uint32 clanId, uint8 livingClansmen) external {
+        _clans[clanId].livingClansmen = livingClansmen;
+    }
+
+    function blockBanditSpawnsForTest() external {
+        uint64 currentTick = this.getWorldState().currentTick;
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            _banditSpawnByRegion[region].lastSpawnTick = currentTick;
+        }
+    }
+
+    function blueprintUnit() external pure returns (uint256) {
+        return BLUEPRINT_UNIT;
     }
 
     function setBanditStrength(uint32 banditId, uint32 strength) external {
@@ -79,7 +93,7 @@ contract BanditAttackResolutionTest is Test {
         uint64 atTick
     );
     event BanditDefeated(uint32 indexed banditId, uint32 indexed targetClanId, uint64 atTick);
-    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint64 tick);
+    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint256 amount, uint64 tick);
     event BanditTargetDied(uint32 indexed banditId, uint32 indexed deadClanId, uint64 tick);
     event LootDistributed(
         uint32 indexed banditId,
@@ -182,14 +196,33 @@ contract BanditAttackResolutionTest is Test {
         bytes32 expectedClanTopic = bytes32(uint256(expectedDeadClanId));
         for (uint256 i = 0; i < logs.length; i++) {
             if (
-                logs[i].topics.length == 3 && logs[i].topics[0] == eventSig
-                    && logs[i].topics[1] == expectedBanditTopic && logs[i].topics[2] == expectedClanTopic
+                logs[i].topics.length == 3 && logs[i].topics[0] == eventSig && logs[i].topics[1] == expectedBanditTopic
+                    && logs[i].topics[2] == expectedClanTopic
             ) {
                 uint64 tick = abi.decode(logs[i].data, (uint64));
                 if (tick == expectedTick) return;
             }
         }
         fail("expected BanditTargetDied log");
+    }
+
+    function _assertBanditAttackResolvedLog(Vm.Log[] memory logs, uint32 expectedBanditId, uint32 expectedTargetClanId)
+        internal
+    {
+        bytes32 eventSig = keccak256(
+            "BanditAttackResolved(uint32,uint32,bool,uint16,uint16,uint16,uint256,uint256,uint256,uint256,uint64)"
+        );
+        bytes32 expectedBanditTopic = bytes32(uint256(expectedBanditId));
+        bytes32 expectedClanTopic = bytes32(uint256(expectedTargetClanId));
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (
+                logs[i].topics.length == 3 && logs[i].topics[0] == eventSig && logs[i].topics[1] == expectedBanditTopic
+                    && logs[i].topics[2] == expectedClanTopic
+            ) {
+                return;
+            }
+        }
+        fail("expected BanditAttackResolved log");
     }
 
     function _activateTargetDefenders(uint32 targetClanId, uint32[] memory defenderClanIds, uint256 countEach)
@@ -254,15 +287,55 @@ contract BanditAttackResolutionTest is Test {
         world.setBanditStrength(banditId, 0);
 
         vm.expectEmit(true, true, false, true, address(world));
-        emit BlueprintEarned(clanId, banditId, world.getWorldState().currentTick);
+        emit BlueprintEarned(clanId, banditId, world.blueprintUnit(), world.getWorldState().currentTick);
 
         _advanceTick();
 
-        assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore + 1, "target blueprint awarded");
+        assertEq(
+            world.getClan(clanId).blueprintBalance, blueprintBefore + world.blueprintUnit(), "target blueprint awarded"
+        );
+    }
+
+    function test_e2e_banditLifecycle_throughHeartbeat() public {
+        uint32 clanId = _mintClan();
+
+        uint32 banditId;
+        for (uint256 i = 0; i < 64; i++) {
+            vm.prevrandao(keccak256(abi.encodePacked("bandit-lifecycle", i)));
+            _advanceTick();
+            banditId = world.getWorldState().activeBanditId;
+            if (banditId != 0) break;
+        }
+        assertGt(banditId, 0, "bandit spawned through heartbeat");
+
+        _advanceTick();
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "spawned to camped");
+
+        uint64 campedAt = world.getBandit(banditId).tickEnteredState;
+        while (world.getWorldState().currentTick < campedAt + ClanWorldConstants.BANDIT_CAMP_TICKS) {
+            _advanceTick();
+        }
+
+        vm.recordLogs();
+        _advanceTick();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        _assertBanditAttackResolvedLog(logs, banditId, clanId);
+
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "attack resolved to escaped");
+
+        for (uint64 i = 0; i < ClanWorldConstants.BANDIT_REST_TICKS; i++) {
+            _advanceTick();
+        }
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "escaped recovered to resting");
     }
 
     function test_deadTargetCleanupReleasesDefendersAndEscapesBandit() public {
+        uint64 winterStart = world.getWorldState().winterStartsAtTick;
+        _advanceUntil(winterStart + 4);
+
         uint32[] memory clanIds = _mintClans(3);
+        world.blockBanditSpawnsForTest();
+
         uint32 defenderClanId = clanIds[0];
         uint32 targetClanId = clanIds[1];
         uint32 unaffectedClanId = clanIds[2];
@@ -277,8 +350,6 @@ contract BanditAttackResolutionTest is Test {
         assertEq(uint8(defenderStateBefore), uint8(ClansmanState.ACTING), "defender active before target death");
         assertEq(world.getActiveDefenders(targetClanId).length, 1, "target has active defender");
 
-        uint64 winterStart = world.getWorldState().winterStartsAtTick;
-        _advanceUntil(winterStart + 4);
         uint64 deathFromTick = winterStart;
         world.setClanUpkeepState(targetClanId, deathFromTick, 0, 0);
 
@@ -359,7 +430,11 @@ contract BanditAttackResolutionTest is Test {
 
         _advanceTick();
 
-        assertEq(world.getClan(clanIds[0]).blueprintBalance, blueprintBefore[0] + 1, "base owner blueprint");
+        assertEq(
+            world.getClan(clanIds[0]).blueprintBalance,
+            blueprintBefore[0] + world.blueprintUnit(),
+            "base owner blueprint"
+        );
         for (uint256 i = 1; i < clanIds.length; i++) {
             assertEq(world.getClan(clanIds[i]).blueprintBalance, blueprintBefore[i], "helper clan no blueprint");
         }
@@ -379,7 +454,47 @@ contract BanditAttackResolutionTest is Test {
 
         _advanceTick();
 
-        assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore + 2, "one blueprint per defeated bandit");
+        assertEq(
+            world.getClan(clanId).blueprintBalance,
+            blueprintBefore + 2 * world.blueprintUnit(),
+            "one blueprint per defeated bandit"
+        );
+    }
+
+    function test_winterStarvationReplayUsesHistoricalWinterTicks() public {
+        uint64 winterStart = world.getWorldState().winterStartsAtTick;
+        _advanceUntil(winterStart + 30);
+        assertFalse(world.getWorldState().winterActive, "test settles after winter");
+
+        uint32 clanId = _mintClan();
+        world.setClanUpkeepState(clanId, winterStart, 0, 0);
+
+        ClanFullView memory preview = world.getClanFullView(clanId);
+        assertEq(uint8(preview.clan.clan.clanState), uint8(ClanState.DEAD), "derived view replays winter deaths");
+        assertEq(preview.clan.clan.livingClansmen, 0, "derived living count");
+
+        world.settleClan(clanId);
+
+        Clan memory settled = world.getClan(clanId);
+        assertEq(uint8(settled.clanState), uint8(ClanState.DEAD), "settlement replays winter deaths");
+        assertEq(settled.livingClansmen, 0, "settled living count");
+    }
+
+    function test_resolveBanditAttackReturnsWhenTargetDiesDuringSettlement() public {
+        uint64 winterStart = world.getWorldState().winterStartsAtTick;
+        _advanceUntil(winterStart + 1);
+
+        uint32 targetClanId = _mintClan();
+        world.setClanUpkeepState(targetClanId, winterStart, 0, 0);
+        world.setLivingClansmenForTest(targetClanId, 1);
+
+        uint32 banditId = _forceAttack(targetClanId, 100);
+
+        _advanceTick();
+
+        assertEq(uint8(world.getClan(targetClanId).clanState), uint8(ClanState.DEAD), "target starved");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped once");
+        assertEq(world.getBandit(banditId).targetClanId, 0, "bandit target cleared");
     }
 
     function test_defeatedBanditLootBurnsWholeTokenOverflowAcrossThreeDefendingClans() public {
@@ -533,8 +648,7 @@ contract BanditAttackResolutionTest is Test {
         world.setStarvationStartsAt(clanId, 1);
 
         uint32 banditId = _forceAttack(clanId, 100);
-        uint32 nonStarvingRoll =
-            world.defenseRoll(world.getWorldState().currentTickSeed, banditId, _csId(clanId, 0));
+        uint32 nonStarvingRoll = world.defenseRoll(world.getWorldState().currentTickSeed, banditId, _csId(clanId, 0));
         assertGt(nonStarvingRoll, 0, "test setup needs nonzero roll");
 
         _advanceTick();
@@ -564,7 +678,10 @@ contract BanditAttackResolutionTest is Test {
         assertEq(uint8(a.getBandit(2).state), uint8(b.getBandit(2).state), "second bandit state deterministic");
     }
 
-    function _setupTwoAttackWorld(BanditAttackHarness target) internal returns (uint32 firstClanId, uint32 secondClanId) {
+    function _setupTwoAttackWorld(BanditAttackHarness target)
+        internal
+        returns (uint32 firstClanId, uint32 secondClanId)
+    {
         vm.prank(elder);
         (firstClanId,) = target.mintClan(elder);
         vm.prank(elder);

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -48,6 +48,10 @@ contract ClanWorldTestHarness is ClanWorld {
     function killClansman(uint32 csId) external {
         _clansmen[csId].state = ClansmanState.DEAD;
     }
+
+    function setLastSettledTickForTest(uint32 clanId, uint64 lastSettledTick) external {
+        _clans[clanId].lastSettledTick = lastSettledTick;
+    }
 }
 
 contract ClanWorldTest is Test {
@@ -68,7 +72,7 @@ contract ClanWorldTest is Test {
     StubPool fishPool;
 
     function setUp() public {
-        world = new ClanWorld();
+        world = new ClanWorldTestHarness();
     }
 
     /// @dev Deploy tokens + pools, call initTreasury + seedPools. Returns wood token address.
@@ -579,17 +583,14 @@ contract ClanWorldTest is Test {
     // -------------------------------------------------------------------------
 
     function test_submitClanOrders_reverts_when_clan_too_far_behind() public {
+        while (world.getWorldState().currentTick <= 200) {
+            _advanceTick();
+        }
+
         uint32 clanId = _mintClan();
         ClanFullView memory view_ = world.getClanFullView(clanId);
         uint32 csId = view_.clansmen[0].clansman.clansman.clansmanId;
-
-        // Advance until the clan is truly >200 ticks behind. Phase 9 bandit
-        // eager-settle may settle candidate-region bases on spawn ticks, so
-        // this test follows the invariant instead of assuming no heartbeat
-        // settlement ever touches the clan.
-        while (world.getWorldState().currentTick <= world.getClan(clanId).lastSettledTick + 200) {
-            _advanceTick();
-        }
+        ClanWorldTestHarness(address(world)).setLastSettledTickForTest(clanId, 0);
 
         // submitClanOrders should return ERR_INVALID_ACTION (ERR_MUST_SETTLE_FIRST proxy)
         // without reverting, for every order in the batch
@@ -1904,7 +1905,11 @@ contract ClanWorldTest is Test {
         // Call settleClansman on-demand — must be idempotent (no crash, no double-credit).
         uint256 ironBefore = world.getClansman(csId).carryIron;
         world.settleClansman(csId);
-        assertEq(world.getClansman(csId).carryIron, ironBefore, "onDemand: settleClansman is idempotent after heartbeat settle");
+        assertEq(
+            world.getClansman(csId).carryIron,
+            ironBefore,
+            "onDemand: settleClansman is idempotent after heartbeat settle"
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -2011,8 +2016,7 @@ contract ClanWorldTest is Test {
         assertEq(ws.seasonStartTick, 0);
         assertEq(ws.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS);
         assertEq(
-            ws.winterStartsAtTick,
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS
+            ws.winterStartsAtTick, ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS
         );
         assertFalse(ws.winterActive);
     }
@@ -2021,8 +2025,7 @@ contract ClanWorldTest is Test {
         // winterStartsAtTick = 100; WinterStarted fires on the heartbeat that opens tick 100
         // i.e. when closedTick=99, newTick=100 >= winterStartsAtTick=100.
         // Advance 99 heartbeats so currentTick=99, then one more heartbeat fires WinterStarted at tick 100.
-        uint64 winterStart =
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
+        uint64 winterStart = ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
         for (uint64 i = 0; i < winterStart - 1; i++) {
             vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
             world.heartbeat();

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -4,57 +4,19 @@ import {
   createWalletClient,
   http,
   type Account,
+  type Abi,
   type PublicClient,
   type WalletClient,
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
+import IClanWorldArtifact from '../../contracts/abi/IClanWorld.json';
 import { baseSepolia } from '@clan-world/shared/adapters';
 import {
   HeartbeatRateLimitedError,
   type IHeartbeatCaller,
 } from '@clan-world/agents/seams';
 
-/**
- * Minimal ABI: only the `heartbeat()` write and the `nextHeartbeatAtTs` field
- * we read out of `getWorldState()`. We avoid pulling in the full IClanWorld
- * ABI here so the runner stays decoupled from contract-package versioning.
- */
-const HEARTBEAT_ABI = [
-  {
-    type: 'function',
-    name: 'heartbeat',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'getWorldState',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        components: [
-          { name: 'currentTick', type: 'uint64' },
-          { name: 'seasonStartTick', type: 'uint64' },
-          { name: 'seasonEndTick', type: 'uint64' },
-          { name: 'seasonFinalized', type: 'bool' },
-          { name: 'nextHeartbeatAtTs', type: 'uint64' },
-          { name: 'nextBanditSpawnEligibleTick', type: 'uint64' },
-          { name: 'currentBanditSpawnChanceBps', type: 'uint16' },
-          { name: 'currentTickSeed', type: 'bytes32' },
-          { name: 'activeBanditId', type: 'uint32' },
-          { name: 'winterActive', type: 'bool' },
-          { name: 'winterStartsAtTick', type: 'uint64' },
-          { name: 'winterEndsAtTick', type: 'uint64' },
-          { name: 'nextCommitSequence', type: 'uint64' },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-] as const;
+export const HEARTBEAT_ABI = IClanWorldArtifact.abi as Abi;
 
 export interface RunnerHeartbeatConfig {
   /** Hex-encoded 64-char private key, optionally 0x-prefixed. */

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,12 +11,14 @@
   },
   "scripts": {
     "build": "tsc -b",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'lint stub'",
     "clean": "rm -rf dist .turbo"
   },
   "devDependencies": {
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^3.2.0"
   },
   "dependencies": {
     "convex": "1.17.4",

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
 import { createPublicClient, createWalletClient, http, fallback, defineChain } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
+import IClanWorldArtifact from '../../../contracts/abi/IClanWorld.json';
 import type { ClanFullView, ClanOrder, Tick } from '../types';
+import type { Abi } from 'viem';
 import { readEnv } from './_env';
 
 export interface IChainClient {
@@ -21,221 +23,7 @@ export const baseSepolia = defineChain({
   },
 });
 
-// Minimal ABI — only the two read functions we call.
-const CLAN_WORLD_ABI = [
-  {
-    type: 'function',
-    name: 'getWorldSnapshot',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        components: [
-          { name: 'currentTick', type: 'uint64' },
-          { name: 'seasonStartTick', type: 'uint64' },
-          { name: 'seasonEndTick', type: 'uint64' },
-          { name: 'seasonFinalized', type: 'bool' },
-          { name: 'winterActive', type: 'bool' },
-          { name: 'winterStartsAtTick', type: 'uint64' },
-          { name: 'winterEndsAtTick', type: 'uint64' },
-          { name: 'activeBanditId', type: 'uint32' },
-          { name: 'currentTickSeed', type: 'bytes32' },
-          {
-            name: 'leaderboard',
-            type: 'tuple[]',
-            components: [
-              { name: 'clanId', type: 'uint32' },
-              { name: 'owner', type: 'address' },
-              { name: 'monumentLevel', type: 'uint8' },
-              { name: 'baseLevel', type: 'uint8' },
-              { name: 'wallLevel', type: 'uint8' },
-              { name: 'livingClansmen', type: 'uint8' },
-              { name: 'state', type: 'uint8' },
-              { name: 'lootValue', type: 'uint256' },
-            ],
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getClanFullView',
-    inputs: [{ name: '', type: 'uint32' }],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        components: [
-          {
-            name: 'clan',
-            type: 'tuple',
-            components: [
-              {
-                name: 'clan',
-                type: 'tuple',
-                components: [
-                  { name: 'clanId', type: 'uint32' },
-                  { name: 'iftTokenId', type: 'uint256' },
-                  { name: 'owner', type: 'address' },
-                  { name: 'clanState', type: 'uint8' },
-                  { name: 'baseRegion', type: 'uint8' },
-                  { name: 'baseLevel', type: 'uint8' },
-                  { name: 'wallLevel', type: 'uint8' },
-                  { name: 'monumentLevel', type: 'uint8' },
-                  { name: 'livingClansmen', type: 'uint8' },
-                  { name: 'lastSettledTick', type: 'uint64' },
-                  { name: 'starvationStartsAtTick', type: 'uint64' },
-                  { name: 'coldDamage', type: 'uint16' },
-                  { name: 'goldBalance', type: 'uint256' },
-                  { name: 'blueprintBalance', type: 'uint256' },
-                  { name: 'vaultWood', type: 'uint256' },
-                  { name: 'vaultIron', type: 'uint256' },
-                  { name: 'vaultWheat', type: 'uint256' },
-                  { name: 'vaultFish', type: 'uint256' },
-                ],
-              },
-              { name: 'isStarving', type: 'bool' },
-              { name: 'lootValue', type: 'uint256' },
-              { name: 'derivedAtTick', type: 'uint64' },
-            ],
-          },
-          // clansmen, westPlot, eastPlot etc. omitted — not needed for Wave 0 mapping
-          {
-            name: 'clansmen',
-            type: 'tuple[]',
-            components: [
-              {
-                name: 'clansman',
-                type: 'tuple',
-                components: [
-                  {
-                    name: 'clansman',
-                    type: 'tuple',
-                    components: [
-                      { name: 'clansmanId', type: 'uint32' },
-                      { name: 'clanId', type: 'uint32' },
-                      { name: 'state', type: 'uint8' },
-                      { name: 'currentRegion', type: 'uint8' },
-                      { name: 'cooldownEndsAtTs', type: 'uint64' },
-                      { name: 'lastMissionNonce', type: 'uint64' },
-                      { name: 'carryWood', type: 'uint256' },
-                      { name: 'carryIron', type: 'uint256' },
-                      { name: 'carryWheat', type: 'uint256' },
-                      { name: 'carryFish', type: 'uint256' },
-                    ],
-                  },
-                  {
-                    name: 'activeMission',
-                    type: 'tuple',
-                    components: [
-                      { name: 'active', type: 'bool' },
-                      { name: 'nonce', type: 'uint64' },
-                      { name: 'clansmanId', type: 'uint32' },
-                      { name: 'startRegion', type: 'uint8' },
-                      { name: 'targetRegion', type: 'uint8' },
-                      { name: 'action', type: 'uint8' },
-                      { name: 'startTick', type: 'uint64' },
-                      { name: 'arrivalTick', type: 'uint64' },
-                      { name: 'actionStartTick', type: 'uint64' },
-                      { name: 'missionSeed', type: 'bytes32' },
-                      { name: 'marketMode', type: 'uint8' },
-                      { name: 'targetClanId', type: 'uint32' },
-                      { name: 'marketToken', type: 'address' },
-                      { name: 'marketAmount', type: 'uint256' },
-                      { name: 'maxGoldIn', type: 'uint256' },
-                    ],
-                  },
-                  { name: 'effectiveRegion', type: 'uint8' },
-                  { name: 'derivedAtTick', type: 'uint64' },
-                ],
-              },
-              {
-                name: 'activeMission',
-                type: 'tuple',
-                components: [
-                  { name: 'active', type: 'bool' },
-                  { name: 'nonce', type: 'uint64' },
-                  { name: 'clansmanId', type: 'uint32' },
-                  { name: 'startRegion', type: 'uint8' },
-                  { name: 'targetRegion', type: 'uint8' },
-                  { name: 'action', type: 'uint8' },
-                  { name: 'startTick', type: 'uint64' },
-                  { name: 'arrivalTick', type: 'uint64' },
-                  { name: 'actionStartTick', type: 'uint64' },
-                  { name: 'missionSeed', type: 'bytes32' },
-                  { name: 'marketMode', type: 'uint8' },
-                  { name: 'targetClanId', type: 'uint32' },
-                  { name: 'marketToken', type: 'address' },
-                  { name: 'marketAmount', type: 'uint256' },
-                  { name: 'maxGoldIn', type: 'uint256' },
-                ],
-              },
-            ],
-          },
-          {
-            name: 'westPlot',
-            type: 'tuple',
-            components: [
-              { name: 'state', type: 'uint8' },
-              { name: 'region', type: 'uint8' },
-              { name: 'remainingWheat', type: 'uint256' },
-              { name: 'regrowUntilTick', type: 'uint64' },
-            ],
-          },
-          {
-            name: 'eastPlot',
-            type: 'tuple',
-            components: [
-              { name: 'state', type: 'uint8' },
-              { name: 'region', type: 'uint8' },
-              { name: 'remainingWheat', type: 'uint256' },
-              { name: 'regrowUntilTick', type: 'uint64' },
-            ],
-          },
-          { name: 'incomingDefenderIds', type: 'uint32[]' },
-          { name: 'thisClanDefendingBaseId', type: 'uint32' },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    name: 'submitClanOrders',
-    type: 'function',
-    inputs: [
-      { name: 'clanId', type: 'uint32' },
-      {
-        name: 'orders',
-        type: 'tuple[]',
-        components: [
-          { name: 'clansmanId', type: 'uint32' },
-          { name: 'gotoRegion', type: 'uint8' },
-          { name: 'action', type: 'uint8' },
-          { name: 'targetClanId', type: 'uint32' },
-          { name: 'marketToken', type: 'address' },
-          { name: 'marketAmount', type: 'uint256' },
-          { name: 'maxGoldIn', type: 'uint256' },
-        ],
-      },
-    ],
-    outputs: [
-      {
-        name: 'results',
-        type: 'tuple[]',
-        components: [
-          { name: 'clansmanId', type: 'uint32' },
-          { name: 'status', type: 'uint8' },
-          { name: 'cooldownEndsAtTs', type: 'uint64' },
-          { name: 'missionNonce', type: 'uint64' },
-        ],
-      },
-    ],
-    stateMutability: 'nonpayable',
-  },
-] as const;
+export const CLAN_WORLD_ABI = IClanWorldArtifact.abi as Abi;
 
 class StubChainClient implements IChainClient {
   async getCurrentTick(): Promise<Tick> {
@@ -282,7 +70,7 @@ class RealChainClient implements IChainClient {
       address: this.contractAddress,
       abi: CLAN_WORLD_ABI,
       functionName: 'getWorldSnapshot',
-    });
+    }) as { currentTick: bigint };
     return Number(snapshot.currentTick); // safe: tick values are small enough to fit Number precisely in Wave 0
   }
 
@@ -380,7 +168,14 @@ class RealChainClient implements IChainClient {
       abi: CLAN_WORLD_ABI,
       functionName: 'getClanFullView',
       args: [parseInt(clanId, 10)],
-    });
+    }) as {
+      clan: {
+        clan: {
+          clanId: number;
+          goldBalance: bigint;
+        };
+      };
+    };
 
     const inner = result.clan.clan;
     return {

--- a/packages/shared/test/clanWorldAbi.test.ts
+++ b/packages/shared/test/clanWorldAbi.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { decodeFunctionResult, encodeAbiParameters } from 'viem';
+import { CLAN_WORLD_ABI } from '../src/adapters/IChainClient';
+
+const ZERO_BYTES32 = `0x${'00'.repeat(32)}` as `0x${string}`;
+
+const worldStateTuple = [
+  {
+    type: 'tuple',
+    components: [
+      { name: 'currentTick', type: 'uint64' },
+      { name: 'seasonStartTick', type: 'uint64' },
+      { name: 'seasonEndTick', type: 'uint64' },
+      { name: 'seasonFinalized', type: 'bool' },
+      { name: 'currentSeasonNumber', type: 'uint64' },
+      { name: 'nextHeartbeatAtTick', type: 'uint64' },
+      { name: 'nextHeartbeatAtTs', type: 'uint64' },
+      { name: 'nextBanditSpawnEligibleTick', type: 'uint64' },
+      { name: 'currentBanditSpawnChanceBps', type: 'uint16' },
+      { name: 'currentTickSeed', type: 'bytes32' },
+      { name: 'activeBanditId', type: 'uint32' },
+      { name: 'winterActive', type: 'bool' },
+      { name: 'winterStartsAtTick', type: 'uint64' },
+      { name: 'winterEndsAtTick', type: 'uint64' },
+      { name: 'nextCommitSequence', type: 'uint64' },
+    ],
+  },
+] as const;
+
+const worldSnapshotTuple = [
+  {
+    type: 'tuple',
+    components: [
+      { name: 'currentTick', type: 'uint64' },
+      { name: 'seasonStartTick', type: 'uint64' },
+      { name: 'seasonEndTick', type: 'uint64' },
+      { name: 'seasonFinalized', type: 'bool' },
+      { name: 'currentSeasonNumber', type: 'uint64' },
+      { name: 'nextHeartbeatAtTick', type: 'uint64' },
+      { name: 'winterActive', type: 'bool' },
+      { name: 'winterStartsAtTick', type: 'uint64' },
+      { name: 'winterEndsAtTick', type: 'uint64' },
+      { name: 'activeBanditId', type: 'uint32' },
+      { name: 'currentTickSeed', type: 'bytes32' },
+      {
+        name: 'leaderboard',
+        type: 'tuple[]',
+        components: [
+          { name: 'clanId', type: 'uint32' },
+          { name: 'owner', type: 'address' },
+          { name: 'monumentLevel', type: 'uint8' },
+          { name: 'baseLevel', type: 'uint8' },
+          { name: 'wallLevel', type: 'uint8' },
+          { name: 'livingClansmen', type: 'uint8' },
+          { name: 'state', type: 'uint8' },
+          { name: 'lootValue', type: 'uint256' },
+        ],
+      },
+    ],
+  },
+] as const;
+
+describe('ClanWorld generated ABI tuple decoding', () => {
+  it('decodes a known-good getWorldState() result with the current Solidity order', () => {
+    const data = encodeAbiParameters(worldStateTuple, [
+      {
+        currentTick: 11n,
+        seasonStartTick: 1n,
+        seasonEndTick: 360n,
+        seasonFinalized: false,
+        currentSeasonNumber: 7n,
+        nextHeartbeatAtTick: 12n,
+        nextHeartbeatAtTs: 1_900_000_001n,
+        nextBanditSpawnEligibleTick: 21n,
+        currentBanditSpawnChanceBps: 3000,
+        currentTickSeed: ZERO_BYTES32,
+        activeBanditId: 42,
+        winterActive: true,
+        winterStartsAtTick: 100n,
+        winterEndsAtTick: 110n,
+        nextCommitSequence: 9n,
+      },
+    ]);
+
+    const state = decodeFunctionResult({
+      abi: CLAN_WORLD_ABI,
+      functionName: 'getWorldState',
+      data,
+    }) as Record<string, unknown>;
+
+    expect(state.currentSeasonNumber).toBe(7n);
+    expect(state.nextHeartbeatAtTick).toBe(12n);
+    expect(state.nextHeartbeatAtTs).toBe(1_900_000_001n);
+    expect(state.winterActive).toBe(true);
+  });
+
+  it('decodes a known-good getWorldSnapshot() result with season fields before winter fields', () => {
+    const data = encodeAbiParameters(worldSnapshotTuple, [
+      {
+        currentTick: 33n,
+        seasonStartTick: 0n,
+        seasonEndTick: 360n,
+        seasonFinalized: false,
+        currentSeasonNumber: 2n,
+        nextHeartbeatAtTick: 34n,
+        winterActive: true,
+        winterStartsAtTick: 100n,
+        winterEndsAtTick: 110n,
+        activeBanditId: 3,
+        currentTickSeed: ZERO_BYTES32,
+        leaderboard: [],
+      },
+    ]);
+
+    const snapshot = decodeFunctionResult({
+      abi: CLAN_WORLD_ABI,
+      functionName: 'getWorldSnapshot',
+      data,
+    }) as Record<string, unknown>;
+
+    expect(snapshot.currentSeasonNumber).toBe(2n);
+    expect(snapshot.nextHeartbeatAtTick).toBe(34n);
+    expect(snapshot.winterActive).toBe(true);
+    expect(snapshot.activeBanditId).toBe(3);
+  });
+});

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.4(@types/node@25.6.0)(lightningcss@1.32.0)
 
 packages:
 


### PR DESCRIPTION
Addresses all 5 HIGH findings from /phase-super-swarm on PR #194. See docs/reviews/pr194-synthesis.md.

Fixes included:
- H1: live heartbeat now advances Camped -> Attacking with deterministic target selection, resolves attacks, and recovers Escaped -> Resting.
- H2: runner/shared TS clients now consume the generated IClanWorld ABI; shared has decode coverage for getWorldState() and getWorldSnapshot().
- H3: starvation replay derives winter status from each historical tick in mutating and simulated settlement.
- H4: defeated bandits award BLUEPRINT_UNIT (1e18), and BlueprintEarned emits the amount.
- H5: bandit attack resolution re-checks target/bandit state after settlement before continuing.

Tests green:
- packages/contracts: forge build && forge test: 133/133 passed.
- packages/runner: pnpm test: 121 passed, 1 skipped.
- packages/shared: pnpm test: 2/2 passed.
- packages/runner: pnpm typecheck: passed.
- packages/shared: pnpm typecheck: passed.

<signed:codex>
