### PR TITLE
fix(contracts): Phase 8 R5 — sim/real fromLevel parity + ABI pretty-print

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1,1 +1,7947 @@
-{"abi":[{"type":"function","name":"finalizeSeason","inputs":[],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"getActionDuration","inputs":[{"name":"action","type":"uint8","internalType":"enum ActionType"}],"outputs":[{"name":"","type":"uint64","internalType":"uint64"}],"stateMutability":"pure"},{"type":"function","name":"getActiveBanditView","inputs":[],"outputs":[{"name":"","type":"tuple","internalType":"struct ActiveBanditView","components":[{"name":"exists","type":"bool","internalType":"bool"},{"name":"banditId","type":"uint32","internalType":"uint32"},{"name":"state","type":"uint8","internalType":"enum BanditState"},{"name":"currentRegion","type":"uint8","internalType":"uint8"},{"name":"attackAttemptsMade","type":"uint8","internalType":"uint8"},{"name":"maxAttemptsRemaining","type":"uint8","internalType":"uint8"},{"name":"stateEnteredTick","type":"uint64","internalType":"uint64"},{"name":"nextActionTick","type":"uint64","internalType":"uint64"},{"name":"tier","type":"uint8","internalType":"uint8"},{"name":"attackPower","type":"uint16","internalType":"uint16"},{"name":"carryWood","type":"uint256","internalType":"uint256"},{"name":"carryIron","type":"uint256","internalType":"uint256"},{"name":"carryWheat","type":"uint256","internalType":"uint256"},{"name":"carryFish","type":"uint256","internalType":"uint256"},{"name":"projectedTargetClanId","type":"uint32","internalType":"uint32"},{"name":"projectedTargetLootValue","type":"uint256","internalType":"uint256"}]}],"stateMutability":"view"},{"type":"function","name":"getActiveDefenders","inputs":[{"name":"targetClanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"clansmanIds","type":"uint32[]","internalType":"uint32[]"}],"stateMutability":"view"},{"type":"function","name":"getActiveMission","inputs":[{"name":"clansmanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"","type":"tuple","internalType":"struct Mission","components":[{"name":"active","type":"bool","internalType":"bool"},{"name":"nonce","type":"uint64","internalType":"uint64"},{"name":"submittedAtTick","type":"uint64","internalType":"uint64"},{"name":"executesAtTick","type":"uint64","internalType":"uint64"},{"name":"settlesAtTick","type":"uint64","internalType":"uint64"},{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"startRegion","type":"uint8","internalType":"uint8"},{"name":"targetRegion","type":"uint8","internalType":"uint8"},{"name":"action","type":"uint8","internalType":"enum ActionType"},{"name":"startTick","type":"uint64","internalType":"uint64"},{"name":"arrivalTick","type":"uint64","internalType":"uint64"},{"name":"actionStartTick","type":"uint64","internalType":"uint64"},{"name":"missionSeed","type":"bytes32","internalType":"bytes32"},{"name":"marketMode","type":"uint8","internalType":"enum MarketExecutionMode"},{"name":"targetClanId","type":"uint32","internalType":"uint32"},{"name":"marketToken","type":"address","internalType":"address"},{"name":"marketAmount","type":"uint256","internalType":"uint256"},{"name":"maxGoldIn","type":"uint256","internalType":"uint256"}]}],"stateMutability":"view"},{"type":"function","name":"getBanditTargetPreview","inputs":[{"name":"banditId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"previewClanId","type":"uint32","internalType":"uint32"}],"stateMutability":"view"},{"type":"function","name":"getBanditTroop","inputs":[{"name":"banditId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"","type":"tuple","internalType":"struct BanditTroop","components":[{"name":"banditId","type":"uint32","internalType":"uint32"},{"name":"state","type":"uint8","internalType":"enum BanditState"},{"name":"currentRegion","type":"uint8","internalType":"uint8"},{"name":"attackAttemptsMade","type":"uint8","internalType":"uint8"},{"name":"stateEnteredTick","type":"uint64","internalType":"uint64"},{"name":"nextActionTick","type":"uint64","internalType":"uint64"},{"name":"tier","type":"uint8","internalType":"uint8"},{"name":"attackPower","type":"uint16","internalType":"uint16"},{"name":"carryWood","type":"uint256","internalType":"uint256"},{"name":"carryIron","type":"uint256","internalType":"uint256"},{"name":"carryWheat","type":"uint256","internalType":"uint256"},{"name":"carryFish","type":"uint256","internalType":"uint256"}]}],"stateMutability":"view"},{"type":"function","name":"getBaseUpgradeCost","inputs":[{"name":"currentLevel","type":"uint8","internalType":"uint8"}],"outputs":[{"name":"wood","type":"uint256","internalType":"uint256"},{"name":"iron","type":"uint256","internalType":"uint256"},{"name":"wheat","type":"uint256","internalType":"uint256"}],"stateMutability":"pure"},{"type":"function","name":"getClan","inputs":[{"name":"clanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"","type":"tuple","internalType":"struct Clan","components":[{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"iftTokenId","type":"uint256","internalType":"uint256"},{"name":"owner","type":"address","internalType":"address"},{"name":"clanState","type":"uint8","internalType":"enum ClanState"},{"name":"baseRegion","type":"uint8","internalType":"uint8"},{"name":"baseLevel","type":"uint8","internalType":"uint8"},{"name":"wallLevel","type":"uint8","internalType":"uint8"},{"name":"monumentLevel","type":"uint8","internalType":"uint8"},{"name":"livingClansmen","type":"uint8","internalType":"uint8"},{"name":"lastSettledTick","type":"uint64","internalType":"uint64"},{"name":"starvationStartsAtTick","type":"uint64","internalType":"uint64"},{"name":"coldDamage","type":"uint16","internalType":"uint16"},{"name":"goldBalance","type":"uint256","internalType":"uint256"},{"name":"blueprintBalance","type":"uint256","internalType":"uint256"},{"name":"vaultWood","type":"uint256","internalType":"uint256"},{"name":"vaultIron","type":"uint256","internalType":"uint256"},{"name":"vaultWheat","type":"uint256","internalType":"uint256"},{"name":"vaultFish","type":"uint256","internalType":"uint256"}]}],"stateMutability":"view"},{"type":"function","name":"getClanFullView","inputs":[{"name":"clanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"","type":"tuple","internalType":"struct ClanFullView","components":[{"name":"clan","type":"tuple","internalType":"struct DerivedClanState","components":[{"name":"clan","type":"tuple","internalType":"struct Clan","components":[{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"iftTokenId","type":"uint256","internalType":"uint256"},{"name":"owner","type":"address","internalType":"address"},{"name":"clanState","type":"uint8","internalType":"enum ClanState"},{"name":"baseRegion","type":"uint8","internalType":"uint8"},{"name":"baseLevel","type":"uint8","internalType":"uint8"},{"name":"wallLevel","type":"uint8","internalType":"uint8"},{"name":"monumentLevel","type":"uint8","internalType":"uint8"},{"name":"livingClansmen","type":"uint8","internalType":"uint8"},{"name":"lastSettledTick","type":"uint64","internalType":"uint64"},{"name":"starvationStartsAtTick","type":"uint64","internalType":"uint64"},{"name":"coldDamage","type":"uint16","internalType":"uint16"},{"name":"goldBalance","type":"uint256","internalType":"uint256"},{"name":"blueprintBalance","type":"uint256","internalType":"uint256"},{"name":"vaultWood","type":"uint256","internalType":"uint256"},{"name":"vaultIron","type":"uint256","internalType":"uint256"},{"name":"vaultWheat","type":"uint256","internalType":"uint256"},{"name":"vaultFish","type":"uint256","internalType":"uint256"}]},{"name":"isStarving","type":"bool","internalType":"bool"},{"name":"lootValue","type":"uint256","internalType":"uint256"},{"name":"derivedAtTick","type":"uint64","internalType":"uint64"}]},{"name":"clansmen","type":"tuple[]","internalType":"struct ClansmanFullView[]","components":[{"name":"clansman","type":"tuple","internalType":"struct DerivedClansmanState","components":[{"name":"clansman","type":"tuple","internalType":"struct Clansman","components":[{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"state","type":"uint8","internalType":"enum ClansmanState"},{"name":"currentRegion","type":"uint8","internalType":"uint8"},{"name":"cooldownEndsAtTs","type":"uint64","internalType":"uint64"},{"name":"lastMissionNonce","type":"uint64","internalType":"uint64"},{"name":"carryWood","type":"uint256","internalType":"uint256"},{"name":"carryIron","type":"uint256","internalType":"uint256"},{"name":"carryWheat","type":"uint256","internalType":"uint256"},{"name":"carryFish","type":"uint256","internalType":"uint256"}]},{"name":"activeMission","type":"tuple","internalType":"struct Mission","components":[{"name":"active","type":"bool","internalType":"bool"},{"name":"nonce","type":"uint64","internalType":"uint64"},{"name":"submittedAtTick","type":"uint64","internalType":"uint64"},{"name":"executesAtTick","type":"uint64","internalType":"uint64"},{"name":"settlesAtTick","type":"uint64","internalType":"uint64"},{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"startRegion","type":"uint8","internalType":"uint8"},{"name":"targetRegion","type":"uint8","internalType":"uint8"},{"name":"action","type":"uint8","internalType":"enum ActionType"},{"name":"startTick","type":"uint64","internalType":"uint64"},{"name":"arrivalTick","type":"uint64","internalType":"uint64"},{"name":"actionStartTick","type":"uint64","internalType":"uint64"},{"name":"missionSeed","type":"bytes32","internalType":"bytes32"},{"name":"marketMode","type":"uint8","internalType":"enum MarketExecutionMode"},{"name":"targetClanId","type":"uint32","internalType":"uint32"},{"name":"marketToken","type":"address","internalType":"address"},{"name":"marketAmount","type":"uint256","internalType":"uint256"},{"name":"maxGoldIn","type":"uint256","internalType":"uint256"}]},{"name":"effectiveRegion","type":"uint8","internalType":"uint8"},{"name":"derivedAtTick","type":"uint64","internalType":"uint64"}]},{"name":"activeMission","type":"tuple","internalType":"struct Mission","components":[{"name":"active","type":"bool","internalType":"bool"},{"name":"nonce","type":"uint64","internalType":"uint64"},{"name":"submittedAtTick","type":"uint64","internalType":"uint64"},{"name":"executesAtTick","type":"uint64","internalType":"uint64"},{"name":"settlesAtTick","type":"uint64","internalType":"uint64"},{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"startRegion","type":"uint8","internalType":"uint8"},{"name":"targetRegion","type":"uint8","internalType":"uint8"},{"name":"action","type":"uint8","internalType":"enum ActionType"},{"name":"startTick","type":"uint64","internalType":"uint64"},{"name":"arrivalTick","type":"uint64","internalType":"uint64"},{"name":"actionStartTick","type":"uint64","internalType":"uint64"},{"name":"missionSeed","type":"bytes32","internalType":"bytes32"},{"name":"marketMode","type":"uint8","internalType":"enum MarketExecutionMode"},{"name":"targetClanId","type":"uint32","internalType":"uint32"},{"name":"marketToken","type":"address","internalType":"address"},{"name":"marketAmount","type":"uint256","internalType":"uint256"},{"name":"maxGoldIn","type":"uint256","internalType":"uint256"}]}]},{"name":"westPlot","type":"tuple","internalType":"struct WheatPlot","components":[{"name":"state","type":"uint8","internalType":"enum WheatPlotState"},{"name":"region","type":"uint8","internalType":"uint8"},{"name":"remainingWheat","type":"uint256","internalType":"uint256"},{"name":"regrowUntilTick","type":"uint64","internalType":"uint64"}]},{"name":"eastPlot","type":"tuple","internalType":"struct WheatPlot","components":[{"name":"state","type":"uint8","internalType":"enum WheatPlotState"},{"name":"region","type":"uint8","internalType":"uint8"},{"name":"remainingWheat","type":"uint256","internalType":"uint256"},{"name":"regrowUntilTick","type":"uint64","internalType":"uint64"}]},{"name":"incomingDefenderIds","type":"uint32[]","internalType":"uint32[]"},{"name":"thisClanDefendingBaseId","type":"uint32","internalType":"uint32"}]}],"stateMutability":"view"},{"type":"function","name":"getClanScore","inputs":[{"name":"clanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"score","type":"uint256","internalType":"uint256"},{"name":"monumentReachedAtTick","type":"uint64","internalType":"uint64"},{"name":"monumentLevel","type":"uint8","internalType":"uint8"}],"stateMutability":"view"},{"type":"function","name":"getClansman","inputs":[{"name":"clansmanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"","type":"tuple","internalType":"struct Clansman","components":[{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"state","type":"uint8","internalType":"enum ClansmanState"},{"name":"currentRegion","type":"uint8","internalType":"uint8"},{"name":"cooldownEndsAtTs","type":"uint64","internalType":"uint64"},{"name":"lastMissionNonce","type":"uint64","internalType":"uint64"},{"name":"carryWood","type":"uint256","internalType":"uint256"},{"name":"carryIron","type":"uint256","internalType":"uint256"},{"name":"carryWheat","type":"uint256","internalType":"uint256"},{"name":"carryFish","type":"uint256","internalType":"uint256"}]}],"stateMutability":"view"},{"type":"function","name":"getDefendingClans","inputs":[{"name":"region","type":"uint8","internalType":"uint8"}],"outputs":[{"name":"clanIds","type":"uint32[]","internalType":"uint32[]"}],"stateMutability":"view"},{"type":"function","name":"getDerivedClanState","inputs":[{"name":"clanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"","type":"tuple","internalType":"struct DerivedClanState","components":[{"name":"clan","type":"tuple","internalType":"struct Clan","components":[{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"iftTokenId","type":"uint256","internalType":"uint256"},{"name":"owner","type":"address","internalType":"address"},{"name":"clanState","type":"uint8","internalType":"enum ClanState"},{"name":"baseRegion","type":"uint8","internalType":"uint8"},{"name":"baseLevel","type":"uint8","internalType":"uint8"},{"name":"wallLevel","type":"uint8","internalType":"uint8"},{"name":"monumentLevel","type":"uint8","internalType":"uint8"},{"name":"livingClansmen","type":"uint8","internalType":"uint8"},{"name":"lastSettledTick","type":"uint64","internalType":"uint64"},{"name":"starvationStartsAtTick","type":"uint64","internalType":"uint64"},{"name":"coldDamage","type":"uint16","internalType":"uint16"},{"name":"goldBalance","type":"uint256","internalType":"uint256"},{"name":"blueprintBalance","type":"uint256","internalType":"uint256"},{"name":"vaultWood","type":"uint256","internalType":"uint256"},{"name":"vaultIron","type":"uint256","internalType":"uint256"},{"name":"vaultWheat","type":"uint256","internalType":"uint256"},{"name":"vaultFish","type":"uint256","internalType":"uint256"}]},{"name":"isStarving","type":"bool","internalType":"bool"},{"name":"lootValue","type":"uint256","internalType":"uint256"},{"name":"derivedAtTick","type":"uint64","internalType":"uint64"}]}],"stateMutability":"view"},{"type":"function","name":"getDerivedClansmanState","inputs":[{"name":"clansmanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"","type":"tuple","internalType":"struct DerivedClansmanState","components":[{"name":"clansman","type":"tuple","internalType":"struct Clansman","components":[{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"state","type":"uint8","internalType":"enum ClansmanState"},{"name":"currentRegion","type":"uint8","internalType":"uint8"},{"name":"cooldownEndsAtTs","type":"uint64","internalType":"uint64"},{"name":"lastMissionNonce","type":"uint64","internalType":"uint64"},{"name":"carryWood","type":"uint256","internalType":"uint256"},{"name":"carryIron","type":"uint256","internalType":"uint256"},{"name":"carryWheat","type":"uint256","internalType":"uint256"},{"name":"carryFish","type":"uint256","internalType":"uint256"}]},{"name":"activeMission","type":"tuple","internalType":"struct Mission","components":[{"name":"active","type":"bool","internalType":"bool"},{"name":"nonce","type":"uint64","internalType":"uint64"},{"name":"submittedAtTick","type":"uint64","internalType":"uint64"},{"name":"executesAtTick","type":"uint64","internalType":"uint64"},{"name":"settlesAtTick","type":"uint64","internalType":"uint64"},{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"startRegion","type":"uint8","internalType":"uint8"},{"name":"targetRegion","type":"uint8","internalType":"uint8"},{"name":"action","type":"uint8","internalType":"enum ActionType"},{"name":"startTick","type":"uint64","internalType":"uint64"},{"name":"arrivalTick","type":"uint64","internalType":"uint64"},{"name":"actionStartTick","type":"uint64","internalType":"uint64"},{"name":"missionSeed","type":"bytes32","internalType":"bytes32"},{"name":"marketMode","type":"uint8","internalType":"enum MarketExecutionMode"},{"name":"targetClanId","type":"uint32","internalType":"uint32"},{"name":"marketToken","type":"address","internalType":"address"},{"name":"marketAmount","type":"uint256","internalType":"uint256"},{"name":"maxGoldIn","type":"uint256","internalType":"uint256"}]},{"name":"effectiveRegion","type":"uint8","internalType":"uint8"},{"name":"derivedAtTick","type":"uint64","internalType":"uint64"}]}],"stateMutability":"view"},{"type":"function","name":"getMarketState","inputs":[],"outputs":[{"name":"","type":"tuple","internalType":"struct MarketState","components":[{"name":"wood","type":"tuple","internalType":"struct PoolReserves","components":[{"name":"resourceToken","type":"address","internalType":"address"},{"name":"resourceReserve","type":"uint256","internalType":"uint256"},{"name":"goldReserve","type":"uint256","internalType":"uint256"},{"name":"spotPriceGoldPerResource","type":"uint256","internalType":"uint256"}]},{"name":"wheat","type":"tuple","internalType":"struct PoolReserves","components":[{"name":"resourceToken","type":"address","internalType":"address"},{"name":"resourceReserve","type":"uint256","internalType":"uint256"},{"name":"goldReserve","type":"uint256","internalType":"uint256"},{"name":"spotPriceGoldPerResource","type":"uint256","internalType":"uint256"}]},{"name":"fish","type":"tuple","internalType":"struct PoolReserves","components":[{"name":"resourceToken","type":"address","internalType":"address"},{"name":"resourceReserve","type":"uint256","internalType":"uint256"},{"name":"goldReserve","type":"uint256","internalType":"uint256"},{"name":"spotPriceGoldPerResource","type":"uint256","internalType":"uint256"}]},{"name":"iron","type":"tuple","internalType":"struct PoolReserves","components":[{"name":"resourceToken","type":"address","internalType":"address"},{"name":"resourceReserve","type":"uint256","internalType":"uint256"},{"name":"goldReserve","type":"uint256","internalType":"uint256"},{"name":"spotPriceGoldPerResource","type":"uint256","internalType":"uint256"}]},{"name":"currentTick","type":"uint64","internalType":"uint64"},{"name":"currentTickQueue","type":"tuple[]","internalType":"struct ScheduledMarketAction[]","components":[{"name":"executeAtTick","type":"uint64","internalType":"uint64"},{"name":"commitSequence","type":"uint64","internalType":"uint64"},{"name":"missionNonce","type":"uint64","internalType":"uint64"},{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"action","type":"uint8","internalType":"enum ActionType"},{"name":"marketToken","type":"address","internalType":"address"},{"name":"marketAmount","type":"uint256","internalType":"uint256"},{"name":"maxGoldIn","type":"uint256","internalType":"uint256"}]},{"name":"nextTickQueue","type":"tuple[]","internalType":"struct ScheduledMarketAction[]","components":[{"name":"executeAtTick","type":"uint64","internalType":"uint64"},{"name":"commitSequence","type":"uint64","internalType":"uint64"},{"name":"missionNonce","type":"uint64","internalType":"uint64"},{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"action","type":"uint8","internalType":"enum ActionType"},{"name":"marketToken","type":"address","internalType":"address"},{"name":"marketAmount","type":"uint256","internalType":"uint256"},{"name":"maxGoldIn","type":"uint256","internalType":"uint256"}]}]}],"stateMutability":"view"},{"type":"function","name":"getMissionTiming","inputs":[{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"clansmanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"submitted","type":"uint64","internalType":"uint64"},{"name":"executes","type":"uint64","internalType":"uint64"},{"name":"settles","type":"uint64","internalType":"uint64"}],"stateMutability":"view"},{"type":"function","name":"getMonumentUpgradeCost","inputs":[{"name":"currentLevel","type":"uint8","internalType":"uint8"}],"outputs":[{"name":"wood","type":"uint256","internalType":"uint256"},{"name":"iron","type":"uint256","internalType":"uint256"},{"name":"wheat","type":"uint256","internalType":"uint256"},{"name":"blueprint","type":"uint256","internalType":"uint256"}],"stateMutability":"pure"},{"type":"function","name":"getRankings","inputs":[],"outputs":[{"name":"clanIdsRanked","type":"uint32[]","internalType":"uint32[]"},{"name":"scores","type":"uint256[]","internalType":"uint256[]"}],"stateMutability":"view"},{"type":"function","name":"getRegionPopulation","inputs":[{"name":"region","type":"uint8","internalType":"uint8"}],"outputs":[{"name":"","type":"tuple[]","internalType":"struct RegionOccupant[]","components":[{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"state","type":"uint8","internalType":"enum ClansmanState"},{"name":"currentAction","type":"uint8","internalType":"enum ActionType"},{"name":"missionNonce","type":"uint64","internalType":"uint64"}]}],"stateMutability":"view"},{"type":"function","name":"getScheduledMarketActionsForTick","inputs":[{"name":"tick","type":"uint64","internalType":"uint64"}],"outputs":[{"name":"","type":"tuple[]","internalType":"struct ScheduledMarketAction[]","components":[{"name":"executeAtTick","type":"uint64","internalType":"uint64"},{"name":"commitSequence","type":"uint64","internalType":"uint64"},{"name":"missionNonce","type":"uint64","internalType":"uint64"},{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"action","type":"uint8","internalType":"enum ActionType"},{"name":"marketToken","type":"address","internalType":"address"},{"name":"marketAmount","type":"uint256","internalType":"uint256"},{"name":"maxGoldIn","type":"uint256","internalType":"uint256"}]}],"stateMutability":"view"},{"type":"function","name":"getTravelTicks","inputs":[{"name":"fromRegion","type":"uint8","internalType":"uint8"},{"name":"toRegion","type":"uint8","internalType":"uint8"}],"outputs":[{"name":"","type":"uint64","internalType":"uint64"}],"stateMutability":"pure"},{"type":"function","name":"getTreasuryState","inputs":[],"outputs":[{"name":"","type":"tuple","internalType":"struct TreasuryState","components":[{"name":"treasuryOwner","type":"address","internalType":"address"},{"name":"prizePotGold","type":"uint256","internalType":"uint256"},{"name":"poolsSeeded","type":"bool","internalType":"bool"},{"name":"woodToken","type":"address","internalType":"address"},{"name":"wheatToken","type":"address","internalType":"address"},{"name":"fishToken","type":"address","internalType":"address"},{"name":"ironToken","type":"address","internalType":"address"},{"name":"goldToken","type":"address","internalType":"address"},{"name":"blueprintToken","type":"address","internalType":"address"},{"name":"woodGoldPool","type":"address","internalType":"address"},{"name":"wheatGoldPool","type":"address","internalType":"address"},{"name":"fishGoldPool","type":"address","internalType":"address"},{"name":"ironGoldPool","type":"address","internalType":"address"}]}],"stateMutability":"view"},{"type":"function","name":"getWallUpgradeCost","inputs":[{"name":"currentLevel","type":"uint8","internalType":"uint8"}],"outputs":[{"name":"wood","type":"uint256","internalType":"uint256"},{"name":"iron","type":"uint256","internalType":"uint256"}],"stateMutability":"pure"},{"type":"function","name":"getWheatPlots","inputs":[{"name":"clanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"west","type":"tuple","internalType":"struct WheatPlot","components":[{"name":"state","type":"uint8","internalType":"enum WheatPlotState"},{"name":"region","type":"uint8","internalType":"uint8"},{"name":"remainingWheat","type":"uint256","internalType":"uint256"},{"name":"regrowUntilTick","type":"uint64","internalType":"uint64"}]},{"name":"east","type":"tuple","internalType":"struct WheatPlot","components":[{"name":"state","type":"uint8","internalType":"enum WheatPlotState"},{"name":"region","type":"uint8","internalType":"uint8"},{"name":"remainingWheat","type":"uint256","internalType":"uint256"},{"name":"regrowUntilTick","type":"uint64","internalType":"uint64"}]}],"stateMutability":"view"},{"type":"function","name":"getWorldSnapshot","inputs":[],"outputs":[{"name":"","type":"tuple","internalType":"struct WorldSnapshot","components":[{"name":"currentTick","type":"uint64","internalType":"uint64"},{"name":"seasonStartTick","type":"uint64","internalType":"uint64"},{"name":"seasonEndTick","type":"uint64","internalType":"uint64"},{"name":"seasonFinalized","type":"bool","internalType":"bool"},{"name":"currentSeasonNumber","type":"uint64","internalType":"uint64"},{"name":"nextHeartbeatAtTick","type":"uint64","internalType":"uint64"},{"name":"winterActive","type":"bool","internalType":"bool"},{"name":"winterStartsAtTick","type":"uint64","internalType":"uint64"},{"name":"winterEndsAtTick","type":"uint64","internalType":"uint64"},{"name":"activeBanditId","type":"uint32","internalType":"uint32"},{"name":"currentTickSeed","type":"bytes32","internalType":"bytes32"},{"name":"leaderboard","type":"tuple[]","internalType":"struct LeaderboardEntry[]","components":[{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"owner","type":"address","internalType":"address"},{"name":"monumentLevel","type":"uint8","internalType":"uint8"},{"name":"baseLevel","type":"uint8","internalType":"uint8"},{"name":"wallLevel","type":"uint8","internalType":"uint8"},{"name":"livingClansmen","type":"uint8","internalType":"uint8"},{"name":"state","type":"uint8","internalType":"enum ClanState"},{"name":"lootValue","type":"uint256","internalType":"uint256"}]}]}],"stateMutability":"view"},{"type":"function","name":"getWorldState","inputs":[],"outputs":[{"name":"","type":"tuple","internalType":"struct WorldState","components":[{"name":"currentTick","type":"uint64","internalType":"uint64"},{"name":"seasonStartTick","type":"uint64","internalType":"uint64"},{"name":"seasonEndTick","type":"uint64","internalType":"uint64"},{"name":"seasonFinalized","type":"bool","internalType":"bool"},{"name":"currentSeasonNumber","type":"uint64","internalType":"uint64"},{"name":"nextHeartbeatAtTick","type":"uint64","internalType":"uint64"},{"name":"nextHeartbeatAtTs","type":"uint64","internalType":"uint64"},{"name":"nextBanditSpawnEligibleTick","type":"uint64","internalType":"uint64"},{"name":"currentBanditSpawnChanceBps","type":"uint16","internalType":"uint16"},{"name":"currentTickSeed","type":"bytes32","internalType":"bytes32"},{"name":"activeBanditId","type":"uint32","internalType":"uint32"},{"name":"winterActive","type":"bool","internalType":"bool"},{"name":"winterStartsAtTick","type":"uint64","internalType":"uint64"},{"name":"winterEndsAtTick","type":"uint64","internalType":"uint64"},{"name":"nextCommitSequence","type":"uint64","internalType":"uint64"}]}],"stateMutability":"view"},{"type":"function","name":"heartbeat","inputs":[],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"initTreasury","inputs":[{"name":"tokens","type":"address[6]","internalType":"address[6]"},{"name":"pools","type":"address[4]","internalType":"address[4]"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"mintClan","inputs":[{"name":"to","type":"address","internalType":"address"}],"outputs":[{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"iftTokenId","type":"uint256","internalType":"uint256"}],"stateMutability":"nonpayable"},{"type":"function","name":"quoteLootValueRaw","inputs":[{"name":"clanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"lootValue","type":"uint256","internalType":"uint256"}],"stateMutability":"view"},{"type":"function","name":"quoteLootValueSettled","inputs":[{"name":"clanId","type":"uint32","internalType":"uint32"}],"outputs":[{"name":"lootValue","type":"uint256","internalType":"uint256"}],"stateMutability":"view"},{"type":"function","name":"quoteTravel","inputs":[{"name":"srcRegion","type":"uint8","internalType":"uint8"},{"name":"dstRegion","type":"uint8","internalType":"uint8"}],"outputs":[{"name":"travelTicks","type":"uint8","internalType":"uint8"},{"name":"path","type":"bytes8","internalType":"bytes8"}],"stateMutability":"view"},{"type":"function","name":"seedPools","inputs":[{"name":"cfg","type":"tuple","internalType":"struct PoolSeedConfig","components":[{"name":"woodSeed","type":"uint256","internalType":"uint256"},{"name":"wheatSeed","type":"uint256","internalType":"uint256"},{"name":"fishSeed","type":"uint256","internalType":"uint256"},{"name":"ironSeed","type":"uint256","internalType":"uint256"},{"name":"goldSeedForWood","type":"uint256","internalType":"uint256"},{"name":"goldSeedForWheat","type":"uint256","internalType":"uint256"},{"name":"goldSeedForFish","type":"uint256","internalType":"uint256"},{"name":"goldSeedForIron","type":"uint256","internalType":"uint256"}]}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"settleClan","inputs":[{"name":"clanId","type":"uint32","internalType":"uint32"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"settleClansman","inputs":[{"name":"csId","type":"uint32","internalType":"uint32"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"submitClanOrders","inputs":[{"name":"clanId","type":"uint32","internalType":"uint32"},{"name":"orders","type":"tuple[]","internalType":"struct ClanOrder[]","components":[{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"gotoRegion","type":"uint8","internalType":"uint8"},{"name":"action","type":"uint8","internalType":"enum ActionType"},{"name":"targetClanId","type":"uint32","internalType":"uint32"},{"name":"marketToken","type":"address","internalType":"address"},{"name":"marketAmount","type":"uint256","internalType":"uint256"},{"name":"maxGoldIn","type":"uint256","internalType":"uint256"}]}],"outputs":[{"name":"","type":"tuple[]","internalType":"struct OrderResult[]","components":[{"name":"clansmanId","type":"uint32","internalType":"uint32"},{"name":"status","type":"uint8","internalType":"enum StatusCode"},{"name":"cooldownEndsAtTs","type":"uint64","internalType":"uint64"},{"name":"missionNonce","type":"uint64","internalType":"uint64"}]}],"stateMutability":"nonpayable"},{"type":"function","name":"transferBlueprint","inputs":[{"name":"fromClanId","type":"uint32","internalType":"uint32"},{"name":"toClanId","type":"uint32","internalType":"uint32"},{"name":"amount","type":"uint256","internalType":"uint256"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"transferBundle","inputs":[{"name":"fromClanId","type":"uint32","internalType":"uint32"},{"name":"toClanId","type":"uint32","internalType":"uint32"},{"name":"gold","type":"uint256","internalType":"uint256"},{"name":"blueprint","type":"uint256","internalType":"uint256"},{"name":"wood","type":"uint256","internalType":"uint256"},{"name":"iron","type":"uint256","internalType":"uint256"},{"name":"wheat","type":"uint256","internalType":"uint256"},{"name":"fish","type":"uint256","internalType":"uint256"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"transferGold","inputs":[{"name":"fromClanId","type":"uint32","internalType":"uint32"},{"name":"toClanId","type":"uint32","internalType":"uint32"},{"name":"amount","type":"uint256","internalType":"uint256"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"transferVaultResource","inputs":[{"name":"fromClanId","type":"uint32","internalType":"uint32"},{"name":"toClanId","type":"uint32","internalType":"uint32"},{"name":"resource","type":"uint8","internalType":"enum ResourceType"},{"name":"amount","type":"uint256","internalType":"uint256"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"event","name":"BanditAttackResolved","inputs":[{"name":"banditId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"targetClanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"defended","type":"bool","indexed":false,"internalType":"bool"},{"name":"attackPower","type":"uint16","indexed":false,"internalType":"uint16"},{"name":"totalDefense","type":"uint16","indexed":false,"internalType":"uint16"},{"name":"wallLevelAfter","type":"uint16","indexed":false,"internalType":"uint16"},{"name":"stolenWood","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"stolenIron","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"stolenWheat","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"stolenFish","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"BanditDefeated","inputs":[{"name":"banditId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"targetClanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"BanditEscaped","inputs":[{"name":"banditId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"BanditMoved","inputs":[{"name":"banditId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"fromRegion","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"toRegion","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"BanditSpawned","inputs":[{"name":"banditId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"region","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"tier","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"attackPower","type":"uint16","indexed":false,"internalType":"uint16"}],"anonymous":false},{"type":"event","name":"BanditStateChanged","inputs":[{"name":"banditId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"oldState","type":"uint8","indexed":false,"internalType":"enum BanditState"},{"name":"newState","type":"uint8","indexed":false,"internalType":"enum BanditState"},{"name":"region","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"BaseLevelChanged","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"oldLevel","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"newLevel","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"BaseUpgraded","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"newLevel","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"settledAtTick","type":"uint32","indexed":false,"internalType":"uint32"}],"anonymous":false},{"type":"event","name":"BlueprintAwarded","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"banditId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"amount","type":"uint256","indexed":false,"internalType":"uint256"}],"anonymous":false},{"type":"event","name":"BlueprintTransferred","inputs":[{"name":"fromClanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"toClanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"amount","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"ClanEliminated","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"tick","type":"uint64","indexed":true,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"ClanSettled","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"settledToTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"ClanSpawned","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"owner","type":"address","indexed":true,"internalType":"address"},{"name":"iftTokenId","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"baseRegion","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"ClanStarvationChanged","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"isStarving","type":"bool","indexed":false,"internalType":"bool"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"ClansmanDiedFromCold","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"ColdDamageApplied","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"oldDamage","type":"uint16","indexed":false,"internalType":"uint16"},{"name":"newDamage","type":"uint16","indexed":false,"internalType":"uint16"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"GoldTransferred","inputs":[{"name":"fromClanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"toClanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"amount","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"ImmediateMarketActionExecuted","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clansmanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"tokenIn","type":"address","indexed":false,"internalType":"address"},{"name":"tokenOut","type":"address","indexed":false,"internalType":"address"},{"name":"amountIn","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"amountOut","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"LootDistributedToDefender","inputs":[{"name":"banditId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clansmanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"wood","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"iron","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"wheat","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"fish","type":"uint256","indexed":false,"internalType":"uint256"}],"anonymous":false},{"type":"event","name":"MarketActionFailed","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clansmanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"action","type":"uint8","indexed":false,"internalType":"enum ActionType"},{"name":"reason","type":"uint8","indexed":false,"internalType":"enum StatusCode"}],"anonymous":false},{"type":"event","name":"MissionAssigned","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clansmanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"missionNonce","type":"uint64","indexed":false,"internalType":"uint64"},{"name":"action","type":"uint8","indexed":false,"internalType":"enum ActionType"},{"name":"startRegion","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"targetRegion","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"startTick","type":"uint64","indexed":false,"internalType":"uint64"},{"name":"arrivalTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"MissionCompleted","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clansmanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"missionNonce","type":"uint64","indexed":false,"internalType":"uint64"},{"name":"action","type":"uint8","indexed":false,"internalType":"enum ActionType"}],"anonymous":false},{"type":"event","name":"MissionInterrupted","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clansmanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"oldMissionNonce","type":"uint64","indexed":false,"internalType":"uint64"},{"name":"newMissionNonce","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"MonumentLevelChanged","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"oldLevel","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"newLevel","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"MonumentUpgraded","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"newLevel","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"settledAtTick","type":"uint32","indexed":false,"internalType":"uint32"}],"anonymous":false},{"type":"event","name":"PoolsSeeded","inputs":[{"name":"woodGoldPool","type":"address","indexed":false,"internalType":"address"},{"name":"wheatGoldPool","type":"address","indexed":false,"internalType":"address"},{"name":"fishGoldPool","type":"address","indexed":false,"internalType":"address"},{"name":"ironGoldPool","type":"address","indexed":false,"internalType":"address"}],"anonymous":false},{"type":"event","name":"ResourcesDeposited","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clansmanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"woodDelta","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"ironDelta","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"wheatDelta","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"fishDelta","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"tick","type":"uint32","indexed":false,"internalType":"uint32"}],"anonymous":false},{"type":"event","name":"ResourcesGathered","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clansmanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"action","type":"uint8","indexed":false,"internalType":"enum ActionType"},{"name":"woodGained","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"ironGained","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"wheatGained","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"fishGained","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"goldBonus","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"ScheduledMarketActionCommitted","inputs":[{"name":"executeAtTick","type":"uint64","indexed":true,"internalType":"uint64"},{"name":"commitSequence","type":"uint64","indexed":true,"internalType":"uint64"},{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clansmanId","type":"uint32","indexed":false,"internalType":"uint32"},{"name":"action","type":"uint8","indexed":false,"internalType":"enum ActionType"},{"name":"marketToken","type":"address","indexed":false,"internalType":"address"},{"name":"marketAmount","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"maxGoldIn","type":"uint256","indexed":false,"internalType":"uint256"}],"anonymous":false},{"type":"event","name":"ScheduledMarketActionExecuted","inputs":[{"name":"executeAtTick","type":"uint64","indexed":true,"internalType":"uint64"},{"name":"commitSequence","type":"uint64","indexed":true,"internalType":"uint64"},{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clansmanId","type":"uint32","indexed":false,"internalType":"uint32"},{"name":"tokenIn","type":"address","indexed":false,"internalType":"address"},{"name":"tokenOut","type":"address","indexed":false,"internalType":"address"},{"name":"amountIn","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"amountOut","type":"uint256","indexed":false,"internalType":"uint256"}],"anonymous":false},{"type":"event","name":"SeasonFinalized","inputs":[{"name":"tick","type":"uint64","indexed":true,"internalType":"uint64"},{"name":"rankedClanIds","type":"uint32[]","indexed":false,"internalType":"uint32[]"}],"anonymous":false},{"type":"event","name":"TickAdvanced","inputs":[{"name":"closedTick","type":"uint64","indexed":false,"internalType":"uint64"},{"name":"openedTick","type":"uint64","indexed":false,"internalType":"uint64"},{"name":"tickSeed","type":"bytes32","indexed":false,"internalType":"bytes32"}],"anonymous":false},{"type":"event","name":"VaultResourceTransferred","inputs":[{"name":"fromClanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"toClanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"resource","type":"uint8","indexed":false,"internalType":"enum ResourceType"},{"name":"amount","type":"uint256","indexed":false,"internalType":"uint256"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"WallLevelChanged","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"oldLevel","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"newLevel","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"atTick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"WallUpgraded","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"newLevel","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"settledAtTick","type":"uint32","indexed":false,"internalType":"uint32"}],"anonymous":false},{"type":"event","name":"WinterEnded","inputs":[{"name":"tick","type":"uint64","indexed":true,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"WinterStarted","inputs":[{"name":"tick","type":"uint64","indexed":true,"internalType":"uint64"}],"anonymous":false},{"type":"event","name":"WorkerArrived","inputs":[{"name":"clanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"clansmanId","type":"uint32","indexed":true,"internalType":"uint32"},{"name":"region","type":"uint8","indexed":false,"internalType":"uint8"},{"name":"tick","type":"uint64","indexed":false,"internalType":"uint64"}],"anonymous":false}],"bytecode":{"object":"0x","sourceMap":"","linkReferences":{}},"deployedBytecode":{"object":"0x","sourceMap":"","linkReferences":{}},"methodIdentifiers":{"finalizeSeason()":"30fb8f8a","getActionDuration(uint8)":"e24864d8","getActiveBanditView()":"19abee0f","getActiveDefenders(uint32)":"d7f55bbc","getActiveMission(uint32)":"c7898535","getBanditTargetPreview(uint32)":"8233c665","getBanditTroop(uint32)":"a237d380","getBaseUpgradeCost(uint8)":"64374ddc","getClan(uint32)":"73c3d0da","getClanFullView(uint32)":"b6b1902d","getClanScore(uint32)":"826a02fc","getClansman(uint32)":"481a43a2","getDefendingClans(uint8)":"922b82d9","getDerivedClanState(uint32)":"1b43cdd8","getDerivedClansmanState(uint32)":"a22e3257","getMarketState()":"d8165743","getMissionTiming(uint32,uint32)":"bb6982c7","getMonumentUpgradeCost(uint8)":"6db7321d","getRankings()":"2c83b4b2","getRegionPopulation(uint8)":"b3d2cbdb","getScheduledMarketActionsForTick(uint64)":"1d0bf24c","getTravelTicks(uint8,uint8)":"c7e29ce6","getTreasuryState()":"23a8bdca","getWallUpgradeCost(uint8)":"000bed87","getWheatPlots(uint32)":"101583da","getWorldSnapshot()":"96fe8161","getWorldState()":"671eb0d2","heartbeat()":"3defb962","initTreasury(address[6],address[4])":"38c7f5c4","mintClan(address)":"b3705e4e","quoteLootValueRaw(uint32)":"1ade4dda","quoteLootValueSettled(uint32)":"7f9e027b","quoteTravel(uint8,uint8)":"135503af","seedPools((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256))":"c46a6fb2","settleClan(uint32)":"3073b90b","settleClansman(uint32)":"f1d68ae2","submitClanOrders(uint32,(uint32,uint8,uint8,uint32,address,uint256,uint256)[])":"7971fc2c","transferBlueprint(uint32,uint32,uint256)":"33f8d51d","transferBundle(uint32,uint32,uint256,uint256,uint256,uint256,uint256,uint256)":"c28492ab","transferGold(uint32,uint32,uint256)":"c3fd8ac9","transferVaultResource(uint32,uint32,uint8,uint256)":"a54e020c"},"rawMetadata":"{\"compiler\":{\"version\":\"0.8.34+commit.80d5c536\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"defended\",\"type\":\"bool\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"attackPower\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"totalDefense\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"wallLevelAfter\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"stolenWood\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"stolenIron\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"stolenWheat\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"stolenFish\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BanditAttackResolved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BanditDefeated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BanditEscaped\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"fromRegion\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"toRegion\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BanditMoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"tier\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"attackPower\",\"type\":\"uint16\"}],\"name\":\"BanditSpawned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"enum BanditState\",\"name\":\"oldState\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"enum BanditState\",\"name\":\"newState\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BanditStateChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"oldLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BaseLevelChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"settledAtTick\",\"type\":\"uint32\"}],\"name\":\"BaseUpgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"BlueprintAwarded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BlueprintTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"}],\"name\":\"ClanEliminated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"settledToTick\",\"type\":\"uint64\"}],\"name\":\"ClanSettled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"iftTokenId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"baseRegion\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ClanSpawned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"isStarving\",\"type\":\"bool\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ClanStarvationChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ClansmanDiedFromCold\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"oldDamage\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"newDamage\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ColdDamageApplied\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"GoldTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"tokenIn\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"tokenOut\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ImmediateMarketActionExecuted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"wood\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"iron\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"wheat\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"fish\",\"type\":\"uint256\"}],\"name\":\"LootDistributedToDefender\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"enum StatusCode\",\"name\":\"reason\",\"type\":\"uint8\"}],\"name\":\"MarketActionFailed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"startRegion\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"targetRegion\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"startTick\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"arrivalTick\",\"type\":\"uint64\"}],\"name\":\"MissionAssigned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"}],\"name\":\"MissionCompleted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"oldMissionNonce\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"newMissionNonce\",\"type\":\"uint64\"}],\"name\":\"MissionInterrupted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"oldLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"MonumentLevelChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"settledAtTick\",\"type\":\"uint32\"}],\"name\":\"MonumentUpgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"woodGoldPool\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"wheatGoldPool\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"fishGoldPool\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"ironGoldPool\",\"type\":\"address\"}],\"name\":\"PoolsSeeded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"woodDelta\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"ironDelta\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"wheatDelta\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"fishDelta\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"tick\",\"type\":\"uint32\"}],\"name\":\"ResourcesDeposited\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"woodGained\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"ironGained\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"wheatGained\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"fishGained\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"goldBonus\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ResourcesGathered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"executeAtTick\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"commitSequence\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"name\":\"ScheduledMarketActionCommitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"executeAtTick\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"commitSequence\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"tokenIn\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"tokenOut\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"}],\"name\":\"ScheduledMarketActionExecuted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint32[]\",\"name\":\"rankedClanIds\",\"type\":\"uint32[]\"}],\"name\":\"SeasonFinalized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"closedTick\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"openedTick\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"tickSeed\",\"type\":\"bytes32\"}],\"name\":\"TickAdvanced\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"enum ResourceType\",\"name\":\"resource\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"VaultResourceTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"oldLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"WallLevelChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"settledAtTick\",\"type\":\"uint32\"}],\"name\":\"WallUpgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"}],\"name\":\"WinterEnded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"}],\"name\":\"WinterStarted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"}],\"name\":\"WorkerArrived\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"finalizeSeason\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"}],\"name\":\"getActionDuration\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getActiveBanditView\",\"outputs\":[{\"components\":[{\"internalType\":\"bool\",\"name\":\"exists\",\"type\":\"bool\"},{\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"internalType\":\"enum BanditState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"currentRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"attackAttemptsMade\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"maxAttemptsRemaining\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"stateEnteredTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextActionTick\",\"type\":\"uint64\"},{\"internalType\":\"uint8\",\"name\":\"tier\",\"type\":\"uint8\"},{\"internalType\":\"uint16\",\"name\":\"attackPower\",\"type\":\"uint16\"},{\"internalType\":\"uint256\",\"name\":\"carryWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryFish\",\"type\":\"uint256\"},{\"internalType\":\"uint32\",\"name\":\"projectedTargetClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"projectedTargetLootValue\",\"type\":\"uint256\"}],\"internalType\":\"struct ActiveBanditView\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"}],\"name\":\"getActiveDefenders\",\"outputs\":[{\"internalType\":\"uint32[]\",\"name\":\"clansmanIds\",\"type\":\"uint32[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"}],\"name\":\"getActiveMission\",\"outputs\":[{\"components\":[{\"internalType\":\"bool\",\"name\":\"active\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"submittedAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"executesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"settlesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"startRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"targetRegion\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"startTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"arrivalTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"actionStartTick\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"missionSeed\",\"type\":\"bytes32\"},{\"internalType\":\"enum MarketExecutionMode\",\"name\":\"marketMode\",\"type\":\"uint8\"},{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct Mission\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"}],\"name\":\"getBanditTargetPreview\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"previewClanId\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"}],\"name\":\"getBanditTroop\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"internalType\":\"enum BanditState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"currentRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"attackAttemptsMade\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"stateEnteredTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextActionTick\",\"type\":\"uint64\"},{\"internalType\":\"uint8\",\"name\":\"tier\",\"type\":\"uint8\"},{\"internalType\":\"uint16\",\"name\":\"attackPower\",\"type\":\"uint16\"},{\"internalType\":\"uint256\",\"name\":\"carryWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryFish\",\"type\":\"uint256\"}],\"internalType\":\"struct BanditTroop\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"currentLevel\",\"type\":\"uint8\"}],\"name\":\"getBaseUpgradeCost\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"wood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"iron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wheat\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"getClan\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"iftTokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"enum ClanState\",\"name\":\"clanState\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"wallLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"monumentLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"livingClansmen\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"lastSettledTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"starvationStartsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint16\",\"name\":\"coldDamage\",\"type\":\"uint16\"},{\"internalType\":\"uint256\",\"name\":\"goldBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blueprintBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clan\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"getClanFullView\",\"outputs\":[{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"iftTokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"enum ClanState\",\"name\":\"clanState\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"wallLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"monumentLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"livingClansmen\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"lastSettledTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"starvationStartsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint16\",\"name\":\"coldDamage\",\"type\":\"uint16\"},{\"internalType\":\"uint256\",\"name\":\"goldBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blueprintBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clan\",\"name\":\"clan\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"isStarving\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"lootValue\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"derivedAtTick\",\"type\":\"uint64\"}],\"internalType\":\"struct DerivedClanState\",\"name\":\"clan\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ClansmanState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"currentRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"cooldownEndsAtTs\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"lastMissionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint256\",\"name\":\"carryWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clansman\",\"name\":\"clansman\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"bool\",\"name\":\"active\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"submittedAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"executesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"settlesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"startRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"targetRegion\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"startTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"arrivalTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"actionStartTick\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"missionSeed\",\"type\":\"bytes32\"},{\"internalType\":\"enum MarketExecutionMode\",\"name\":\"marketMode\",\"type\":\"uint8\"},{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct Mission\",\"name\":\"activeMission\",\"type\":\"tuple\"},{\"internalType\":\"uint8\",\"name\":\"effectiveRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"derivedAtTick\",\"type\":\"uint64\"}],\"internalType\":\"struct DerivedClansmanState\",\"name\":\"clansman\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"bool\",\"name\":\"active\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"submittedAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"executesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"settlesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"startRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"targetRegion\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"startTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"arrivalTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"actionStartTick\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"missionSeed\",\"type\":\"bytes32\"},{\"internalType\":\"enum MarketExecutionMode\",\"name\":\"marketMode\",\"type\":\"uint8\"},{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct Mission\",\"name\":\"activeMission\",\"type\":\"tuple\"}],\"internalType\":\"struct ClansmanFullView[]\",\"name\":\"clansmen\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enum WheatPlotState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"remainingWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"regrowUntilTick\",\"type\":\"uint64\"}],\"internalType\":\"struct WheatPlot\",\"name\":\"westPlot\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"enum WheatPlotState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"remainingWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"regrowUntilTick\",\"type\":\"uint64\"}],\"internalType\":\"struct WheatPlot\",\"name\":\"eastPlot\",\"type\":\"tuple\"},{\"internalType\":\"uint32[]\",\"name\":\"incomingDefenderIds\",\"type\":\"uint32[]\"},{\"internalType\":\"uint32\",\"name\":\"thisClanDefendingBaseId\",\"type\":\"uint32\"}],\"internalType\":\"struct ClanFullView\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"getClanScore\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"score\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"monumentReachedAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint8\",\"name\":\"monumentLevel\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"}],\"name\":\"getClansman\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ClansmanState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"currentRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"cooldownEndsAtTs\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"lastMissionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint256\",\"name\":\"carryWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clansman\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"}],\"name\":\"getDefendingClans\",\"outputs\":[{\"internalType\":\"uint32[]\",\"name\":\"clanIds\",\"type\":\"uint32[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"getDerivedClanState\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"iftTokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"enum ClanState\",\"name\":\"clanState\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"wallLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"monumentLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"livingClansmen\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"lastSettledTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"starvationStartsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint16\",\"name\":\"coldDamage\",\"type\":\"uint16\"},{\"internalType\":\"uint256\",\"name\":\"goldBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blueprintBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clan\",\"name\":\"clan\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"isStarving\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"lootValue\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"derivedAtTick\",\"type\":\"uint64\"}],\"internalType\":\"struct DerivedClanState\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"}],\"name\":\"getDerivedClansmanState\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ClansmanState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"currentRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"cooldownEndsAtTs\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"lastMissionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint256\",\"name\":\"carryWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clansman\",\"name\":\"clansman\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"bool\",\"name\":\"active\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"submittedAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"executesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"settlesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"startRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"targetRegion\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"startTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"arrivalTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"actionStartTick\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"missionSeed\",\"type\":\"bytes32\"},{\"internalType\":\"enum MarketExecutionMode\",\"name\":\"marketMode\",\"type\":\"uint8\"},{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct Mission\",\"name\":\"activeMission\",\"type\":\"tuple\"},{\"internalType\":\"uint8\",\"name\":\"effectiveRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"derivedAtTick\",\"type\":\"uint64\"}],\"internalType\":\"struct DerivedClansmanState\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getMarketState\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"resourceToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"resourceReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"spotPriceGoldPerResource\",\"type\":\"uint256\"}],\"internalType\":\"struct PoolReserves\",\"name\":\"wood\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"resourceToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"resourceReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"spotPriceGoldPerResource\",\"type\":\"uint256\"}],\"internalType\":\"struct PoolReserves\",\"name\":\"wheat\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"resourceToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"resourceReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"spotPriceGoldPerResource\",\"type\":\"uint256\"}],\"internalType\":\"struct PoolReserves\",\"name\":\"fish\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"resourceToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"resourceReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"spotPriceGoldPerResource\",\"type\":\"uint256\"}],\"internalType\":\"struct PoolReserves\",\"name\":\"iron\",\"type\":\"tuple\"},{\"internalType\":\"uint64\",\"name\":\"currentTick\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint64\",\"name\":\"executeAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"commitSequence\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct ScheduledMarketAction[]\",\"name\":\"currentTickQueue\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint64\",\"name\":\"executeAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"commitSequence\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct ScheduledMarketAction[]\",\"name\":\"nextTickQueue\",\"type\":\"tuple[]\"}],\"internalType\":\"struct MarketState\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"}],\"name\":\"getMissionTiming\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"submitted\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"executes\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"settles\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"currentLevel\",\"type\":\"uint8\"}],\"name\":\"getMonumentUpgradeCost\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"wood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"iron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blueprint\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getRankings\",\"outputs\":[{\"internalType\":\"uint32[]\",\"name\":\"clanIdsRanked\",\"type\":\"uint32[]\"},{\"internalType\":\"uint256[]\",\"name\":\"scores\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"}],\"name\":\"getRegionPopulation\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ClansmanState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"currentAction\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"}],\"internalType\":\"struct RegionOccupant[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"}],\"name\":\"getScheduledMarketActionsForTick\",\"outputs\":[{\"components\":[{\"internalType\":\"uint64\",\"name\":\"executeAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"commitSequence\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct ScheduledMarketAction[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"fromRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"toRegion\",\"type\":\"uint8\"}],\"name\":\"getTravelTicks\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getTreasuryState\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"treasuryOwner\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"prizePotGold\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"poolsSeeded\",\"type\":\"bool\"},{\"internalType\":\"address\",\"name\":\"woodToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"wheatToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"fishToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"ironToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"goldToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"blueprintToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"woodGoldPool\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"wheatGoldPool\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"fishGoldPool\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"ironGoldPool\",\"type\":\"address\"}],\"internalType\":\"struct TreasuryState\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"currentLevel\",\"type\":\"uint8\"}],\"name\":\"getWallUpgradeCost\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"wood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"iron\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"getWheatPlots\",\"outputs\":[{\"components\":[{\"internalType\":\"enum WheatPlotState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"remainingWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"regrowUntilTick\",\"type\":\"uint64\"}],\"internalType\":\"struct WheatPlot\",\"name\":\"west\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"enum WheatPlotState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"remainingWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"regrowUntilTick\",\"type\":\"uint64\"}],\"internalType\":\"struct WheatPlot\",\"name\":\"east\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getWorldSnapshot\",\"outputs\":[{\"components\":[{\"internalType\":\"uint64\",\"name\":\"currentTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"seasonStartTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"seasonEndTick\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"seasonFinalized\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"currentSeasonNumber\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextHeartbeatAtTick\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"winterActive\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"winterStartsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"winterEndsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"activeBanditId\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"currentTickSeed\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"uint8\",\"name\":\"monumentLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"wallLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"livingClansmen\",\"type\":\"uint8\"},{\"internalType\":\"enum ClanState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"lootValue\",\"type\":\"uint256\"}],\"internalType\":\"struct LeaderboardEntry[]\",\"name\":\"leaderboard\",\"type\":\"tuple[]\"}],\"internalType\":\"struct WorldSnapshot\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getWorldState\",\"outputs\":[{\"components\":[{\"internalType\":\"uint64\",\"name\":\"currentTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"seasonStartTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"seasonEndTick\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"seasonFinalized\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"currentSeasonNumber\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextHeartbeatAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextHeartbeatAtTs\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextBanditSpawnEligibleTick\",\"type\":\"uint64\"},{\"internalType\":\"uint16\",\"name\":\"currentBanditSpawnChanceBps\",\"type\":\"uint16\"},{\"internalType\":\"bytes32\",\"name\":\"currentTickSeed\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"activeBanditId\",\"type\":\"uint32\"},{\"internalType\":\"bool\",\"name\":\"winterActive\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"winterStartsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"winterEndsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextCommitSequence\",\"type\":\"uint64\"}],\"internalType\":\"struct WorldState\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"heartbeat\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[6]\",\"name\":\"tokens\",\"type\":\"address[6]\"},{\"internalType\":\"address[4]\",\"name\":\"pools\",\"type\":\"address[4]\"}],\"name\":\"initTreasury\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"mintClan\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"iftTokenId\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"quoteLootValueRaw\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"lootValue\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"quoteLootValueSettled\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"lootValue\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"srcRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"dstRegion\",\"type\":\"uint8\"}],\"name\":\"quoteTravel\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"travelTicks\",\"type\":\"uint8\"},{\"internalType\":\"bytes8\",\"name\":\"path\",\"type\":\"bytes8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"woodSeed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wheatSeed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"fishSeed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"ironSeed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldSeedForWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldSeedForWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldSeedForFish\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldSeedForIron\",\"type\":\"uint256\"}],\"internalType\":\"struct PoolSeedConfig\",\"name\":\"cfg\",\"type\":\"tuple\"}],\"name\":\"seedPools\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"settleClan\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"csId\",\"type\":\"uint32\"}],\"name\":\"settleClansman\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"gotoRegion\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct ClanOrder[]\",\"name\":\"orders\",\"type\":\"tuple[]\"}],\"name\":\"submitClanOrders\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"enum StatusCode\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"cooldownEndsAtTs\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"}],\"internalType\":\"struct OrderResult[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transferBlueprint\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"gold\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blueprint\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"iron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"fish\",\"type\":\"uint256\"}],\"name\":\"transferBundle\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transferGold\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ResourceType\",\"name\":\"resource\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transferVaultResource\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{\"getClanScore(uint32)\":{\"details\":\"Score is ordered by monument level, then earliest first-reached tick for that level,      then settled vault loot value, then wall level. The loot component matches      quoteLootValueSettled's read-only settled-vault basis.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"finalizeSeason()\":{\"notice\":\"Finalize the current season. Permissionless after seasonEndTick.\"},\"getActiveBanditView()\":{\"notice\":\"Single-call bandit drama state, including projected target if         attack resolved this tick. Drives the bandit warning UI.\"},\"getBanditTargetPreview(uint32)\":{\"notice\":\"Non-binding preview. Bandit targeting is recomputed at attack         resolution time using then-current eagerly settled state.\"},\"getClanFullView(uint32)\":{\"notice\":\"Single-call complete clan rendering data: derived clan + all         clansmen with derived state and active missions + plot states +         defender bookkeeping. Drives the entire sprite layer.\"},\"getClanScore(uint32)\":{\"notice\":\"Ranking score preview for a clan.\"},\"getMarketState()\":{\"notice\":\"Single-call market panel data: 4 pool reserves + spot prices +         scheduled queues for current and next tick. Drives market UI         and indexer's per-tick price-history sampling.\"},\"getRankings()\":{\"notice\":\"Live clans sorted by score descending, with clanId ascending for exact ties.\"},\"getRegionPopulation(uint8)\":{\"notice\":\"Optional. List clansmen currently in a region for tap-to-inspect         tooltips. Can be derived clientside; included for completeness.\"},\"getWorldSnapshot()\":{\"notice\":\"Single-call top-level world state plus per-clan leaderboard data.         Drives top HUD bar, season clock, winter indicator, leaderboard.\"},\"heartbeat()\":{\"notice\":\"Permissionless heartbeat. Closes the current tick, resolves         scheduled market actions and world events, advances the tick.         Rate-limited by WorldState.nextHeartbeatAtTs.\"},\"initTreasury(address[6],address[4])\":{\"notice\":\"Owner-only. Registers token and pool addresses once before seeding.         tokens order: wood, iron, wheat, fish, gold, blueprint.         pools order: wood, wheat, fish, iron.\"},\"mintClan(address)\":{\"notice\":\"Mint a new clan iNFT and spawn its homebase in a valid region.\"},\"seedPools((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256))\":{\"notice\":\"Owner-only. Seeds the four Unicorn Town pools at deploy time.\"},\"settleClan(uint32)\":{\"notice\":\"Lazily settle a clan forward to current tick. Idempotent.\"},\"settleClansman(uint32)\":{\"notice\":\"Lazily settle a single clansman's mission to current tick. Idempotent.\"},\"submitClanOrders(uint32,(uint32,uint8,uint8,uint32,address,uint256,uint256)[])\":{\"notice\":\"Submit one or more orders for a single clan's clansmen.         Per-order failures do not revert the tx.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/IClanWorld.sol\":\"IClanWorld\"},\"evmVersion\":\"prague\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[\":forge-std/=lib/forge-std/src/\"],\"viaIR\":true},\"sources\":{\"src/IClanWorld.sol\":{\"keccak256\":\"0x2bb8f2b4dd423591858ebacb7d4b6eb3e826b57d67ec4ee5e1c99f452134dbb9\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://e0f1e37ac103f748e5ba0e5483ee360ce066f919f207605d90f74e1bcc1ef603\",\"dweb:/ipfs/QmXVFbaMSwBJQSS873E6n2WzwpuPZnoKomZMcg2tMWQTmk\"]}},\"version\":1}","metadata":{"compiler":{"version":"0.8.34+commit.80d5c536"},"language":"Solidity","output":{"abi":[{"inputs":[{"internalType":"uint32","name":"banditId","type":"uint32","indexed":true},{"internalType":"uint32","name":"targetClanId","type":"uint32","indexed":true},{"internalType":"bool","name":"defended","type":"bool","indexed":false},{"internalType":"uint16","name":"attackPower","type":"uint16","indexed":false},{"internalType":"uint16","name":"totalDefense","type":"uint16","indexed":false},{"internalType":"uint16","name":"wallLevelAfter","type":"uint16","indexed":false},{"internalType":"uint256","name":"stolenWood","type":"uint256","indexed":false},{"internalType":"uint256","name":"stolenIron","type":"uint256","indexed":false},{"internalType":"uint256","name":"stolenWheat","type":"uint256","indexed":false},{"internalType":"uint256","name":"stolenFish","type":"uint256","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"BanditAttackResolved","anonymous":false},{"inputs":[{"internalType":"uint32","name":"banditId","type":"uint32","indexed":true},{"internalType":"uint32","name":"targetClanId","type":"uint32","indexed":true},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"BanditDefeated","anonymous":false},{"inputs":[{"internalType":"uint32","name":"banditId","type":"uint32","indexed":true},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"BanditEscaped","anonymous":false},{"inputs":[{"internalType":"uint32","name":"banditId","type":"uint32","indexed":true},{"internalType":"uint8","name":"fromRegion","type":"uint8","indexed":false},{"internalType":"uint8","name":"toRegion","type":"uint8","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"BanditMoved","anonymous":false},{"inputs":[{"internalType":"uint32","name":"banditId","type":"uint32","indexed":true},{"internalType":"uint8","name":"region","type":"uint8","indexed":false},{"internalType":"uint8","name":"tier","type":"uint8","indexed":false},{"internalType":"uint16","name":"attackPower","type":"uint16","indexed":false}],"type":"event","name":"BanditSpawned","anonymous":false},{"inputs":[{"internalType":"uint32","name":"banditId","type":"uint32","indexed":true},{"internalType":"enum BanditState","name":"oldState","type":"uint8","indexed":false},{"internalType":"enum BanditState","name":"newState","type":"uint8","indexed":false},{"internalType":"uint8","name":"region","type":"uint8","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"BanditStateChanged","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint8","name":"oldLevel","type":"uint8","indexed":false},{"internalType":"uint8","name":"newLevel","type":"uint8","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"BaseLevelChanged","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint8","name":"newLevel","type":"uint8","indexed":false},{"internalType":"uint32","name":"settledAtTick","type":"uint32","indexed":false}],"type":"event","name":"BaseUpgraded","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"banditId","type":"uint32","indexed":true},{"internalType":"uint256","name":"amount","type":"uint256","indexed":false}],"type":"event","name":"BlueprintAwarded","anonymous":false},{"inputs":[{"internalType":"uint32","name":"fromClanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"toClanId","type":"uint32","indexed":true},{"internalType":"uint256","name":"amount","type":"uint256","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"BlueprintTransferred","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint64","name":"tick","type":"uint64","indexed":true}],"type":"event","name":"ClanEliminated","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint64","name":"settledToTick","type":"uint64","indexed":false}],"type":"event","name":"ClanSettled","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"address","name":"owner","type":"address","indexed":true},{"internalType":"uint256","name":"iftTokenId","type":"uint256","indexed":false},{"internalType":"uint8","name":"baseRegion","type":"uint8","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"ClanSpawned","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"bool","name":"isStarving","type":"bool","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"ClanStarvationChanged","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"ClansmanDiedFromCold","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint16","name":"oldDamage","type":"uint16","indexed":false},{"internalType":"uint16","name":"newDamage","type":"uint16","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"ColdDamageApplied","anonymous":false},{"inputs":[{"internalType":"uint32","name":"fromClanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"toClanId","type":"uint32","indexed":true},{"internalType":"uint256","name":"amount","type":"uint256","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"GoldTransferred","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clansmanId","type":"uint32","indexed":true},{"internalType":"address","name":"tokenIn","type":"address","indexed":false},{"internalType":"address","name":"tokenOut","type":"address","indexed":false},{"internalType":"uint256","name":"amountIn","type":"uint256","indexed":false},{"internalType":"uint256","name":"amountOut","type":"uint256","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"ImmediateMarketActionExecuted","anonymous":false},{"inputs":[{"internalType":"uint32","name":"banditId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clansmanId","type":"uint32","indexed":true},{"internalType":"uint256","name":"wood","type":"uint256","indexed":false},{"internalType":"uint256","name":"iron","type":"uint256","indexed":false},{"internalType":"uint256","name":"wheat","type":"uint256","indexed":false},{"internalType":"uint256","name":"fish","type":"uint256","indexed":false}],"type":"event","name":"LootDistributedToDefender","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clansmanId","type":"uint32","indexed":true},{"internalType":"enum ActionType","name":"action","type":"uint8","indexed":false},{"internalType":"enum StatusCode","name":"reason","type":"uint8","indexed":false}],"type":"event","name":"MarketActionFailed","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clansmanId","type":"uint32","indexed":true},{"internalType":"uint64","name":"missionNonce","type":"uint64","indexed":false},{"internalType":"enum ActionType","name":"action","type":"uint8","indexed":false},{"internalType":"uint8","name":"startRegion","type":"uint8","indexed":false},{"internalType":"uint8","name":"targetRegion","type":"uint8","indexed":false},{"internalType":"uint64","name":"startTick","type":"uint64","indexed":false},{"internalType":"uint64","name":"arrivalTick","type":"uint64","indexed":false}],"type":"event","name":"MissionAssigned","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clansmanId","type":"uint32","indexed":true},{"internalType":"uint64","name":"missionNonce","type":"uint64","indexed":false},{"internalType":"enum ActionType","name":"action","type":"uint8","indexed":false}],"type":"event","name":"MissionCompleted","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clansmanId","type":"uint32","indexed":true},{"internalType":"uint64","name":"oldMissionNonce","type":"uint64","indexed":false},{"internalType":"uint64","name":"newMissionNonce","type":"uint64","indexed":false}],"type":"event","name":"MissionInterrupted","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint8","name":"oldLevel","type":"uint8","indexed":false},{"internalType":"uint8","name":"newLevel","type":"uint8","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"MonumentLevelChanged","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint8","name":"newLevel","type":"uint8","indexed":false},{"internalType":"uint32","name":"settledAtTick","type":"uint32","indexed":false}],"type":"event","name":"MonumentUpgraded","anonymous":false},{"inputs":[{"internalType":"address","name":"woodGoldPool","type":"address","indexed":false},{"internalType":"address","name":"wheatGoldPool","type":"address","indexed":false},{"internalType":"address","name":"fishGoldPool","type":"address","indexed":false},{"internalType":"address","name":"ironGoldPool","type":"address","indexed":false}],"type":"event","name":"PoolsSeeded","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clansmanId","type":"uint32","indexed":true},{"internalType":"uint256","name":"woodDelta","type":"uint256","indexed":false},{"internalType":"uint256","name":"ironDelta","type":"uint256","indexed":false},{"internalType":"uint256","name":"wheatDelta","type":"uint256","indexed":false},{"internalType":"uint256","name":"fishDelta","type":"uint256","indexed":false},{"internalType":"uint32","name":"tick","type":"uint32","indexed":false}],"type":"event","name":"ResourcesDeposited","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clansmanId","type":"uint32","indexed":true},{"internalType":"enum ActionType","name":"action","type":"uint8","indexed":false},{"internalType":"uint256","name":"woodGained","type":"uint256","indexed":false},{"internalType":"uint256","name":"ironGained","type":"uint256","indexed":false},{"internalType":"uint256","name":"wheatGained","type":"uint256","indexed":false},{"internalType":"uint256","name":"fishGained","type":"uint256","indexed":false},{"internalType":"uint256","name":"goldBonus","type":"uint256","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"ResourcesGathered","anonymous":false},{"inputs":[{"internalType":"uint64","name":"executeAtTick","type":"uint64","indexed":true},{"internalType":"uint64","name":"commitSequence","type":"uint64","indexed":true},{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clansmanId","type":"uint32","indexed":false},{"internalType":"enum ActionType","name":"action","type":"uint8","indexed":false},{"internalType":"address","name":"marketToken","type":"address","indexed":false},{"internalType":"uint256","name":"marketAmount","type":"uint256","indexed":false},{"internalType":"uint256","name":"maxGoldIn","type":"uint256","indexed":false}],"type":"event","name":"ScheduledMarketActionCommitted","anonymous":false},{"inputs":[{"internalType":"uint64","name":"executeAtTick","type":"uint64","indexed":true},{"internalType":"uint64","name":"commitSequence","type":"uint64","indexed":true},{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clansmanId","type":"uint32","indexed":false},{"internalType":"address","name":"tokenIn","type":"address","indexed":false},{"internalType":"address","name":"tokenOut","type":"address","indexed":false},{"internalType":"uint256","name":"amountIn","type":"uint256","indexed":false},{"internalType":"uint256","name":"amountOut","type":"uint256","indexed":false}],"type":"event","name":"ScheduledMarketActionExecuted","anonymous":false},{"inputs":[{"internalType":"uint64","name":"tick","type":"uint64","indexed":true},{"internalType":"uint32[]","name":"rankedClanIds","type":"uint32[]","indexed":false}],"type":"event","name":"SeasonFinalized","anonymous":false},{"inputs":[{"internalType":"uint64","name":"closedTick","type":"uint64","indexed":false},{"internalType":"uint64","name":"openedTick","type":"uint64","indexed":false},{"internalType":"bytes32","name":"tickSeed","type":"bytes32","indexed":false}],"type":"event","name":"TickAdvanced","anonymous":false},{"inputs":[{"internalType":"uint32","name":"fromClanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"toClanId","type":"uint32","indexed":true},{"internalType":"enum ResourceType","name":"resource","type":"uint8","indexed":false},{"internalType":"uint256","name":"amount","type":"uint256","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"VaultResourceTransferred","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint8","name":"oldLevel","type":"uint8","indexed":false},{"internalType":"uint8","name":"newLevel","type":"uint8","indexed":false},{"internalType":"uint64","name":"atTick","type":"uint64","indexed":false}],"type":"event","name":"WallLevelChanged","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint8","name":"newLevel","type":"uint8","indexed":false},{"internalType":"uint32","name":"settledAtTick","type":"uint32","indexed":false}],"type":"event","name":"WallUpgraded","anonymous":false},{"inputs":[{"internalType":"uint64","name":"tick","type":"uint64","indexed":true}],"type":"event","name":"WinterEnded","anonymous":false},{"inputs":[{"internalType":"uint64","name":"tick","type":"uint64","indexed":true}],"type":"event","name":"WinterStarted","anonymous":false},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32","indexed":true},{"internalType":"uint32","name":"clansmanId","type":"uint32","indexed":true},{"internalType":"uint8","name":"region","type":"uint8","indexed":false},{"internalType":"uint64","name":"tick","type":"uint64","indexed":false}],"type":"event","name":"WorkerArrived","anonymous":false},{"inputs":[],"stateMutability":"nonpayable","type":"function","name":"finalizeSeason"},{"inputs":[{"internalType":"enum ActionType","name":"action","type":"uint8"}],"stateMutability":"pure","type":"function","name":"getActionDuration","outputs":[{"internalType":"uint64","name":"","type":"uint64"}]},{"inputs":[],"stateMutability":"view","type":"function","name":"getActiveBanditView","outputs":[{"internalType":"struct ActiveBanditView","name":"","type":"tuple","components":[{"internalType":"bool","name":"exists","type":"bool"},{"internalType":"uint32","name":"banditId","type":"uint32"},{"internalType":"enum BanditState","name":"state","type":"uint8"},{"internalType":"uint8","name":"currentRegion","type":"uint8"},{"internalType":"uint8","name":"attackAttemptsMade","type":"uint8"},{"internalType":"uint8","name":"maxAttemptsRemaining","type":"uint8"},{"internalType":"uint64","name":"stateEnteredTick","type":"uint64"},{"internalType":"uint64","name":"nextActionTick","type":"uint64"},{"internalType":"uint8","name":"tier","type":"uint8"},{"internalType":"uint16","name":"attackPower","type":"uint16"},{"internalType":"uint256","name":"carryWood","type":"uint256"},{"internalType":"uint256","name":"carryIron","type":"uint256"},{"internalType":"uint256","name":"carryWheat","type":"uint256"},{"internalType":"uint256","name":"carryFish","type":"uint256"},{"internalType":"uint32","name":"projectedTargetClanId","type":"uint32"},{"internalType":"uint256","name":"projectedTargetLootValue","type":"uint256"}]}]},{"inputs":[{"internalType":"uint32","name":"targetClanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getActiveDefenders","outputs":[{"internalType":"uint32[]","name":"clansmanIds","type":"uint32[]"}]},{"inputs":[{"internalType":"uint32","name":"clansmanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getActiveMission","outputs":[{"internalType":"struct Mission","name":"","type":"tuple","components":[{"internalType":"bool","name":"active","type":"bool"},{"internalType":"uint64","name":"nonce","type":"uint64"},{"internalType":"uint64","name":"submittedAtTick","type":"uint64"},{"internalType":"uint64","name":"executesAtTick","type":"uint64"},{"internalType":"uint64","name":"settlesAtTick","type":"uint64"},{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"uint8","name":"startRegion","type":"uint8"},{"internalType":"uint8","name":"targetRegion","type":"uint8"},{"internalType":"enum ActionType","name":"action","type":"uint8"},{"internalType":"uint64","name":"startTick","type":"uint64"},{"internalType":"uint64","name":"arrivalTick","type":"uint64"},{"internalType":"uint64","name":"actionStartTick","type":"uint64"},{"internalType":"bytes32","name":"missionSeed","type":"bytes32"},{"internalType":"enum MarketExecutionMode","name":"marketMode","type":"uint8"},{"internalType":"uint32","name":"targetClanId","type":"uint32"},{"internalType":"address","name":"marketToken","type":"address"},{"internalType":"uint256","name":"marketAmount","type":"uint256"},{"internalType":"uint256","name":"maxGoldIn","type":"uint256"}]}]},{"inputs":[{"internalType":"uint32","name":"banditId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getBanditTargetPreview","outputs":[{"internalType":"uint32","name":"previewClanId","type":"uint32"}]},{"inputs":[{"internalType":"uint32","name":"banditId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getBanditTroop","outputs":[{"internalType":"struct BanditTroop","name":"","type":"tuple","components":[{"internalType":"uint32","name":"banditId","type":"uint32"},{"internalType":"enum BanditState","name":"state","type":"uint8"},{"internalType":"uint8","name":"currentRegion","type":"uint8"},{"internalType":"uint8","name":"attackAttemptsMade","type":"uint8"},{"internalType":"uint64","name":"stateEnteredTick","type":"uint64"},{"internalType":"uint64","name":"nextActionTick","type":"uint64"},{"internalType":"uint8","name":"tier","type":"uint8"},{"internalType":"uint16","name":"attackPower","type":"uint16"},{"internalType":"uint256","name":"carryWood","type":"uint256"},{"internalType":"uint256","name":"carryIron","type":"uint256"},{"internalType":"uint256","name":"carryWheat","type":"uint256"},{"internalType":"uint256","name":"carryFish","type":"uint256"}]}]},{"inputs":[{"internalType":"uint8","name":"currentLevel","type":"uint8"}],"stateMutability":"pure","type":"function","name":"getBaseUpgradeCost","outputs":[{"internalType":"uint256","name":"wood","type":"uint256"},{"internalType":"uint256","name":"iron","type":"uint256"},{"internalType":"uint256","name":"wheat","type":"uint256"}]},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getClan","outputs":[{"internalType":"struct Clan","name":"","type":"tuple","components":[{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"uint256","name":"iftTokenId","type":"uint256"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"enum ClanState","name":"clanState","type":"uint8"},{"internalType":"uint8","name":"baseRegion","type":"uint8"},{"internalType":"uint8","name":"baseLevel","type":"uint8"},{"internalType":"uint8","name":"wallLevel","type":"uint8"},{"internalType":"uint8","name":"monumentLevel","type":"uint8"},{"internalType":"uint8","name":"livingClansmen","type":"uint8"},{"internalType":"uint64","name":"lastSettledTick","type":"uint64"},{"internalType":"uint64","name":"starvationStartsAtTick","type":"uint64"},{"internalType":"uint16","name":"coldDamage","type":"uint16"},{"internalType":"uint256","name":"goldBalance","type":"uint256"},{"internalType":"uint256","name":"blueprintBalance","type":"uint256"},{"internalType":"uint256","name":"vaultWood","type":"uint256"},{"internalType":"uint256","name":"vaultIron","type":"uint256"},{"internalType":"uint256","name":"vaultWheat","type":"uint256"},{"internalType":"uint256","name":"vaultFish","type":"uint256"}]}]},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getClanFullView","outputs":[{"internalType":"struct ClanFullView","name":"","type":"tuple","components":[{"internalType":"struct DerivedClanState","name":"clan","type":"tuple","components":[{"internalType":"struct Clan","name":"clan","type":"tuple","components":[{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"uint256","name":"iftTokenId","type":"uint256"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"enum ClanState","name":"clanState","type":"uint8"},{"internalType":"uint8","name":"baseRegion","type":"uint8"},{"internalType":"uint8","name":"baseLevel","type":"uint8"},{"internalType":"uint8","name":"wallLevel","type":"uint8"},{"internalType":"uint8","name":"monumentLevel","type":"uint8"},{"internalType":"uint8","name":"livingClansmen","type":"uint8"},{"internalType":"uint64","name":"lastSettledTick","type":"uint64"},{"internalType":"uint64","name":"starvationStartsAtTick","type":"uint64"},{"internalType":"uint16","name":"coldDamage","type":"uint16"},{"internalType":"uint256","name":"goldBalance","type":"uint256"},{"internalType":"uint256","name":"blueprintBalance","type":"uint256"},{"internalType":"uint256","name":"vaultWood","type":"uint256"},{"internalType":"uint256","name":"vaultIron","type":"uint256"},{"internalType":"uint256","name":"vaultWheat","type":"uint256"},{"internalType":"uint256","name":"vaultFish","type":"uint256"}]},{"internalType":"bool","name":"isStarving","type":"bool"},{"internalType":"uint256","name":"lootValue","type":"uint256"},{"internalType":"uint64","name":"derivedAtTick","type":"uint64"}]},{"internalType":"struct ClansmanFullView[]","name":"clansmen","type":"tuple[]","components":[{"internalType":"struct DerivedClansmanState","name":"clansman","type":"tuple","components":[{"internalType":"struct Clansman","name":"clansman","type":"tuple","components":[{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"enum ClansmanState","name":"state","type":"uint8"},{"internalType":"uint8","name":"currentRegion","type":"uint8"},{"internalType":"uint64","name":"cooldownEndsAtTs","type":"uint64"},{"internalType":"uint64","name":"lastMissionNonce","type":"uint64"},{"internalType":"uint256","name":"carryWood","type":"uint256"},{"internalType":"uint256","name":"carryIron","type":"uint256"},{"internalType":"uint256","name":"carryWheat","type":"uint256"},{"internalType":"uint256","name":"carryFish","type":"uint256"}]},{"internalType":"struct Mission","name":"activeMission","type":"tuple","components":[{"internalType":"bool","name":"active","type":"bool"},{"internalType":"uint64","name":"nonce","type":"uint64"},{"internalType":"uint64","name":"submittedAtTick","type":"uint64"},{"internalType":"uint64","name":"executesAtTick","type":"uint64"},{"internalType":"uint64","name":"settlesAtTick","type":"uint64"},{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"uint8","name":"startRegion","type":"uint8"},{"internalType":"uint8","name":"targetRegion","type":"uint8"},{"internalType":"enum ActionType","name":"action","type":"uint8"},{"internalType":"uint64","name":"startTick","type":"uint64"},{"internalType":"uint64","name":"arrivalTick","type":"uint64"},{"internalType":"uint64","name":"actionStartTick","type":"uint64"},{"internalType":"bytes32","name":"missionSeed","type":"bytes32"},{"internalType":"enum MarketExecutionMode","name":"marketMode","type":"uint8"},{"internalType":"uint32","name":"targetClanId","type":"uint32"},{"internalType":"address","name":"marketToken","type":"address"},{"internalType":"uint256","name":"marketAmount","type":"uint256"},{"internalType":"uint256","name":"maxGoldIn","type":"uint256"}]},{"internalType":"uint8","name":"effectiveRegion","type":"uint8"},{"internalType":"uint64","name":"derivedAtTick","type":"uint64"}]},{"internalType":"struct Mission","name":"activeMission","type":"tuple","components":[{"internalType":"bool","name":"active","type":"bool"},{"internalType":"uint64","name":"nonce","type":"uint64"},{"internalType":"uint64","name":"submittedAtTick","type":"uint64"},{"internalType":"uint64","name":"executesAtTick","type":"uint64"},{"internalType":"uint64","name":"settlesAtTick","type":"uint64"},{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"uint8","name":"startRegion","type":"uint8"},{"internalType":"uint8","name":"targetRegion","type":"uint8"},{"internalType":"enum ActionType","name":"action","type":"uint8"},{"internalType":"uint64","name":"startTick","type":"uint64"},{"internalType":"uint64","name":"arrivalTick","type":"uint64"},{"internalType":"uint64","name":"actionStartTick","type":"uint64"},{"internalType":"bytes32","name":"missionSeed","type":"bytes32"},{"internalType":"enum MarketExecutionMode","name":"marketMode","type":"uint8"},{"internalType":"uint32","name":"targetClanId","type":"uint32"},{"internalType":"address","name":"marketToken","type":"address"},{"internalType":"uint256","name":"marketAmount","type":"uint256"},{"internalType":"uint256","name":"maxGoldIn","type":"uint256"}]}]},{"internalType":"struct WheatPlot","name":"westPlot","type":"tuple","components":[{"internalType":"enum WheatPlotState","name":"state","type":"uint8"},{"internalType":"uint8","name":"region","type":"uint8"},{"internalType":"uint256","name":"remainingWheat","type":"uint256"},{"internalType":"uint64","name":"regrowUntilTick","type":"uint64"}]},{"internalType":"struct WheatPlot","name":"eastPlot","type":"tuple","components":[{"internalType":"enum WheatPlotState","name":"state","type":"uint8"},{"internalType":"uint8","name":"region","type":"uint8"},{"internalType":"uint256","name":"remainingWheat","type":"uint256"},{"internalType":"uint64","name":"regrowUntilTick","type":"uint64"}]},{"internalType":"uint32[]","name":"incomingDefenderIds","type":"uint32[]"},{"internalType":"uint32","name":"thisClanDefendingBaseId","type":"uint32"}]}]},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getClanScore","outputs":[{"internalType":"uint256","name":"score","type":"uint256"},{"internalType":"uint64","name":"monumentReachedAtTick","type":"uint64"},{"internalType":"uint8","name":"monumentLevel","type":"uint8"}]},{"inputs":[{"internalType":"uint32","name":"clansmanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getClansman","outputs":[{"internalType":"struct Clansman","name":"","type":"tuple","components":[{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"enum ClansmanState","name":"state","type":"uint8"},{"internalType":"uint8","name":"currentRegion","type":"uint8"},{"internalType":"uint64","name":"cooldownEndsAtTs","type":"uint64"},{"internalType":"uint64","name":"lastMissionNonce","type":"uint64"},{"internalType":"uint256","name":"carryWood","type":"uint256"},{"internalType":"uint256","name":"carryIron","type":"uint256"},{"internalType":"uint256","name":"carryWheat","type":"uint256"},{"internalType":"uint256","name":"carryFish","type":"uint256"}]}]},{"inputs":[{"internalType":"uint8","name":"region","type":"uint8"}],"stateMutability":"view","type":"function","name":"getDefendingClans","outputs":[{"internalType":"uint32[]","name":"clanIds","type":"uint32[]"}]},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getDerivedClanState","outputs":[{"internalType":"struct DerivedClanState","name":"","type":"tuple","components":[{"internalType":"struct Clan","name":"clan","type":"tuple","components":[{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"uint256","name":"iftTokenId","type":"uint256"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"enum ClanState","name":"clanState","type":"uint8"},{"internalType":"uint8","name":"baseRegion","type":"uint8"},{"internalType":"uint8","name":"baseLevel","type":"uint8"},{"internalType":"uint8","name":"wallLevel","type":"uint8"},{"internalType":"uint8","name":"monumentLevel","type":"uint8"},{"internalType":"uint8","name":"livingClansmen","type":"uint8"},{"internalType":"uint64","name":"lastSettledTick","type":"uint64"},{"internalType":"uint64","name":"starvationStartsAtTick","type":"uint64"},{"internalType":"uint16","name":"coldDamage","type":"uint16"},{"internalType":"uint256","name":"goldBalance","type":"uint256"},{"internalType":"uint256","name":"blueprintBalance","type":"uint256"},{"internalType":"uint256","name":"vaultWood","type":"uint256"},{"internalType":"uint256","name":"vaultIron","type":"uint256"},{"internalType":"uint256","name":"vaultWheat","type":"uint256"},{"internalType":"uint256","name":"vaultFish","type":"uint256"}]},{"internalType":"bool","name":"isStarving","type":"bool"},{"internalType":"uint256","name":"lootValue","type":"uint256"},{"internalType":"uint64","name":"derivedAtTick","type":"uint64"}]}]},{"inputs":[{"internalType":"uint32","name":"clansmanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getDerivedClansmanState","outputs":[{"internalType":"struct DerivedClansmanState","name":"","type":"tuple","components":[{"internalType":"struct Clansman","name":"clansman","type":"tuple","components":[{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"enum ClansmanState","name":"state","type":"uint8"},{"internalType":"uint8","name":"currentRegion","type":"uint8"},{"internalType":"uint64","name":"cooldownEndsAtTs","type":"uint64"},{"internalType":"uint64","name":"lastMissionNonce","type":"uint64"},{"internalType":"uint256","name":"carryWood","type":"uint256"},{"internalType":"uint256","name":"carryIron","type":"uint256"},{"internalType":"uint256","name":"carryWheat","type":"uint256"},{"internalType":"uint256","name":"carryFish","type":"uint256"}]},{"internalType":"struct Mission","name":"activeMission","type":"tuple","components":[{"internalType":"bool","name":"active","type":"bool"},{"internalType":"uint64","name":"nonce","type":"uint64"},{"internalType":"uint64","name":"submittedAtTick","type":"uint64"},{"internalType":"uint64","name":"executesAtTick","type":"uint64"},{"internalType":"uint64","name":"settlesAtTick","type":"uint64"},{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"uint8","name":"startRegion","type":"uint8"},{"internalType":"uint8","name":"targetRegion","type":"uint8"},{"internalType":"enum ActionType","name":"action","type":"uint8"},{"internalType":"uint64","name":"startTick","type":"uint64"},{"internalType":"uint64","name":"arrivalTick","type":"uint64"},{"internalType":"uint64","name":"actionStartTick","type":"uint64"},{"internalType":"bytes32","name":"missionSeed","type":"bytes32"},{"internalType":"enum MarketExecutionMode","name":"marketMode","type":"uint8"},{"internalType":"uint32","name":"targetClanId","type":"uint32"},{"internalType":"address","name":"marketToken","type":"address"},{"internalType":"uint256","name":"marketAmount","type":"uint256"},{"internalType":"uint256","name":"maxGoldIn","type":"uint256"}]},{"internalType":"uint8","name":"effectiveRegion","type":"uint8"},{"internalType":"uint64","name":"derivedAtTick","type":"uint64"}]}]},{"inputs":[],"stateMutability":"view","type":"function","name":"getMarketState","outputs":[{"internalType":"struct MarketState","name":"","type":"tuple","components":[{"internalType":"struct PoolReserves","name":"wood","type":"tuple","components":[{"internalType":"address","name":"resourceToken","type":"address"},{"internalType":"uint256","name":"resourceReserve","type":"uint256"},{"internalType":"uint256","name":"goldReserve","type":"uint256"},{"internalType":"uint256","name":"spotPriceGoldPerResource","type":"uint256"}]},{"internalType":"struct PoolReserves","name":"wheat","type":"tuple","components":[{"internalType":"address","name":"resourceToken","type":"address"},{"internalType":"uint256","name":"resourceReserve","type":"uint256"},{"internalType":"uint256","name":"goldReserve","type":"uint256"},{"internalType":"uint256","name":"spotPriceGoldPerResource","type":"uint256"}]},{"internalType":"struct PoolReserves","name":"fish","type":"tuple","components":[{"internalType":"address","name":"resourceToken","type":"address"},{"internalType":"uint256","name":"resourceReserve","type":"uint256"},{"internalType":"uint256","name":"goldReserve","type":"uint256"},{"internalType":"uint256","name":"spotPriceGoldPerResource","type":"uint256"}]},{"internalType":"struct PoolReserves","name":"iron","type":"tuple","components":[{"internalType":"address","name":"resourceToken","type":"address"},{"internalType":"uint256","name":"resourceReserve","type":"uint256"},{"internalType":"uint256","name":"goldReserve","type":"uint256"},{"internalType":"uint256","name":"spotPriceGoldPerResource","type":"uint256"}]},{"internalType":"uint64","name":"currentTick","type":"uint64"},{"internalType":"struct ScheduledMarketAction[]","name":"currentTickQueue","type":"tuple[]","components":[{"internalType":"uint64","name":"executeAtTick","type":"uint64"},{"internalType":"uint64","name":"commitSequence","type":"uint64"},{"internalType":"uint64","name":"missionNonce","type":"uint64"},{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"enum ActionType","name":"action","type":"uint8"},{"internalType":"address","name":"marketToken","type":"address"},{"internalType":"uint256","name":"marketAmount","type":"uint256"},{"internalType":"uint256","name":"maxGoldIn","type":"uint256"}]},{"internalType":"struct ScheduledMarketAction[]","name":"nextTickQueue","type":"tuple[]","components":[{"internalType":"uint64","name":"executeAtTick","type":"uint64"},{"internalType":"uint64","name":"commitSequence","type":"uint64"},{"internalType":"uint64","name":"missionNonce","type":"uint64"},{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"enum ActionType","name":"action","type":"uint8"},{"internalType":"address","name":"marketToken","type":"address"},{"internalType":"uint256","name":"marketAmount","type":"uint256"},{"internalType":"uint256","name":"maxGoldIn","type":"uint256"}]}]}]},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"uint32","name":"clansmanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getMissionTiming","outputs":[{"internalType":"uint64","name":"submitted","type":"uint64"},{"internalType":"uint64","name":"executes","type":"uint64"},{"internalType":"uint64","name":"settles","type":"uint64"}]},{"inputs":[{"internalType":"uint8","name":"currentLevel","type":"uint8"}],"stateMutability":"pure","type":"function","name":"getMonumentUpgradeCost","outputs":[{"internalType":"uint256","name":"wood","type":"uint256"},{"internalType":"uint256","name":"iron","type":"uint256"},{"internalType":"uint256","name":"wheat","type":"uint256"},{"internalType":"uint256","name":"blueprint","type":"uint256"}]},{"inputs":[],"stateMutability":"view","type":"function","name":"getRankings","outputs":[{"internalType":"uint32[]","name":"clanIdsRanked","type":"uint32[]"},{"internalType":"uint256[]","name":"scores","type":"uint256[]"}]},{"inputs":[{"internalType":"uint8","name":"region","type":"uint8"}],"stateMutability":"view","type":"function","name":"getRegionPopulation","outputs":[{"internalType":"struct RegionOccupant[]","name":"","type":"tuple[]","components":[{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"enum ClansmanState","name":"state","type":"uint8"},{"internalType":"enum ActionType","name":"currentAction","type":"uint8"},{"internalType":"uint64","name":"missionNonce","type":"uint64"}]}]},{"inputs":[{"internalType":"uint64","name":"tick","type":"uint64"}],"stateMutability":"view","type":"function","name":"getScheduledMarketActionsForTick","outputs":[{"internalType":"struct ScheduledMarketAction[]","name":"","type":"tuple[]","components":[{"internalType":"uint64","name":"executeAtTick","type":"uint64"},{"internalType":"uint64","name":"commitSequence","type":"uint64"},{"internalType":"uint64","name":"missionNonce","type":"uint64"},{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"enum ActionType","name":"action","type":"uint8"},{"internalType":"address","name":"marketToken","type":"address"},{"internalType":"uint256","name":"marketAmount","type":"uint256"},{"internalType":"uint256","name":"maxGoldIn","type":"uint256"}]}]},{"inputs":[{"internalType":"uint8","name":"fromRegion","type":"uint8"},{"internalType":"uint8","name":"toRegion","type":"uint8"}],"stateMutability":"pure","type":"function","name":"getTravelTicks","outputs":[{"internalType":"uint64","name":"","type":"uint64"}]},{"inputs":[],"stateMutability":"view","type":"function","name":"getTreasuryState","outputs":[{"internalType":"struct TreasuryState","name":"","type":"tuple","components":[{"internalType":"address","name":"treasuryOwner","type":"address"},{"internalType":"uint256","name":"prizePotGold","type":"uint256"},{"internalType":"bool","name":"poolsSeeded","type":"bool"},{"internalType":"address","name":"woodToken","type":"address"},{"internalType":"address","name":"wheatToken","type":"address"},{"internalType":"address","name":"fishToken","type":"address"},{"internalType":"address","name":"ironToken","type":"address"},{"internalType":"address","name":"goldToken","type":"address"},{"internalType":"address","name":"blueprintToken","type":"address"},{"internalType":"address","name":"woodGoldPool","type":"address"},{"internalType":"address","name":"wheatGoldPool","type":"address"},{"internalType":"address","name":"fishGoldPool","type":"address"},{"internalType":"address","name":"ironGoldPool","type":"address"}]}]},{"inputs":[{"internalType":"uint8","name":"currentLevel","type":"uint8"}],"stateMutability":"pure","type":"function","name":"getWallUpgradeCost","outputs":[{"internalType":"uint256","name":"wood","type":"uint256"},{"internalType":"uint256","name":"iron","type":"uint256"}]},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"getWheatPlots","outputs":[{"internalType":"struct WheatPlot","name":"west","type":"tuple","components":[{"internalType":"enum WheatPlotState","name":"state","type":"uint8"},{"internalType":"uint8","name":"region","type":"uint8"},{"internalType":"uint256","name":"remainingWheat","type":"uint256"},{"internalType":"uint64","name":"regrowUntilTick","type":"uint64"}]},{"internalType":"struct WheatPlot","name":"east","type":"tuple","components":[{"internalType":"enum WheatPlotState","name":"state","type":"uint8"},{"internalType":"uint8","name":"region","type":"uint8"},{"internalType":"uint256","name":"remainingWheat","type":"uint256"},{"internalType":"uint64","name":"regrowUntilTick","type":"uint64"}]}]},{"inputs":[],"stateMutability":"view","type":"function","name":"getWorldSnapshot","outputs":[{"internalType":"struct WorldSnapshot","name":"","type":"tuple","components":[{"internalType":"uint64","name":"currentTick","type":"uint64"},{"internalType":"uint64","name":"seasonStartTick","type":"uint64"},{"internalType":"uint64","name":"seasonEndTick","type":"uint64"},{"internalType":"bool","name":"seasonFinalized","type":"bool"},{"internalType":"uint64","name":"currentSeasonNumber","type":"uint64"},{"internalType":"uint64","name":"nextHeartbeatAtTick","type":"uint64"},{"internalType":"bool","name":"winterActive","type":"bool"},{"internalType":"uint64","name":"winterStartsAtTick","type":"uint64"},{"internalType":"uint64","name":"winterEndsAtTick","type":"uint64"},{"internalType":"uint32","name":"activeBanditId","type":"uint32"},{"internalType":"bytes32","name":"currentTickSeed","type":"bytes32"},{"internalType":"struct LeaderboardEntry[]","name":"leaderboard","type":"tuple[]","components":[{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"uint8","name":"monumentLevel","type":"uint8"},{"internalType":"uint8","name":"baseLevel","type":"uint8"},{"internalType":"uint8","name":"wallLevel","type":"uint8"},{"internalType":"uint8","name":"livingClansmen","type":"uint8"},{"internalType":"enum ClanState","name":"state","type":"uint8"},{"internalType":"uint256","name":"lootValue","type":"uint256"}]}]}]},{"inputs":[],"stateMutability":"view","type":"function","name":"getWorldState","outputs":[{"internalType":"struct WorldState","name":"","type":"tuple","components":[{"internalType":"uint64","name":"currentTick","type":"uint64"},{"internalType":"uint64","name":"seasonStartTick","type":"uint64"},{"internalType":"uint64","name":"seasonEndTick","type":"uint64"},{"internalType":"bool","name":"seasonFinalized","type":"bool"},{"internalType":"uint64","name":"currentSeasonNumber","type":"uint64"},{"internalType":"uint64","name":"nextHeartbeatAtTick","type":"uint64"},{"internalType":"uint64","name":"nextHeartbeatAtTs","type":"uint64"},{"internalType":"uint64","name":"nextBanditSpawnEligibleTick","type":"uint64"},{"internalType":"uint16","name":"currentBanditSpawnChanceBps","type":"uint16"},{"internalType":"bytes32","name":"currentTickSeed","type":"bytes32"},{"internalType":"uint32","name":"activeBanditId","type":"uint32"},{"internalType":"bool","name":"winterActive","type":"bool"},{"internalType":"uint64","name":"winterStartsAtTick","type":"uint64"},{"internalType":"uint64","name":"winterEndsAtTick","type":"uint64"},{"internalType":"uint64","name":"nextCommitSequence","type":"uint64"}]}]},{"inputs":[],"stateMutability":"nonpayable","type":"function","name":"heartbeat"},{"inputs":[{"internalType":"address[6]","name":"tokens","type":"address[6]"},{"internalType":"address[4]","name":"pools","type":"address[4]"}],"stateMutability":"nonpayable","type":"function","name":"initTreasury"},{"inputs":[{"internalType":"address","name":"to","type":"address"}],"stateMutability":"nonpayable","type":"function","name":"mintClan","outputs":[{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"uint256","name":"iftTokenId","type":"uint256"}]},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"quoteLootValueRaw","outputs":[{"internalType":"uint256","name":"lootValue","type":"uint256"}]},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32"}],"stateMutability":"view","type":"function","name":"quoteLootValueSettled","outputs":[{"internalType":"uint256","name":"lootValue","type":"uint256"}]},{"inputs":[{"internalType":"uint8","name":"srcRegion","type":"uint8"},{"internalType":"uint8","name":"dstRegion","type":"uint8"}],"stateMutability":"view","type":"function","name":"quoteTravel","outputs":[{"internalType":"uint8","name":"travelTicks","type":"uint8"},{"internalType":"bytes8","name":"path","type":"bytes8"}]},{"inputs":[{"internalType":"struct PoolSeedConfig","name":"cfg","type":"tuple","components":[{"internalType":"uint256","name":"woodSeed","type":"uint256"},{"internalType":"uint256","name":"wheatSeed","type":"uint256"},{"internalType":"uint256","name":"fishSeed","type":"uint256"},{"internalType":"uint256","name":"ironSeed","type":"uint256"},{"internalType":"uint256","name":"goldSeedForWood","type":"uint256"},{"internalType":"uint256","name":"goldSeedForWheat","type":"uint256"},{"internalType":"uint256","name":"goldSeedForFish","type":"uint256"},{"internalType":"uint256","name":"goldSeedForIron","type":"uint256"}]}],"stateMutability":"nonpayable","type":"function","name":"seedPools"},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32"}],"stateMutability":"nonpayable","type":"function","name":"settleClan"},{"inputs":[{"internalType":"uint32","name":"csId","type":"uint32"}],"stateMutability":"nonpayable","type":"function","name":"settleClansman"},{"inputs":[{"internalType":"uint32","name":"clanId","type":"uint32"},{"internalType":"struct ClanOrder[]","name":"orders","type":"tuple[]","components":[{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"uint8","name":"gotoRegion","type":"uint8"},{"internalType":"enum ActionType","name":"action","type":"uint8"},{"internalType":"uint32","name":"targetClanId","type":"uint32"},{"internalType":"address","name":"marketToken","type":"address"},{"internalType":"uint256","name":"marketAmount","type":"uint256"},{"internalType":"uint256","name":"maxGoldIn","type":"uint256"}]}],"stateMutability":"nonpayable","type":"function","name":"submitClanOrders","outputs":[{"internalType":"struct OrderResult[]","name":"","type":"tuple[]","components":[{"internalType":"uint32","name":"clansmanId","type":"uint32"},{"internalType":"enum StatusCode","name":"status","type":"uint8"},{"internalType":"uint64","name":"cooldownEndsAtTs","type":"uint64"},{"internalType":"uint64","name":"missionNonce","type":"uint64"}]}]},{"inputs":[{"internalType":"uint32","name":"fromClanId","type":"uint32"},{"internalType":"uint32","name":"toClanId","type":"uint32"},{"internalType":"uint256","name":"amount","type":"uint256"}],"stateMutability":"nonpayable","type":"function","name":"transferBlueprint"},{"inputs":[{"internalType":"uint32","name":"fromClanId","type":"uint32"},{"internalType":"uint32","name":"toClanId","type":"uint32"},{"internalType":"uint256","name":"gold","type":"uint256"},{"internalType":"uint256","name":"blueprint","type":"uint256"},{"internalType":"uint256","name":"wood","type":"uint256"},{"internalType":"uint256","name":"iron","type":"uint256"},{"internalType":"uint256","name":"wheat","type":"uint256"},{"internalType":"uint256","name":"fish","type":"uint256"}],"stateMutability":"nonpayable","type":"function","name":"transferBundle"},{"inputs":[{"internalType":"uint32","name":"fromClanId","type":"uint32"},{"internalType":"uint32","name":"toClanId","type":"uint32"},{"internalType":"uint256","name":"amount","type":"uint256"}],"stateMutability":"nonpayable","type":"function","name":"transferGold"},{"inputs":[{"internalType":"uint32","name":"fromClanId","type":"uint32"},{"internalType":"uint32","name":"toClanId","type":"uint32"},{"internalType":"enum ResourceType","name":"resource","type":"uint8"},{"internalType":"uint256","name":"amount","type":"uint256"}],"stateMutability":"nonpayable","type":"function","name":"transferVaultResource"}],"devdoc":{"kind":"dev","methods":{"getClanScore(uint32)":{"details":"Score is ordered by monument level, then earliest first-reached tick for that level,      then settled vault loot value, then wall level. The loot component matches      quoteLootValueSettled's read-only settled-vault basis."}},"version":1},"userdoc":{"kind":"user","methods":{"finalizeSeason()":{"notice":"Finalize the current season. Permissionless after seasonEndTick."},"getActiveBanditView()":{"notice":"Single-call bandit drama state, including projected target if         attack resolved this tick. Drives the bandit warning UI."},"getBanditTargetPreview(uint32)":{"notice":"Non-binding preview. Bandit targeting is recomputed at attack         resolution time using then-current eagerly settled state."},"getClanFullView(uint32)":{"notice":"Single-call complete clan rendering data: derived clan + all         clansmen with derived state and active missions + plot states +         defender bookkeeping. Drives the entire sprite layer."},"getClanScore(uint32)":{"notice":"Ranking score preview for a clan."},"getMarketState()":{"notice":"Single-call market panel data: 4 pool reserves + spot prices +         scheduled queues for current and next tick. Drives market UI         and indexer's per-tick price-history sampling."},"getRankings()":{"notice":"Live clans sorted by score descending, with clanId ascending for exact ties."},"getRegionPopulation(uint8)":{"notice":"Optional. List clansmen currently in a region for tap-to-inspect         tooltips. Can be derived clientside; included for completeness."},"getWorldSnapshot()":{"notice":"Single-call top-level world state plus per-clan leaderboard data.         Drives top HUD bar, season clock, winter indicator, leaderboard."},"heartbeat()":{"notice":"Permissionless heartbeat. Closes the current tick, resolves         scheduled market actions and world events, advances the tick.         Rate-limited by WorldState.nextHeartbeatAtTs."},"initTreasury(address[6],address[4])":{"notice":"Owner-only. Registers token and pool addresses once before seeding.         tokens order: wood, iron, wheat, fish, gold, blueprint.         pools order: wood, wheat, fish, iron."},"mintClan(address)":{"notice":"Mint a new clan iNFT and spawn its homebase in a valid region."},"seedPools((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256))":{"notice":"Owner-only. Seeds the four Unicorn Town pools at deploy time."},"settleClan(uint32)":{"notice":"Lazily settle a clan forward to current tick. Idempotent."},"settleClansman(uint32)":{"notice":"Lazily settle a single clansman's mission to current tick. Idempotent."},"submitClanOrders(uint32,(uint32,uint8,uint8,uint32,address,uint256,uint256)[])":{"notice":"Submit one or more orders for a single clan's clansmen.         Per-order failures do not revert the tx."}},"version":1}},"settings":{"remappings":["forge-std/=lib/forge-std/src/"],"optimizer":{"enabled":true,"runs":200},"metadata":{"bytecodeHash":"ipfs"},"compilationTarget":{"src/IClanWorld.sol":"IClanWorld"},"evmVersion":"prague","libraries":{},"viaIR":true},"sources":{"src/IClanWorld.sol":{"keccak256":"0x2bb8f2b4dd423591858ebacb7d4b6eb3e826b57d67ec4ee5e1c99f452134dbb9","urls":["bzz-raw://e0f1e37ac103f748e5ba0e5483ee360ce066f919f207605d90f74e1bcc1ef603","dweb:/ipfs/QmXVFbaMSwBJQSS873E6n2WzwpuPZnoKomZMcg2tMWQTmk"],"license":"MIT"}},"version":1},"id":24}
+{
+  "abi": [
+    {
+      "type": "function",
+      "name": "finalizeSeason",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "getActionDuration",
+      "inputs": [
+        {
+          "name": "action",
+          "type": "uint8",
+          "internalType": "enum ActionType"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getActiveBanditView",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct ActiveBanditView",
+          "components": [
+            {
+              "name": "exists",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "banditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum BanditState"
+            },
+            {
+              "name": "currentRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackAttemptsMade",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "maxAttemptsRemaining",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "stateEnteredTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextActionTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "tier",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackPower",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "projectedTargetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "projectedTargetLootValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getActiveDefenders",
+      "inputs": [
+        {
+          "name": "targetClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "clansmanIds",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getActiveMission",
+      "inputs": [
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct Mission",
+          "components": [
+            {
+              "name": "active",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "nonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "submittedAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "executesAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "settlesAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "startRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "targetRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "action",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "startTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "arrivalTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "actionStartTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "missionSeed",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "marketMode",
+              "type": "uint8",
+              "internalType": "enum MarketExecutionMode"
+            },
+            {
+              "name": "targetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "marketToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "marketAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "maxGoldIn",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getBanditTargetPreview",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "previewClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getBanditTroop",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct BanditTroop",
+          "components": [
+            {
+              "name": "banditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum BanditState"
+            },
+            {
+              "name": "currentRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackAttemptsMade",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "stateEnteredTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextActionTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "tier",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackPower",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getBaseUpgradeCost",
+      "inputs": [
+        {
+          "name": "currentLevel",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "wood",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "iron",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheat",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getClan",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct Clan",
+          "components": [
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "iftTokenId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "clanState",
+              "type": "uint8",
+              "internalType": "enum ClanState"
+            },
+            {
+              "name": "baseRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "baseLevel",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "wallLevel",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "monumentLevel",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "livingClansmen",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "lastSettledTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "starvationStartsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "coldDamage",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "goldBalance",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "blueprintBalance",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "vaultFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getClanFullView",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct ClanFullView",
+          "components": [
+            {
+              "name": "clan",
+              "type": "tuple",
+              "internalType": "struct DerivedClanState",
+              "components": [
+                {
+                  "name": "clan",
+                  "type": "tuple",
+                  "internalType": "struct Clan",
+                  "components": [
+                    {
+                      "name": "clanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "iftTokenId",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "owner",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "clanState",
+                      "type": "uint8",
+                      "internalType": "enum ClanState"
+                    },
+                    {
+                      "name": "baseRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "baseLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "wallLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "monumentLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "livingClansmen",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "lastSettledTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "starvationStartsAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "coldDamage",
+                      "type": "uint16",
+                      "internalType": "uint16"
+                    },
+                    {
+                      "name": "goldBalance",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "blueprintBalance",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultWood",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultIron",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultWheat",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultFish",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "name": "isStarving",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "lootValue",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "derivedAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "clansmen",
+              "type": "tuple[]",
+              "internalType": "struct ClansmanFullView[]",
+              "components": [
+                {
+                  "name": "clansman",
+                  "type": "tuple",
+                  "internalType": "struct DerivedClansmanState",
+                  "components": [
+                    {
+                      "name": "clansman",
+                      "type": "tuple",
+                      "internalType": "struct Clansman",
+                      "components": [
+                        {
+                          "name": "clansmanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "clanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "state",
+                          "type": "uint8",
+                          "internalType": "enum ClansmanState"
+                        },
+                        {
+                          "name": "currentRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "cooldownEndsAtTs",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "lastMissionNonce",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "carryWood",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryIron",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryWheat",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryFish",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "activeMission",
+                      "type": "tuple",
+                      "internalType": "struct Mission",
+                      "components": [
+                        {
+                          "name": "active",
+                          "type": "bool",
+                          "internalType": "bool"
+                        },
+                        {
+                          "name": "nonce",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "submittedAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "executesAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "settlesAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "clansmanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "startRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "targetRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "action",
+                          "type": "uint8",
+                          "internalType": "enum ActionType"
+                        },
+                        {
+                          "name": "startTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "arrivalTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "actionStartTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "missionSeed",
+                          "type": "bytes32",
+                          "internalType": "bytes32"
+                        },
+                        {
+                          "name": "marketMode",
+                          "type": "uint8",
+                          "internalType": "enum MarketExecutionMode"
+                        },
+                        {
+                          "name": "targetClanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "marketToken",
+                          "type": "address",
+                          "internalType": "address"
+                        },
+                        {
+                          "name": "marketAmount",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "maxGoldIn",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "effectiveRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "derivedAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    }
+                  ]
+                },
+                {
+                  "name": "activeMission",
+                  "type": "tuple",
+                  "internalType": "struct Mission",
+                  "components": [
+                    {
+                      "name": "active",
+                      "type": "bool",
+                      "internalType": "bool"
+                    },
+                    {
+                      "name": "nonce",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "submittedAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "executesAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "settlesAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "clansmanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "startRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "targetRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "action",
+                      "type": "uint8",
+                      "internalType": "enum ActionType"
+                    },
+                    {
+                      "name": "startTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "arrivalTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "actionStartTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "missionSeed",
+                      "type": "bytes32",
+                      "internalType": "bytes32"
+                    },
+                    {
+                      "name": "marketMode",
+                      "type": "uint8",
+                      "internalType": "enum MarketExecutionMode"
+                    },
+                    {
+                      "name": "targetClanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "marketToken",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "marketAmount",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "maxGoldIn",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "westPlot",
+              "type": "tuple",
+              "internalType": "struct WheatPlot",
+              "components": [
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum WheatPlotState"
+                },
+                {
+                  "name": "region",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "remainingWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "regrowUntilTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "eastPlot",
+              "type": "tuple",
+              "internalType": "struct WheatPlot",
+              "components": [
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum WheatPlotState"
+                },
+                {
+                  "name": "region",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "remainingWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "regrowUntilTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "incomingDefenderIds",
+              "type": "uint32[]",
+              "internalType": "uint32[]"
+            },
+            {
+              "name": "thisClanDefendingBaseId",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getClanScore",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "score",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "monumentReachedAtTick",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "monumentLevel",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getClansman",
+      "inputs": [
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct Clansman",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum ClansmanState"
+            },
+            {
+              "name": "currentRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "cooldownEndsAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "lastMissionNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getDefendingClans",
+      "inputs": [
+        {
+          "name": "region",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "clanIds",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getDerivedClanState",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct DerivedClanState",
+          "components": [
+            {
+              "name": "clan",
+              "type": "tuple",
+              "internalType": "struct Clan",
+              "components": [
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "iftTokenId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "owner",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "clanState",
+                  "type": "uint8",
+                  "internalType": "enum ClanState"
+                },
+                {
+                  "name": "baseRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "baseLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "wallLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "monumentLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "livingClansmen",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "lastSettledTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "starvationStartsAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "coldDamage",
+                  "type": "uint16",
+                  "internalType": "uint16"
+                },
+                {
+                  "name": "goldBalance",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "blueprintBalance",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultWood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultIron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultFish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "isStarving",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "lootValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "derivedAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getDerivedClansmanState",
+      "inputs": [
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct DerivedClansmanState",
+          "components": [
+            {
+              "name": "clansman",
+              "type": "tuple",
+              "internalType": "struct Clansman",
+              "components": [
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum ClansmanState"
+                },
+                {
+                  "name": "currentRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "cooldownEndsAtTs",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "lastMissionNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "carryWood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryIron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryFish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "activeMission",
+              "type": "tuple",
+              "internalType": "struct Mission",
+              "components": [
+                {
+                  "name": "active",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "submittedAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "executesAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "settlesAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "startRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "targetRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "startTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "arrivalTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "actionStartTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "missionSeed",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "marketMode",
+                  "type": "uint8",
+                  "internalType": "enum MarketExecutionMode"
+                },
+                {
+                  "name": "targetClanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "effectiveRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "derivedAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMarketState",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct MarketState",
+          "components": [
+            {
+              "name": "wood",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "wheat",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "fish",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "iron",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "currentTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "currentTickQueue",
+              "type": "tuple[]",
+              "internalType": "struct ScheduledMarketAction[]",
+              "components": [
+                {
+                  "name": "executeAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "commitSequence",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "missionNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "nextTickQueue",
+              "type": "tuple[]",
+              "internalType": "struct ScheduledMarketAction[]",
+              "components": [
+                {
+                  "name": "executeAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "commitSequence",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "missionNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMissionTiming",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "submitted",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "executes",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "settles",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMonumentUpgradeCost",
+      "inputs": [
+        {
+          "name": "currentLevel",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "wood",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "iron",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheat",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "blueprint",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getRankings",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "clanIdsRanked",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
+        },
+        {
+          "name": "scores",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRegionPopulation",
+      "inputs": [
+        {
+          "name": "region",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct RegionOccupant[]",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum ClansmanState"
+            },
+            {
+              "name": "currentAction",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "missionNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getScheduledMarketActionsForTick",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct ScheduledMarketAction[]",
+          "components": [
+            {
+              "name": "executeAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "commitSequence",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "missionNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "action",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "marketToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "marketAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "maxGoldIn",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getTravelTicks",
+      "inputs": [
+        {
+          "name": "fromRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "toRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getTreasuryState",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct TreasuryState",
+          "components": [
+            {
+              "name": "treasuryOwner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "prizePotGold",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "poolsSeeded",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "woodToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "wheatToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "fishToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "ironToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "goldToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "blueprintToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "woodGoldPool",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "wheatGoldPool",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "fishGoldPool",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "ironGoldPool",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getWallUpgradeCost",
+      "inputs": [
+        {
+          "name": "currentLevel",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "wood",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "iron",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "getWheatPlots",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "west",
+          "type": "tuple",
+          "internalType": "struct WheatPlot",
+          "components": [
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum WheatPlotState"
+            },
+            {
+              "name": "region",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "remainingWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "regrowUntilTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        },
+        {
+          "name": "east",
+          "type": "tuple",
+          "internalType": "struct WheatPlot",
+          "components": [
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum WheatPlotState"
+            },
+            {
+              "name": "region",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "remainingWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "regrowUntilTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getWorldSnapshot",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct WorldSnapshot",
+          "components": [
+            {
+              "name": "currentTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonStartTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonEndTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonFinalized",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "currentSeasonNumber",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextHeartbeatAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "winterActive",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "winterStartsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "winterEndsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "activeBanditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "currentTickSeed",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "leaderboard",
+              "type": "tuple[]",
+              "internalType": "struct LeaderboardEntry[]",
+              "components": [
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "owner",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "monumentLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "baseLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "wallLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "livingClansmen",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum ClanState"
+                },
+                {
+                  "name": "lootValue",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getWorldState",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct WorldState",
+          "components": [
+            {
+              "name": "currentTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonStartTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonEndTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonFinalized",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "currentSeasonNumber",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextHeartbeatAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextHeartbeatAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextBanditSpawnEligibleTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "currentBanditSpawnChanceBps",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "currentTickSeed",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "activeBanditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "winterActive",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "winterStartsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "winterEndsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextCommitSequence",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "heartbeat",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "initTreasury",
+      "inputs": [
+        {
+          "name": "tokens",
+          "type": "address[6]",
+          "internalType": "address[6]"
+        },
+        {
+          "name": "pools",
+          "type": "address[4]",
+          "internalType": "address[4]"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "mintClan",
+      "inputs": [
+        {
+          "name": "to",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "iftTokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "quoteLootValueRaw",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "lootValue",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "quoteLootValueSettled",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "lootValue",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "quoteTravel",
+      "inputs": [
+        {
+          "name": "srcRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "dstRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "travelTicks",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "path",
+          "type": "bytes8",
+          "internalType": "bytes8"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "seedPools",
+      "inputs": [
+        {
+          "name": "cfg",
+          "type": "tuple",
+          "internalType": "struct PoolSeedConfig",
+          "components": [
+            {
+              "name": "woodSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "wheatSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "fishSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "ironSeed",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "goldSeedForIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "settleClan",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "settleClansman",
+      "inputs": [
+        {
+          "name": "csId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "submitClanOrders",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "orders",
+          "type": "tuple[]",
+          "internalType": "struct ClanOrder[]",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "gotoRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "action",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "targetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "marketToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "marketAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "maxGoldIn",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct OrderResult[]",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "status",
+              "type": "uint8",
+              "internalType": "enum StatusCode"
+            },
+            {
+              "name": "cooldownEndsAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "missionNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferBlueprint",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferBundle",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "gold",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "blueprint",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "wood",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "iron",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheat",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "fish",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferGold",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferVaultResource",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "resource",
+          "type": "uint8",
+          "internalType": "enum ResourceType"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "BanditAttackResolved",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "targetClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "defended",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        },
+        {
+          "name": "attackPower",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "totalDefense",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "wallLevelAfter",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "stolenWood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "stolenIron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "stolenWheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "stolenFish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditDefeated",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "targetClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditEscaped",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditMoved",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "fromRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "toRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditSpawned",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "region",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "tier",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "attackPower",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BanditStateChanged",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldState",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum BanditState"
+        },
+        {
+          "name": "newState",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum BanditState"
+        },
+        {
+          "name": "region",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BaseLevelChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BaseUpgraded",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "settledAtTick",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BlueprintAwarded",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BlueprintTransferred",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanEliminated",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanSettled",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "settledToTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanSpawned",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "iftTokenId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "baseRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanStarvationChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "isStarving",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClansmanDiedFromCold",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ColdDamageApplied",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldDamage",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "newDamage",
+          "type": "uint16",
+          "indexed": false,
+          "internalType": "uint16"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "GoldTransferred",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ImmediateMarketActionExecuted",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tokenIn",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "tokenOut",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "amountIn",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "amountOut",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "LootDistributedToDefender",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "wood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "iron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MarketActionFailed",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "reason",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum StatusCode"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MissionAssigned",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "missionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "startRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "targetRegion",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "startTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "arrivalTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MissionCompleted",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "missionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MissionInterrupted",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldMissionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "newMissionNonce",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MonumentLevelChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MonumentUpgraded",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "settledAtTick",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PoolsSeeded",
+      "inputs": [
+        {
+          "name": "woodGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "wheatGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "fishGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "ironGoldPool",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ResourcesDeposited",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "woodDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "ironDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheatDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fishDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "tick",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ResourcesGathered",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "woodGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "ironGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheatGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fishGained",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "goldBonus",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ScheduledMarketActionCommitted",
+      "inputs": [
+        {
+          "name": "executeAtTick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "commitSequence",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        },
+        {
+          "name": "action",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ActionType"
+        },
+        {
+          "name": "marketToken",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "marketAmount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "maxGoldIn",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ScheduledMarketActionExecuted",
+      "inputs": [
+        {
+          "name": "executeAtTick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "commitSequence",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tokenIn",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "tokenOut",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "amountIn",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "amountOut",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SeasonFinalized",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "rankedClanIds",
+          "type": "uint32[]",
+          "indexed": false,
+          "internalType": "uint32[]"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TickAdvanced",
+      "inputs": [
+        {
+          "name": "closedTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "openedTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "tickSeed",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "VaultResourceTransferred",
+      "inputs": [
+        {
+          "name": "fromClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "toClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "resource",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum ResourceType"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WallLevelChanged",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WallUpgraded",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "settledAtTick",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WinterEnded",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WinterStarted",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WorkerArrived",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "region",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    }
+  ],
+  "bytecode": {
+    "object": "0x",
+    "sourceMap": "",
+    "linkReferences": {}
+  },
+  "deployedBytecode": {
+    "object": "0x",
+    "sourceMap": "",
+    "linkReferences": {}
+  },
+  "methodIdentifiers": {
+    "finalizeSeason()": "30fb8f8a",
+    "getActionDuration(uint8)": "e24864d8",
+    "getActiveBanditView()": "19abee0f",
+    "getActiveDefenders(uint32)": "d7f55bbc",
+    "getActiveMission(uint32)": "c7898535",
+    "getBanditTargetPreview(uint32)": "8233c665",
+    "getBanditTroop(uint32)": "a237d380",
+    "getBaseUpgradeCost(uint8)": "64374ddc",
+    "getClan(uint32)": "73c3d0da",
+    "getClanFullView(uint32)": "b6b1902d",
+    "getClanScore(uint32)": "826a02fc",
+    "getClansman(uint32)": "481a43a2",
+    "getDefendingClans(uint8)": "922b82d9",
+    "getDerivedClanState(uint32)": "1b43cdd8",
+    "getDerivedClansmanState(uint32)": "a22e3257",
+    "getMarketState()": "d8165743",
+    "getMissionTiming(uint32,uint32)": "bb6982c7",
+    "getMonumentUpgradeCost(uint8)": "6db7321d",
+    "getRankings()": "2c83b4b2",
+    "getRegionPopulation(uint8)": "b3d2cbdb",
+    "getScheduledMarketActionsForTick(uint64)": "1d0bf24c",
+    "getTravelTicks(uint8,uint8)": "c7e29ce6",
+    "getTreasuryState()": "23a8bdca",
+    "getWallUpgradeCost(uint8)": "000bed87",
+    "getWheatPlots(uint32)": "101583da",
+    "getWorldSnapshot()": "96fe8161",
+    "getWorldState()": "671eb0d2",
+    "heartbeat()": "3defb962",
+    "initTreasury(address[6],address[4])": "38c7f5c4",
+    "mintClan(address)": "b3705e4e",
+    "quoteLootValueRaw(uint32)": "1ade4dda",
+    "quoteLootValueSettled(uint32)": "7f9e027b",
+    "quoteTravel(uint8,uint8)": "135503af",
+    "seedPools((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256))": "c46a6fb2",
+    "settleClan(uint32)": "3073b90b",
+    "settleClansman(uint32)": "f1d68ae2",
+    "submitClanOrders(uint32,(uint32,uint8,uint8,uint32,address,uint256,uint256)[])": "7971fc2c",
+    "transferBlueprint(uint32,uint32,uint256)": "33f8d51d",
+    "transferBundle(uint32,uint32,uint256,uint256,uint256,uint256,uint256,uint256)": "c28492ab",
+    "transferGold(uint32,uint32,uint256)": "c3fd8ac9",
+    "transferVaultResource(uint32,uint32,uint8,uint256)": "a54e020c"
+  },
+  "rawMetadata": "{\"compiler\":{\"version\":\"0.8.34+commit.80d5c536\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"defended\",\"type\":\"bool\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"attackPower\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"totalDefense\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"wallLevelAfter\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"stolenWood\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"stolenIron\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"stolenWheat\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"stolenFish\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BanditAttackResolved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BanditDefeated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BanditEscaped\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"fromRegion\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"toRegion\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BanditMoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"tier\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"attackPower\",\"type\":\"uint16\"}],\"name\":\"BanditSpawned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"enum BanditState\",\"name\":\"oldState\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"enum BanditState\",\"name\":\"newState\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BanditStateChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"oldLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BaseLevelChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"settledAtTick\",\"type\":\"uint32\"}],\"name\":\"BaseUpgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"BlueprintAwarded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"BlueprintTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"}],\"name\":\"ClanEliminated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"settledToTick\",\"type\":\"uint64\"}],\"name\":\"ClanSettled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"iftTokenId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"baseRegion\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ClanSpawned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"isStarving\",\"type\":\"bool\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ClanStarvationChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ClansmanDiedFromCold\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"oldDamage\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"newDamage\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ColdDamageApplied\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"GoldTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"tokenIn\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"tokenOut\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ImmediateMarketActionExecuted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"wood\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"iron\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"wheat\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"fish\",\"type\":\"uint256\"}],\"name\":\"LootDistributedToDefender\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"enum StatusCode\",\"name\":\"reason\",\"type\":\"uint8\"}],\"name\":\"MarketActionFailed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"startRegion\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"targetRegion\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"startTick\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"arrivalTick\",\"type\":\"uint64\"}],\"name\":\"MissionAssigned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"}],\"name\":\"MissionCompleted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"oldMissionNonce\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"newMissionNonce\",\"type\":\"uint64\"}],\"name\":\"MissionInterrupted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"oldLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"MonumentLevelChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"settledAtTick\",\"type\":\"uint32\"}],\"name\":\"MonumentUpgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"woodGoldPool\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"wheatGoldPool\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"fishGoldPool\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"ironGoldPool\",\"type\":\"address\"}],\"name\":\"PoolsSeeded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"woodDelta\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"ironDelta\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"wheatDelta\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"fishDelta\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"tick\",\"type\":\"uint32\"}],\"name\":\"ResourcesDeposited\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"woodGained\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"ironGained\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"wheatGained\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"fishGained\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"goldBonus\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"ResourcesGathered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"executeAtTick\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"commitSequence\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"name\":\"ScheduledMarketActionCommitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"executeAtTick\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"commitSequence\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"tokenIn\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"tokenOut\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"}],\"name\":\"ScheduledMarketActionExecuted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint32[]\",\"name\":\"rankedClanIds\",\"type\":\"uint32[]\"}],\"name\":\"SeasonFinalized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"closedTick\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"openedTick\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"tickSeed\",\"type\":\"bytes32\"}],\"name\":\"TickAdvanced\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"enum ResourceType\",\"name\":\"resource\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"VaultResourceTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"oldLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"atTick\",\"type\":\"uint64\"}],\"name\":\"WallLevelChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"newLevel\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"settledAtTick\",\"type\":\"uint32\"}],\"name\":\"WallUpgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"}],\"name\":\"WinterEnded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"}],\"name\":\"WinterStarted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"}],\"name\":\"WorkerArrived\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"finalizeSeason\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"}],\"name\":\"getActionDuration\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getActiveBanditView\",\"outputs\":[{\"components\":[{\"internalType\":\"bool\",\"name\":\"exists\",\"type\":\"bool\"},{\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"internalType\":\"enum BanditState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"currentRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"attackAttemptsMade\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"maxAttemptsRemaining\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"stateEnteredTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextActionTick\",\"type\":\"uint64\"},{\"internalType\":\"uint8\",\"name\":\"tier\",\"type\":\"uint8\"},{\"internalType\":\"uint16\",\"name\":\"attackPower\",\"type\":\"uint16\"},{\"internalType\":\"uint256\",\"name\":\"carryWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryFish\",\"type\":\"uint256\"},{\"internalType\":\"uint32\",\"name\":\"projectedTargetClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"projectedTargetLootValue\",\"type\":\"uint256\"}],\"internalType\":\"struct ActiveBanditView\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"}],\"name\":\"getActiveDefenders\",\"outputs\":[{\"internalType\":\"uint32[]\",\"name\":\"clansmanIds\",\"type\":\"uint32[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"}],\"name\":\"getActiveMission\",\"outputs\":[{\"components\":[{\"internalType\":\"bool\",\"name\":\"active\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"submittedAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"executesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"settlesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"startRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"targetRegion\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"startTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"arrivalTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"actionStartTick\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"missionSeed\",\"type\":\"bytes32\"},{\"internalType\":\"enum MarketExecutionMode\",\"name\":\"marketMode\",\"type\":\"uint8\"},{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct Mission\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"}],\"name\":\"getBanditTargetPreview\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"previewClanId\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"}],\"name\":\"getBanditTroop\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"banditId\",\"type\":\"uint32\"},{\"internalType\":\"enum BanditState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"currentRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"attackAttemptsMade\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"stateEnteredTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextActionTick\",\"type\":\"uint64\"},{\"internalType\":\"uint8\",\"name\":\"tier\",\"type\":\"uint8\"},{\"internalType\":\"uint16\",\"name\":\"attackPower\",\"type\":\"uint16\"},{\"internalType\":\"uint256\",\"name\":\"carryWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryFish\",\"type\":\"uint256\"}],\"internalType\":\"struct BanditTroop\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"currentLevel\",\"type\":\"uint8\"}],\"name\":\"getBaseUpgradeCost\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"wood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"iron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wheat\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"getClan\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"iftTokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"enum ClanState\",\"name\":\"clanState\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"wallLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"monumentLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"livingClansmen\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"lastSettledTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"starvationStartsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint16\",\"name\":\"coldDamage\",\"type\":\"uint16\"},{\"internalType\":\"uint256\",\"name\":\"goldBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blueprintBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clan\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"getClanFullView\",\"outputs\":[{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"iftTokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"enum ClanState\",\"name\":\"clanState\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"wallLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"monumentLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"livingClansmen\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"lastSettledTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"starvationStartsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint16\",\"name\":\"coldDamage\",\"type\":\"uint16\"},{\"internalType\":\"uint256\",\"name\":\"goldBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blueprintBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clan\",\"name\":\"clan\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"isStarving\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"lootValue\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"derivedAtTick\",\"type\":\"uint64\"}],\"internalType\":\"struct DerivedClanState\",\"name\":\"clan\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ClansmanState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"currentRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"cooldownEndsAtTs\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"lastMissionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint256\",\"name\":\"carryWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clansman\",\"name\":\"clansman\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"bool\",\"name\":\"active\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"submittedAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"executesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"settlesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"startRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"targetRegion\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"startTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"arrivalTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"actionStartTick\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"missionSeed\",\"type\":\"bytes32\"},{\"internalType\":\"enum MarketExecutionMode\",\"name\":\"marketMode\",\"type\":\"uint8\"},{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct Mission\",\"name\":\"activeMission\",\"type\":\"tuple\"},{\"internalType\":\"uint8\",\"name\":\"effectiveRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"derivedAtTick\",\"type\":\"uint64\"}],\"internalType\":\"struct DerivedClansmanState\",\"name\":\"clansman\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"bool\",\"name\":\"active\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"submittedAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"executesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"settlesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"startRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"targetRegion\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"startTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"arrivalTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"actionStartTick\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"missionSeed\",\"type\":\"bytes32\"},{\"internalType\":\"enum MarketExecutionMode\",\"name\":\"marketMode\",\"type\":\"uint8\"},{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct Mission\",\"name\":\"activeMission\",\"type\":\"tuple\"}],\"internalType\":\"struct ClansmanFullView[]\",\"name\":\"clansmen\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"enum WheatPlotState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"remainingWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"regrowUntilTick\",\"type\":\"uint64\"}],\"internalType\":\"struct WheatPlot\",\"name\":\"westPlot\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"enum WheatPlotState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"remainingWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"regrowUntilTick\",\"type\":\"uint64\"}],\"internalType\":\"struct WheatPlot\",\"name\":\"eastPlot\",\"type\":\"tuple\"},{\"internalType\":\"uint32[]\",\"name\":\"incomingDefenderIds\",\"type\":\"uint32[]\"},{\"internalType\":\"uint32\",\"name\":\"thisClanDefendingBaseId\",\"type\":\"uint32\"}],\"internalType\":\"struct ClanFullView\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"getClanScore\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"score\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"monumentReachedAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint8\",\"name\":\"monumentLevel\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"}],\"name\":\"getClansman\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ClansmanState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"currentRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"cooldownEndsAtTs\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"lastMissionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint256\",\"name\":\"carryWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clansman\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"}],\"name\":\"getDefendingClans\",\"outputs\":[{\"internalType\":\"uint32[]\",\"name\":\"clanIds\",\"type\":\"uint32[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"getDerivedClanState\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"iftTokenId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"enum ClanState\",\"name\":\"clanState\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"wallLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"monumentLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"livingClansmen\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"lastSettledTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"starvationStartsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint16\",\"name\":\"coldDamage\",\"type\":\"uint16\"},{\"internalType\":\"uint256\",\"name\":\"goldBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blueprintBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"vaultFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clan\",\"name\":\"clan\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"isStarving\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"lootValue\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"derivedAtTick\",\"type\":\"uint64\"}],\"internalType\":\"struct DerivedClanState\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"}],\"name\":\"getDerivedClansmanState\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ClansmanState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"currentRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"cooldownEndsAtTs\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"lastMissionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint256\",\"name\":\"carryWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryIron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"carryFish\",\"type\":\"uint256\"}],\"internalType\":\"struct Clansman\",\"name\":\"clansman\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"bool\",\"name\":\"active\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"submittedAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"executesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"settlesAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"startRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"targetRegion\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"startTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"arrivalTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"actionStartTick\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"missionSeed\",\"type\":\"bytes32\"},{\"internalType\":\"enum MarketExecutionMode\",\"name\":\"marketMode\",\"type\":\"uint8\"},{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct Mission\",\"name\":\"activeMission\",\"type\":\"tuple\"},{\"internalType\":\"uint8\",\"name\":\"effectiveRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"derivedAtTick\",\"type\":\"uint64\"}],\"internalType\":\"struct DerivedClansmanState\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getMarketState\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"resourceToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"resourceReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"spotPriceGoldPerResource\",\"type\":\"uint256\"}],\"internalType\":\"struct PoolReserves\",\"name\":\"wood\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"resourceToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"resourceReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"spotPriceGoldPerResource\",\"type\":\"uint256\"}],\"internalType\":\"struct PoolReserves\",\"name\":\"wheat\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"resourceToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"resourceReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"spotPriceGoldPerResource\",\"type\":\"uint256\"}],\"internalType\":\"struct PoolReserves\",\"name\":\"fish\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"resourceToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"resourceReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldReserve\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"spotPriceGoldPerResource\",\"type\":\"uint256\"}],\"internalType\":\"struct PoolReserves\",\"name\":\"iron\",\"type\":\"tuple\"},{\"internalType\":\"uint64\",\"name\":\"currentTick\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint64\",\"name\":\"executeAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"commitSequence\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct ScheduledMarketAction[]\",\"name\":\"currentTickQueue\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint64\",\"name\":\"executeAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"commitSequence\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct ScheduledMarketAction[]\",\"name\":\"nextTickQueue\",\"type\":\"tuple[]\"}],\"internalType\":\"struct MarketState\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"}],\"name\":\"getMissionTiming\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"submitted\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"executes\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"settles\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"currentLevel\",\"type\":\"uint8\"}],\"name\":\"getMonumentUpgradeCost\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"wood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"iron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blueprint\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getRankings\",\"outputs\":[{\"internalType\":\"uint32[]\",\"name\":\"clanIdsRanked\",\"type\":\"uint32[]\"},{\"internalType\":\"uint256[]\",\"name\":\"scores\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"}],\"name\":\"getRegionPopulation\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ClansmanState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"currentAction\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"}],\"internalType\":\"struct RegionOccupant[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"tick\",\"type\":\"uint64\"}],\"name\":\"getScheduledMarketActionsForTick\",\"outputs\":[{\"components\":[{\"internalType\":\"uint64\",\"name\":\"executeAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"commitSequence\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct ScheduledMarketAction[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"fromRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"toRegion\",\"type\":\"uint8\"}],\"name\":\"getTravelTicks\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getTreasuryState\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"treasuryOwner\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"prizePotGold\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"poolsSeeded\",\"type\":\"bool\"},{\"internalType\":\"address\",\"name\":\"woodToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"wheatToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"fishToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"ironToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"goldToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"blueprintToken\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"woodGoldPool\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"wheatGoldPool\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"fishGoldPool\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"ironGoldPool\",\"type\":\"address\"}],\"internalType\":\"struct TreasuryState\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"currentLevel\",\"type\":\"uint8\"}],\"name\":\"getWallUpgradeCost\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"wood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"iron\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"getWheatPlots\",\"outputs\":[{\"components\":[{\"internalType\":\"enum WheatPlotState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"remainingWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"regrowUntilTick\",\"type\":\"uint64\"}],\"internalType\":\"struct WheatPlot\",\"name\":\"west\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"enum WheatPlotState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"region\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"remainingWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"regrowUntilTick\",\"type\":\"uint64\"}],\"internalType\":\"struct WheatPlot\",\"name\":\"east\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getWorldSnapshot\",\"outputs\":[{\"components\":[{\"internalType\":\"uint64\",\"name\":\"currentTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"seasonStartTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"seasonEndTick\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"seasonFinalized\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"currentSeasonNumber\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextHeartbeatAtTick\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"winterActive\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"winterStartsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"winterEndsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"activeBanditId\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"currentTickSeed\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"uint8\",\"name\":\"monumentLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"baseLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"wallLevel\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"livingClansmen\",\"type\":\"uint8\"},{\"internalType\":\"enum ClanState\",\"name\":\"state\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"lootValue\",\"type\":\"uint256\"}],\"internalType\":\"struct LeaderboardEntry[]\",\"name\":\"leaderboard\",\"type\":\"tuple[]\"}],\"internalType\":\"struct WorldSnapshot\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getWorldState\",\"outputs\":[{\"components\":[{\"internalType\":\"uint64\",\"name\":\"currentTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"seasonStartTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"seasonEndTick\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"seasonFinalized\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"currentSeasonNumber\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextHeartbeatAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextHeartbeatAtTs\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextBanditSpawnEligibleTick\",\"type\":\"uint64\"},{\"internalType\":\"uint16\",\"name\":\"currentBanditSpawnChanceBps\",\"type\":\"uint16\"},{\"internalType\":\"bytes32\",\"name\":\"currentTickSeed\",\"type\":\"bytes32\"},{\"internalType\":\"uint32\",\"name\":\"activeBanditId\",\"type\":\"uint32\"},{\"internalType\":\"bool\",\"name\":\"winterActive\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"winterStartsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"winterEndsAtTick\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"nextCommitSequence\",\"type\":\"uint64\"}],\"internalType\":\"struct WorldState\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"heartbeat\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[6]\",\"name\":\"tokens\",\"type\":\"address[6]\"},{\"internalType\":\"address[4]\",\"name\":\"pools\",\"type\":\"address[4]\"}],\"name\":\"initTreasury\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"mintClan\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"iftTokenId\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"quoteLootValueRaw\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"lootValue\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"quoteLootValueSettled\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"lootValue\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"srcRegion\",\"type\":\"uint8\"},{\"internalType\":\"uint8\",\"name\":\"dstRegion\",\"type\":\"uint8\"}],\"name\":\"quoteTravel\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"travelTicks\",\"type\":\"uint8\"},{\"internalType\":\"bytes8\",\"name\":\"path\",\"type\":\"bytes8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"woodSeed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wheatSeed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"fishSeed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"ironSeed\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldSeedForWood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldSeedForWheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldSeedForFish\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"goldSeedForIron\",\"type\":\"uint256\"}],\"internalType\":\"struct PoolSeedConfig\",\"name\":\"cfg\",\"type\":\"tuple\"}],\"name\":\"seedPools\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"}],\"name\":\"settleClan\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"csId\",\"type\":\"uint32\"}],\"name\":\"settleClansman\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clanId\",\"type\":\"uint32\"},{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"gotoRegion\",\"type\":\"uint8\"},{\"internalType\":\"enum ActionType\",\"name\":\"action\",\"type\":\"uint8\"},{\"internalType\":\"uint32\",\"name\":\"targetClanId\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"marketToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"marketAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxGoldIn\",\"type\":\"uint256\"}],\"internalType\":\"struct ClanOrder[]\",\"name\":\"orders\",\"type\":\"tuple[]\"}],\"name\":\"submitClanOrders\",\"outputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"clansmanId\",\"type\":\"uint32\"},{\"internalType\":\"enum StatusCode\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"cooldownEndsAtTs\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"missionNonce\",\"type\":\"uint64\"}],\"internalType\":\"struct OrderResult[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transferBlueprint\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"gold\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"blueprint\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wood\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"iron\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"wheat\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"fish\",\"type\":\"uint256\"}],\"name\":\"transferBundle\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transferGold\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"fromClanId\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"toClanId\",\"type\":\"uint32\"},{\"internalType\":\"enum ResourceType\",\"name\":\"resource\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transferVaultResource\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{\"getClanScore(uint32)\":{\"details\":\"Score is ordered by monument level, then earliest first-reached tick for that level,      then settled vault loot value, then wall level. The loot component matches      quoteLootValueSettled's read-only settled-vault basis.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"finalizeSeason()\":{\"notice\":\"Finalize the current season. Permissionless after seasonEndTick.\"},\"getActiveBanditView()\":{\"notice\":\"Single-call bandit drama state, including projected target if         attack resolved this tick. Drives the bandit warning UI.\"},\"getBanditTargetPreview(uint32)\":{\"notice\":\"Non-binding preview. Bandit targeting is recomputed at attack         resolution time using then-current eagerly settled state.\"},\"getClanFullView(uint32)\":{\"notice\":\"Single-call complete clan rendering data: derived clan + all         clansmen with derived state and active missions + plot states +         defender bookkeeping. Drives the entire sprite layer.\"},\"getClanScore(uint32)\":{\"notice\":\"Ranking score preview for a clan.\"},\"getMarketState()\":{\"notice\":\"Single-call market panel data: 4 pool reserves + spot prices +         scheduled queues for current and next tick. Drives market UI         and indexer's per-tick price-history sampling.\"},\"getRankings()\":{\"notice\":\"Live clans sorted by score descending, with clanId ascending for exact ties.\"},\"getRegionPopulation(uint8)\":{\"notice\":\"Optional. List clansmen currently in a region for tap-to-inspect         tooltips. Can be derived clientside; included for completeness.\"},\"getWorldSnapshot()\":{\"notice\":\"Single-call top-level world state plus per-clan leaderboard data.         Drives top HUD bar, season clock, winter indicator, leaderboard.\"},\"heartbeat()\":{\"notice\":\"Permissionless heartbeat. Closes the current tick, resolves         scheduled market actions and world events, advances the tick.         Rate-limited by WorldState.nextHeartbeatAtTs.\"},\"initTreasury(address[6],address[4])\":{\"notice\":\"Owner-only. Registers token and pool addresses once before seeding.         tokens order: wood, iron, wheat, fish, gold, blueprint.         pools order: wood, wheat, fish, iron.\"},\"mintClan(address)\":{\"notice\":\"Mint a new clan iNFT and spawn its homebase in a valid region.\"},\"seedPools((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256))\":{\"notice\":\"Owner-only. Seeds the four Unicorn Town pools at deploy time.\"},\"settleClan(uint32)\":{\"notice\":\"Lazily settle a clan forward to current tick. Idempotent.\"},\"settleClansman(uint32)\":{\"notice\":\"Lazily settle a single clansman's mission to current tick. Idempotent.\"},\"submitClanOrders(uint32,(uint32,uint8,uint8,uint32,address,uint256,uint256)[])\":{\"notice\":\"Submit one or more orders for a single clan's clansmen.         Per-order failures do not revert the tx.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/IClanWorld.sol\":\"IClanWorld\"},\"evmVersion\":\"prague\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[\":forge-std/=lib/forge-std/src/\"],\"viaIR\":true},\"sources\":{\"src/IClanWorld.sol\":{\"keccak256\":\"0x2bb8f2b4dd423591858ebacb7d4b6eb3e826b57d67ec4ee5e1c99f452134dbb9\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://e0f1e37ac103f748e5ba0e5483ee360ce066f919f207605d90f74e1bcc1ef603\",\"dweb:/ipfs/QmXVFbaMSwBJQSS873E6n2WzwpuPZnoKomZMcg2tMWQTmk\"]}},\"version\":1}",
+  "metadata": {
+    "compiler": {
+      "version": "0.8.34+commit.80d5c536"
+    },
+    "language": "Solidity",
+    "output": {
+      "abi": [
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "banditId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "targetClanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "bool",
+              "name": "defended",
+              "type": "bool",
+              "indexed": false
+            },
+            {
+              "internalType": "uint16",
+              "name": "attackPower",
+              "type": "uint16",
+              "indexed": false
+            },
+            {
+              "internalType": "uint16",
+              "name": "totalDefense",
+              "type": "uint16",
+              "indexed": false
+            },
+            {
+              "internalType": "uint16",
+              "name": "wallLevelAfter",
+              "type": "uint16",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "stolenWood",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "stolenIron",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "stolenWheat",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "stolenFish",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "BanditAttackResolved",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "banditId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "targetClanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "BanditDefeated",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "banditId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "BanditEscaped",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "banditId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint8",
+              "name": "fromRegion",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint8",
+              "name": "toRegion",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "BanditMoved",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "banditId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint8",
+              "name": "region",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint8",
+              "name": "tier",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint16",
+              "name": "attackPower",
+              "type": "uint16",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "BanditSpawned",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "banditId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "enum BanditState",
+              "name": "oldState",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "enum BanditState",
+              "name": "newState",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint8",
+              "name": "region",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "BanditStateChanged",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint8",
+              "name": "oldLevel",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint8",
+              "name": "newLevel",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "BaseLevelChanged",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint8",
+              "name": "newLevel",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint32",
+              "name": "settledAtTick",
+              "type": "uint32",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "BaseUpgraded",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "banditId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "BlueprintAwarded",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "fromClanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "toClanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "BlueprintTransferred",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint64",
+              "name": "tick",
+              "type": "uint64",
+              "indexed": true
+            }
+          ],
+          "type": "event",
+          "name": "ClanEliminated",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint64",
+              "name": "settledToTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ClanSettled",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "address",
+              "name": "owner",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "iftTokenId",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint8",
+              "name": "baseRegion",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ClanSpawned",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "bool",
+              "name": "isStarving",
+              "type": "bool",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ClanStarvationChanged",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ClansmanDiedFromCold",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint16",
+              "name": "oldDamage",
+              "type": "uint16",
+              "indexed": false
+            },
+            {
+              "internalType": "uint16",
+              "name": "newDamage",
+              "type": "uint16",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ColdDamageApplied",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "fromClanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "toClanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "GoldTransferred",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "address",
+              "name": "tokenIn",
+              "type": "address",
+              "indexed": false
+            },
+            {
+              "internalType": "address",
+              "name": "tokenOut",
+              "type": "address",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountIn",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountOut",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ImmediateMarketActionExecuted",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "banditId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "wood",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "iron",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "wheat",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "fish",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "LootDistributedToDefender",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "enum ActionType",
+              "name": "action",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "enum StatusCode",
+              "name": "reason",
+              "type": "uint8",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "MarketActionFailed",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint64",
+              "name": "missionNonce",
+              "type": "uint64",
+              "indexed": false
+            },
+            {
+              "internalType": "enum ActionType",
+              "name": "action",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint8",
+              "name": "startRegion",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint8",
+              "name": "targetRegion",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "startTick",
+              "type": "uint64",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "arrivalTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "MissionAssigned",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint64",
+              "name": "missionNonce",
+              "type": "uint64",
+              "indexed": false
+            },
+            {
+              "internalType": "enum ActionType",
+              "name": "action",
+              "type": "uint8",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "MissionCompleted",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint64",
+              "name": "oldMissionNonce",
+              "type": "uint64",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "newMissionNonce",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "MissionInterrupted",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint8",
+              "name": "oldLevel",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint8",
+              "name": "newLevel",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "MonumentLevelChanged",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint8",
+              "name": "newLevel",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint32",
+              "name": "settledAtTick",
+              "type": "uint32",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "MonumentUpgraded",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "woodGoldPool",
+              "type": "address",
+              "indexed": false
+            },
+            {
+              "internalType": "address",
+              "name": "wheatGoldPool",
+              "type": "address",
+              "indexed": false
+            },
+            {
+              "internalType": "address",
+              "name": "fishGoldPool",
+              "type": "address",
+              "indexed": false
+            },
+            {
+              "internalType": "address",
+              "name": "ironGoldPool",
+              "type": "address",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "PoolsSeeded",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "woodDelta",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "ironDelta",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "wheatDelta",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "fishDelta",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint32",
+              "name": "tick",
+              "type": "uint32",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ResourcesDeposited",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "enum ActionType",
+              "name": "action",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "woodGained",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "ironGained",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "wheatGained",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "fishGained",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "goldBonus",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ResourcesGathered",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "executeAtTick",
+              "type": "uint64",
+              "indexed": true
+            },
+            {
+              "internalType": "uint64",
+              "name": "commitSequence",
+              "type": "uint64",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32",
+              "indexed": false
+            },
+            {
+              "internalType": "enum ActionType",
+              "name": "action",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "address",
+              "name": "marketToken",
+              "type": "address",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "marketAmount",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxGoldIn",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ScheduledMarketActionCommitted",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "executeAtTick",
+              "type": "uint64",
+              "indexed": true
+            },
+            {
+              "internalType": "uint64",
+              "name": "commitSequence",
+              "type": "uint64",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32",
+              "indexed": false
+            },
+            {
+              "internalType": "address",
+              "name": "tokenIn",
+              "type": "address",
+              "indexed": false
+            },
+            {
+              "internalType": "address",
+              "name": "tokenOut",
+              "type": "address",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountIn",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountOut",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ScheduledMarketActionExecuted",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "tick",
+              "type": "uint64",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32[]",
+              "name": "rankedClanIds",
+              "type": "uint32[]",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "SeasonFinalized",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "closedTick",
+              "type": "uint64",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "openedTick",
+              "type": "uint64",
+              "indexed": false
+            },
+            {
+              "internalType": "bytes32",
+              "name": "tickSeed",
+              "type": "bytes32",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "TickAdvanced",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "fromClanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "toClanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "enum ResourceType",
+              "name": "resource",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "VaultResourceTransferred",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint8",
+              "name": "oldLevel",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint8",
+              "name": "newLevel",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "atTick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "WallLevelChanged",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint8",
+              "name": "newLevel",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint32",
+              "name": "settledAtTick",
+              "type": "uint32",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "WallUpgraded",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "tick",
+              "type": "uint64",
+              "indexed": true
+            }
+          ],
+          "type": "event",
+          "name": "WinterEnded",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "tick",
+              "type": "uint64",
+              "indexed": true
+            }
+          ],
+          "type": "event",
+          "name": "WinterStarted",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32",
+              "indexed": true
+            },
+            {
+              "internalType": "uint8",
+              "name": "region",
+              "type": "uint8",
+              "indexed": false
+            },
+            {
+              "internalType": "uint64",
+              "name": "tick",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "WorkerArrived",
+          "anonymous": false
+        },
+        {
+          "inputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "finalizeSeason"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "enum ActionType",
+              "name": "action",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "pure",
+          "type": "function",
+          "name": "getActionDuration",
+          "outputs": [
+            {
+              "internalType": "uint64",
+              "name": "",
+              "type": "uint64"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getActiveBanditView",
+          "outputs": [
+            {
+              "internalType": "struct ActiveBanditView",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "bool",
+                  "name": "exists",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "banditId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "enum BanditState",
+                  "name": "state",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "currentRegion",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "attackAttemptsMade",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "maxAttemptsRemaining",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "stateEnteredTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nextActionTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "tier",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint16",
+                  "name": "attackPower",
+                  "type": "uint16"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryWood",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryIron",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryWheat",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryFish",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "projectedTargetClanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "projectedTargetLootValue",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "targetClanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getActiveDefenders",
+          "outputs": [
+            {
+              "internalType": "uint32[]",
+              "name": "clansmanIds",
+              "type": "uint32[]"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getActiveMission",
+          "outputs": [
+            {
+              "internalType": "struct Mission",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "bool",
+                  "name": "active",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "submittedAtTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "executesAtTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "settlesAtTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "clansmanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "startRegion",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "targetRegion",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "enum ActionType",
+                  "name": "action",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "startTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "arrivalTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "actionStartTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "missionSeed",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "enum MarketExecutionMode",
+                  "name": "marketMode",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "targetClanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "address",
+                  "name": "marketToken",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "marketAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "maxGoldIn",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "banditId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getBanditTargetPreview",
+          "outputs": [
+            {
+              "internalType": "uint32",
+              "name": "previewClanId",
+              "type": "uint32"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "banditId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getBanditTroop",
+          "outputs": [
+            {
+              "internalType": "struct BanditTroop",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "banditId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "enum BanditState",
+                  "name": "state",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "currentRegion",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "attackAttemptsMade",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "stateEnteredTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nextActionTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "tier",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint16",
+                  "name": "attackPower",
+                  "type": "uint16"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryWood",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryIron",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryWheat",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryFish",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint8",
+              "name": "currentLevel",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "pure",
+          "type": "function",
+          "name": "getBaseUpgradeCost",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "wood",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "iron",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "wheat",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getClan",
+          "outputs": [
+            {
+              "internalType": "struct Clan",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "clanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "iftTokenId",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "address",
+                  "name": "owner",
+                  "type": "address"
+                },
+                {
+                  "internalType": "enum ClanState",
+                  "name": "clanState",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "baseRegion",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "baseLevel",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "wallLevel",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "monumentLevel",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "livingClansmen",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "lastSettledTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "starvationStartsAtTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint16",
+                  "name": "coldDamage",
+                  "type": "uint16"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "goldBalance",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "blueprintBalance",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "vaultWood",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "vaultIron",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "vaultWheat",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "vaultFish",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getClanFullView",
+          "outputs": [
+            {
+              "internalType": "struct ClanFullView",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "struct DerivedClanState",
+                  "name": "clan",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "struct Clan",
+                      "name": "clan",
+                      "type": "tuple",
+                      "components": [
+                        {
+                          "internalType": "uint32",
+                          "name": "clanId",
+                          "type": "uint32"
+                        },
+                        {
+                          "internalType": "uint256",
+                          "name": "iftTokenId",
+                          "type": "uint256"
+                        },
+                        {
+                          "internalType": "address",
+                          "name": "owner",
+                          "type": "address"
+                        },
+                        {
+                          "internalType": "enum ClanState",
+                          "name": "clanState",
+                          "type": "uint8"
+                        },
+                        {
+                          "internalType": "uint8",
+                          "name": "baseRegion",
+                          "type": "uint8"
+                        },
+                        {
+                          "internalType": "uint8",
+                          "name": "baseLevel",
+                          "type": "uint8"
+                        },
+                        {
+                          "internalType": "uint8",
+                          "name": "wallLevel",
+                          "type": "uint8"
+                        },
+                        {
+                          "internalType": "uint8",
+                          "name": "monumentLevel",
+                          "type": "uint8"
+                        },
+                        {
+                          "internalType": "uint8",
+                          "name": "livingClansmen",
+                          "type": "uint8"
+                        },
+                        {
+                          "internalType": "uint64",
+                          "name": "lastSettledTick",
+                          "type": "uint64"
+                        },
+                        {
+                          "internalType": "uint64",
+                          "name": "starvationStartsAtTick",
+                          "type": "uint64"
+                        },
+                        {
+                          "internalType": "uint16",
+                          "name": "coldDamage",
+                          "type": "uint16"
+                        },
+                        {
+                          "internalType": "uint256",
+                          "name": "goldBalance",
+                          "type": "uint256"
+                        },
+                        {
+                          "internalType": "uint256",
+                          "name": "blueprintBalance",
+                          "type": "uint256"
+                        },
+                        {
+                          "internalType": "uint256",
+                          "name": "vaultWood",
+                          "type": "uint256"
+                        },
+                        {
+                          "internalType": "uint256",
+                          "name": "vaultIron",
+                          "type": "uint256"
+                        },
+                        {
+                          "internalType": "uint256",
+                          "name": "vaultWheat",
+                          "type": "uint256"
+                        },
+                        {
+                          "internalType": "uint256",
+                          "name": "vaultFish",
+                          "type": "uint256"
+                        }
+                      ]
+                    },
+                    {
+                      "internalType": "bool",
+                      "name": "isStarving",
+                      "type": "bool"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "lootValue",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "derivedAtTick",
+                      "type": "uint64"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "struct ClansmanFullView[]",
+                  "name": "clansmen",
+                  "type": "tuple[]",
+                  "components": [
+                    {
+                      "internalType": "struct DerivedClansmanState",
+                      "name": "clansman",
+                      "type": "tuple",
+                      "components": [
+                        {
+                          "internalType": "struct Clansman",
+                          "name": "clansman",
+                          "type": "tuple",
+                          "components": [
+                            {
+                              "internalType": "uint32",
+                              "name": "clansmanId",
+                              "type": "uint32"
+                            },
+                            {
+                              "internalType": "uint32",
+                              "name": "clanId",
+                              "type": "uint32"
+                            },
+                            {
+                              "internalType": "enum ClansmanState",
+                              "name": "state",
+                              "type": "uint8"
+                            },
+                            {
+                              "internalType": "uint8",
+                              "name": "currentRegion",
+                              "type": "uint8"
+                            },
+                            {
+                              "internalType": "uint64",
+                              "name": "cooldownEndsAtTs",
+                              "type": "uint64"
+                            },
+                            {
+                              "internalType": "uint64",
+                              "name": "lastMissionNonce",
+                              "type": "uint64"
+                            },
+                            {
+                              "internalType": "uint256",
+                              "name": "carryWood",
+                              "type": "uint256"
+                            },
+                            {
+                              "internalType": "uint256",
+                              "name": "carryIron",
+                              "type": "uint256"
+                            },
+                            {
+                              "internalType": "uint256",
+                              "name": "carryWheat",
+                              "type": "uint256"
+                            },
+                            {
+                              "internalType": "uint256",
+                              "name": "carryFish",
+                              "type": "uint256"
+                            }
+                          ]
+                        },
+                        {
+                          "internalType": "struct Mission",
+                          "name": "activeMission",
+                          "type": "tuple",
+                          "components": [
+                            {
+                              "internalType": "bool",
+                              "name": "active",
+                              "type": "bool"
+                            },
+                            {
+                              "internalType": "uint64",
+                              "name": "nonce",
+                              "type": "uint64"
+                            },
+                            {
+                              "internalType": "uint64",
+                              "name": "submittedAtTick",
+                              "type": "uint64"
+                            },
+                            {
+                              "internalType": "uint64",
+                              "name": "executesAtTick",
+                              "type": "uint64"
+                            },
+                            {
+                              "internalType": "uint64",
+                              "name": "settlesAtTick",
+                              "type": "uint64"
+                            },
+                            {
+                              "internalType": "uint32",
+                              "name": "clansmanId",
+                              "type": "uint32"
+                            },
+                            {
+                              "internalType": "uint8",
+                              "name": "startRegion",
+                              "type": "uint8"
+                            },
+                            {
+                              "internalType": "uint8",
+                              "name": "targetRegion",
+                              "type": "uint8"
+                            },
+                            {
+                              "internalType": "enum ActionType",
+                              "name": "action",
+                              "type": "uint8"
+                            },
+                            {
+                              "internalType": "uint64",
+                              "name": "startTick",
+                              "type": "uint64"
+                            },
+                            {
+                              "internalType": "uint64",
+                              "name": "arrivalTick",
+                              "type": "uint64"
+                            },
+                            {
+                              "internalType": "uint64",
+                              "name": "actionStartTick",
+                              "type": "uint64"
+                            },
+                            {
+                              "internalType": "bytes32",
+                              "name": "missionSeed",
+                              "type": "bytes32"
+                            },
+                            {
+                              "internalType": "enum MarketExecutionMode",
+                              "name": "marketMode",
+                              "type": "uint8"
+                            },
+                            {
+                              "internalType": "uint32",
+                              "name": "targetClanId",
+                              "type": "uint32"
+                            },
+                            {
+                              "internalType": "address",
+                              "name": "marketToken",
+                              "type": "address"
+                            },
+                            {
+                              "internalType": "uint256",
+                              "name": "marketAmount",
+                              "type": "uint256"
+                            },
+                            {
+                              "internalType": "uint256",
+                              "name": "maxGoldIn",
+                              "type": "uint256"
+                            }
+                          ]
+                        },
+                        {
+                          "internalType": "uint8",
+                          "name": "effectiveRegion",
+                          "type": "uint8"
+                        },
+                        {
+                          "internalType": "uint64",
+                          "name": "derivedAtTick",
+                          "type": "uint64"
+                        }
+                      ]
+                    },
+                    {
+                      "internalType": "struct Mission",
+                      "name": "activeMission",
+                      "type": "tuple",
+                      "components": [
+                        {
+                          "internalType": "bool",
+                          "name": "active",
+                          "type": "bool"
+                        },
+                        {
+                          "internalType": "uint64",
+                          "name": "nonce",
+                          "type": "uint64"
+                        },
+                        {
+                          "internalType": "uint64",
+                          "name": "submittedAtTick",
+                          "type": "uint64"
+                        },
+                        {
+                          "internalType": "uint64",
+                          "name": "executesAtTick",
+                          "type": "uint64"
+                        },
+                        {
+                          "internalType": "uint64",
+                          "name": "settlesAtTick",
+                          "type": "uint64"
+                        },
+                        {
+                          "internalType": "uint32",
+                          "name": "clansmanId",
+                          "type": "uint32"
+                        },
+                        {
+                          "internalType": "uint8",
+                          "name": "startRegion",
+                          "type": "uint8"
+                        },
+                        {
+                          "internalType": "uint8",
+                          "name": "targetRegion",
+                          "type": "uint8"
+                        },
+                        {
+                          "internalType": "enum ActionType",
+                          "name": "action",
+                          "type": "uint8"
+                        },
+                        {
+                          "internalType": "uint64",
+                          "name": "startTick",
+                          "type": "uint64"
+                        },
+                        {
+                          "internalType": "uint64",
+                          "name": "arrivalTick",
+                          "type": "uint64"
+                        },
+                        {
+                          "internalType": "uint64",
+                          "name": "actionStartTick",
+                          "type": "uint64"
+                        },
+                        {
+                          "internalType": "bytes32",
+                          "name": "missionSeed",
+                          "type": "bytes32"
+                        },
+                        {
+                          "internalType": "enum MarketExecutionMode",
+                          "name": "marketMode",
+                          "type": "uint8"
+                        },
+                        {
+                          "internalType": "uint32",
+                          "name": "targetClanId",
+                          "type": "uint32"
+                        },
+                        {
+                          "internalType": "address",
+                          "name": "marketToken",
+                          "type": "address"
+                        },
+                        {
+                          "internalType": "uint256",
+                          "name": "marketAmount",
+                          "type": "uint256"
+                        },
+                        {
+                          "internalType": "uint256",
+                          "name": "maxGoldIn",
+                          "type": "uint256"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "internalType": "struct WheatPlot",
+                  "name": "westPlot",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "enum WheatPlotState",
+                      "name": "state",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "region",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "remainingWheat",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "regrowUntilTick",
+                      "type": "uint64"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "struct WheatPlot",
+                  "name": "eastPlot",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "enum WheatPlotState",
+                      "name": "state",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "region",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "remainingWheat",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "regrowUntilTick",
+                      "type": "uint64"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "uint32[]",
+                  "name": "incomingDefenderIds",
+                  "type": "uint32[]"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "thisClanDefendingBaseId",
+                  "type": "uint32"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getClanScore",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "score",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint64",
+              "name": "monumentReachedAtTick",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint8",
+              "name": "monumentLevel",
+              "type": "uint8"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getClansman",
+          "outputs": [
+            {
+              "internalType": "struct Clansman",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "clansmanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "clanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "enum ClansmanState",
+                  "name": "state",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "currentRegion",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "cooldownEndsAtTs",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "lastMissionNonce",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryWood",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryIron",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryWheat",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "carryFish",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint8",
+              "name": "region",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getDefendingClans",
+          "outputs": [
+            {
+              "internalType": "uint32[]",
+              "name": "clanIds",
+              "type": "uint32[]"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getDerivedClanState",
+          "outputs": [
+            {
+              "internalType": "struct DerivedClanState",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "struct Clan",
+                  "name": "clan",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "uint32",
+                      "name": "clanId",
+                      "type": "uint32"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "iftTokenId",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "owner",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "enum ClanState",
+                      "name": "clanState",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "baseRegion",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "baseLevel",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "wallLevel",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "monumentLevel",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "livingClansmen",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "lastSettledTick",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "starvationStartsAtTick",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint16",
+                      "name": "coldDamage",
+                      "type": "uint16"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "goldBalance",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "blueprintBalance",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "vaultWood",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "vaultIron",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "vaultWheat",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "vaultFish",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "bool",
+                  "name": "isStarving",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lootValue",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "derivedAtTick",
+                  "type": "uint64"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getDerivedClansmanState",
+          "outputs": [
+            {
+              "internalType": "struct DerivedClansmanState",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "struct Clansman",
+                  "name": "clansman",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "uint32",
+                      "name": "clansmanId",
+                      "type": "uint32"
+                    },
+                    {
+                      "internalType": "uint32",
+                      "name": "clanId",
+                      "type": "uint32"
+                    },
+                    {
+                      "internalType": "enum ClansmanState",
+                      "name": "state",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "currentRegion",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "cooldownEndsAtTs",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "lastMissionNonce",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "carryWood",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "carryIron",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "carryWheat",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "carryFish",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "struct Mission",
+                  "name": "activeMission",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "bool",
+                      "name": "active",
+                      "type": "bool"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "nonce",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "submittedAtTick",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "executesAtTick",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "settlesAtTick",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint32",
+                      "name": "clansmanId",
+                      "type": "uint32"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "startRegion",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "targetRegion",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "enum ActionType",
+                      "name": "action",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "startTick",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "arrivalTick",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "actionStartTick",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "bytes32",
+                      "name": "missionSeed",
+                      "type": "bytes32"
+                    },
+                    {
+                      "internalType": "enum MarketExecutionMode",
+                      "name": "marketMode",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint32",
+                      "name": "targetClanId",
+                      "type": "uint32"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "marketToken",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "marketAmount",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "maxGoldIn",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "effectiveRegion",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "derivedAtTick",
+                  "type": "uint64"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getMarketState",
+          "outputs": [
+            {
+              "internalType": "struct MarketState",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "struct PoolReserves",
+                  "name": "wood",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "address",
+                      "name": "resourceToken",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "resourceReserve",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "goldReserve",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "spotPriceGoldPerResource",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "struct PoolReserves",
+                  "name": "wheat",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "address",
+                      "name": "resourceToken",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "resourceReserve",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "goldReserve",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "spotPriceGoldPerResource",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "struct PoolReserves",
+                  "name": "fish",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "address",
+                      "name": "resourceToken",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "resourceReserve",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "goldReserve",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "spotPriceGoldPerResource",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "struct PoolReserves",
+                  "name": "iron",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "address",
+                      "name": "resourceToken",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "resourceReserve",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "goldReserve",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "spotPriceGoldPerResource",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "currentTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "struct ScheduledMarketAction[]",
+                  "name": "currentTickQueue",
+                  "type": "tuple[]",
+                  "components": [
+                    {
+                      "internalType": "uint64",
+                      "name": "executeAtTick",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "commitSequence",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "missionNonce",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint32",
+                      "name": "clanId",
+                      "type": "uint32"
+                    },
+                    {
+                      "internalType": "uint32",
+                      "name": "clansmanId",
+                      "type": "uint32"
+                    },
+                    {
+                      "internalType": "enum ActionType",
+                      "name": "action",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "marketToken",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "marketAmount",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "maxGoldIn",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "struct ScheduledMarketAction[]",
+                  "name": "nextTickQueue",
+                  "type": "tuple[]",
+                  "components": [
+                    {
+                      "internalType": "uint64",
+                      "name": "executeAtTick",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "commitSequence",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint64",
+                      "name": "missionNonce",
+                      "type": "uint64"
+                    },
+                    {
+                      "internalType": "uint32",
+                      "name": "clanId",
+                      "type": "uint32"
+                    },
+                    {
+                      "internalType": "uint32",
+                      "name": "clansmanId",
+                      "type": "uint32"
+                    },
+                    {
+                      "internalType": "enum ActionType",
+                      "name": "action",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "marketToken",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "marketAmount",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "maxGoldIn",
+                      "type": "uint256"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint32",
+              "name": "clansmanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getMissionTiming",
+          "outputs": [
+            {
+              "internalType": "uint64",
+              "name": "submitted",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "executes",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "settles",
+              "type": "uint64"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint8",
+              "name": "currentLevel",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "pure",
+          "type": "function",
+          "name": "getMonumentUpgradeCost",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "wood",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "iron",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "wheat",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "blueprint",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getRankings",
+          "outputs": [
+            {
+              "internalType": "uint32[]",
+              "name": "clanIdsRanked",
+              "type": "uint32[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "scores",
+              "type": "uint256[]"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint8",
+              "name": "region",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getRegionPopulation",
+          "outputs": [
+            {
+              "internalType": "struct RegionOccupant[]",
+              "name": "",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "clansmanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "clanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "enum ClansmanState",
+                  "name": "state",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "enum ActionType",
+                  "name": "currentAction",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "missionNonce",
+                  "type": "uint64"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "tick",
+              "type": "uint64"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getScheduledMarketActionsForTick",
+          "outputs": [
+            {
+              "internalType": "struct ScheduledMarketAction[]",
+              "name": "",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "uint64",
+                  "name": "executeAtTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "commitSequence",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "missionNonce",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "clanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "clansmanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "enum ActionType",
+                  "name": "action",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "address",
+                  "name": "marketToken",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "marketAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "maxGoldIn",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint8",
+              "name": "fromRegion",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint8",
+              "name": "toRegion",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "pure",
+          "type": "function",
+          "name": "getTravelTicks",
+          "outputs": [
+            {
+              "internalType": "uint64",
+              "name": "",
+              "type": "uint64"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getTreasuryState",
+          "outputs": [
+            {
+              "internalType": "struct TreasuryState",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "treasuryOwner",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "prizePotGold",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "poolsSeeded",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "address",
+                  "name": "woodToken",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "wheatToken",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "fishToken",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "ironToken",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "goldToken",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "blueprintToken",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "woodGoldPool",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "wheatGoldPool",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "fishGoldPool",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "ironGoldPool",
+                  "type": "address"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint8",
+              "name": "currentLevel",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "pure",
+          "type": "function",
+          "name": "getWallUpgradeCost",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "wood",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "iron",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getWheatPlots",
+          "outputs": [
+            {
+              "internalType": "struct WheatPlot",
+              "name": "west",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "enum WheatPlotState",
+                  "name": "state",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "region",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "remainingWheat",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "regrowUntilTick",
+                  "type": "uint64"
+                }
+              ]
+            },
+            {
+              "internalType": "struct WheatPlot",
+              "name": "east",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "enum WheatPlotState",
+                  "name": "state",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "region",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "remainingWheat",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "regrowUntilTick",
+                  "type": "uint64"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getWorldSnapshot",
+          "outputs": [
+            {
+              "internalType": "struct WorldSnapshot",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "uint64",
+                  "name": "currentTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "seasonStartTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "seasonEndTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "seasonFinalized",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "currentSeasonNumber",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nextHeartbeatAtTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "winterActive",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "winterStartsAtTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "winterEndsAtTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "activeBanditId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "currentTickSeed",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "struct LeaderboardEntry[]",
+                  "name": "leaderboard",
+                  "type": "tuple[]",
+                  "components": [
+                    {
+                      "internalType": "uint32",
+                      "name": "clanId",
+                      "type": "uint32"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "owner",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "monumentLevel",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "baseLevel",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "wallLevel",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint8",
+                      "name": "livingClansmen",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "enum ClanState",
+                      "name": "state",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "lootValue",
+                      "type": "uint256"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getWorldState",
+          "outputs": [
+            {
+              "internalType": "struct WorldState",
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "uint64",
+                  "name": "currentTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "seasonStartTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "seasonEndTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "seasonFinalized",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "currentSeasonNumber",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nextHeartbeatAtTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nextHeartbeatAtTs",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nextBanditSpawnEligibleTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint16",
+                  "name": "currentBanditSpawnChanceBps",
+                  "type": "uint16"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "currentTickSeed",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "activeBanditId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "winterActive",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "winterStartsAtTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "winterEndsAtTick",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nextCommitSequence",
+                  "type": "uint64"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "heartbeat"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address[6]",
+              "name": "tokens",
+              "type": "address[6]"
+            },
+            {
+              "internalType": "address[4]",
+              "name": "pools",
+              "type": "address[4]"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "initTreasury"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "mintClan",
+          "outputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "iftTokenId",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "quoteLootValueRaw",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "lootValue",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "quoteLootValueSettled",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "lootValue",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint8",
+              "name": "srcRegion",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint8",
+              "name": "dstRegion",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "quoteTravel",
+          "outputs": [
+            {
+              "internalType": "uint8",
+              "name": "travelTicks",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bytes8",
+              "name": "path",
+              "type": "bytes8"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "struct PoolSeedConfig",
+              "name": "cfg",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "woodSeed",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "wheatSeed",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "fishSeed",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "ironSeed",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "goldSeedForWood",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "goldSeedForWheat",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "goldSeedForFish",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "goldSeedForIron",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "seedPools"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "settleClan"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "csId",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "settleClansman"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "clanId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "struct ClanOrder[]",
+              "name": "orders",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "clansmanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "gotoRegion",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "enum ActionType",
+                  "name": "action",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "targetClanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "address",
+                  "name": "marketToken",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "marketAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "maxGoldIn",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "submitClanOrders",
+          "outputs": [
+            {
+              "internalType": "struct OrderResult[]",
+              "name": "",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "clansmanId",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "enum StatusCode",
+                  "name": "status",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "cooldownEndsAtTs",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "missionNonce",
+                  "type": "uint64"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "fromClanId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint32",
+              "name": "toClanId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "transferBlueprint"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "fromClanId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint32",
+              "name": "toClanId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "gold",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "blueprint",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "wood",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "iron",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "wheat",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "fish",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "transferBundle"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "fromClanId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint32",
+              "name": "toClanId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "transferGold"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint32",
+              "name": "fromClanId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint32",
+              "name": "toClanId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "enum ResourceType",
+              "name": "resource",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "transferVaultResource"
+        }
+      ],
+      "devdoc": {
+        "kind": "dev",
+        "methods": {
+          "getClanScore(uint32)": {
+            "details": "Score is ordered by monument level, then earliest first-reached tick for that level,      then settled vault loot value, then wall level. The loot component matches      quoteLootValueSettled's read-only settled-vault basis."
+          }
+        },
+        "version": 1
+      },
+      "userdoc": {
+        "kind": "user",
+        "methods": {
+          "finalizeSeason()": {
+            "notice": "Finalize the current season. Permissionless after seasonEndTick."
+          },
+          "getActiveBanditView()": {
+            "notice": "Single-call bandit drama state, including projected target if         attack resolved this tick. Drives the bandit warning UI."
+          },
+          "getBanditTargetPreview(uint32)": {
+            "notice": "Non-binding preview. Bandit targeting is recomputed at attack         resolution time using then-current eagerly settled state."
+          },
+          "getClanFullView(uint32)": {
+            "notice": "Single-call complete clan rendering data: derived clan + all         clansmen with derived state and active missions + plot states +         defender bookkeeping. Drives the entire sprite layer."
+          },
+          "getClanScore(uint32)": {
+            "notice": "Ranking score preview for a clan."
+          },
+          "getMarketState()": {
+            "notice": "Single-call market panel data: 4 pool reserves + spot prices +         scheduled queues for current and next tick. Drives market UI         and indexer's per-tick price-history sampling."
+          },
+          "getRankings()": {
+            "notice": "Live clans sorted by score descending, with clanId ascending for exact ties."
+          },
+          "getRegionPopulation(uint8)": {
+            "notice": "Optional. List clansmen currently in a region for tap-to-inspect         tooltips. Can be derived clientside; included for completeness."
+          },
+          "getWorldSnapshot()": {
+            "notice": "Single-call top-level world state plus per-clan leaderboard data.         Drives top HUD bar, season clock, winter indicator, leaderboard."
+          },
+          "heartbeat()": {
+            "notice": "Permissionless heartbeat. Closes the current tick, resolves         scheduled market actions and world events, advances the tick.         Rate-limited by WorldState.nextHeartbeatAtTs."
+          },
+          "initTreasury(address[6],address[4])": {
+            "notice": "Owner-only. Registers token and pool addresses once before seeding.         tokens order: wood, iron, wheat, fish, gold, blueprint.         pools order: wood, wheat, fish, iron."
+          },
+          "mintClan(address)": {
+            "notice": "Mint a new clan iNFT and spawn its homebase in a valid region."
+          },
+          "seedPools((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256))": {
+            "notice": "Owner-only. Seeds the four Unicorn Town pools at deploy time."
+          },
+          "settleClan(uint32)": {
+            "notice": "Lazily settle a clan forward to current tick. Idempotent."
+          },
+          "settleClansman(uint32)": {
+            "notice": "Lazily settle a single clansman's mission to current tick. Idempotent."
+          },
+          "submitClanOrders(uint32,(uint32,uint8,uint8,uint32,address,uint256,uint256)[])": {
+            "notice": "Submit one or more orders for a single clan's clansmen.         Per-order failures do not revert the tx."
+          }
+        },
+        "version": 1
+      }
+    },
+    "settings": {
+      "remappings": [
+        "forge-std/=lib/forge-std/src/"
+      ],
+      "optimizer": {
+        "enabled": true,
+        "runs": 200
+      },
+      "metadata": {
+        "bytecodeHash": "ipfs"
+      },
+      "compilationTarget": {
+        "src/IClanWorld.sol": "IClanWorld"
+      },
+      "evmVersion": "prague",
+      "libraries": {},
+      "viaIR": true
+    },
+    "sources": {
+      "src/IClanWorld.sol": {
+        "keccak256": "0x2bb8f2b4dd423591858ebacb7d4b6eb3e826b57d67ec4ee5e1c99f452134dbb9",
+        "urls": [
+          "bzz-raw://e0f1e37ac103f748e5ba0e5483ee360ce066f919f207605d90f74e1bcc1ef603",
+          "dweb:/ipfs/QmXVFbaMSwBJQSS873E6n2WzwpuPZnoKomZMcg2tMWQTmk"
+        ],
+        "license": "MIT"
+      }
+    },
+    "version": 1
+  },
+  "id": 24
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "scripts": {
     "build": "if command -v forge >/dev/null 2>&1; then forge build; else echo 'forge not installed; skipping (install via foundryup)'; fi",
-    "check:abi": "if command -v forge >/dev/null 2>&1; then forge build && diff -u out/IClanWorld.sol/IClanWorld.json abi/IClanWorld.json; else echo 'forge not installed; skipping ABI drift check'; fi",
-    "test": "if command -v forge >/dev/null 2>&1; then forge build && diff -u out/IClanWorld.sol/IClanWorld.json abi/IClanWorld.json && forge test;  else echo 'forge not installed; skipping'; fi",
+    "check:abi": "forge_bin=$(command -v forge || command -v \"$HOME/.foundry/bin/forge\" || true); if [ -n \"$forge_bin\" ]; then command -v jq >/dev/null 2>&1 || { echo 'jq not installed; cannot check ABI'; exit 1; }; \"$forge_bin\" build && tmp_out=$(mktemp) && tmp_abi=$(mktemp) && jq . out/IClanWorld.sol/IClanWorld.json > \"$tmp_out\" && jq . abi/IClanWorld.json > \"$tmp_abi\" && diff -u \"$tmp_abi\" abi/IClanWorld.json && diff -u \"$tmp_out\" \"$tmp_abi\"; status=$?; rm -f \"$tmp_out\" \"$tmp_abi\"; exit $status; else echo 'forge not installed; skipping ABI drift check'; fi",
+    "test": "forge_bin=$(command -v forge || command -v \"$HOME/.foundry/bin/forge\" || true); if [ -n \"$forge_bin\" ]; then pnpm run check:abi && \"$forge_bin\" test;  else echo 'forge not installed; skipping'; fi",
     "typecheck": "echo 'no TS in contracts package'",
     "lint": "echo 'lint stub'",
     "clean": "rm -rf out cache .turbo"

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -120,6 +120,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         Mission[] missions;
         WheatPlot[2] wheatPlots;
         uint64[11] simMonumentReachedAt;
+        bool[] simWallReservationCleared;
+        bool[] simBaseReservationCleared;
+        bool[] simMonumentReservationCleared;
     }
 
     struct HeldUpgradeResources {
@@ -966,6 +969,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32[] storage clansmanIds = _clanClansmanIds[clanId];
         sim.clansmen = new Clansman[](clansmanIds.length);
         sim.missions = new Mission[](clansmanIds.length);
+        sim.simWallReservationCleared = new bool[](clansmanIds.length);
+        sim.simBaseReservationCleared = new bool[](clansmanIds.length);
+        sim.simMonumentReservationCleared = new bool[](clansmanIds.length);
         for (uint256 i = 0; i < clansmanIds.length; i++) {
             uint32 clansmanId = clansmanIds[i];
             sim.clansmen[i] = _clansmen[clansmanId];
@@ -1269,10 +1275,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         view
         returns (bool)
     {
+        if (_simUpgradeReservationCleared(sim, clansmanId, ActionType.UpgradeWall)) return true;
         WallUpgradeReservation memory held = _wallUpgradeReservations[clansmanId];
         if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return true;
         if (sim.clan.wallLevel >= WALL_MAX_LEVEL) return true;
-        if (held.fromLevel != sim.clan.wallLevel) return false;
+        if (held.fromLevel != sim.clan.wallLevel) {
+            _simClearUpgradeReservation(sim, clansmanId, ActionType.UpgradeWall);
+            return false;
+        }
 
         (uint256 woodCost, uint256 ironCost) = _wallUpgradeCost(sim.clan.wallLevel);
         uint256 woodDebit = _min(held.woodCost, woodCost);
@@ -1290,10 +1300,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         view
         returns (bool)
     {
+        if (_simUpgradeReservationCleared(sim, clansmanId, ActionType.UpgradeBase)) return true;
         BaseUpgradeReservation memory held = _baseUpgradeReservations[clansmanId];
         if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return true;
         if (sim.clan.baseLevel >= BASE_MAX_LEVEL) return true;
-        if (held.fromLevel != sim.clan.baseLevel) return false;
+        if (held.fromLevel != sim.clan.baseLevel) {
+            _simClearUpgradeReservation(sim, clansmanId, ActionType.UpgradeBase);
+            return false;
+        }
 
         (uint256 woodCost, uint256 ironCost, uint256 wheatCost) = _baseUpgradeCost(sim.clan.baseLevel);
         uint256 woodDebit = _min(held.woodCost, woodCost);
@@ -1316,10 +1330,16 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint64 missionNonce,
         uint64 tick
     ) internal view returns (bool) {
+        if (_simUpgradeReservationCleared(sim, clansmanId, ActionType.UpgradeMonument)) {
+            return true;
+        }
         MonumentUpgradeReservation memory held = _monumentUpgradeReservations[clansmanId];
         if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return true;
         if (sim.clan.monumentLevel >= MONUMENT_MAX_LEVEL) return true;
-        if (held.fromLevel != sim.clan.monumentLevel) return false;
+        if (held.fromLevel != sim.clan.monumentLevel) {
+            _simClearUpgradeReservation(sim, clansmanId, ActionType.UpgradeMonument);
+            return false;
+        }
 
         (uint256 woodCost, uint256 ironCost, uint256 wheatCost, uint256 blueprintCost) =
             _monumentUpgradeCost(sim.clan.monumentLevel);
@@ -1339,6 +1359,45 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         sim.clan.monumentLevel += 1;
         sim.simMonumentReachedAt[sim.clan.monumentLevel] = tick;
         return true;
+    }
+
+    function _simUpgradeReservationCleared(SettlementSimulation memory sim, uint32 clansmanId, ActionType action)
+        internal
+        pure
+        returns (bool)
+    {
+        (uint256 index, bool found) = _simClansmanIndex(sim, clansmanId);
+        if (!found) return false;
+        if (action == ActionType.UpgradeWall) return sim.simWallReservationCleared[index];
+        if (action == ActionType.UpgradeBase) return sim.simBaseReservationCleared[index];
+        if (action == ActionType.UpgradeMonument) return sim.simMonumentReservationCleared[index];
+        return false;
+    }
+
+    function _simClearUpgradeReservation(SettlementSimulation memory sim, uint32 clansmanId, ActionType action)
+        internal
+        pure
+    {
+        (uint256 index, bool found) = _simClansmanIndex(sim, clansmanId);
+        if (!found) return;
+        if (action == ActionType.UpgradeWall) {
+            sim.simWallReservationCleared[index] = true;
+        } else if (action == ActionType.UpgradeBase) {
+            sim.simBaseReservationCleared[index] = true;
+        } else if (action == ActionType.UpgradeMonument) {
+            sim.simMonumentReservationCleared[index] = true;
+        }
+    }
+
+    function _simClansmanIndex(SettlementSimulation memory sim, uint32 clansmanId)
+        internal
+        pure
+        returns (uint256, bool)
+    {
+        for (uint256 i = 0; i < sim.clansmen.length; i++) {
+            if (sim.clansmen[i].clansmanId == clansmanId) return (i, true);
+        }
+        return (0, false);
     }
 
     function _simulateCompleteMission(Clansman memory cs, Mission memory m)

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -825,7 +825,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             _clearWallUpgradeReservation(clansmanId);
             return true;
         }
-        if (held.fromLevel != clan.wallLevel && _hasEarlierWallUpgradeReservation(clanId, clansmanId, clan.wallLevel)) {
+        if (held.fromLevel != clan.wallLevel) {
+            _refundWallUpgradeReservation(clansmanId);
             return false;
         }
 
@@ -861,7 +862,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             _clearBaseUpgradeReservation(clansmanId);
             return true;
         }
-        if (held.fromLevel != clan.baseLevel && _hasEarlierBaseUpgradeReservation(clanId, clansmanId, clan.baseLevel)) {
+        if (held.fromLevel != clan.baseLevel) {
+            _refundBaseUpgradeReservation(clansmanId);
             return false;
         }
 
@@ -902,10 +904,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             _clearMonumentUpgradeReservation(clansmanId);
             return true;
         }
-        if (
-            held.fromLevel != clan.monumentLevel
-                && _hasEarlierMonumentUpgradeReservation(clanId, clansmanId, clan.monumentLevel)
-        ) {
+        if (held.fromLevel != clan.monumentLevel) {
+            _refundMonumentUpgradeReservation(clansmanId);
             return false;
         }
 
@@ -1250,58 +1250,64 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         ActionType action,
         uint64 tick
     ) internal view returns (Clansman memory, Mission memory) {
+        bool finished = true;
         if (cs.currentRegion == sim.clan.baseRegion) {
             if (action == ActionType.UpgradeWall) {
-                _simulateSettleWallUpgrade(sim, cs.clansmanId, m.nonce);
+                finished = _simulateSettleWallUpgrade(sim, cs.clansmanId, m.nonce);
             } else if (action == ActionType.UpgradeBase) {
-                _simulateSettleBaseUpgrade(sim, cs.clansmanId, m.nonce);
+                finished = _simulateSettleBaseUpgrade(sim, cs.clansmanId, m.nonce);
             } else if (action == ActionType.UpgradeMonument) {
-                _simulateSettleMonumentUpgrade(sim, cs.clansmanId, m.nonce, tick);
+                finished = _simulateSettleMonumentUpgrade(sim, cs.clansmanId, m.nonce, tick);
             }
         }
-        return _simulateCompleteMission(cs, m);
+        if (finished) return _simulateCompleteMission(cs, m);
+        return (cs, m);
     }
 
     function _simulateSettleWallUpgrade(SettlementSimulation memory sim, uint32 clansmanId, uint64 missionNonce)
         internal
         view
+        returns (bool)
     {
         WallUpgradeReservation memory held = _wallUpgradeReservations[clansmanId];
-        if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return;
-        if (sim.clan.wallLevel >= WALL_MAX_LEVEL) return;
-        if (held.fromLevel != sim.clan.wallLevel) return;
+        if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return true;
+        if (sim.clan.wallLevel >= WALL_MAX_LEVEL) return true;
+        if (held.fromLevel != sim.clan.wallLevel) return false;
 
         (uint256 woodCost, uint256 ironCost) = _wallUpgradeCost(sim.clan.wallLevel);
         uint256 woodDebit = _min(held.woodCost, woodCost);
         uint256 ironDebit = _min(held.ironCost, ironCost);
-        if (sim.clan.vaultWood < woodDebit || sim.clan.vaultIron < ironDebit) return;
+        if (sim.clan.vaultWood < woodDebit || sim.clan.vaultIron < ironDebit) return false;
 
         sim.clan.vaultWood -= woodDebit;
         sim.clan.vaultIron -= ironDebit;
         sim.clan.wallLevel += 1;
+        return true;
     }
 
     function _simulateSettleBaseUpgrade(SettlementSimulation memory sim, uint32 clansmanId, uint64 missionNonce)
         internal
         view
+        returns (bool)
     {
         BaseUpgradeReservation memory held = _baseUpgradeReservations[clansmanId];
-        if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return;
-        if (sim.clan.baseLevel >= BASE_MAX_LEVEL) return;
-        if (held.fromLevel != sim.clan.baseLevel) return;
+        if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return true;
+        if (sim.clan.baseLevel >= BASE_MAX_LEVEL) return true;
+        if (held.fromLevel != sim.clan.baseLevel) return false;
 
         (uint256 woodCost, uint256 ironCost, uint256 wheatCost) = _baseUpgradeCost(sim.clan.baseLevel);
         uint256 woodDebit = _min(held.woodCost, woodCost);
         uint256 ironDebit = _min(held.ironCost, ironCost);
         uint256 wheatDebit = _min(held.wheatCost, wheatCost);
         if (sim.clan.vaultWood < woodDebit || sim.clan.vaultIron < ironDebit || sim.clan.vaultWheat < wheatDebit) {
-            return;
+            return false;
         }
 
         sim.clan.vaultWood -= woodDebit;
         sim.clan.vaultIron -= ironDebit;
         sim.clan.vaultWheat -= wheatDebit;
         sim.clan.baseLevel += 1;
+        return true;
     }
 
     function _simulateSettleMonumentUpgrade(
@@ -1309,11 +1315,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clansmanId,
         uint64 missionNonce,
         uint64 tick
-    ) internal view {
+    ) internal view returns (bool) {
         MonumentUpgradeReservation memory held = _monumentUpgradeReservations[clansmanId];
-        if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return;
-        if (sim.clan.monumentLevel >= MONUMENT_MAX_LEVEL) return;
-        if (held.fromLevel != sim.clan.monumentLevel) return;
+        if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return true;
+        if (sim.clan.monumentLevel >= MONUMENT_MAX_LEVEL) return true;
+        if (held.fromLevel != sim.clan.monumentLevel) return false;
 
         (uint256 woodCost, uint256 ironCost, uint256 wheatCost, uint256 blueprintCost) =
             _monumentUpgradeCost(sim.clan.monumentLevel);
@@ -1324,7 +1330,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (
             sim.clan.vaultWood < woodDebit || sim.clan.vaultIron < ironDebit || sim.clan.vaultWheat < wheatDebit
                 || sim.clan.blueprintBalance < blueprintDebit
-        ) return;
+        ) return false;
 
         sim.clan.vaultWood -= woodDebit;
         sim.clan.vaultIron -= ironDebit;
@@ -1332,6 +1338,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         sim.clan.blueprintBalance -= blueprintDebit;
         sim.clan.monumentLevel += 1;
         sim.simMonumentReachedAt[sim.clan.monumentLevel] = tick;
+        return true;
     }
 
     function _simulateCompleteMission(Clansman memory cs, Mission memory m)

--- a/packages/contracts/test/BaseUpgrades.t.sol
+++ b/packages/contracts/test/BaseUpgrades.t.sol
@@ -20,6 +20,22 @@ contract BaseUpgradeHarness is ClanWorld {
         _clans[clanId].vaultWheat = wheat;
         _clans[clanId].vaultFish = fish;
     }
+
+    function setCurrentTick(uint64 tick) external {
+        _world.currentTick = tick;
+        _world.nextHeartbeatAtTick = tick + 1;
+    }
+
+    function settleClanAndGetStoredScore(uint32 clanId)
+        external
+        returns (uint256 score, uint256 lootValue, uint8 baseLevel)
+    {
+        _settleClan(clanId);
+        Clan memory clan = _clans[clanId];
+        (score,,) = _getClanScoreFromClan(clanId, clan);
+        lootValue = _lootValueRaw(clan);
+        baseLevel = clan.baseLevel;
+    }
 }
 
 contract BaseUpgradesTest is Test {
@@ -177,5 +193,27 @@ contract BaseUpgradesTest is Test {
 
         assertEq(world.getClan(clanA).baseLevel, 2, "clan A base");
         assertEq(world.getClan(clanB).baseLevel, 1, "clan B base");
+    }
+
+    function test_upgradeBase_simHidesRefundedReservationFromLaterRetry() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 firstCsId = _csAt(clanId, 0);
+        uint32 secondCsId = _csAt(clanId, 1);
+        world.setVault(clanId, 500e18, 500e18, 500e18, 100e18);
+
+        OrderResult[] memory second = _submitOrder(elder, clanId, secondCsId, ActionType.UpgradeBase);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "second clansman queues level 2");
+        OrderResult[] memory first = _submitOrder(elder, clanId, firstCsId, ActionType.UpgradeBase);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first clansman queues level 3");
+
+        world.setCurrentTick(world.getActionDuration(ActionType.UpgradeBase) + 2);
+        uint256 simLoot = world.quoteLootValueSettled(clanId);
+        (uint256 simScore,,) = world.getClanScore(clanId);
+
+        (uint256 realScore, uint256 realLoot, uint8 baseLevel) = world.settleClanAndGetStoredScore(clanId);
+
+        assertEq(baseLevel, 2, "real refunds stale level-3 reservation");
+        assertEq(realLoot, simLoot, "sim and real loot match");
+        assertEq(realScore, simScore, "sim and real score match");
     }
 }

--- a/packages/contracts/test/MonumentUpgrades.t.sol
+++ b/packages/contracts/test/MonumentUpgrades.t.sol
@@ -28,6 +28,22 @@ contract MonumentUpgradeHarness is ClanWorld {
     function setMonumentLevel(uint32 clanId, uint8 level) external {
         _clans[clanId].monumentLevel = level;
     }
+
+    function setCurrentTick(uint64 tick) external {
+        _world.currentTick = tick;
+        _world.nextHeartbeatAtTick = tick + 1;
+    }
+
+    function settleClanAndGetStoredScore(uint32 clanId)
+        external
+        returns (uint256 score, uint256 lootValue, uint8 monumentLevel)
+    {
+        _settleClan(clanId);
+        Clan memory clan = _clans[clanId];
+        (score,,) = _getClanScoreFromClan(clanId, clan);
+        lootValue = _lootValueRaw(clan);
+        monumentLevel = clan.monumentLevel;
+    }
 }
 
 contract MonumentUpgradesTest is Test {
@@ -210,5 +226,28 @@ contract MonumentUpgradesTest is Test {
 
         assertEq(world.getClan(clanA).monumentLevel, 1, "clan A monument");
         assertEq(world.getClan(clanB).monumentLevel, 0, "clan B monument");
+    }
+
+    function test_upgradeMonument_simHidesRefundedReservationFromLaterRetry() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 firstCsId = _csAt(clanId, 0);
+        uint32 secondCsId = _csAt(clanId, 1);
+        world.setVault(clanId, 500e18, 500e18, 500e18, 100e18);
+        world.setBlueprint(clanId, 5e18);
+
+        OrderResult[] memory second = _submitOrder(elder, clanId, secondCsId, ActionType.UpgradeMonument);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "second clansman queues level 1");
+        OrderResult[] memory first = _submitOrder(elder, clanId, firstCsId, ActionType.UpgradeMonument);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first clansman queues level 2");
+
+        world.setCurrentTick(world.getActionDuration(ActionType.UpgradeMonument) + 2);
+        uint256 simLoot = world.quoteLootValueSettled(clanId);
+        (uint256 simScore,,) = world.getClanScore(clanId);
+
+        (uint256 realScore, uint256 realLoot, uint8 monumentLevel) = world.settleClanAndGetStoredScore(clanId);
+
+        assertEq(monumentLevel, 1, "real refunds stale level-2 reservation");
+        assertEq(realLoot, simLoot, "sim and real loot match");
+        assertEq(realScore, simScore, "sim and real score match");
     }
 }

--- a/packages/contracts/test/WallUpgrades.t.sol
+++ b/packages/contracts/test/WallUpgrades.t.sol
@@ -33,6 +33,17 @@ contract WallUpgradeHarness is ClanWorld {
         _world.nextHeartbeatAtTick = tick + 1;
     }
 
+    function settleClanAndGetStoredScore(uint32 clanId)
+        external
+        returns (uint256 score, uint256 lootValue, uint8 wallLevel)
+    {
+        _settleClan(clanId);
+        Clan memory clan = _clans[clanId];
+        (score,,) = _getClanScoreFromClan(clanId, clan);
+        lootValue = _lootValueRaw(clan);
+        wallLevel = clan.wallLevel;
+    }
+
     function installDeprecatedBuildWallMission(uint32 clanId, uint32 clansmanId, uint64 settlesAtTick) external {
         Clan storage clan = _clans[clanId];
         _clansmen[clansmanId].state = ClansmanState.ACTING;
@@ -201,9 +212,10 @@ contract WallUpgradesTest is Test {
         assertEq(uint8(second[0].status), uint8(StatusCode.OK), "reservation released for requeue");
     }
 
-    function test_upgradeWall_repricesLowerLevelAfterEarlierReservationCancelled() public {
+    function test_upgradeWall_invalidatesFutureReservationAfterEarlierReservationCancelled() public {
         uint32 clanId = _mintClan(elder);
         uint32 firstCsId = _csAt(clanId, 0);
+        uint32 secondCsId = _csAt(clanId, 1);
         world.setVault(clanId, 100e18, 100e18, 100e18, 100e18);
 
         OrderResult[] memory batch = _submitUpgradeBatch(elder, clanId, 2);
@@ -216,16 +228,17 @@ contract WallUpgradesTest is Test {
 
         _advanceTicks(world.getActionDuration(ActionType.UpgradeWall) + 1);
 
-        assertEq(world.getClan(clanId).wallLevel, 1, "second settles one level");
-        assertEq(world.getClan(clanId).vaultWood, 80e18, "only level-1 cost debited");
-        assertEq(world.getClan(clanId).vaultIron, 100e18, "no level-2 iron debit");
+        assertEq(world.getClan(clanId).wallLevel, 0, "future-level reservation does not reprice");
+        assertEq(world.getClan(clanId).vaultWood, 100e18, "stale reservation does not debit wood");
+        assertEq(world.getClan(clanId).vaultIron, 100e18, "stale reservation does not debit iron");
+        assertTrue(world.getActiveMission(secondCsId).active, "stale mission stays pending for retry pass");
 
         _advanceTicks(2);
         OrderResult[] memory next = _submitOrder(elder, clanId, firstCsId, ActionType.UpgradeWall);
         assertEq(uint8(next[0].status), uint8(StatusCode.OK), "pending count released");
     }
 
-    function test_upgradeWall_reversedClansmanSettlementPaysSequentialCosts() public {
+    function test_upgradeWall_reversedClansmanSettlementInvalidatesFutureReservation() public {
         uint32 clanId = _mintClan(elder);
         uint32 firstCsId = _csAt(clanId, 0);
         uint32 secondCsId = _csAt(clanId, 1);
@@ -238,9 +251,36 @@ contract WallUpgradesTest is Test {
 
         _advanceTicks(world.getActionDuration(ActionType.UpgradeWall) + 2);
 
-        assertEq(world.getClan(clanId).wallLevel, 2, "both upgrades settle");
-        assertEq(world.getClan(clanId).vaultWood, 45e18, "level 1 plus level 2 costs debited");
+        assertEq(world.getClan(clanId).wallLevel, 1, "only current-level reservation settles");
+        assertEq(world.getClan(clanId).vaultWood, 80e18, "only level 1 cost debited");
         assertEq(world.getClan(clanId).vaultIron, 100e18, "no iron before level 3");
+    }
+
+    function test_upgradeWall_simAndRealScoresMatchAfterOutOfOrderCancellation() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 firstCsId = _csAt(clanId, 0);
+        uint32 secondCsId = _csAt(clanId, 1);
+        world.setVault(clanId, 100e18, 100e18, 100e18, 100e18);
+
+        OrderResult[] memory second = _submitOrder(elder, clanId, secondCsId, ActionType.UpgradeWall);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "second clansman queues level 1");
+        OrderResult[] memory first = _submitOrder(elder, clanId, firstCsId, ActionType.UpgradeWall);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first clansman queues level 2");
+
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS);
+        OrderResult[] memory cancelSecond = _submitOrder(elder, clanId, secondCsId, ActionType.Wait);
+        assertEq(uint8(cancelSecond[0].status), uint8(StatusCode.OK), "cancel current-level reservation");
+
+        world.setCurrentTick(2);
+        uint256 simLoot = world.quoteLootValueSettled(clanId);
+        (uint256 simScore,,) = world.getClanScore(clanId);
+
+        (uint256 realScore, uint256 realLoot, uint8 wallLevel) = world.settleClanAndGetStoredScore(clanId);
+
+        assertEq(realLoot, simLoot, "sim and real loot match");
+        assertEq(realScore, simScore, "sim and real score match");
+        assertEq(wallLevel, 0, "stale future reservation did not apply");
+        assertTrue(world.getActiveMission(firstCsId).active, "failed upgrade remains pending for retry pass");
     }
 
     function test_deprecatedBuildWallFlightedMissionCompletes() public {

--- a/packages/contracts/test/WallUpgrades.t.sol
+++ b/packages/contracts/test/WallUpgrades.t.sol
@@ -283,6 +283,28 @@ contract WallUpgradesTest is Test {
         assertTrue(world.getActiveMission(firstCsId).active, "failed upgrade remains pending for retry pass");
     }
 
+    function test_upgradeWall_simHidesRefundedReservationFromLaterRetry() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 firstCsId = _csAt(clanId, 0);
+        uint32 secondCsId = _csAt(clanId, 1);
+        world.setVault(clanId, 100e18, 100e18, 100e18, 100e18);
+
+        OrderResult[] memory second = _submitOrder(elder, clanId, secondCsId, ActionType.UpgradeWall);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "second clansman queues level 1");
+        OrderResult[] memory first = _submitOrder(elder, clanId, firstCsId, ActionType.UpgradeWall);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first clansman queues level 2");
+
+        world.setCurrentTick(world.getActionDuration(ActionType.UpgradeWall) + 2);
+        uint256 simLoot = world.quoteLootValueSettled(clanId);
+        (uint256 simScore,,) = world.getClanScore(clanId);
+
+        (uint256 realScore, uint256 realLoot, uint8 wallLevel) = world.settleClanAndGetStoredScore(clanId);
+
+        assertEq(wallLevel, 1, "real refunds stale level-2 reservation");
+        assertEq(realLoot, simLoot, "sim and real loot match");
+        assertEq(realScore, simScore, "sim and real score match");
+    }
+
     function test_deprecatedBuildWallFlightedMissionCompletes() public {
         uint32 clanId = _mintClan(elder);
         uint32 csId = _firstCs(clanId);


### PR DESCRIPTION
Per cloud review on PR #291. Addresses 4-finding cross-tier consensus (Codex P1 + Copilot 3 inline) + 1 Copilot M nit.

**H1 — Real-vs-sim divergence on `fromLevel` strict match (4-finding consensus)**

R4 added strict `fromLevel == clan.<level>` checks in the SIMULATION path (`_simulateSettle*Upgrade`) but the REAL settlement path (`_settle*Upgrade`) was permissive — proceeding when `held.fromLevel != clan.<level>` if no other reservation existed at the current level. Result: real and sim disagreed on reservation validity → view/score divergence + potential under-debit when stale reservation had `held.fromLevel < currentLevel`.

PLUS: `_simulateDoBuilding` always called `_simulateCompleteMission` even when level-binding failed in the sim path. Failed-but-pending upgrades should remain ACTIVE for future-tick retry, not transition to COMPLETE.

**Fix — three pieces, all applied:**

1. `_settleWallUpgrade`, `_settleBaseUpgrade`, `_settleMonumentUpgrade`: replaced permissive logic with STRICT `fromLevel` match. Stale reservation → refund + decrement pending counter, do NOT apply, mission stays pending for future retry.
2. `_simulateDoBuilding`: when `_simulateSettle*Upgrade` returns fromLevel mismatch, no longer calls `_simulateCompleteMission`. Mission stays ACTIVE for sim retry.
3. Real + sim paths now functionally identical on fromLevel decision.

**Regression test:** `test_upgradeWall_simAndRealScoresMatchAfterOutOfOrderCancellation` — simulates out-of-order cancel-current-level scenario, asserts `quoteLootValueSettled(clanId)` and stored score match `_settleClan; _getClanScoreFromClan` post-cancellation. Existing tests `test_upgradeWall_invalidatesFutureReservationAfterEarlierReservationCancelled` + `test_upgradeWall_reversedClansmanSettlementInvalidatesFutureReservation` updated to reflect new strict semantics.

**M1 — ABI JSON minified to single line (Copilot)**: regenerated pretty-printed.

**Tests:**
- `forge test`: 129 passed
- `pnpm test` (contracts): ABI check + 129 passed
- `packages/runner pnpm test`: 121 passed, 1 skipped
- `packages/shared pnpm typecheck`: passed
- `git diff --check`: clean

`<signed:codex>`