### PR TITLE
fix(contracts): Phase 6 R3 — wheelbarrow vault→carry + sell validation

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -245,6 +245,33 @@
               "name": "maxGoldIn",
               "type": "uint256",
               "internalType": "uint256"
+            },
+            {
+              "name": "withdrawResources",
+              "type": "tuple",
+              "internalType": "struct WithdrawResourcesData",
+              "components": [
+                {
+                  "name": "wood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "iron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "wheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "fish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
             }
           ]
         }
@@ -758,6 +785,33 @@
                           "name": "maxGoldIn",
                           "type": "uint256",
                           "internalType": "uint256"
+                        },
+                        {
+                          "name": "withdrawResources",
+                          "type": "tuple",
+                          "internalType": "struct WithdrawResourcesData",
+                          "components": [
+                            {
+                              "name": "wood",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            },
+                            {
+                              "name": "iron",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            },
+                            {
+                              "name": "wheat",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            },
+                            {
+                              "name": "fish",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            }
+                          ]
                         }
                       ]
                     },
@@ -867,6 +921,33 @@
                       "name": "maxGoldIn",
                       "type": "uint256",
                       "internalType": "uint256"
+                    },
+                    {
+                      "name": "withdrawResources",
+                      "type": "tuple",
+                      "internalType": "struct WithdrawResourcesData",
+                      "components": [
+                        {
+                          "name": "wood",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "iron",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "wheat",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "fish",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -1331,6 +1412,33 @@
                   "name": "maxGoldIn",
                   "type": "uint256",
                   "internalType": "uint256"
+                },
+                {
+                  "name": "withdrawResources",
+                  "type": "tuple",
+                  "internalType": "struct WithdrawResourcesData",
+                  "components": [
+                    {
+                      "name": "wood",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "iron",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "wheat",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "fish",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
                 }
               ]
             },
@@ -2413,6 +2521,33 @@
               "name": "maxGoldIn",
               "type": "uint256",
               "internalType": "uint256"
+            },
+            {
+              "name": "withdrawResources",
+              "type": "tuple",
+              "internalType": "struct WithdrawResourcesData",
+              "components": [
+                {
+                  "name": "wood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "iron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "wheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "fish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
             }
           ]
         }
@@ -3541,6 +3676,55 @@
           "type": "uint64",
           "indexed": false,
           "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ResourcesWithdrawn",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "woodDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "ironDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheatDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fishDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "tick",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
         }
       ],
       "anonymous": false

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -26,6 +26,7 @@ import {
     DerivedClanState,
     DerivedClansmanState,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     PoolSeedConfig,
     LeaderboardEntry,
@@ -456,6 +457,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // Deposit event ABI intentionally stores the current tick as uint32.
             // forge-lint: disable-next-line(unsafe-typecast)
             _doDeposit(clan, cs, m, clanId, uint32(tick));
+        } else if (action == ActionType.WithdrawResources) {
+            // Withdraw event ABI intentionally mirrors ResourcesDeposited's uint32 tick.
+            // forge-lint: disable-next-line(unsafe-typecast)
+            _doWithdrawResources(clan, cs, m, clanId, uint32(tick));
         } else if (action == ActionType.Wait) {
             // NOOP — worker stays ACTING (continuous), no transition needed
             // Wait mission is effectively persistent until interrupted
@@ -467,7 +472,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // Phase 1 stub: check homebase, check resources; if ok, stub success
             _doBuilding(clan, cs, m, clanId, tick, action);
         } else if (action == ActionType.MarketBuy || action == ActionType.MarketSell) {
-            _enqueueScheduledMarketAction(clanId, cs.clansmanId, m);
             _completeMission(cs, m);
         }
     }
@@ -696,6 +700,34 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         cs.carryFish = 0;
 
         emit ResourcesDeposited(clanId, cs.clansmanId, woodDelta, ironDelta, wheatDelta, fishDelta, tick);
+        _completeMission(cs, m);
+    }
+
+    function _doWithdrawResources(Clan storage clan, Clansman storage cs, Mission storage m, uint32 clanId, uint32 tick)
+        internal
+    {
+        if (cs.currentRegion != clan.baseRegion) {
+            _completeMission(cs, m);
+            return;
+        }
+
+        WithdrawResourcesData memory req = m.withdrawResources;
+        if (!_hasWithdrawRequest(req) || !_hasVaultResources(clan, req) || !_hasCarryCapacityForWithdraw(cs, req)) {
+            _completeMission(cs, m);
+            return;
+        }
+
+        clan.vaultWood -= req.wood;
+        clan.vaultIron -= req.iron;
+        clan.vaultWheat -= req.wheat;
+        clan.vaultFish -= req.fish;
+
+        cs.carryWood += req.wood;
+        cs.carryIron += req.iron;
+        cs.carryWheat += req.wheat;
+        cs.carryFish += req.fish;
+
+        emit ResourcesWithdrawn(clanId, cs.clansmanId, req.wood, req.iron, req.wheat, req.fish, tick);
         _completeMission(cs, m);
     }
 
@@ -1222,7 +1254,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             }
             _clearDefender(cs.clansmanId);
 
-            result.status = StatusCode.OK;
+            result.status =
+                order.action == ActionType.MarketSell && marketStatus != StatusCode.OK ? marketStatus : StatusCode.OK;
             result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
             result.missionNonce = ctx.newNonce;
             result.marketMode = MarketExecutionMode.Immediate;
@@ -1282,6 +1315,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
         result.missionNonce = ctx.newNonce;
         result.marketMode = isMarketAction ? MarketExecutionMode.Scheduled : MarketExecutionMode.None;
+        if (isMarketAction) {
+            _enqueueScheduledMarketAction(clanId, cs.clansmanId, existingM);
+        }
         return result;
     }
 
@@ -1310,6 +1346,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         m.marketToken = order.marketToken;
         m.marketAmount = order.marketAmount;
         m.maxGoldIn = order.maxGoldIn;
