### PR TITLE
fix(contracts): Phase 10 R3 — cold-reset regression + cloud findings

### DIFF
--- a/docs/planning/clanworld_v4_spec.md
+++ b/docs/planning/clanworld_v4_spec.md
@@ -823,7 +823,7 @@ This is a required bookkeeping part of the combat model.
 # 7. Winter Rules
 
 ## 7.1 Winter cadence
-Winter occurs every `110` ticks.
+Winter occurs every `110` ticks. The first winter opens at tick `110`, so ticks `[100, 110)` remain pre-winter preparation time.
 
 ## 7.2 Winter duration
 Winter lasts `10` ticks.

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2836,9 +2836,9 @@
         },
         {
           "name": "tick",
-          "type": "uint32",
+          "type": "uint64",
           "indexed": false,
-          "internalType": "uint32"
+          "internalType": "uint64"
         },
         {
           "name": "woodShort",
@@ -2992,9 +2992,9 @@
         },
         {
           "name": "tick",
-          "type": "uint32",
+          "type": "uint64",
           "indexed": false,
-          "internalType": "uint32"
+          "internalType": "uint64"
         }
       ],
       "anonymous": false
@@ -3707,9 +3707,9 @@
         },
         {
           "name": "tick",
-          "type": "uint32",
+          "type": "uint64",
           "indexed": false,
-          "internalType": "uint32"
+          "internalType": "uint64"
         }
       ],
       "anonymous": false

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -78,8 +78,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
-    /// @dev Caps winter crop boundary work: 24 clans x 2 wheat plots = 48 plot writes.
+    /// @dev Caps winter crop boundary work; mintClan keeps the clan cap within this budget.
     uint256 public constant MAX_CROP_TRANSITION_PER_TICK = 48;
+    uint256 private constant MAX_CLANS_FOR_CROP_TRANSITIONS = MAX_CROP_TRANSITION_PER_TICK / 2;
 
     // =========================================================================
     // CONSTRUCTOR
@@ -437,14 +438,20 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             emit ClanStarvationChanged(clan.clanId, false, tick);
         }
 
-        if (winter && starving && clan.starvationStartsAtTick < tick) {
-            _killNextClansmanFromStarvation(clan, tick);
+        uint8 livingBeforeStarvation = clan.livingClansmen;
+        if (winter && starving) {
+            (, uint64 winterStartsAtTick,) = _winterWindowForTick(tick);
+            uint64 effectiveStarvationStartsAtTick =
+                clan.starvationStartsAtTick > winterStartsAtTick ? clan.starvationStartsAtTick : winterStartsAtTick;
+            if (effectiveStarvationStartsAtTick < tick) {
+                _killNextClansmanFromStarvation(clan, tick);
+            }
         }
         if (clan.clanState == ClanState.DEAD) return;
 
         if (winter) {
-            uint256 woodNeeded = ClanWorldConstants.WINTER_WOOD_BURN_PER_BASE
-                + uint256(clan.livingClansmen) * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
+            uint256 woodNeeded = ClanWorldConstants.WINTER_WOOD_BURN_PER_BASE + uint256(livingBeforeStarvation)
+                * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
             if (clan.vaultWood >= woodNeeded) {
                 clan.vaultWood -= woodNeeded;
             } else {
@@ -454,7 +461,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 if (clan.coldDamage < type(uint16).max) {
                     clan.coldDamage += 1;
                 }
-                emit ClanColdShortage(clan.clanId, _eventTick(tick), woodShort);
+                emit ClanColdShortage(clan.clanId, tick, woodShort);
                 _applyColdDamageConsequence(clan, tick, oldColdDamage);
             }
         }
@@ -471,7 +478,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             ) return;
 
             clan.wallLevel--;
-            emit WallDegradedByCold(clan.clanId, clan.wallLevel, _eventTick(tick));
+            emit WallDegradedByCold(clan.clanId, clan.wallLevel, tick);
             return;
         }
 
