### PR TITLE
feat(contracts): Phase 6B — carry-based market trades + 3 companion fixes (Closes #271 #272 #273 #274)

### DIFF
--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -5,7 +5,7 @@ import {Script, console} from "forge-std/Script.sol";
 import {MinimalERC20} from "../src/MinimalERC20.sol";
 import {StubPool} from "../src/StubPool.sol";
 import {ClanWorld} from "../src/ClanWorld.sol";
-import {PoolSeedConfig, ResourceType} from "../src/IClanWorld.sol";
+import {PoolSeedConfig} from "../src/IClanWorld.sol";
 
 contract Deploy is Script {
     function run() external {
@@ -32,11 +32,6 @@ contract Deploy is Script {
         // 2. Deploy ClanWorld first (needed as engine arg for pools).
         ClanWorld game = new ClanWorld();
         console.log("CLAN_WORLD_CONTRACT_ADDRESS:", address(game));
-
-        wood.configureBoundary(uint8(ResourceType.Wood), address(game));
-        iron.configureBoundary(uint8(ResourceType.Iron), address(game));
-        wheat.configureBoundary(uint8(ResourceType.Wheat), address(game));
-        fish.configureBoundary(uint8(ResourceType.Fish), address(game));
 
         // 3. Deploy 4 AMM pools (Phase 6.2: constant-product pools).
         StubPool woodGold = new StubPool(address(wood), address(gold), address(game));

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1174,7 +1174,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         // Cooldown check. Market orders may still fall back to the scheduled path;
         // only the immediate path requires the worker to be off cooldown.
-        if (!isMarketAction && block.timestamp < cs.cooldownEndsAtTs) {
+        if (block.timestamp < cs.cooldownEndsAtTs) {
             result.status = StatusCode.ERR_COOLDOWN_ACTIVE;
             result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
             result.missionNonce = cs.lastMissionNonce;
@@ -1457,14 +1457,23 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     function _sortScheduledMarketActionsByCommitSequence(ScheduledMarketAction[] storage actions) internal {
-        for (uint256 i = 1; i < actions.length; i++) {
-            ScheduledMarketAction memory key = actions[i];
+        uint256 len = actions.length;
+        if (len <= 1) return;
+        ScheduledMarketAction[] memory arr = new ScheduledMarketAction[](len);
+        for (uint256 i = 0; i < len; i++) {
+            arr[i] = actions[i];
+        }
+        for (uint256 i = 1; i < len; i++) {
+            ScheduledMarketAction memory key = arr[i];
             uint256 j = i;
-            while (j > 0 && actions[j - 1].commitSequence > key.commitSequence) {
-                actions[j] = actions[j - 1];
+            while (j > 0 && arr[j - 1].commitSequence > key.commitSequence) {
+                arr[j] = arr[j - 1];
                 j--;
             }
-            actions[j] = key;
+            arr[j] = key;
+        }
+        for (uint256 i = 0; i < len; i++) {
+            actions[i] = arr[i];
         }
     }
 
@@ -1568,6 +1577,45 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return false;
     }
 
+    function _hasCarryBalance(Clansman storage cs, address token, uint256 amount) internal view returns (bool) {
+        if (token == _treasury.woodToken) return cs.carryWood >= amount;
+        if (token == _treasury.ironToken) return cs.carryIron >= amount;
+        if (token == _treasury.wheatToken) return cs.carryWheat >= amount;
+        if (token == _treasury.fishToken) return cs.carryFish >= amount;
+        return false;
+    }
+
+    function _deductFromCarry(Clansman storage cs, address token, uint256 amount) internal returns (bool) {
+        if (token == _treasury.woodToken) {
+            if (cs.carryWood < amount) return false;
+            cs.carryWood -= amount;
+            return true;
+        }
+        if (token == _treasury.ironToken) {
+            if (cs.carryIron < amount) return false;
+            cs.carryIron -= amount;
+            return true;
+        }
+        if (token == _treasury.wheatToken) {
+            if (cs.carryWheat < amount) return false;
+            cs.carryWheat -= amount;
+            return true;
+        }
+        if (token == _treasury.fishToken) {
+            if (cs.carryFish < amount) return false;
+            cs.carryFish -= amount;
+            return true;
+        }
+        return false;
+    }
+
+    function _addToCarry(Clansman storage cs, address token, uint256 amount) internal {
+        if (token == _treasury.woodToken) { cs.carryWood += amount; return; }
+        if (token == _treasury.ironToken) { cs.carryIron += amount; return; }
+        if (token == _treasury.wheatToken) { cs.carryWheat += amount; return; }
+        if (token == _treasury.fishToken) { cs.carryFish += amount; return; }
+    }
+
     /// @dev Check a clan vault balance without mutating storage.
     function _hasVaultBalance(Clan storage clan, address token, uint256 amount) internal view returns (bool) {
         if (token == _treasury.woodToken) return clan.vaultWood >= amount;
@@ -1654,7 +1702,20 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         Clan storage clan = _clans[clanId];
-        if (!_hasVaultBalance(clan, token, amount)) {
+        Clansman storage cs = _clansmen[clansmanId];
+        if (!_hasCarryBalance(cs, token, amount)) {
+            return _handleMarketFailure(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MISSING_RESOURCES,
+                _world.currentTick
+            );
+        }
+
+        // CEI: deduct carry before external call
+        if (!_deductFromCarry(cs, token, amount)) {
             return _handleMarketFailure(
                 clanId,
                 clansmanId,
@@ -1666,7 +1727,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         try StubPool(poolAddr).swapExactInForOut(amount, 1) returns (uint256 goldOut) {
-            _deductFromVault(clan, token, amount);
             clan.goldBalance += goldOut;
             emit ImmediateMarketActionExecuted(
                 clanId,
@@ -1680,6 +1740,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             );
             return StatusCode.OK;
         } catch {
+            _addToCarry(cs, token, amount); // restore carry on swap failure
             return _handleMarketFailure(
                 clanId,
                 clansmanId,
@@ -1770,7 +1831,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         try StubPool(poolAddr).swapExactOutForInWithMaxIn(amountOut, maxGoldIn) returns (uint256 actualGoldIn) {
             clan.goldBalance -= actualGoldIn;
-            _addToVault(clan, token, amountOut);
+            _addToCarry(cs, token, amountOut);
             emit ImmediateMarketActionExecuted(
                 clanId,
                 clansmanId,
@@ -1822,7 +1883,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         Clan storage clan = _clans[clanId];
-        if (!_deductFromVault(clan, token, amount)) {
+        Clansman storage cs = _clansmen[clansmanId];
+        if (!_deductFromCarry(cs, token, amount)) {
             return _handleMarketFailure(
                 clanId,
                 clansmanId,
@@ -1944,7 +2006,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         clan.goldBalance -= actualGoldIn;
-        _addToVault(clan, token, amountOut);
+        _addToCarry(cs, token, amountOut);
 
         emit ScheduledMarketActionExecuted(
             clanId,

--- a/packages/contracts/src/MinimalERC20.sol
+++ b/packages/contracts/src/MinimalERC20.sol
@@ -9,9 +9,6 @@ contract MinimalERC20 {
 
     uint256 public totalSupply;
     address public immutable DEPLOYER;
-    address public engine;
-    uint8 public resourceType;
-    bool public boundaryConfigured;
     bool public treasurySeeded;
 
     mapping(address => uint256) public balanceOf;
@@ -19,15 +16,11 @@ contract MinimalERC20 {
 
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner_, address indexed spender, uint256 value);
-    event BoundaryConfigured(uint8 indexed resourceType, address indexed engine);
-    event ResourceMinted(uint8 indexed resourceType, address indexed to, uint256 amount);
-    event ResourceBurned(uint8 indexed resourceType, address indexed from, uint256 amount);
 
     constructor(string memory name_, string memory symbol_) {
         name = name_;
         symbol = symbol_;
         DEPLOYER = msg.sender;
-        resourceType = type(uint8).max;
     }
 
     /// @dev Wrapped per forge-lint unwrapped-modifier-logic — keeps modifier
@@ -36,29 +29,9 @@ contract MinimalERC20 {
         require(msg.sender == DEPLOYER, "MinimalERC20: not deployer");
     }
 
-    function _onlyEngine() internal view {
-        require(boundaryConfigured && msg.sender == engine, "MinimalERC20: not engine");
-    }
-
     modifier onlyDeployer() {
         _onlyDeployer();
         _;
-    }
-
-    modifier onlyEngine() {
-        _onlyEngine();
-        _;
-    }
-
-    function configureBoundary(uint8 resourceType_, address engine_) external onlyDeployer {
-        require(!boundaryConfigured, "MinimalERC20: boundary configured");
-        require(engine_ != address(0), "MinimalERC20: zero engine");
-
-        resourceType = resourceType_;
-        engine = engine_;
-        boundaryConfigured = true;
-
-        emit BoundaryConfigured(resourceType_, engine_);
     }
 
     function seedTreasury(address treasury, uint256 amount) external onlyDeployer {
@@ -67,18 +40,6 @@ contract MinimalERC20 {
 
         treasurySeeded = true;
         _mint(treasury, amount);
-    }
-
-    function mint(address to, uint256 amount) external onlyEngine {
-        _mint(to, amount);
-        emit ResourceMinted(resourceType, to, amount);
-    }
-
-    function burn(address from, uint256 amount) external onlyEngine {
-        balanceOf[from] -= amount;
-        totalSupply -= amount;
-        emit Transfer(from, address(0), amount);
-        emit ResourceBurned(resourceType, from, amount);
     }
 
     function _mint(address to, uint256 amount) internal {

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -773,10 +773,12 @@ contract ClanWorldTest is Test {
     }
 
     function test_immediateMarketSell_executesInSubmitTx() public {
-        (, address woodAddr, uint32 clanId, uint32 csId) =
+        (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) =
             _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+        harness.setCarry(csId, 10e18, 0, 0, 0);
 
         Clan memory beforeClan = world.getClan(clanId);
+        Clansman memory beforeCs = world.getClansman(csId);
         uint256 expectedGoldOut = woodPool.getAmountOutForExactIn(5e18);
 
         vm.expectEmit(true, false, false, true);
@@ -797,7 +799,8 @@ contract ClanWorldTest is Test {
 
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "immediate sell should be accepted");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "sell should be immediate");
-        assertEq(afterClan.vaultWood, beforeClan.vaultWood - 5e18, "vault wood should be sold immediately");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "vault wood should be unchanged");
+        assertEq(cs.carryWood, beforeCs.carryWood - 5e18, "carry wood should be sold immediately");
         assertGt(afterClan.goldBalance, beforeClan.goldBalance, "gold should be credited immediately");
         assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "worker should remain waiting");
         assertEq(cs.currentRegion, ClanWorldConstants.REGION_UNICORN_TOWN, "worker should stay in town");
@@ -813,18 +816,11 @@ contract ClanWorldTest is Test {
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
-        Mission memory m = world.getActiveMission(csId);
 
-        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "market order should schedule while cooling down");
-        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "cooldown should force scheduled mode");
-        assertTrue(m.active, "scheduled fallback should install a mission");
-        assertEq(uint8(m.marketMode), uint8(MarketExecutionMode.Scheduled), "mission should be scheduled");
         assertEq(
-            world.getScheduledMarketActionsForTick(m.settlesAtTick).length,
-            0,
-            "scheduled action queues when mission settles"
+            uint8(r[0].status), uint8(StatusCode.ERR_COOLDOWN_ACTIVE), "market order on cooldown must be rejected"
         );
-        assertEq(world.getClan(clanId).goldBalance, goldBefore, "scheduled fallback should not trade immediately");
+        assertEq(world.getClan(clanId).goldBalance, goldBefore, "cooldown rejection should not trade");
     }
 
     function test_immediateMarket_notInTown_fallsBackToScheduled() public {
@@ -866,6 +862,7 @@ contract ClanWorldTest is Test {
             _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
 
         Clan memory beforeClan = world.getClan(clanId);
+        Clansman memory beforeCs = world.getClansman(csId);
         uint256 expectedGoldIn = woodPool.getAmountInForExactOut(1e18);
 
         vm.expectEmit(true, false, false, true);
@@ -882,9 +879,11 @@ contract ClanWorldTest is Test {
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 2e18);
 
         Clan memory afterClan = world.getClan(clanId);
+        Clansman memory afterCs = world.getClansman(csId);
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "immediate buy should be accepted");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "buy should be immediate");
-        assertGt(afterClan.vaultWood, beforeClan.vaultWood, "vault wood should increase immediately");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "vault wood should be unchanged");
+        assertGt(afterCs.carryWood, beforeCs.carryWood, "carry wood should increase immediately");
         assertLt(afterClan.goldBalance, beforeClan.goldBalance, "gold should be debited immediately");
         assertFalse(world.getActiveMission(csId).active, "immediate buy should not install a mission");
     }
@@ -1006,11 +1005,14 @@ contract ClanWorldTest is Test {
     // -------------------------------------------------------------------------
 
     function test_sell_creditsGold() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
+        // Give clansman carry wood so scheduled sell has something to sell
+        harness.setCarry(csId, 10e18, 0, 0, 0);
 
-        // Clan starts with 20 wood in vault (starter pack)
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 
         // Submit sell order — clansman travels to Unicorn Town then executes when the market mission settles
@@ -1063,6 +1065,7 @@ contract ClanWorldTest is Test {
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
         uint256 vaultWoodBefore = world.getClan(clanId).vaultWood;
+        uint256 carryWoodBefore = world.getClansman(csId).carryWood;
 
         // Submit buy order for 1e18 wood, maxGoldIn = generous 500e18
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 500e18);
@@ -1081,8 +1084,10 @@ contract ClanWorldTest is Test {
 
         uint256 goldAfter = world.getClan(clanId).goldBalance;
         uint256 vaultWoodAfter = world.getClan(clanId).vaultWood;
+        uint256 carryWoodAfter = world.getClansman(csId).carryWood;
         assertLt(goldAfter, goldBefore, "gold should decrease after buy");
-        assertGt(vaultWoodAfter, vaultWoodBefore, "vault wood should increase after buy");
+        assertEq(vaultWoodAfter, vaultWoodBefore, "vault wood should be unchanged after buy");
+        assertGt(carryWoodAfter, carryWoodBefore, "carry wood should increase after buy");
     }
 
     // -------------------------------------------------------------------------
@@ -1250,9 +1255,13 @@ contract ClanWorldTest is Test {
     }
 
     function test_scheduledMarket_sameTypeRetask_skipsStaleNonce() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
+        // Give carry wood so the replacement sell executes
+        harness.setCarry(csId, 10e18, 0, 0, 0);
 
         OrderResult[] memory r1 = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
         assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "first sell order should be accepted");
@@ -1289,6 +1298,8 @@ contract ClanWorldTest is Test {
     }
 
     function test_scheduledMarket_executesAllActionsForClosedTick() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
         uint32[] memory distOneClans = new uint32[](12);
         uint32[] memory distTwoClans = new uint32[](12);
@@ -1298,6 +1309,10 @@ contract ClanWorldTest is Test {
         for (uint256 i = 0; i < 12; i++) {
             uint32 clanId = _mintClan();
             ClanFullView memory view_ = world.getClanFullView(clanId);
+            // Give every clansman carry wood so their scheduled sell can execute
+            for (uint256 j = 0; j < view_.clansmen.length; j++) {
+                harness.setCarry(view_.clansmen[j].clansman.clansman.clansmanId, 10e18, 0, 0, 0);
+            }
             (uint8 travelTicks,) = world.quoteTravel(view_.clan.clan.baseRegion, ClanWorldConstants.REGION_UNICORN_TOWN);
             if (travelTicks == 1) {
                 distOneClans[distOneCount++] = clanId;
@@ -1348,9 +1363,15 @@ contract ClanWorldTest is Test {
     // -------------------------------------------------------------------------
 
     function test_scheduledMarket_fifo() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
         uint32 clanId = _mintClan();
         ClanFullView memory view_ = world.getClanFullView(clanId);
+        // Give each clansman carry wood (must be >= their respective sell amount)
+        for (uint256 i = 0; i < 3; i++) {
+            harness.setCarry(view_.clansmen[i].clansman.clansman.clansmanId, 10e18, 0, 0, 0);
+        }
 
         ClanOrder[] memory orders = new ClanOrder[](3);
         for (uint256 i = 0; i < orders.length; i++) {
@@ -1407,6 +1428,8 @@ contract ClanWorldTest is Test {
     // -------------------------------------------------------------------------
 
     function test_twoClan_sellBuyCycle() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
 
         uint32 clanId1 = _mintClan();
@@ -1415,6 +1438,8 @@ contract ClanWorldTest is Test {
 
         uint32 csId1 = _firstCs(clanId1);
         uint32 csId2 = world.getClanFullView(clanId2).clansmen[0].clansman.clansman.clansmanId;
+        // Give csId1 carry wood so scheduled sell has something to sell
+        harness.setCarry(csId1, 10e18, 0, 0, 0);
 
         // Clan 1: sell 5e18 wood
         ClanOrder[] memory sellOrders = new ClanOrder[](1);
@@ -1484,13 +1509,17 @@ contract ClanWorldTest is Test {
         assertTrue(sawClan2BuyEvent, "buy event should carry clan2 id");
         // Clan1 sold wood → gold should increase
         assertGt(world.getClan(clanId1).goldBalance, 3e18, "clan1 should have more gold after sell");
-        // Clan2 bought wood → vault wood should increase beyond starter 20e18
-        assertGt(world.getClan(clanId2).vaultWood, 20e18, "clan2 should have more vault wood after buy");
+        // Clan2 bought wood → carry wood should increase
+        assertGt(world.getClansman(csId2).carryWood, 0, "clan2 clansman should carry wood after buy");
+        // Clan2 vault is unchanged
+        assertEq(world.getClan(clanId2).vaultWood, 20e18, "clan2 vault wood should be unchanged after buy");
         // Clan2 spent gold
         assertLt(world.getClan(clanId2).goldBalance, 3e18, "clan2 should have less gold after buy");
     }
 
     function test_scheduledMarketFailure_doesNotAffectAnotherClan() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
 
         uint32 clanId1 = _mintClan();
@@ -1499,6 +1528,8 @@ contract ClanWorldTest is Test {
 
         uint32 csId1 = _firstCs(clanId1);
         uint32 csId2 = world.getClanFullView(clanId2).clansmen[0].clansman.clansman.clansmanId;
+        // Give csId2 carry wood so the sell succeeds
+        harness.setCarry(csId2, 10e18, 0, 0, 0);
 
         OrderResult[] memory buyFail = _submitMarketOrder(clanId1, csId1, ActionType.MarketBuy, woodAddr, 1e18, 0);
         assertEq(uint8(buyFail[0].status), uint8(StatusCode.OK), "failing buy should enqueue");
@@ -2460,5 +2491,122 @@ contract ClanWorldTest is Test {
         WorldState memory ws1 = world.getWorldState();
         assertEq(ws1.currentTick, 1);
         assertEq(ws1.nextHeartbeatAtTick, 2, "after tick 1, next = tick 2");
+    }
+
+    function test_marketSell_deductsFromCarry_notVault() public {
+        // Use harness to directly set carry and test immediate sell
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        _setupMarket();
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+
+        // Place worker at UT WAITING with carry wood
+        harness.setClansmanForTest(csId, ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+        harness.setCarry(csId, 10e18, 0, 0, 0);
+
+        uint256 carryBefore = world.getClansman(csId).carryWood;
+        uint256 vaultBefore = world.getClan(clanId).vaultWood;
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+
+        address woodTok = world.getTreasuryState().woodToken;
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketSell,
+            targetClanId: 0,
+            marketToken: woodTok,
+            marketAmount: 5e18,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "immediate sell must succeed");
+        assertEq(world.getClansman(csId).carryWood, carryBefore - 5e18, "sell: carry must decrease by sell amount");
+        assertEq(world.getClan(clanId).vaultWood, vaultBefore, "sell: vault must be unchanged");
+        assertGt(world.getClan(clanId).goldBalance, goldBefore, "sell: gold must increase");
+    }
+
+    function test_marketSell_fails_emptyCarry_fullVault() public {
+        // Setup: worker in UT with empty carry but vault has wood
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        // Advance cs to UT with no carry (no gather)
+        _submitOrder(clanId, csId, ClanWorldConstants.REGION_UNICORN_TOWN, ActionType.Wait);
+        (uint8 travelToUT,) = world.quoteTravel(v.clan.clan.baseRegion, ClanWorldConstants.REGION_UNICORN_TOWN);
+        for (uint256 i = 0; i < uint256(travelToUT) + 2; i++) _advanceTick();
+        world.settleClansman(csId);
+        // Clan starts with vault wood from minting; carry is 0
+        assertEq(world.getClansman(csId).carryWood, 0, "carry must be 0");
+        assertGt(world.getClan(clanId).vaultWood, 0, "vault must have wood");
+
+        address woodTok = world.getTreasuryState().woodToken;
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketSell,
+            targetClanId: 0,
+            marketToken: woodTok,
+            marketAmount: 1e18,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+        // Immediate path: carry empty → ERR_MISSING_RESOURCES or market failure
+        // Either the order returns ERR_MISSING_RESOURCES at submit, or it's enqueued and fails at execution
+        // With carry-based validation, immediate sell should fail
+        assertNotEq(uint8(results[0].status), uint8(StatusCode.OK), "empty carry sell must not succeed");
+    }
+
+    function test_marketCooldown_noBypassViaScheduled() public {
+        // Use harness to set worker directly at UT with active cooldown
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        _setupMarket();
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+
+        // Place worker at UT, WAITING, with cooldown active
+        uint64 cooldownEnds = uint64(block.timestamp + 120); // 2 ticks of cooldown
+        harness.setClansmanForTest(csId, ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, cooldownEnds);
+
+        // Submit a market sell — with cooldown active, must be rejected
+        address woodTok = world.getTreasuryState().woodToken;
+        ClanOrder[] memory o2 = new ClanOrder[](1);
+        o2[0] = ClanOrder({clansmanId: csId, gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketSell, targetClanId: 0, marketToken: woodTok,
+            marketAmount: 1e18, maxGoldIn: 0});
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, o2);
+        assertEq(uint8(results[0].status), uint8(StatusCode.ERR_COOLDOWN_ACTIVE),
+            "market order on cooldown must be rejected, not scheduled");
+    }
+
+    function test_marketBuy_creditsCarry_notVault() public {
+        (, address woodTok, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+
+        uint256 vaultWoodBefore = world.getClan(clanId).vaultWood;
+        uint256 carryWoodBefore = world.getClansman(csId).carryWood;
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+
+        uint256 buyAmt = 1e18;
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({clansmanId: csId, gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketBuy, targetClanId: 0, marketToken: woodTok,
+            marketAmount: buyAmt, maxGoldIn: type(uint256).max});
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "buy: immediate market buy must succeed");
+        assertGt(world.getClansman(csId).carryWood, carryWoodBefore, "buy: carry must increase");
+        assertEq(world.getClan(clanId).vaultWood, vaultWoodBefore, "buy: vault must be unchanged");
+        assertLt(world.getClan(clanId).goldBalance, goldBefore, "buy: gold must decrease");
     }
 }

--- a/packages/contracts/test/HeartbeatOrdering.t.sol
+++ b/packages/contracts/test/HeartbeatOrdering.t.sol
@@ -219,8 +219,10 @@ contract HeartbeatOrderingTest is Test {
         assertEq(sellMission.arrivalTick, t0 + 2, "sell arrivalTick must be t0+2");
         assertEq(sellMission.settlesAtTick, t0 + 3, "sell settlesAtTick must be t0+3");
 
-        // Give cs0 carry wood. Zero vault so market sell only succeeds if step1 ran first.
+        // Give cs0 carry wood (for deposit) and cs1 carry wood (for sell).
+        // Sell now draws from carry, not vault — zero vault to confirm vault is not involved.
         world.setCarryWood(csId0, 10e18);
+        world.setCarryWood(csId1, 5e18);
         world.setVaultWood(clanId, 0);
         assertEq(world.getClan(clanId).vaultWood, 0, "vault wood must be 0 before test tick");
 
@@ -228,8 +230,7 @@ contract HeartbeatOrderingTest is Test {
 
         // Advance to tick t0+4. The heartbeat closing t0+3 runs:
         //   Step 1: _settleCompletingMissions(t0+3) → deposit fires, cs0 carry 10e18 → vault
-        //   Step 2: _executeScheduledMarketActions(t0+3) → sell fires, 5e18 vault wood → gold
-        // If reversed: sell would fail (vault=0), gold unchanged.
+        //   Step 2: _executeScheduledMarketActions(t0+3) → sell fires, cs1 carry 5e18 → gold
         _advanceToTick(t0 + 4);
 
         uint256 goldAfter = world.getClan(clanId).goldBalance;
@@ -340,7 +341,8 @@ contract HeartbeatOrderingTest is Test {
         assertEq(world.getActiveMission(csId0).settlesAtTick, t0 + 3, "deposit settlesAtTick must be t0+3");
 
         // cs1: at Forest, sells wood to UT. Forest→UT = 2 ticks. settlesAtTick = t0+3.
-        // Vault has 20e18 starter wood — sell always has enough.
+        // Give cs1 carry wood — sell draws from carry (not vault).
+        world.setCarryWood(csId1, 10e18);
         OrderResult[] memory r1 = _submitMarketOrder(clanId, csId1, ActionType.MarketSell, address(woodToken), 5e18, 0);
         assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "market sell must enqueue");
         assertEq(world.getActiveMission(csId1).arrivalTick, t0 + 2, "sell arrivalTick must be t0+2");

--- a/packages/contracts/test/Reentrancy.t.sol
+++ b/packages/contracts/test/Reentrancy.t.sol
@@ -94,8 +94,14 @@ contract MockReentrantPool {
     }
 }
 
+contract ClanWorldReentrantHarness is ClanWorld {
+    function setCarryWood(uint32 csId, uint256 amount) external {
+        _clansmen[csId].carryWood = amount;
+    }
+}
+
 contract ReentrancyTest is Test {
-    ClanWorld world;
+    ClanWorldReentrantHarness world;
     address elder = address(0xA1);
 
     MinimalERC20 woodToken;
@@ -110,13 +116,15 @@ contract ReentrancyTest is Test {
     StubPool fishPool;
 
     function setUp() public {
-        world = new ClanWorld();
+        world = new ClanWorldReentrantHarness();
     }
 
     function test_marketPoolHeartbeatCallback_revertsWithReentrancyGuard() public {
         _setupReentrantMarket();
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
+        // Give clansman carry wood so the scheduled sell has something to sell
+        world.setCarryWood(csId, 10e18);
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 

--- a/packages/contracts/test/ResourceBoundaryTokens.t.sol
+++ b/packages/contracts/test/ResourceBoundaryTokens.t.sol
@@ -8,9 +8,6 @@ import {StubPool} from "../src/StubPool.sol";
 import {ResourceType} from "../src/IClanWorld.sol";
 
 contract ResourceBoundaryTokensTest is Test {
-    event ResourceMinted(uint8 indexed resourceType, address indexed to, uint256 amount);
-    event ResourceBurned(uint8 indexed resourceType, address indexed from, uint256 amount);
-
     ClanWorld world;
     MinimalERC20 woodToken;
     MinimalERC20 ironToken;
@@ -27,11 +24,6 @@ contract ResourceBoundaryTokensTest is Test {
         fishToken = new MinimalERC20("Fish", "FISH");
         goldToken = new MinimalERC20("Gold", "GOLD");
         blueprintToken = new MinimalERC20("BPRT", "BPRT");
-
-        woodToken.configureBoundary(uint8(ResourceType.Wood), address(world));
-        ironToken.configureBoundary(uint8(ResourceType.Iron), address(world));
-        wheatToken.configureBoundary(uint8(ResourceType.Wheat), address(world));
-        fishToken.configureBoundary(uint8(ResourceType.Fish), address(world));
     }
 
     function test_getResourceTokenReturnsConfiguredBoundaryTokens() public {
@@ -56,27 +48,6 @@ contract ResourceBoundaryTokensTest is Test {
         assertEq(world.getResourceToken(uint8(ResourceType.Iron)), address(ironToken), "iron");
         assertEq(world.getResourceToken(uint8(ResourceType.Wheat)), address(wheatToken), "wheat");
         assertEq(world.getResourceToken(uint8(ResourceType.Fish)), address(fishToken), "fish");
-    }
-
-    function test_onlyEngineCanMintAndBurnBoundaryTokens() public {
-        address holder = address(0xCAFE);
-
-        vm.expectRevert(bytes("MinimalERC20: not engine"));
-        woodToken.mint(holder, 10e18);
-
-        vm.expectEmit(true, true, false, true, address(woodToken));
-        emit ResourceMinted(uint8(ResourceType.Wood), holder, 10e18);
-        vm.prank(address(world));
-        woodToken.mint(holder, 10e18);
-
-        assertEq(woodToken.balanceOf(holder), 10e18, "minted balance");
-
-        vm.expectEmit(true, true, false, true, address(woodToken));
-        emit ResourceBurned(uint8(ResourceType.Wood), holder, 4e18);
-        vm.prank(address(world));
-        woodToken.burn(holder, 4e18);
-
-        assertEq(woodToken.balanceOf(holder), 6e18, "burned balance");
     }
 
     function test_seedTreasuryMintsStartingSupply() public {


### PR DESCRIPTION
## Summary

Addresses all 4 Phase 6B milestone issues (#23) in a single sub-PR into `dev-phase-6-market`. Phase 6 release PR #198 stays open.

- **#271 (3/3 super-swarm consensus HIGH):** Market trades now operate on worker carry (`cs.carry*`) not clan vault. Added `_hasCarryBalance` / `_deductFromCarry` / `_addToCarry` helpers. Fixed `_executeImmediateMarketSell`, `_executeImmediateMarketBuy`, `_executeMarketSell` (scheduled), `_executeMarketBuy` (scheduled). CEI-correct: carry deducted before external swap call; restored in catch on swap failure.
- **#272 (single-model HIGH):** Cooldown bypass via scheduled fallback — removed `!isMarketAction &&` guard so cooldown gates all orders including market.
- **#274 (single-model HIGH):** O(n²) insertion sort on storage array — now sorts via in-memory array, writes back once (~50 SSTOREs vs ~10K).
- **#273 (2/3 cross-model HIGH/MED):** Deleted dead `MinimalERC20.mint/burn/configureBoundary` surface + backing storage + events. Removed `configureBoundary` calls from Deploy.s.sol.

## Review trail

Local 3-tier swarm: implementation agent (Claude) + Codex + Gemini.

Swarm found 2 real issues in the initial implementation, both fixed before push:
- **CEI violation** (Codex MEDIUM + Gemini HIGH): `_deductFromCarry` was firing AFTER `swapExactInForOut` external call. Fixed: deduct before swap, restore in catch.
- **Vacuous test** (Codex LOW + Gemini LOW): `test_marketBuy_creditsCarry_notVault` assertions were inside `if (status == OK)` with no pool setup — always skipped. Fixed: uses `_setupHarnessClanAt(WAITING, REGION_UNICORN_TOWN, 0)`, hard-asserts OK status.

**False positive dismissed:** Gemini flagged `cs` scoping for buy path — confirmed separate functions, cs correctly loaded in both.

## Test plan

- [ ] 119/119 tests pass (`forge test --summary`)
- [ ] `test_marketSell_deductsFromCarry_notVault` — sell deducts carry, vault unchanged, gold increases
- [ ] `test_marketSell_fails_emptyCarry_fullVault` — empty carry + full vault → sell fails
- [ ] `test_marketBuy_creditsCarry_notVault` — buy credits carry, vault unchanged, gold decreases
- [ ] `test_marketCooldown_noBypassViaScheduled` — market order on cooldown → ERR_COOLDOWN_ACTIVE, not queued
- [ ] All 19 existing market tests updated to assert on carry (not vault)

Closes #271
Closes #272
Closes #273
Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)