+        m.withdrawResources = order.withdrawResources;
 
         if (m.marketMode == MarketExecutionMode.Scheduled) {
             _marketMissionCommitSequence[cs.clansmanId] = _world.nextCommitSequence++;
@@ -1610,10 +1647,22 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     function _addToCarry(Clansman storage cs, address token, uint256 amount) internal {
-        if (token == _treasury.woodToken) { cs.carryWood += amount; return; }
-        if (token == _treasury.ironToken) { cs.carryIron += amount; return; }
-        if (token == _treasury.wheatToken) { cs.carryWheat += amount; return; }
-        if (token == _treasury.fishToken) { cs.carryFish += amount; return; }
+        if (token == _treasury.woodToken) {
+            cs.carryWood += amount;
+            return;
+        }
+        if (token == _treasury.ironToken) {
+            cs.carryIron += amount;
+            return;
+        }
+        if (token == _treasury.wheatToken) {
+            cs.carryWheat += amount;
+            return;
+        }
+        if (token == _treasury.fishToken) {
+            cs.carryFish += amount;
+            return;
+        }
     }
 
     /// @dev Check a clan vault balance without mutating storage.
@@ -1623,6 +1672,31 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (token == _treasury.wheatToken) return clan.vaultWheat >= amount;
         if (token == _treasury.fishToken) return clan.vaultFish >= amount;
         return false;
+    }
+
+    function _hasWithdrawRequest(WithdrawResourcesData memory req) internal pure returns (bool) {
+        return req.wood > 0 || req.iron > 0 || req.wheat > 0 || req.fish > 0;
+    }
+
+    function _hasVaultResources(Clan storage clan, WithdrawResourcesData memory req) internal view returns (bool) {
+        return clan.vaultWood >= req.wood && clan.vaultIron >= req.iron && clan.vaultWheat >= req.wheat
+            && clan.vaultFish >= req.fish;
+    }
+
+    function _hasCarryCapacityForWithdraw(Clansman storage cs, WithdrawResourcesData memory req)
+        internal
+        view
+        returns (bool)
+    {
+        return req.wood <= _remainingCapacity(cs.carryWood, ClanWorldConstants.WOOD_CAP)
+            && req.iron <= _remainingCapacity(cs.carryIron, ClanWorldConstants.IRON_CAP)
+            && req.wheat <= _remainingCapacity(cs.carryWheat, ClanWorldConstants.WHEAT_CAP)
+            && req.fish <= _remainingCapacity(cs.carryFish, ClanWorldConstants.FISH_CAP);
+    }
+
+    function _remainingCapacity(uint256 carried, uint256 cap) internal pure returns (uint256) {
+        if (carried >= cap) return 0;
+        return cap - carried;
     }
 
     function _handleMarketFailure(
@@ -2030,9 +2104,16 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         if (action == ActionType.None) return StatusCode.ERR_INVALID_ACTION;
 
-        // DepositResources: must go to homebase
+        // DepositResources / WithdrawResources: must go to homebase
         if (action == ActionType.DepositResources) {
             if (gotoRegion != clan.baseRegion) return StatusCode.ERR_INVALID_REGION;
+        }
+        if (action == ActionType.WithdrawResources) {
+            if (gotoRegion != clan.baseRegion) return StatusCode.ERR_NOT_AT_HOMEBASE;
+            WithdrawResourcesData memory req = order.withdrawResources;
+            if (!_hasWithdrawRequest(req)) return StatusCode.ERR_EMPTY_CARGO;
+            if (!_hasVaultResources(clan, req)) return StatusCode.ERR_MISSING_RESOURCES;
+            if (!_hasCarryCapacityForWithdraw(cs, req)) return StatusCode.ERR_CARRY_FULL;
         }
 
         // BuildWall / UpgradeBase / UpgradeMonument: must go to homebase
@@ -2095,6 +2176,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // Over-capacity buys are rejected at submission; no partial fills or overflow refunds.
             if (action == ActionType.MarketBuy && order.marketAmount > _remainingCarryForToken(cs, tok)) {
                 return StatusCode.ERR_CARRY_FULL;
+            }
+            if (action == ActionType.MarketSell && !_hasCarryBalance(cs, tok, order.marketAmount)) {
+                return StatusCode.ERR_MISSING_RESOURCES;
             }
             // Immediate market orders execute during submitClanOrders when the
             // worker is waiting in Unicorn Town and off cooldown. Other valid
@@ -2266,7 +2350,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             return 4;
         }
 