@@ -535,7 +542,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     function _markClansmanDeadFromCold(Clan storage clan, Clansman storage cs, uint64 tick) internal {
         _markClansmanDead(clan, cs);
 
-        emit ClansmanColdDeath(clan.clanId, cs.clansmanId, _eventTick(tick));
+        emit ClansmanColdDeath(clan.clanId, cs.clansmanId, tick);
         if (clan.livingClansmen == 0) {
             _markClanDead(clan.clanId, "cold", tick);
         }
@@ -1123,7 +1130,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             emit WinterStarted(_winterEventTick(newTick));
         }
         if (wasWinter && !nowWinter) {
-            _resetColdDamageForAllClans();
             _restartWheatPlotsAfterWinter(newTick);
             emit WinterEnded(_winterEventTick(newTick));
         }
@@ -1161,20 +1167,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
     }
 
-    function _resetColdDamageForAllClans() internal {
-        for (uint256 i = 0; i < _allClanIds.length; i++) {
-            _clans[_allClanIds[i]].coldDamage = 0;
-        }
-    }
-
     function _winterEventTick(uint64 tick) internal pure returns (uint64) {
         return tick;
-    }
-
-    function _eventTick(uint64 tick) internal pure returns (uint32) {
-        require(tick <= type(uint32).max, "ClanWorld: winter tick overflow");
-        // forge-lint: disable-next-line(unsafe-typecast)
-        return uint32(tick);
     }
 
     function _isWinterActiveAt(uint64 tick) internal pure returns (bool) {
@@ -1237,6 +1231,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     function mintClan(address to) external override nonReentrant returns (uint32 clanId, uint256 iftTokenId) {
         require(to != address(0), "ClanWorld: zero address");
         require(_allClanIds.length < 12, "ClanWorld: max clans");
+        require(_allClanIds.length < MAX_CLANS_FOR_CROP_TRANSITIONS, "ClanWorld: clan cap");
         clanId = _nextClanId++;
         iftTokenId = uint256(clanId); // Phase 1 placeholder; real iNFT is Phase 7
 
@@ -1275,18 +1270,20 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         WheatPlotState startingPlotState =
             _isWinterActiveAt(_world.currentTick) ? WheatPlotState.WinterLocked : WheatPlotState.Harvestable;
+        uint256 startingWheat =
+            startingPlotState == WheatPlotState.WinterLocked ? 0 : ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT;
 
         // Wheat plots
         _wheatPlots[clanId][0] = WheatPlot({
             state: startingPlotState,
             region: ClanWorldConstants.REGION_WEST_FARMS,
-            remainingWheat: ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT,
+            remainingWheat: startingWheat,
             regrowUntilTick: 0
         });
         _wheatPlots[clanId][1] = WheatPlot({
             state: startingPlotState,
             region: ClanWorldConstants.REGION_EAST_FARMS,
-            remainingWheat: ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT,
+            remainingWheat: startingWheat,
             regrowUntilTick: 0
         });
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -26,6 +26,7 @@ pragma solidity ^0.8.34;
 library ClanWorldConstants {
     // World cadence
     uint64 internal constant HEARTBEAT_INTERVAL_SECONDS = 60;
+    // First winter opens at tick 110; ticks [100,110) remain pre-winter runway.
     uint64 internal constant WINTER_START_TICK = 110;
     uint64 internal constant WINTER_DURATION_TICKS = 10;
     uint64 internal constant WINTER_PERIOD_TICKS = 110;
@@ -507,9 +508,9 @@ interface IClanWorldEvents {
     event ClanEliminated(uint32 indexed clanId, uint64 indexed tick);
     event ClanDied(uint32 indexed clanId, uint64 tick, string reason);
     event ClanStarvationChanged(uint32 indexed clanId, bool isStarving, uint64 atTick);
-    event ClanColdShortage(uint32 indexed clanId, uint32 tick, uint256 woodShort);
-    event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint32 tick);
-    event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint32 tick);
+    event ClanColdShortage(uint32 indexed clanId, uint64 tick, uint256 woodShort);
+    event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint64 tick);
+    event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint64 tick);
 
     // ----- missions -----
     event MissionAssigned(

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -2169,7 +2169,7 @@ contract ClanWorldTest is Test {
         harness.setClanUpkeepState(clanId, winterStart, 1e18, 100e18, 100e18, 0);
 
         vm.expectEmit(true, false, false, true);
-        emit IClanWorldEvents.ClanColdShortage(clanId, uint32(winterStart), 2e18);
+        emit IClanWorldEvents.ClanColdShortage(clanId, winterStart, 2e18);
         world.settleClan(clanId);
 
         Clan memory clan = world.getClan(clanId);
@@ -2188,7 +2188,7 @@ contract ClanWorldTest is Test {
         harness.setClanUpkeepState(clanId, winterStart, 0, 100e18, 100e18, 1);
 
         vm.expectEmit(true, false, false, true);
-        emit IClanWorldEvents.WallDegradedByCold(clanId, 1, uint32(winterStart));
+        emit IClanWorldEvents.WallDegradedByCold(clanId, 1, winterStart);
         world.settleClan(clanId);
 
         Clan memory clan = world.getClan(clanId);
@@ -2214,7 +2214,7 @@ contract ClanWorldTest is Test {
         assertEq(clan.coldDamage, 2, "cold damage should hit death threshold");
         assertEq(clan.wallLevel, 0, "wall should remain clamped at zero");
         assertEq(clan.livingClansmen, 3, "one clansman should die from cold");
-        assertEq(_countLogs(logs, keccak256("ClansmanColdDeath(uint32,uint32,uint32)")), 1, "cold death should emit");
+        assertEq(_countLogs(logs, keccak256("ClansmanColdDeath(uint32,uint32,uint64)")), 1, "cold death should emit");
 
         ClanFullView memory view_ = world.getClanFullView(clanId);
         uint256 deadCount = 0;
@@ -2232,20 +2232,93 @@ contract ClanWorldTest is Test {
         uint32 preWinterStarver = _mintClan();
         uint32 winterStarver = _mintClan();
         uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
-        _advanceToTick(winterStart + 6);
+        _advanceToTick(winterStart + 2);
 
-        harness.setClanUpkeepState(preWinterStarver, winterStart + 3, 100e18, 0, 0, 0);
+        harness.setClanUpkeepState(preWinterStarver, winterStart, 100e18, 0, 0, 0);
         harness.setClanStarvationStartsAtTick(preWinterStarver, winterStart - 5);
-        harness.setClanUpkeepState(winterStarver, winterStart + 3, 100e18, 0, 0, 0);
-        harness.setClanStarvationStartsAtTick(winterStarver, winterStart + 2);
+        harness.setClanUpkeepState(winterStarver, winterStart, 100e18, 0, 0, 0);
 
         world.settleClan(preWinterStarver);
         world.settleClan(winterStarver);
 
         Clan memory preWinterClan = world.getClan(preWinterStarver);
         Clan memory winterClan = world.getClan(winterStarver);
-        assertEq(preWinterClan.livingClansmen, 1, "pre-winter starver should lose one clansman per winter tick");
-        assertEq(winterClan.livingClansmen, 1, "fresh winter starver should lose clansmen at the same cadence");
+        assertEq(preWinterClan.livingClansmen, 3, "pre-winter starver should skip first winter tick death");
+        assertEq(winterClan.livingClansmen, 3, "fresh winter starver should match pre-winter cadence");
+    }
+
+    function test_winter_starvationWoodBurnUsesPreDeathLivingCount() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart + 2);
+
+        harness.setClanUpkeepState(clanId, winterStart + 1, 25e17, 0, 0, 0);
+        harness.setClanStarvationStartsAtTick(clanId, winterStart);
+
+        world.settleClan(clanId);
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(clan.livingClansmen, 3, "starvation should kill one clansman");
+        assertEq(clan.vaultWood, 0, "wood should be consumed after shortage");
+        assertEq(clan.coldDamage, 1, "wood burn should use the pre-starvation living count");
+    }
+
+    function test_winterColdDamageResetIsLazyPerClanAfterPartialSettlement() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 partiallySettledClan = _mintClan();
+        uint32 neverSettledClan = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        uint64 winterEnd = winterStart + ClanWorldConstants.WINTER_DURATION_TICKS;
+        _advanceToTick(winterStart + 3);
+
+        harness.setClanWallLevel(partiallySettledClan, 10);
+        harness.setClanWallLevel(neverSettledClan, 10);
+        harness.setClanUpkeepState(partiallySettledClan, winterStart, 0, 100e18, 100e18, 0);
+        harness.setClanUpkeepState(neverSettledClan, winterStart, 0, 100e18, 100e18, 0);
+
+        world.settleClan(partiallySettledClan);
+        Clan memory partialMidWinter = world.getClan(partiallySettledClan);
+        assertEq(partialMidWinter.wallLevel, 9, "three shortages should have degraded one wall level");
+        assertEq(partialMidWinter.coldDamage, 3, "mid-winter settlement should preserve accrued cold");
+
+        _advanceToTick(winterEnd);
+        world.settleClan(partiallySettledClan);
+        world.settleClan(neverSettledClan);
+
+        Clan memory partialAfterWinter = world.getClan(partiallySettledClan);
+        Clan memory neverAfterWinter = world.getClan(neverSettledClan);
+        assertEq(
+            partialAfterWinter.wallLevel, neverAfterWinter.wallLevel, "partial and lazy settlement should converge"
+        );
+        assertEq(partialAfterWinter.wallLevel, 5, "ten shortages should degrade five wall levels");
+        assertEq(partialAfterWinter.coldDamage, 0, "partial clan cold damage resets after crossing winter end");
+        assertEq(neverAfterWinter.coldDamage, 0, "lazy clan cold damage resets after crossing winter end");
+    }
+
+    function test_winterMintedClanStartsWithLockedEmptyWheatPlots() public {
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart);
+
+        uint32 clanId = _mintClan();
+        ClanFullView memory view_ = world.getClanFullView(clanId);
+        assertEq(uint8(view_.westPlot.state), uint8(WheatPlotState.WinterLocked), "west plot should start locked");
+        assertEq(uint8(view_.eastPlot.state), uint8(WheatPlotState.WinterLocked), "east plot should start locked");
+        assertEq(view_.westPlot.remainingWheat, 0, "west locked plot should start empty");
+        assertEq(view_.eastPlot.remainingWheat, 0, "east locked plot should start empty");
+    }
+
+    function test_winterCropTransitionCapCoversCurrentClanCap() public {
+        for (uint256 i = 0; i < 12; i++) {
+            _mintClan();
+        }
+        assertGe(world.MAX_CROP_TRANSITION_PER_TICK(), 24, "transition cap must cover 12 clans x 2 plots");
+
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart);
+        assertEq(world.getWorldState().currentTick, winterStart, "full clan cap should not brick winter heartbeat");
     }
 
     function test_starvation_kill_deferred_to_next_tick() public {

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -40,6 +40,8 @@ const HEARTBEAT_ABI = [
           { name: 'seasonStartTick', type: 'uint64' },
           { name: 'seasonEndTick', type: 'uint64' },
           { name: 'seasonFinalized', type: 'bool' },
+          { name: 'currentSeasonNumber', type: 'uint64' },
+          { name: 'nextHeartbeatAtTick', type: 'uint64' },
           { name: 'nextHeartbeatAtTs', type: 'uint64' },
           { name: 'nextBanditSpawnEligibleTick', type: 'uint64' },
           { name: 'currentBanditSpawnChanceBps', type: 'uint16' },

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -36,6 +36,8 @@ const CLAN_WORLD_ABI = [
           { name: 'seasonStartTick', type: 'uint64' },
           { name: 'seasonEndTick', type: 'uint64' },
           { name: 'seasonFinalized', type: 'bool' },
+          { name: 'currentSeasonNumber', type: 'uint64' },
+          { name: 'nextHeartbeatAtTick', type: 'uint64' },
           { name: 'winterActive', type: 'bool' },
           { name: 'winterStartsAtTick', type: 'uint64' },
           { name: 'winterEndsAtTick', type: 'uint64' },


### PR DESCRIPTION
Per super-swarm R2 + cloud findings on PR #250. Fixes H3 cold-reset regression (introduced by R1 fix; Opus 4.7 reproduced locally), H1 starvation guard (codex 5.5), H2 TS ABI staleness (codex 5.5), H4 crop-transition brick (Gemini-CA HIGH), + 4 MED (wood-burn ordering, winter-mint plot state, winter-tick doc, event-tick width).

Validation:
- packages/contracts: `~/.foundry/bin/forge build && ~/.foundry/bin/forge test` — 105/105 passing
- packages/runner: `pnpm test 2>&1 | tail -5` — 121 passed, 1 skipped
- packages/shared: `pnpm test` is unavailable because the package has no test script; `pnpm typecheck` passes

<signed:codex>
