### PR TITLE
fix(contracts): Phase 6 R4 — ActionType enum stability + MarketBuy error + uintValue robustness

### DIFF
--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1254,8 +1254,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             }
             _clearDefender(cs.clansmanId);
 
-            result.status =
-                order.action == ActionType.MarketSell && marketStatus != StatusCode.OK ? marketStatus : StatusCode.OK;
+            result.status = marketStatus;
             result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
             result.missionNonce = ctx.newNonce;
             result.marketMode = MarketExecutionMode.Immediate;

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -139,14 +139,14 @@ enum ActionType {
     FishDeepSea,
     HarvestWheat,
     DepositResources,
-    WithdrawResources,
     BuildWall,
     UpgradeBase,
     UpgradeMonument,
     DefendBase,
     MarketBuy,
     MarketSell,
-    Wait
+    Wait,
+    WithdrawResources
 }
 
 enum MarketExecutionMode {

--- a/packages/contracts/test/ActionTypeEnumStability.t.sol
+++ b/packages/contracts/test/ActionTypeEnumStability.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ActionType} from "../src/IClanWorld.sol";
+
+contract ActionTypeEnumStabilityTest is Test {
+    function test_actionTypeNumericValuesAreStable() public pure {
+        assertEq(uint8(ActionType.None), 0, "None");
+        assertEq(uint8(ActionType.ChopWood), 1, "ChopWood");
+        assertEq(uint8(ActionType.MineIron), 2, "MineIron");
+        assertEq(uint8(ActionType.FishDocks), 3, "FishDocks");
+        assertEq(uint8(ActionType.FishDeepSea), 4, "FishDeepSea");
+        assertEq(uint8(ActionType.HarvestWheat), 5, "HarvestWheat");
+        assertEq(uint8(ActionType.DepositResources), 6, "DepositResources");
+        assertEq(uint8(ActionType.BuildWall), 7, "BuildWall");
+        assertEq(uint8(ActionType.UpgradeBase), 8, "UpgradeBase");
+        assertEq(uint8(ActionType.UpgradeMonument), 9, "UpgradeMonument");
+        assertEq(uint8(ActionType.DefendBase), 10, "DefendBase");
+        assertEq(uint8(ActionType.MarketBuy), 11, "MarketBuy");
+        assertEq(uint8(ActionType.MarketSell), 12, "MarketSell");
+        assertEq(uint8(ActionType.Wait), 13, "Wait");
+        assertEq(uint8(ActionType.WithdrawResources), 14, "WithdrawResources");
+    }
+}

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -1084,7 +1084,9 @@ contract ClanWorldTest is Test {
         Clan memory afterClan = world.getClan(clanId);
         Clansman memory cs = world.getClansman(csId);
 
-        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(
+            uint8(r[0].status), uint8(StatusCode.ERR_LIQUIDITY_INSUFFICIENT), "failed immediate buy should propagate"
+        );
         assertEq(
             uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed immediate action stays immediate"
         );
@@ -1115,7 +1117,9 @@ contract ClanWorldTest is Test {
         Clan memory afterClan = world.getClan(clanId);
         Clansman memory cs = world.getClansman(csId);
 
-        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(
+            uint8(r[0].status), uint8(StatusCode.ERR_MAX_GOLD_IN_EXCEEDED), "failed immediate buy should propagate"
+        );
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed buy should report immediate");
         assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
@@ -1144,7 +1148,7 @@ contract ClanWorldTest is Test {
         Clan memory afterClan = world.getClan(clanId);
         Clansman memory cs = world.getClansman(csId);
 
-        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_NOT_ENOUGH_GOLD), "failed immediate buy should propagate");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed buy should report immediate");
         assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,11 +12,13 @@
   "scripts": {
     "build": "tsc -b",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "lint": "echo 'lint stub'",
     "clean": "rm -rf dist .turbo"
   },
   "devDependencies": {
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^3.2.0"
   },
   "dependencies": {
     "convex": "1.17.4",

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -30,7 +30,7 @@ export function uintValue(value: unknown): bigint {
 
   if (typeof value === 'string') {
     if (!/^\d+$/.test(value)) {
-      throw new Error(`uintValue: not a positive integer string: ${value}`);
+      throw new Error(`uintValue: not a non-negative integer string: ${value}`);
     }
     return BigInt(value);
   }

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -10,6 +10,34 @@ import { privateKeyToAccount } from 'viem/accounts';
 import type { ClanFullView, ClanOrder, Tick } from '../types';
 import { readEnv } from './_env';
 
+export function uintValue(value: unknown): bigint {
+  if (typeof value === 'bigint') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      throw new Error(`uintValue: non-integer number ${value}`);
+    }
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`uintValue: unsafe integer number ${value}`);
+    }
+    if (value < 0) {
+      throw new Error(`uintValue: negative number ${value}`);
+    }
+    return BigInt(value);
+  }
+
+  if (typeof value === 'string') {
+    if (!/^\d+$/.test(value)) {
+      throw new Error(`uintValue: not a positive integer string: ${value}`);
+    }
+    return BigInt(value);
+  }
+
+  throw new Error(`uintValue: unsupported type ${typeof value}`);
+}
+
 export interface IChainClient {
   getCurrentTick(): Promise<Tick>;
   submitOrders(
@@ -374,8 +402,8 @@ class RealChainClient implements IChainClient {
           typeof o.payload.withdrawResources === 'object'
             ? (o.payload.withdrawResources as Record<string, unknown>)
             : o.payload;
-        const uintValue = (value: unknown): bigint =>
-          value === undefined || value === null ? 0n : BigInt(String(value));
+        const optionalUintValue = (value: unknown): bigint =>
+          value === undefined || value === null ? 0n : uintValue(value);
         return {
           clansmanId: Number(o.payload.clansmanId),
           gotoRegion: Number(o.payload.gotoRegion),
@@ -386,10 +414,10 @@ class RealChainClient implements IChainClient {
           marketAmount: 0n,
           maxGoldIn: 0n,
           withdrawResources: {
-            wood: uintValue(withdraw.wood),
-            iron: uintValue(withdraw.iron),
-            wheat: uintValue(withdraw.wheat),
-            fish: uintValue(withdraw.fish),
+            wood: optionalUintValue(withdraw.wood),
+            iron: optionalUintValue(withdraw.iron),
+            wheat: optionalUintValue(withdraw.wheat),
+            fish: optionalUintValue(withdraw.fish),
           },
         };
       });

--- a/packages/shared/test/uintValue.test.ts
+++ b/packages/shared/test/uintValue.test.ts
@@ -19,8 +19,8 @@ describe('uintValue', () => {
   });
 
   it('rejects non-integer strings', () => {
-    expect(() => uintValue('1e18')).toThrow('not a positive integer string');
-    expect(() => uintValue('1.5')).toThrow('not a positive integer string');
+    expect(() => uintValue('1e18')).toThrow('not a non-negative integer string');
+    expect(() => uintValue('1.5')).toThrow('not a non-negative integer string');
   });
 
   it('rejects unsupported values', () => {

--- a/packages/shared/test/uintValue.test.ts
+++ b/packages/shared/test/uintValue.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { uintValue } from '../src/adapters/IChainClient';
+
+describe('uintValue', () => {
+  it('accepts bigint, safe integer numbers, and integer strings', () => {
+    expect(uintValue(12n)).toBe(12n);
+    expect(uintValue(12)).toBe(12n);
+    expect(uintValue('12')).toBe(12n);
+  });
+
+  it('rejects non-integer numbers', () => {
+    expect(() => uintValue(1.5)).toThrow('non-integer number');
+  });
+
+  it('rejects unsafe integer numbers', () => {
+    expect(() => uintValue(Number.MAX_SAFE_INTEGER + 1)).toThrow(
+      'unsafe integer number',
+    );
+  });
+
+  it('rejects non-integer strings', () => {
+    expect(() => uintValue('1e18')).toThrow('not a positive integer string');
+    expect(() => uintValue('1.5')).toThrow('not a positive integer string');
+  });
+
+  it('rejects unsupported values', () => {
+    expect(() => uintValue(null)).toThrow('unsupported type object');
+    expect(() => uintValue(undefined)).toThrow('unsupported type undefined');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.4(@types/node@25.6.0)(lightningcss@1.32.0)
 
 packages:
 


### PR DESCRIPTION
Per cloud review on PR #294. Addresses:

**H1 — ActionType enum reorder breaks numeric clients (Codex P1)**: `WithdrawResources` was inserted mid-enum in R3, shifting numeric values of all subsequent ActionType slots. Off-chain serializers, indexers, and hardcoded test fixtures using numeric encoding would silently see different actions. Fixed by APPENDING `WithdrawResources` to the END of the enum. Restored numeric stability for all preceding slots.

**H2 — MarketBuy returns OK on error (Copilot HIGH)**: same pattern as MarketSell that R3 fixed. `_processOrder` for immediate MarketBuy discarded failure return from `_executeImmediateMarketBuy` and returned `OK`. Now propagates failure status — symmetric fix to sell-side.

**M1 — uintValue brittleness (Copilot)**: `uintValue` accepted `BigInt(String(value))` which threw on non-integer strings (e.g. `'1e18'`) and silently lost precision on JS numbers > MAX_SAFE_INTEGER. Tightened: rejects non-integer numbers, unsafe-integer numbers, scientific-notation strings, and unsupported types with descriptive errors.

**Tests:**
- `forge test`: 128 passed
- `packages/runner pnpm test`: 121 passed, 1 skipped
- `packages/shared pnpm typecheck`: passed
- `packages/shared pnpm test`: 5 passed (incl. new uintValue.test.ts)
- New regression: `ActionTypeEnumStability.t.sol` asserts each enum value matches a hardcoded numeric expectation

`<signed:codex>`