-        if (action == ActionType.DepositResources) {
+        if (action == ActionType.DepositResources || action == ActionType.WithdrawResources) {
             return DEPOSIT_DURATION_TICKS;
         }
 

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -26,6 +26,7 @@ import {
     DerivedClanState,
     DerivedClansmanState,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     PoolSeedConfig,
     LeaderboardEntry,
@@ -51,8 +52,7 @@ contract ClanWorldStub is IClanWorld {
         _world.seasonEndTick = ClanWorldConstants.SEASON_DURATION_TICKS;
         _world.currentSeasonNumber = 1;
         _world.nextHeartbeatAtTick = _world.currentTick + 1;
-        _world.winterStartsAtTick =
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS;
+        _world.winterStartsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS;
         _world.winterEndsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
         _world.winterActive = false;
 
@@ -214,7 +214,8 @@ contract ClanWorldStub is IClanWorld {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
     }
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -139,6 +139,7 @@ enum ActionType {
     FishDeepSea,
     HarvestWheat,
     DepositResources,
+    WithdrawResources,
     BuildWall,
     UpgradeBase,
     UpgradeMonument,
@@ -302,6 +303,8 @@ struct Mission {
     address marketToken; // market token for buy/sell
     uint256 marketAmount; // exact-in for sell, exact-out for buy
     uint256 maxGoldIn; // market_buy only, 0 otherwise
+
+    WithdrawResourcesData withdrawResources; // WithdrawResources only
 }
 
 struct BanditTroop {
@@ -368,6 +371,20 @@ struct DerivedClansmanState {
 // WRITE INPUT / OUTPUT STRUCTS
 // =============================================================================
 
+struct DepositResourcesData {
+    uint256 wood;
+    uint256 iron;
+    uint256 wheat;
+    uint256 fish;
+}
+
+struct WithdrawResourcesData {
+    uint256 wood;
+    uint256 iron;
+    uint256 wheat;
+    uint256 fish;
+}
+
 struct ClanOrder {
     uint32 clansmanId;
     uint8 gotoRegion;
@@ -377,6 +394,8 @@ struct ClanOrder {
     address marketToken;
     uint256 marketAmount;
     uint256 maxGoldIn;
+
+    WithdrawResourcesData withdrawResources;
 }
 
 struct OrderResult {
@@ -539,6 +558,15 @@ interface IClanWorldEvents {
         uint64 atTick
     );
     event ResourcesDeposited(
+        uint32 indexed clanId,
+        uint32 indexed clansmanId,
+        uint256 woodDelta,
+        uint256 ironDelta,
+        uint256 wheatDelta,
+        uint256 fishDelta,
+        uint32 tick
+    );
+    event ResourcesWithdrawn(
         uint32 indexed clanId,
         uint32 indexed clansmanId,
         uint256 woodDelta,

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -30,6 +30,7 @@ import {
     DerivedClanState,
     DerivedClansmanState,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     PoolSeedConfig,
     LeaderboardEntry,
@@ -53,6 +54,13 @@ contract ClanWorldTestHarness is ClanWorld {
         _clansmen[csId].carryIron = iron;
         _clansmen[csId].carryWheat = wheat;
         _clansmen[csId].carryFish = fish;
+    }
+
+    function setVault(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        _clans[clanId].vaultWood = wood;
+        _clans[clanId].vaultIron = iron;
+        _clans[clanId].vaultWheat = wheat;
+        _clans[clanId].vaultFish = fish;
     }
 
     function setClansmanForTest(uint32 csId, ClansmanState state, uint8 region, uint64 cooldownEndsAtTs) external {
@@ -146,6 +154,34 @@ contract ClanWorldTest is Test {
         return address(woodToken);
     }
 
+    function _initMarketWithoutSeed() internal returns (address woodAddr) {
+        woodToken = new MinimalERC20("Wood", "WOOD");
+        ironToken = new MinimalERC20("Iron", "IRON");
+        wheatToken = new MinimalERC20("Wheat", "WHEAT");
+        fishToken = new MinimalERC20("Fish", "FISH");
+        goldToken = new MinimalERC20("Gold", "GOLD");
+        blueprintToken = new MinimalERC20("BPRT", "BPRT");
+
+        address wAddr = address(world);
+        woodPool = new StubPool(address(woodToken), address(goldToken), wAddr);
+        ironPool = new StubPool(address(ironToken), address(goldToken), wAddr);
+        wheatPool = new StubPool(address(wheatToken), address(goldToken), wAddr);
+        fishPool = new StubPool(address(fishToken), address(goldToken), wAddr);
+
+        address[6] memory tokens = [
+            address(woodToken),
+            address(ironToken),
+            address(wheatToken),
+            address(fishToken),
+            address(goldToken),
+            address(blueprintToken)
+        ];
+        address[4] memory pools = [address(woodPool), address(wheatPool), address(fishPool), address(ironPool)];
+
+        world.initTreasury(tokens, pools);
+        return address(woodToken);
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
@@ -172,10 +208,36 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);
+    }
+
+    function _submitWithdrawOrder(
+        ClanWorldTestHarness harness,
+        uint32 clanId,
+        uint32 csId,
+        uint8 gotoRegion,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish
+    ) internal returns (OrderResult[] memory) {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: gotoRegion,
+            action: ActionType.WithdrawResources,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: wood, iron: iron, wheat: wheat, fish: fish})
+        });
+        vm.prank(elder);
+        return harness.submitClanOrders(clanId, orders);
     }
 
     // -------------------------------------------------------------------------
@@ -331,7 +393,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         // Invalid order: non-existent clansmanId
         orders[1] = ClanOrder({
@@ -341,7 +404,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         vm.prank(elder);
@@ -389,7 +453,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         vm.prank(elder);
@@ -594,6 +659,108 @@ contract ClanWorldTest is Test {
         _advanceTickHarness(harness);
     }
 
+    function test_withdrawResources_vaultToCarry_happyPath() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 8e18, 3e18, 4e18, 2e18);
+
+        OrderResult[] memory r = _submitWithdrawOrder(harness, clanId, csId, homeRegion, 5e18, 2e18, 1e18, 1e18);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "withdraw order should be accepted");
+
+        _advanceTickHarness(harness);
+        vm.expectEmit(true, true, false, true);
+        emit IClanWorldEvents.ResourcesWithdrawn(clanId, csId, 5e18, 2e18, 1e18, 1e18, 1);
+        _advanceTickHarness(harness);
+
+        Clan memory clan = harness.getClan(clanId);
+        Clansman memory cs = harness.getClansman(csId);
+        assertEq(clan.vaultWood, 3e18, "wood leaves vault");
+        assertEq(clan.vaultIron, 1e18, "iron leaves vault");
+        assertEq(clan.vaultWheat, 3e18, "wheat leaves vault");
+        assertEq(clan.vaultFish, 1e18, "fish leaves vault");
+        assertEq(cs.carryWood, 5e18, "wood enters carry");
+        assertEq(cs.carryIron, 2e18, "iron enters carry");
+        assertEq(cs.carryWheat, 1e18, "wheat enters carry");
+        assertEq(cs.carryFish, 1e18, "fish enters carry");
+    }
+
+    function test_withdrawResources_failsWhenInsufficientVault() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 1e18, 0, 0, 0);
+
+        OrderResult[] memory r = _submitWithdrawOrder(harness, clanId, csId, homeRegion, 2e18, 0, 0, 0);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "vault must cover request");
+        assertFalse(harness.getActiveMission(csId).active, "rejected withdraw should not install mission");
+    }
+
+    function test_withdrawResources_failsWhenCarryAtCap() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 2e18, 0, 0, 0);
+        harness.setCarry(csId, ClanWorldConstants.WOOD_CAP, 0, 0, 0);
+
+        OrderResult[] memory r = _submitWithdrawOrder(harness, clanId, csId, homeRegion, 1e18, 0, 0, 0);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_CARRY_FULL), "withdraw must fit carry cap");
+        assertFalse(harness.getActiveMission(csId).active, "rejected withdraw should not install mission");
+    }
+
+    function test_withdrawResources_failsWhenNotAtHomebase() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        uint8 nonHomeRegion = homeRegion == ClanWorldConstants.REGION_FOREST
+            ? ClanWorldConstants.REGION_MOUNTAINS
+            : ClanWorldConstants.REGION_FOREST;
+        harness.setVault(clanId, 2e18, 0, 0, 0);
+
+        OrderResult[] memory r = _submitWithdrawOrder(harness, clanId, csId, nonHomeRegion, 1e18, 0, 0, 0);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_NOT_AT_HOMEBASE), "withdraw must target homebase");
+        assertFalse(harness.getActiveMission(csId).active, "rejected withdraw should not install mission");
+    }
+
+    function test_withdrawThenMarketSell_endToEnd() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        address woodAddr = _setupMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 6e18, 0, 0, 0);
+
+        uint256 goldBefore = harness.getClan(clanId).goldBalance;
+        OrderResult[] memory withdraw = _submitWithdrawOrder(harness, clanId, csId, homeRegion, 5e18, 0, 0, 0);
+        assertEq(uint8(withdraw[0].status), uint8(StatusCode.OK), "withdraw should start wheelbarrow flow");
+
+        _advanceTickHarness(harness);
+        _advanceTickHarness(harness);
+        assertEq(harness.getClansman(csId).carryWood, 5e18, "worker loaded from vault");
+        assertEq(harness.getClan(clanId).vaultWood, 1e18, "vault stockpile reduced");
+
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
+        OrderResult[] memory sell = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 5e18, 0);
+        assertEq(uint8(sell[0].status), uint8(StatusCode.OK), "loaded worker can sell at market");
+
+        uint64 executeAtTick = world.getActiveMission(csId).settlesAtTick;
+        while (world.getWorldState().currentTick <= executeAtTick) {
+            _advanceTick();
+        }
+
+        assertEq(harness.getClansman(csId).carryWood, 0, "sold wood leaves carry");
+        assertGt(harness.getClan(clanId).goldBalance, goldBefore, "market sale credits clan gold");
+
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
+        OrderResult[] memory backHome = _submitOrder(clanId, csId, homeRegion, ActionType.Wait);
+        assertEq(uint8(backHome[0].status), uint8(StatusCode.OK), "worker can return home after sale");
+        uint64 returnTick = world.getActiveMission(csId).settlesAtTick;
+        while (world.getWorldState().currentTick <= returnTick) {
+            _advanceTick();
+        }
+        assertEq(harness.getClansman(csId).currentRegion, homeRegion, "worker returns to homebase");
+    }
+
     function test_quoteTravel_outOfBounds_returnsZero() public {
         (uint8 ticks, bytes8 path) = world.quoteTravel(9, 1);
         assertEq(ticks, 0, "out-of-range src should return 0 ticks");
@@ -640,7 +807,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, orders);
@@ -705,7 +873,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: token,
             marketAmount: amount,
-            maxGoldIn: maxGold
+            maxGoldIn: maxGold,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);
@@ -729,7 +898,8 @@ contract ClanWorldTest is Test {
                 targetClanId: 0,
                 marketToken: token,
                 marketAmount: 1e18,
-                maxGoldIn: 0
+                maxGoldIn: 0,
+                withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
             });
         }
         vm.prank(elder);
@@ -817,15 +987,14 @@ contract ClanWorldTest is Test {
         uint256 goldBefore = world.getClan(clanId).goldBalance;
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
 
-        assertEq(
-            uint8(r[0].status), uint8(StatusCode.ERR_COOLDOWN_ACTIVE), "market order on cooldown must be rejected"
-        );
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_COOLDOWN_ACTIVE), "market order on cooldown must be rejected");
         assertEq(world.getClan(clanId).goldBalance, goldBefore, "cooldown rejection should not trade");
     }
 
     function test_immediateMarket_notInTown_fallsBackToScheduled() public {
-        (, address woodAddr, uint32 clanId, uint32 csId) =
+        (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) =
             _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_FOREST, 0);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
 
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
         Mission memory m = world.getActiveMission(csId);
@@ -833,16 +1002,13 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "out-of-town market order should schedule");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "out-of-town should be scheduled");
         assertTrue(m.active, "scheduled fallback should install a mission");
-        assertEq(
-            world.getScheduledMarketActionsForTick(m.settlesAtTick).length,
-            0,
-            "scheduled action queues when mission settles"
-        );
+        assertEq(world.getScheduledMarketActionsForTick(m.settlesAtTick).length, 1, "scheduled action queues at submit");
     }
 
     function test_immediateMarket_busyWorker_fallsBackToScheduled() public {
-        (, address woodAddr, uint32 clanId, uint32 csId) =
+        (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) =
             _setupHarnessClanAt(ClansmanState.ACTING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
 
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
         Mission memory m = world.getActiveMission(csId);
@@ -850,11 +1016,20 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "busy market worker should schedule");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "busy worker should be scheduled");
         assertTrue(m.active, "scheduled fallback should install a mission");
-        assertEq(
-            world.getScheduledMarketActionsForTick(m.settlesAtTick).length,
-            0,
-            "scheduled action queues when mission settles"
-        );
+        assertEq(world.getScheduledMarketActionsForTick(m.settlesAtTick).length, 1, "scheduled action queues at submit");
+    }
+
+    function test_scheduledMarket_queueVisibleAtSubmit() public {
+        (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_FOREST, 0);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
+        Mission memory m = world.getActiveMission(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "scheduled sell should be accepted");
+        assertEq(world.getScheduledMarketActionsForTick(m.settlesAtTick).length, 1, "queue visible immediately");
+        assertEq(world.getMarketState().nextTickQueue.length, 0, "future queue stays off next tick when not next tick");
     }
 
     function test_immediateMarketBuy_executesWhenMaxGoldSatisfied() public {
@@ -998,6 +1173,45 @@ contract ClanWorldTest is Test {
         assertEq(cs.cooldownEndsAtTs, beforeCs.cooldownEndsAtTs, "rejected buy should not consume cooldown");
         assertEq(uint8(cs.state), uint8(beforeCs.state), "rejected buy should not change worker state");
         assertFalse(world.getActiveMission(csId).active, "rejected buy should not install a mission");
+    }
+
+    function test_marketSell_emptyCarry_rejectsAtSubmit_noTickConsumed() public {
+        (, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+
+        Clansman memory beforeCs = world.getClansman(csId);
+        uint64 tickBefore = world.getWorldState().currentTick;
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
+
+        Clansman memory afterCs = world.getClansman(csId);
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "empty carry sell rejects at submit");
+        assertEq(world.getWorldState().currentTick, tickBefore, "submit rejection should not advance tick");
+        assertEq(afterCs.cooldownEndsAtTs, beforeCs.cooldownEndsAtTs, "submit rejection should not consume cooldown");
+        assertEq(uint8(afterCs.state), uint8(beforeCs.state), "submit rejection should not change worker state");
+        assertEq(world.getClan(clanId).goldBalance, goldBefore, "submit rejection should not trade");
+        assertFalse(world.getActiveMission(csId).active, "submit rejection should not install mission");
+    }
+
+    function test_immediateMarketSell_failurePropagatesStatus() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        address woodAddr = _initMarketWithoutSeed();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+        harness.setClansmanForTest(csId, ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
+
+        assertEq(
+            uint8(r[0].status),
+            uint8(StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN),
+            "immediate sell failure should propagate"
+        );
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failure still used immediate path");
+        assertFalse(world.getActiveMission(csId).active, "failed immediate sell should not install a mission");
     }
 
     // -------------------------------------------------------------------------
@@ -1232,9 +1446,12 @@ contract ClanWorldTest is Test {
     // -------------------------------------------------------------------------
 
     function test_scheduledMarket_deletedAfterHeartbeat() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
 
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
         assertEq(uint8(r[0].status), uint8(StatusCode.OK));
@@ -1277,12 +1494,12 @@ contract ClanWorldTest is Test {
         uint64 newExecuteAtTick = newMission.settlesAtTick;
         assertGt(newMission.nonce, oldMission.nonce, "replacement should bump nonce");
 
-        assertEq(
-            world.getScheduledMarketActionsForTick(oldExecuteAtTick).length, 0, "old mission not queued before settle"
-        );
-        assertEq(
-            world.getScheduledMarketActionsForTick(newExecuteAtTick).length, 0, "new mission not queued before settle"
-        );
+        if (oldExecuteAtTick == newExecuteAtTick) {
+            assertEq(world.getScheduledMarketActionsForTick(oldExecuteAtTick).length, 2, "both missions queued");
+        } else {
+            assertEq(world.getScheduledMarketActionsForTick(oldExecuteAtTick).length, 1, "old mission queued at submit");
+            assertEq(world.getScheduledMarketActionsForTick(newExecuteAtTick).length, 1, "new mission queued at submit");
+        }
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 
@@ -1382,7 +1599,8 @@ contract ClanWorldTest is Test {
                 targetClanId: 0,
                 marketToken: woodAddr,
                 marketAmount: uint256(i + 1) * 1e18,
-                maxGoldIn: 0
+                maxGoldIn: 0,
+                withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
             });
         }
         vm.prank(elder);
@@ -1450,7 +1668,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodAddr,
             marketAmount: 5e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         world.submitClanOrders(clanId1, sellOrders);
@@ -1464,7 +1683,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodAddr,
             marketAmount: 1e18,
-            maxGoldIn: 100e18
+            maxGoldIn: 100e18,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder2);
         world.submitClanOrders(clanId2, buyOrders);
@@ -1542,7 +1762,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodAddr,
             marketAmount: 5e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder2);
         OrderResult[] memory sellOk = world.submitClanOrders(clanId2, sellOrders);
@@ -1582,7 +1803,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodAddr,
             marketAmount: 1e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, orders);
@@ -1604,7 +1826,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0xBEEF),
             marketAmount: 1e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         orders[1] = ClanOrder({
             clansmanId: noopCsId,
@@ -1613,7 +1836,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         vm.prank(elder);
@@ -1646,7 +1870,8 @@ contract ClanWorldTest is Test {
             targetClanId: clanId,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r1 = world.submitClanOrders(clanId, orders);
@@ -1718,7 +1943,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r = world.submitClanOrders(clanId1, orders);
@@ -1750,7 +1976,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r = harness.submitClanOrders(clanId, orders);
@@ -1872,7 +2099,8 @@ contract ClanWorldTest is Test {
             targetClanId: clanId,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r = world.submitClanOrders(clanId, orders);
@@ -1994,7 +2222,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return harness.submitClanOrders(clanId, orders);
@@ -2181,7 +2410,8 @@ contract ClanWorldTest is Test {
             targetClanId: clanId,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r = world.submitClanOrders(clanId, orders);
@@ -2252,7 +2482,8 @@ contract ClanWorldTest is Test {
             targetClanId: clanId,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r = harness.submitClanOrders(clanId, orders);
@@ -2356,7 +2587,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         // Order 1: invalid clansmanId 9999
@@ -2367,7 +2599,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         // Order 2: valid — cs1 Wait at homebase (NOOP)
@@ -2378,7 +2611,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         // Order 3: invalid — cs2 ChopWood to Mountains (wrong region for ChopWood)
@@ -2389,7 +2623,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         vm.prank(elder);
@@ -2519,7 +2754,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodTok,
             marketAmount: 5e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, orders);
@@ -2532,13 +2768,16 @@ contract ClanWorldTest is Test {
 
     function test_marketSell_fails_emptyCarry_fullVault() public {
         // Setup: worker in UT with empty carry but vault has wood
+        _setupMarket();
         uint32 clanId = _mintClan();
         ClanFullView memory v = world.getClanFullView(clanId);
         uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
         // Advance cs to UT with no carry (no gather)
         _submitOrder(clanId, csId, ClanWorldConstants.REGION_UNICORN_TOWN, ActionType.Wait);
         (uint8 travelToUT,) = world.quoteTravel(v.clan.clan.baseRegion, ClanWorldConstants.REGION_UNICORN_TOWN);
-        for (uint256 i = 0; i < uint256(travelToUT) + 2; i++) _advanceTick();
+        for (uint256 i = 0; i < uint256(travelToUT) + 2; i++) {
+            _advanceTick();
+        }
         world.settleClansman(csId);
         // Clan starts with vault wood from minting; carry is 0
         assertEq(world.getClansman(csId).carryWood, 0, "carry must be 0");
@@ -2553,14 +2792,12 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodTok,
             marketAmount: 1e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, orders);
-        // Immediate path: carry empty → ERR_MISSING_RESOURCES or market failure
-        // Either the order returns ERR_MISSING_RESOURCES at submit, or it's enqueued and fails at execution
-        // With carry-based validation, immediate sell should fail
-        assertNotEq(uint8(results[0].status), uint8(StatusCode.OK), "empty carry sell must not succeed");
+        assertEq(uint8(results[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "empty carry sell must fail");
     }
 
     function test_marketCooldown_noBypassViaScheduled() public {
@@ -2579,13 +2816,23 @@ contract ClanWorldTest is Test {
         // Submit a market sell — with cooldown active, must be rejected
         address woodTok = world.getTreasuryState().woodToken;
         ClanOrder[] memory o2 = new ClanOrder[](1);
-        o2[0] = ClanOrder({clansmanId: csId, gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
-            action: ActionType.MarketSell, targetClanId: 0, marketToken: woodTok,
-            marketAmount: 1e18, maxGoldIn: 0});
+        o2[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketSell,
+            targetClanId: 0,
+            marketToken: woodTok,
+            marketAmount: 1e18,
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
+        });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, o2);
-        assertEq(uint8(results[0].status), uint8(StatusCode.ERR_COOLDOWN_ACTIVE),
-            "market order on cooldown must be rejected, not scheduled");
+        assertEq(
+            uint8(results[0].status),
+            uint8(StatusCode.ERR_COOLDOWN_ACTIVE),
+            "market order on cooldown must be rejected, not scheduled"
+        );
     }
 
     function test_marketBuy_creditsCarry_notVault() public {
@@ -2598,9 +2845,16 @@ contract ClanWorldTest is Test {
 
         uint256 buyAmt = 1e18;
         ClanOrder[] memory orders = new ClanOrder[](1);
-        orders[0] = ClanOrder({clansmanId: csId, gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
-            action: ActionType.MarketBuy, targetClanId: 0, marketToken: woodTok,
-            marketAmount: buyAmt, maxGoldIn: type(uint256).max});
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketBuy,
+            targetClanId: 0,
+            marketToken: woodTok,
+            marketAmount: buyAmt,
+            maxGoldIn: type(uint256).max,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
+        });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, orders);
 

--- a/packages/contracts/test/DefendBase.t.sol
+++ b/packages/contracts/test/DefendBase.t.sol
@@ -12,6 +12,7 @@ import {
     Clansman,
     Mission,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult
 } from "../src/IClanWorld.sol";
 
@@ -41,7 +42,8 @@ contract DefendBaseTest is Test {
             targetClanId: targetClanId,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         return orders;
     }
@@ -55,7 +57,8 @@ contract DefendBaseTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         return orders;
     }

--- a/packages/contracts/test/Gathering.t.sol
+++ b/packages/contracts/test/Gathering.t.sol
@@ -12,6 +12,7 @@ import {
     Mission,
     ClanFullView,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult
 } from "../src/IClanWorld.sol";
 
@@ -59,7 +60,8 @@ contract GatheringTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         vm.prank(elder);

--- a/packages/contracts/test/HeartbeatOrdering.t.sol
+++ b/packages/contracts/test/HeartbeatOrdering.t.sol
@@ -13,6 +13,7 @@ import {
     StatusCode,
     WorldState,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     Mission,
     Clan,
@@ -96,7 +97,8 @@ contract HeartbeatOrderingTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);
@@ -118,7 +120,8 @@ contract HeartbeatOrderingTest is Test {
             targetClanId: 0,
             marketToken: token,
             marketAmount: amount,
-            maxGoldIn: maxGold
+            maxGoldIn: maxGold,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);
@@ -211,6 +214,13 @@ contract HeartbeatOrderingTest is Test {
         Mission memory depositMission = world.getActiveMission(csId0);
         assertEq(depositMission.settlesAtTick, t0 + 3, "deposit settlesAtTick must be t0+3");
 
+        // Give cs0 carry wood (for deposit) and cs1 carry wood (for sell).
+        // Sell now draws from carry, not vault — zero vault to confirm vault is not involved.
+        world.setCarryWood(csId0, 10e18);
+        world.setCarryWood(csId1, 5e18);
+        world.setVaultWood(clanId, 0);
+        assertEq(world.getClan(clanId).vaultWood, 0, "vault wood must be 0 before test tick");
+
         // cs1: at Forest. Submit MarketSell to UT. Forest→UT = 2 ticks.
         // settlesAtTick = t0+3. Same tick as deposit settles.
         OrderResult[] memory r1 = _submitMarketOrder(clanId, csId1, ActionType.MarketSell, address(woodToken), 5e18, 0);
@@ -218,13 +228,6 @@ contract HeartbeatOrderingTest is Test {
         Mission memory sellMission = world.getActiveMission(csId1);
         assertEq(sellMission.arrivalTick, t0 + 2, "sell arrivalTick must be t0+2");
         assertEq(sellMission.settlesAtTick, t0 + 3, "sell settlesAtTick must be t0+3");
-
-        // Give cs0 carry wood (for deposit) and cs1 carry wood (for sell).
-        // Sell now draws from carry, not vault — zero vault to confirm vault is not involved.
-        world.setCarryWood(csId0, 10e18);
-        world.setCarryWood(csId1, 5e18);
-        world.setVaultWood(clanId, 0);
-        assertEq(world.getClan(clanId).vaultWood, 0, "vault wood must be 0 before test tick");
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 

--- a/packages/contracts/test/MissionTiming.t.sol
+++ b/packages/contracts/test/MissionTiming.t.sol
@@ -11,6 +11,7 @@ import {
     ClanFullView,
     Clansman,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     Mission
 } from "../src/IClanWorld.sol";
@@ -56,7 +57,8 @@ contract MissionTimingTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);

--- a/packages/contracts/test/Reentrancy.t.sol
+++ b/packages/contracts/test/Reentrancy.t.sol
@@ -11,6 +11,7 @@ import {
     ActionType,
     StatusCode,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     Mission,
     PoolSeedConfig
@@ -223,7 +224,8 @@ contract ReentrancyTest is Test {
             targetClanId: 0,
             marketToken: token,
             marketAmount: amount,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -1,16 +1,26 @@
 import fs from 'node:fs';
-import { createPublicClient, createWalletClient, http, fallback, defineChain } from 'viem';
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  fallback,
+  defineChain,
+} from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import type { ClanFullView, ClanOrder, Tick } from '../types';
 import { readEnv } from './_env';
 
 export interface IChainClient {
   getCurrentTick(): Promise<Tick>;
-  submitOrders(clanId: string, orders: ClanOrder[]): Promise<{ txHash: string }>;
+  submitOrders(
+    clanId: string,
+    orders: ClanOrder[],
+  ): Promise<{ txHash: string }>;
   getClanFullView(clanId: string): Promise<ClanFullView>;
 }
 
-const DEFAULT_CONTRACT_ADDRESS = '0x1BF5649f29CbB53E117a5aE969A18A71790f83E8' as const;
+const DEFAULT_CONTRACT_ADDRESS =
+  '0x1BF5649f29CbB53E117a5aE969A18A71790f83E8' as const;
 
 export const baseSepolia = defineChain({
   id: 84532,
@@ -146,6 +156,16 @@ const CLAN_WORLD_ABI = [
                       { name: 'marketToken', type: 'address' },
                       { name: 'marketAmount', type: 'uint256' },
                       { name: 'maxGoldIn', type: 'uint256' },
+                      {
+                        name: 'withdrawResources',
+                        type: 'tuple',
+                        components: [
+                          { name: 'wood', type: 'uint256' },
+                          { name: 'iron', type: 'uint256' },
+                          { name: 'wheat', type: 'uint256' },
+                          { name: 'fish', type: 'uint256' },
+                        ],
+                      },
                     ],
                   },
                   { name: 'effectiveRegion', type: 'uint8' },
@@ -171,6 +191,16 @@ const CLAN_WORLD_ABI = [
                   { name: 'marketToken', type: 'address' },
                   { name: 'marketAmount', type: 'uint256' },
                   { name: 'maxGoldIn', type: 'uint256' },
+                  {
+                    name: 'withdrawResources',
+                    type: 'tuple',
+                    components: [
+                      { name: 'wood', type: 'uint256' },
+                      { name: 'iron', type: 'uint256' },
+                      { name: 'wheat', type: 'uint256' },
+                      { name: 'fish', type: 'uint256' },
+                    ],
+                  },
                 ],
               },
             ],
@@ -218,6 +248,16 @@ const CLAN_WORLD_ABI = [
           { name: 'marketToken', type: 'address' },
           { name: 'marketAmount', type: 'uint256' },
           { name: 'maxGoldIn', type: 'uint256' },
+          {
+            name: 'withdrawResources',
+            type: 'tuple',
+            components: [
+              { name: 'wood', type: 'uint256' },
+              { name: 'iron', type: 'uint256' },
+              { name: 'wheat', type: 'uint256' },
+              { name: 'fish', type: 'uint256' },
+            ],
+          },
         ],
       },
     ],
@@ -230,6 +270,7 @@ const CLAN_WORLD_ABI = [
           { name: 'status', type: 'uint8' },
           { name: 'cooldownEndsAtTs', type: 'uint64' },
           { name: 'missionNonce', type: 'uint64' },
+          { name: 'marketMode', type: 'uint8' },
         ],
       },
     ],
@@ -241,7 +282,10 @@ class StubChainClient implements IChainClient {
   async getCurrentTick(): Promise<Tick> {
     return 0;
   }
-  async submitOrders(_clanId: string, _orders: ClanOrder[]): Promise<{ txHash: string }> {
+  async submitOrders(
+    _clanId: string,
+    _orders: ClanOrder[],
+  ): Promise<{ txHash: string }> {
     return { txHash: '0xstub' };
   }
   async getClanFullView(clanId: string): Promise<ClanFullView> {
@@ -257,7 +301,9 @@ class StubChainClient implements IChainClient {
 class RealChainClient implements IChainClient {
   private readonly client: ReturnType<typeof createPublicClient>;
   private readonly contractAddress: `0x${string}`;
-  private readonly transport: ReturnType<typeof http> | ReturnType<typeof fallback>;
+  private readonly transport:
+    | ReturnType<typeof http>
+    | ReturnType<typeof fallback>;
 
   constructor() {
     const primaryRpc = readEnv('RPC_URL_PRIMARY');
@@ -286,38 +332,67 @@ class RealChainClient implements IChainClient {
     return Number(snapshot.currentTick); // safe: tick values are small enough to fit Number precisely in Wave 0
   }
 
-  async submitOrders(clanId: string, orders: ClanOrder[]): Promise<{ txHash: string }> {
+  async submitOrders(
+    clanId: string,
+    orders: ClanOrder[],
+  ): Promise<{ txHash: string }> {
     // Wave 0: single-Elder only — concurrent nonce coordination deferred to Wave 1
     const parsedClanId = parseInt(clanId, 10);
     if (isNaN(parsedClanId) || String(parsedClanId) !== clanId.trim()) {
-      throw new Error(`submitOrders: clanId must be a decimal integer, got '${clanId}'`);
+      throw new Error(
+        `submitOrders: clanId must be a decimal integer, got '${clanId}'`,
+      );
     }
 
     for (const order of orders) {
       if (order.kind === 'mission') {
         const { clansmanId, gotoRegion, action } = order.payload;
-        if (clansmanId === undefined || gotoRegion === undefined || action === undefined) {
-          throw new Error(`submitOrders: mission order missing required payload fields (clansmanId, gotoRegion, action)`);
+        if (
+          clansmanId === undefined ||
+          gotoRegion === undefined ||
+          action === undefined
+        ) {
+          throw new Error(
+            `submitOrders: mission order missing required payload fields (clansmanId, gotoRegion, action)`,
+          );
         }
       }
     }
 
-    const nonMissionOrders = orders.filter(o => o.kind !== 'mission');
+    const nonMissionOrders = orders.filter((o) => o.kind !== 'mission');
     if (nonMissionOrders.length > 0) {
-      console.warn(`[RealChainClient] submitOrders: ${nonMissionOrders.length} non-mission order(s) skipped (Wave 0 only supports 'mission' kind)`);
+      console.warn(
+        `[RealChainClient] submitOrders: ${nonMissionOrders.length} non-mission order(s) skipped (Wave 0 only supports 'mission' kind)`,
+      );
     }
 
     const contractOrders = orders
-      .filter(o => o.kind === 'mission')
-      .map(o => ({
-        clansmanId: Number(o.payload.clansmanId),
-        gotoRegion: Number(o.payload.gotoRegion),
-        action: Number(o.payload.action),
-        targetClanId: 0,
-        marketToken: '0x0000000000000000000000000000000000000000' as `0x${string}`,
-        marketAmount: 0n,
-        maxGoldIn: 0n,
-      }));
+      .filter((o) => o.kind === 'mission')
+      .map((o) => {
+        const withdraw =
+          o.payload.withdrawResources &&
+          typeof o.payload.withdrawResources === 'object'
+            ? (o.payload.withdrawResources as Record<string, unknown>)
+            : o.payload;
+        const uintValue = (value: unknown): bigint =>
+          value === undefined || value === null ? 0n : BigInt(String(value));
+        return {
+          clansmanId: Number(o.payload.clansmanId),
+          gotoRegion: Number(o.payload.gotoRegion),
+          action: Number(o.payload.action),
+          targetClanId: 0,
+          marketToken:
+            '0x0000000000000000000000000000000000000000' as `0x${string}`,
+          marketAmount: 0n,
+          maxGoldIn: 0n,
+          withdrawResources: {
+            wood: uintValue(withdraw.wood),
+            iron: uintValue(withdraw.iron),
+            wheat: uintValue(withdraw.wheat),
+            fish: uintValue(withdraw.fish),
+          },
+        };
+      });
 
     if (contractOrders.length === 0) {
       throw new Error('submitOrders: no valid mission orders to submit');
@@ -331,23 +406,35 @@ class RealChainClient implements IChainClient {
         pk = fs.readFileSync(keyPath, 'utf8').trim();
         pkSource = `ELDER_WALLET_KEY_PATH file at ${keyPath}`;
       } catch (err) {
-        if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+        if (
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          err.code === 'ENOENT'
+        ) {
           throw new Error(
             `ELDER_WALLET_KEY_PATH file not found at ${keyPath}; either set DEPLOYER_PRIVATE_KEY env var or provide a key file`,
           );
         }
         const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`Failed to read ELDER_WALLET_KEY_PATH file at ${keyPath}: ${msg}`);
+        throw new Error(
+          `Failed to read ELDER_WALLET_KEY_PATH file at ${keyPath}: ${msg}`,
+        );
       }
     } else {
       const fallbackKey = readEnv('DEPLOYER_PRIVATE_KEY');
       if (fallbackKey) {
-        console.warn('[RealChainClient] ELDER_WALLET_KEY_PATH not set; falling back to DEPLOYER_PRIVATE_KEY (deprecated)');
+        console.warn(
+          '[RealChainClient] ELDER_WALLET_KEY_PATH not set; falling back to DEPLOYER_PRIVATE_KEY (deprecated)',
+        );
         pk = fallbackKey;
         pkSource = 'DEPLOYER_PRIVATE_KEY env var';
       }
     }
-    if (!pk) throw new Error('Neither ELDER_WALLET_KEY_PATH nor DEPLOYER_PRIVATE_KEY is set');
+    if (!pk)
+      throw new Error(
+        'Neither ELDER_WALLET_KEY_PATH nor DEPLOYER_PRIVATE_KEY is set',
+      );
 
     // Normalize: add 0x prefix if missing
     if (!pk.startsWith('0x')) pk = '0x' + pk;


### PR DESCRIPTION
Per Liam directive 2026-04-29 22:02 ET (Path A1) on PR #198 super-swarm R2.

Adds new `WithdrawResources` action type closing the wheelbarrow design loop end-to-end (vault -> carry -> market or bandit-defense), fixes H1 sell-side submit-time carry validation (3/3 cross-model), and restores M1 scheduled queue observability for indexers/UI.

Validation:
- `cd packages/contracts && ~/.foundry/bin/forge build`
- `cd packages/contracts && ~/.foundry/bin/forge test` -> 127/127 passing
- `cd packages/runner && pnpm test` -> 121 passing, 1 skipped
- `cd packages/shared && pnpm typecheck` -> green

<signed:codex>
