### PR TITLE
docs+feat(contracts): EIP-2535 Diamond design doc + skeleton — Phase 1 of #337

### DIFF
--- a/docs/architecture/diamond-pattern.md
+++ b/docs/architecture/diamond-pattern.md
@@ -716,6 +716,7 @@ These rules apply to ALL contributors on ALL PRs touching facets or LibStorage. 
 
 ### Checklist
 
+- [ ] **No contract-level state variables in facets:** Facets MUST NOT declare any state variables at the contract level (e.g., `uint256 private myVar`). Such declarations occupy Slot 0 of the contract's own storage, but under `delegatecall` they write to the DIAMOND's Slot 0 — which overlaps with `LibDiamond`'s ownership data. All state MUST go through `LibStorage.appStorage()`. The Solidity compiler does NOT warn about this — it is a silent slot collision.
 - [ ] **Storage append-only:** New fields added at END of `AppStorage` only. No mid-struct inserts. No field reordering. (See §Storage Safety.)
 - [ ] **Storage snapshot updated:** If `LibStorage.sol` or any embedded struct is modified, `test/snapshots/storage-layout.json` is regenerated and committed.
 - [ ] **`nonReentrant` on all state-writing externals:** Every `external` function that writes AppStorage state MUST use the `nonReentrant` modifier (backed by `AppStorage.reentrancyStatus`), UNLESS it is an orchestrator entry-point access-controlled by role or address check (e.g., `heartbeat()` which is engine-only). If a facet reads state only (`pure`/`view`), the modifier is not required.
@@ -814,6 +815,21 @@ Both engines returned NEEDS WORK on R1 revision.
 | R2-L2 | LOW | Codex | Delayed Phase 3 heartbeat isolation keeps fragile model during migration | Deferred — acknowledged explicitly in §Heartbeat Failure Model; same failure mode as monolith today |
 | R2-L3 | LOW | Codex + Gemini | Alternatives (minimal dispatcher, logic-only facets, data-first redesign) | Deferred — brief note in §Known Limitations |
 | R2-L4 | LOW | Gemini | `via_ir` retention for per-facet compilation | Deferred — existing Open Question #6 for Liam |
+
+### Round 6 — 2026-04-30 (DA-COMPLETE)
+
+**Engines:** Codex + Gemini Pro (gemini-2.5-pro-preview-05-06)
+
+Both engines returned NEEDS WORK. R6 contained one new concrete doc finding; all other findings were repetition of previously addressed concerns or philosophical opposition to the Diamond/single-AppStorage architectural choice (which is a made decision, documented with explicit tradeoff rationale).
+
+After this round, the DA process is declared complete. All concrete, actionable documentation gaps have been addressed across R1–R6. The remaining engine concerns are architectural preference objections to decisions that have been explicitly made and documented.
+
+**New findings summary:**
+
+| ID | Severity | Engine | Finding | Disposition |
+|---|---|---|---|---|
+| R6-H1 | HIGH | Gemini | Storage pointer shadowing — facet-level contract state variables (e.g., `uint256 private myVar`) collide with Diamond Slot 0 (LibDiamond owner); compiler does not warn | **ADDRESSED** in §Development Invariants — explicit prohibition on contract-level state variables in facets |
+| R6-L1–L12 | LOW | Both | Repeated concerns: AppStorage blast radius, heartbeat reentrancy Option A, via_ir stack limits, timeline optimism, governance aspirational, alternatives, size projections | All previously addressed; no new actionable doc changes |
 
 ### Round 5 — 2026-04-30
 

--- a/docs/architecture/diamond-pattern.md
+++ b/docs/architecture/diamond-pattern.md
@@ -29,6 +29,8 @@ The previous plan (`clanworld-eip170-split-plan.md`) proposed extracting interna
 
 Diamond (EIP-2535) solves the problem at the root: each facet is an independent contract (≤24,576 B) that shares storage through a deterministic pointer. There is no `delegatecall`-over-library fragility, no inlining guesswork, no 1 KB margin. The ABI surface (`IClanWorld`) stays byte-stable.
 
+**No live state migration required.** ClanWorld has NOT been deployed to production — the monolith exceeds the 24,576 B EIP-170 limit and cannot be deployed at all. The Diamond is a fresh first deployment. There is no existing on-chain user state to migrate.
+
 **Off-chain compatibility note:** The Diamond proxy is deployed at a new address. All off-chain consumers (indexers, frontends, bots) must update their contract address. Additionally: (1) events are emitted with `address = Diamond proxy`, not the facet — indexers that filter by contract address need no change if they target the proxy; (2) revert strings bubble through the proxy unchanged; (3) gas profiles change (~700 gas overhead per external call through proxy). Off-chain gas estimation scripts must be recalibrated after migration.
 
 The reference implementation (Nick Mudgen's Diamond-3) is battle-tested in production (Aavegotchi, DeFi protocols). The pattern is well-understood by Solidity auditors.
@@ -317,10 +319,15 @@ struct AppStorage {
     uint256 reentrancyStatus;                          // 1 = not entered, 2 = entered
 
     // -------------------------------------------------------------------------
-    // Initialization guard + ownership (set atomically in DiamondInit._init())
+    // Initialization guard (set atomically in DiamondInit._init())
     // -------------------------------------------------------------------------
     bool initialized;                                  // true after first init; prevents re-init
-    address owner;                                     // DiamondCut owner / multisig address
+
+    // NOTE: ownership is NOT stored in AppStorage. Diamond-3's LibDiamond has its own
+    // storage slot for the contract owner (used for diamondCut authorization). App-level
+    // access control (e.g., who can call initTreasury, seedPools) checks LibDiamond.owner()
+    // directly. Do NOT add a duplicate `owner` field to AppStorage — two ownership records
+    // create split-brain bugs during emergency cuts and ownership transfers.
 
     // -------------------------------------------------------------------------
     // Constants stored at deploy time (not in IClanWorld; inline here for Diamond)
@@ -543,14 +550,14 @@ The Diamond standard's `diamondCut` function accepts `_init` (address) and `_cal
 // DiamondInit.sol — deployed as a separate contract, used once
 contract DiamondInit {
     function init(
-        address owner,
         address[6] calldata tokens,
         address[4] calldata pools
     ) external {
         AppStorage storage s = LibStorage.appStorage();
         require(!s.initialized, "ClanWorld: already initialized");
         s.initialized = true;
-        s.owner = owner;
+        // Ownership is set in the Diamond constructor (LibDiamond.setContractOwner),
+        // not here. DiamondInit only sets game-state initial values.
         // ... set initial treasury, world config ...
     }
 }
@@ -587,11 +594,14 @@ If a bad `diamondCut` ships (wrong function selector mapping, broken facet bytec
 
 ### Ownership transfer
 
-Diamond owner key transfer:
-1. New owner prepares transfer via `Ownable.transferOwnership(newOwner)` (or multisig equivalent)
+Diamond-3 stores contract owner in `LibDiamond` at a dedicated storage slot (separate from `AppStorage`). Ownership governs who can call `diamondCut`. Transfer procedure:
+
+1. Current owner calls `LibDiamond.setContractOwner(newOwner)` (or equivalent on the Diamond's cut facet)
 2. 48h timelock applies (functional upgrade tier)
-3. New owner accepts transfer
+3. New owner address is now authorized for `diamondCut`
 4. Update `packages/contracts/DEPLOYMENT.md` with new owner address
+
+**Single ownership record:** Only `LibDiamond` is the source of truth for ownership. Do NOT maintain a duplicate `AppStorage.owner`. App-level guarded functions (like `initTreasury`) call `LibDiamond.contractOwner()` to check authorization.
 
 Never transfer ownership to address(0) without first confirming immutable-diamond intent and removing the DiamondCut facet.
 
@@ -681,7 +691,7 @@ The Diamond migration is an architectural rewrite. "Tests mostly need a new depl
 7. Deploy `BanditsFacet` (stub)
 8. Deploy `WintersFacet` (stub)
 9. Deploy `DiamondInit` — one-shot initialization contract
-10. Assemble `initialDiamondCut` array (all facets) + encode `DiamondInit.init(owner, tokens, pools)` calldata
+10. Assemble `initialDiamondCut` array (all facets) + encode `DiamondInit.init(tokens, pools)` calldata
 11. Deploy `Diamond(owner, initialDiamondCut, address(diamondInit), initCalldata)` — all facets cut + state initialized atomically in constructor
 12. Verify: call `IDiamondLoupe(diamond).facets()` to confirm all selectors registered
 
@@ -804,6 +814,20 @@ Both engines returned NEEDS WORK on R1 revision.
 | R2-L2 | LOW | Codex | Delayed Phase 3 heartbeat isolation keeps fragile model during migration | Deferred — acknowledged explicitly in §Heartbeat Failure Model; same failure mode as monolith today |
 | R2-L3 | LOW | Codex + Gemini | Alternatives (minimal dispatcher, logic-only facets, data-first redesign) | Deferred — brief note in §Known Limitations |
 | R2-L4 | LOW | Gemini | `via_ir` retention for per-facet compilation | Deferred — existing Open Question #6 for Liam |
+
+### Round 5 — 2026-04-30
+
+**Engines:** Codex + Gemini Pro (gemini-2.5-pro-preview-05-06)
+
+Both engines returned NEEDS WORK but R5 findings were primarily continued philosophical opposition to Diamond complexity and repetition of addressed concerns. Two concrete doc fixes identified.
+
+**New findings summary:**
+
+| ID | Severity | Engine | Finding | Disposition |
+|---|---|---|---|---|
+| R5-H1 | HIGH | Codex | Ownership model inconsistent — `AppStorage.owner` vs `LibDiamond` owner creates split-brain during emergency cuts | **ADDRESSED** — `AppStorage.owner` field removed from struct; NOTE added explaining Diamond-3 `LibDiamond` is the single ownership record; DiamondInit code sample fixed; Operational Safety ownership section updated |
+| R5-H2 | HIGH | Codex | No state migration story — "game reset not viable" conflicts with new-address deployment | **ADDRESSED** — §Executive Summary clarifies ClanWorld has never been deployed to production (over EIP-170 limit); Diamond is fresh first deployment; no live state migration needed |
+| R5-L1–L10 | LOW | Both | Repeated concerns: AppStorage blast radius, reentrancy Option A, timeline optimism, alternatives, CI enforcement | All previously addressed; engines continuing to raise same issues from prior rounds |
 
 ### Round 4 — 2026-04-30
 

--- a/docs/architecture/diamond-pattern.md
+++ b/docs/architecture/diamond-pattern.md
@@ -111,7 +111,20 @@ Logic that is stateless or has no external-call risk moves into a `library` (e.g
 - Market execution loop: Pattern B — `_executeScheduledMarketActions` becomes an external selector on MarketFacet, called from heartbeat via `IClanWorld(address(this))`
 - State-reading shared logic (`_poolReserves`): Pattern A — move to `LibMarket` (pure computation against treasury state)
 
-**Note:** Functions in Pattern A (library) do NOT appear in the Diamond's selector table. Functions in Pattern B (external self-calls) DO appear as selectors and can be called by anyone unless access-controlled. All Pattern B functions that modify state must be access-controlled to `address(this)` only.
+**Pattern B access control:** Functions in Pattern A (library) do NOT appear in the Diamond's selector table. Functions in Pattern B (external self-calls) DO appear as selectors and can be called by any external caller unless explicitly guarded. Access control for Pattern B internal-orchestration functions:
+
+```solidity
+// All Pattern B "internal-only" selectors MUST enforce this guard:
+modifier onlyDiamond() {
+    require(msg.sender == address(this), "ClanWorld: only diamond");
+    _;
+}
+
+// e.g., in MarketFacet:
+function _executeScheduledMarketActions(uint64 tick) external onlyDiamond { ... }
+```
+
+`msg.sender == address(this)` is the correct guard here because: (1) under `delegatecall`, `address(this)` is the Diamond proxy; (2) only calls routed through the proxy have `msg.sender == proxy`; (3) external callers cannot spoof `msg.sender` as the proxy address. This provides real access control — not just any facet, but specifically the proxy itself initiating the call via the heartbeat execution path.
 
 ### Function assignment by facet
 
@@ -385,7 +398,11 @@ Even "harmless" reordering (swapping two adjacent fields of the same type) chang
 
 Rule 1 says "append to `AppStorage`." Rule 4 extends this: the same append-only constraint applies to **all structs nested inside `AppStorage`**, including `WorldState`, `TreasuryState`, `Clan`, `Clansman`, `Mission`, and `WheatPlot`.
 
-Adding a field inside `WorldState` shifts the storage slots of every `AppStorage` field that comes after it, just as if you had inserted a field in `AppStorage` directly. The snapshot check covers this: `forge inspect` reports the full recursive layout, so any nested-struct change shows up as a diff.
+Adding a field inside `WorldState` shifts the storage slots of every `AppStorage` field that comes after it, just as if you had inserted a field in `AppStorage` directly.
+
+**Special case: structs used as mapping values.** `AppStorage` contains `mapping(uint32 => Clan) clans`. Adding a field at the END of the `Clan` struct is safe on already-deployed data ONLY because mapping slot calculation is `keccak256(key . mappingSlot)` — each Clan's base slot is computed independently, and new fields land at `base + N` (extending beyond existing fields). This is safe for append-only. However, INSERTING a field in the middle of `Clan` shifts the position of every existing field within every Clan instance — this is catastrophic data corruption. The append-only rule applies equally to value-type structs inside mappings.
+
+The snapshot check covers nested structs: `forge inspect CoreFacet storageLayout` reports the full recursive layout, so any nested-struct change shows up as a diff.
 
 ### Stack depth mitigation for large AppStorage
 
@@ -787,6 +804,23 @@ Both engines returned NEEDS WORK on R1 revision.
 | R2-L2 | LOW | Codex | Delayed Phase 3 heartbeat isolation keeps fragile model during migration | Deferred — acknowledged explicitly in §Heartbeat Failure Model; same failure mode as monolith today |
 | R2-L3 | LOW | Codex + Gemini | Alternatives (minimal dispatcher, logic-only facets, data-first redesign) | Deferred — brief note in §Known Limitations |
 | R2-L4 | LOW | Gemini | `via_ir` retention for per-facet compilation | Deferred — existing Open Question #6 for Liam |
+
+### Round 4 — 2026-04-30
+
+**Engines:** Codex + Gemini Pro (gemini-2.5-pro-preview-05-06)
+
+Both engines returned NEEDS WORK but R4 findings were primarily:
+- Philosophical opposition to single AppStorage (architectural preference, not doc gap — decision is documented with rationale in §4)
+- Repetition of previously-addressed concerns (stack depth, timeline, alternatives)
+- Two new concrete doc fixes
+
+**New findings summary:**
+
+| ID | Severity | Engine | Finding | Disposition |
+|---|---|---|---|---|
+| R4-H1 | MED | Gemini | Struct-in-mapping slot concern — unclear if appending to `Clan` struct is safe for deployed mapping data | **ADDRESSED** in §Storage Safety Rule 4 — clarified that appending to mapping-value structs IS safe (base slot independent); inserting mid-struct is NOT safe (same rule as always) |
+| R4-H2 | MED | Codex | Pattern B `msg.sender == address(this)` "not real authorization" — any facet could call it | **ADDRESSED** in §Facet Boundaries — `onlyDiamond()` modifier defined and explained; clarification that `msg.sender == proxy` requires the call to route through the proxy, which is genuine access control |
+| R4-L1–L8 | LOW | Both | Repeated concerns: single AppStorage blast radius, heartbeat brittleness, timeline optimism, alternatives, governance implementation, library bytecode duplication | All previously addressed or deferred; no new actionable doc changes |
 
 ### Round 3 — 2026-04-30
 

--- a/docs/architecture/diamond-pattern.md
+++ b/docs/architecture/diamond-pattern.md
@@ -27,7 +27,9 @@ The previous plan (`clanworld-eip170-split-plan.md`) proposed extracting interna
 
 ### Final decision: EIP-2535 Diamond with single AppStorage
 
-Diamond (EIP-2535) solves the problem at the root: each facet is an independent contract (≤24,576 B) that shares storage through a deterministic pointer. There is no `delegatecall`-over-library fragility, no inlining guesswork, no 1 KB margin. The ABI surface (`IClanWorld`) stays byte-stable. Off-chain consumers see no change.
+Diamond (EIP-2535) solves the problem at the root: each facet is an independent contract (≤24,576 B) that shares storage through a deterministic pointer. There is no `delegatecall`-over-library fragility, no inlining guesswork, no 1 KB margin. The ABI surface (`IClanWorld`) stays byte-stable.
+
+**Off-chain compatibility note:** The Diamond proxy is deployed at a new address. All off-chain consumers (indexers, frontends, bots) must update their contract address. Additionally: (1) events are emitted with `address = Diamond proxy`, not the facet — indexers that filter by contract address need no change if they target the proxy; (2) revert strings bubble through the proxy unchanged; (3) gas profiles change (~700 gas overhead per external call through proxy). Off-chain gas estimation scripts must be recalibrated after migration.
 
 The reference implementation (Nick Mudgen's Diamond-3) is battle-tested in production (Aavegotchi, DeFi protocols). The pattern is well-understood by Solidity auditors.
 
@@ -351,6 +353,32 @@ The snapshot file is committed to the repo at `packages/contracts/test/snapshots
 
 Even "harmless" reordering (swapping two adjacent fields of the same type) changes slot assignments for all fields below them. There is no safe reorder. If a field is in the wrong logical position, add a comment — do not move it.
 
+### Rule 4: Nested struct modification is equally dangerous
+
+Rule 1 says "append to `AppStorage`." Rule 4 extends this: the same append-only constraint applies to **all structs nested inside `AppStorage`**, including `WorldState`, `TreasuryState`, `Clan`, `Clansman`, `Mission`, and `WheatPlot`.
+
+Adding a field inside `WorldState` shifts the storage slots of every `AppStorage` field that comes after it, just as if you had inserted a field in `AppStorage` directly. The snapshot check covers this: `forge inspect` reports the full recursive layout, so any nested-struct change shows up as a diff.
+
+### Stack depth mitigation for large AppStorage
+
+`AppStorage` contains 15+ mappings and structs. Complex facets (GatheringFacet, CoreFacet) that access many fields in one function may hit Solidity's "Stack Too Deep" limit, even with `via_ir = true`.
+
+Mitigation pattern — cache fields into local memory variables at function entry:
+
+```solidity
+function _settleClan(uint32 clanId) internal {
+    AppStorage storage s = LibStorage.appStorage();
+    // Cache frequently accessed fields to reduce stack references:
+    Clan storage clan = s.clans[clanId];
+    uint64 currentTick = s.world.currentTick;
+    // ... function body uses `clan` and `currentTick`, not `s.clans[clanId]` repeatedly
+}
+```
+
+If a function still hits the stack limit after caching, split it into sub-functions. `via_ir` handles this well — each sub-function is a separate optimizer scope.
+
+**Pre-migration validation (required before PR 2):** Deploy a `MockCoreFacet` that imports the full `AppStorage` and performs a complex calculation accessing 10+ struct fields. If this compiles and passes tests without stack errors, the single-struct approach is confirmed viable. If it hits stack limits, the struct must be split before migration begins.
+
 <!-- TODO: add forge storage-layout snapshot CI step (Makefile target) in PR 2 -->
 
 ---
@@ -388,9 +416,23 @@ try IClanWorld(address(this))._executeScheduledMarketActions(tick) {
 
 This requires `_executeScheduledMarketActions` to be an `external` function (called via the proxy, not as an internal call). Under `delegatecall`, `address(this)` resolves to the Diamond proxy, so this pattern is safe and standard.
 
+### Reentrancy guard interaction with try/catch self-calls
+
+**This is a known architectural constraint.** The `nonReentrant` modifier uses `AppStorage.reentrancyStatus` (set to 2 on entry, reset to 1 on exit). If `heartbeat()` is `nonReentrant` and it calls `_executeScheduledMarketActions` via `IClanWorld(address(this))`, the self-call goes through the Diamond proxy as a new external call — but `reentrancyStatus` is already 2 from the outer `heartbeat()`, causing the inner call to revert.
+
+**Resolution for Phase 3:**
+
+Option A — `heartbeat()` is NOT `nonReentrant`; market executor IS `nonReentrant`.  
+Rationale: `heartbeat()` is permissioned (only the engine/cron can call it). The reentrancy risk on `heartbeat()` is negligible. The state-writing inner loop (`_executeScheduledMarketActions`) is the protection target.
+
+Option B — `heartbeat()` IS `nonReentrant`; `_executeScheduledMarketActions` uses an `internalReentrant` flag exempt from the cross-call check.  
+More complex — avoid unless Option A has a concrete exploit path.
+
+**Recommended: Option A.** Implement in Phase 3. The Development Invariants rule (§Development Invariants) is adjusted to: "every `external` state-writing function MUST be `nonReentrant` UNLESS it is an orchestrator entry-point that is already access-controlled by role/address check."
+
 **Current scope:** The `try/catch` isolation is NOT implemented in Phase 1 (skeleton) or Phase 2 (CoreFacet migration). It is a Phase 3 follow-up once the facet split is stable. Rationale: the monolith has the same failure mode today; adding isolation during the migration would conflate two architectural changes.
 
-**Phase 3 action item:** When migrating MarketFacet (PR 3), add `try/catch` isolation for the market execution loop in `heartbeat()`. Document the revert vs. drop decision for each market action type.
+**Phase 3 action item:** When migrating MarketFacet (PR 3), add `try/catch` isolation for the market execution loop in `heartbeat()`. Use Option A reentrancy model. Document the revert vs. drop decision for each market action type.
 
 <!-- TODO: add try/catch heartbeat isolation in MarketFacet PR (Phase 3) -->
 
@@ -440,30 +482,40 @@ Additional safeguards:
 
 ## 8. Operational Safety
 
-### Initializer locking
+### Initializer locking — atomic via `diamondCut` `_init` parameter
 
-The Diamond pattern requires an initializer function (equivalent to a constructor) that sets up initial state after all facets are cut in. This initializer MUST be callable exactly once.
+The Diamond standard's `diamondCut` function accepts `_init` (address) and `_calldata` (bytes) parameters. When non-zero, the Diamond calls `_init.delegatecall(_calldata)` in the same transaction as the cut. This is the correct, front-run-proof initialization pattern.
 
-Implementation pattern:
+**Do NOT use a separate post-cut `initialize()` call.** If initialization is executed as a separate transaction after `diamondCut`, an attacker can front-run it on any public testnet (or mainnet) and set themselves as owner or corrupt initial treasury state. The window between `diamondCut` succeeding and `initialize()` being called is publicly observable in the mempool.
+
+**Correct pattern:**
+
 ```solidity
-// In LibStorage:
-struct AppStorage {
-    // ... fields ...
-    bool initialized;
+// DiamondInit.sol — deployed as a separate contract, used once
+contract DiamondInit {
+    function init(
+        address owner,
+        address[6] calldata tokens,
+        address[4] calldata pools
+    ) external {
+        AppStorage storage s = LibStorage.appStorage();
+        require(!s.initialized, "ClanWorld: already initialized");
+        s.initialized = true;
+        s.owner = owner;
+        // ... set initial treasury, world config ...
+    }
 }
 
-// In a dedicated InitializerFacet (or in CoreFacet):
-function initialize(...) external {
-    AppStorage storage s = LibStorage.appStorage();
-    require(!s.initialized, "ClanWorld: already initialized");
-    s.initialized = true;
-    // ... set initial state ...
-}
+// In DeployDiamond.s.sol:
+DiamondInit diamondInit = new DiamondInit();
+bytes memory initData = abi.encodeCall(DiamondInit.init, (owner, tokens, pools));
+IDiamondCut(address(diamond)).diamondCut(facetCuts, address(diamondInit), initData);
+// ^ initialization happened atomically in the same tx as the cut
 ```
 
-After `initialize()` is called, the `initialized` flag is permanently set. Re-initialization is impossible without a Diamond cut replacing the initializer facet.
+The `initialized` flag in `AppStorage` prevents re-initialization if a second `diamondCut` call passes a non-zero `_init`. The `DiamondInit` contract is a one-shot helper — it does not need to remain registered as a facet.
 
-<!-- TODO: confirm whether InitializerFacet is a separate facet or a function in CoreFacet (decision in PR 2) -->
+<!-- TODO: confirm whether DiamondInit is a standalone contract or the first CoreFacet setup function — decision in PR 2 -->
 
 ### Emergency pause policy
 
@@ -604,8 +656,9 @@ These rules apply to ALL contributors on ALL PRs touching facets or LibStorage. 
 
 - [ ] **Storage append-only:** New fields added at END of `AppStorage` only. No mid-struct inserts. No field reordering. (See §Storage Safety.)
 - [ ] **Storage snapshot updated:** If `LibStorage.sol` or any embedded struct is modified, `test/snapshots/storage-layout.json` is regenerated and committed.
-- [ ] **`nonReentrant` on all state-writing externals:** Every `external` function that writes AppStorage state MUST use the `nonReentrant` modifier (backed by `AppStorage.reentrancyStatus`). No exceptions. If a facet reads state only (`pure`/`view`), the modifier is not required.
+- [ ] **`nonReentrant` on all state-writing externals:** Every `external` function that writes AppStorage state MUST use the `nonReentrant` modifier (backed by `AppStorage.reentrancyStatus`), UNLESS it is an orchestrator entry-point access-controlled by role or address check (e.g., `heartbeat()` which is engine-only). If a facet reads state only (`pure`/`view`), the modifier is not required.
 - [ ] **Reentrancy guard is shared:** The `nonReentrant` implementation MUST read/write `AppStorage.reentrancyStatus`. Per-facet reentrancy guards are FORBIDDEN — they do not protect cross-facet re-entry through the Diamond proxy.
+- [ ] **No `nonReentrant` on heartbeat orchestrator functions** that use `try/catch` self-calls through the proxy (see §Heartbeat Failure Model — Reentrancy guard interaction). The inner state-writing functions they call ARE `nonReentrant`.
 - [ ] **Size check before merge:** Run `forge build --sizes` before opening any migration PR. Confirm each facet runtime bytes < 20,000 B (≥4 KB headroom). If any facet is 20–24 KB, split before merging.
 - [ ] **No `ClanWorld.sol` modifications during migration:** The monolith stays untouched until PR 6. All migration PRs add new facet files only.
 
@@ -678,6 +731,27 @@ These decisions need explicit sign-off before code migration begins (PR 2+):
 | M4 | MED | Reentrancy guard across facets — per-facet guard ineffective for cross-facet re-entry | **ADDRESSED** — `reentrancyStatus` added to AppStorage; invariant rule added in §Development Invariants |
 | M5 | MED | Per-facet Diamond Storage not evaluated | **ADDRESSED** in §AppStorage Decision Rationale — explicit comparison + rationale for single AppStorage |
 | L1–L5 | LOW | Etherscan verification, bus factor, event debugging, alternatives considered | **DEFERRED** — inline TODO comments added; §Known Limitations added |
+
+### Round 2 — 2026-04-30
+
+**Engines:** Codex + Gemini Pro (gemini-2.5-pro-preview-05-06)
+
+Both engines returned NEEDS WORK on R1 revision.
+
+**Findings summary:**
+
+| ID | Severity | Engine | Finding | Disposition |
+|---|---|---|---|---|
+| R2-H1 | HIGH | Codex | `nonReentrant` + `try/catch` self-call conflict — heartbeat `try IClanWorld(address(this))._executeScheduledMarketActions` trips shared reentrancy guard if both caller and callee are `nonReentrant` | **ADDRESSED** in §Heartbeat Failure Model — explicit Option A resolution: `heartbeat()` exempt from `nonReentrant`, inner executor is protected; Development Invariants updated |
+| R2-H2 | HIGH | Codex + Gemini | Initialization atomicity — post-cut `initialize()` call is front-runnable on public testnet | **ADDRESSED** in §Operational Safety — atomic `_init` parameter in `diamondCut` documented; separate post-cut initialize explicitly forbidden |
+| R2-H3 | HIGH | Gemini | Stack Too Deep risk — large single `AppStorage` struct may hit Solidity stack limits in complex facets | **ADDRESSED** in §Storage Safety — cache-into-memory mitigation pattern documented; pre-migration `MockCoreFacet` validation step added |
+| R2-H4 | HIGH | Gemini | Nested struct modification equally dangerous — `WorldState` field reorder same risk as top-level `AppStorage` reorder; not covered in R1 | **ADDRESSED** in §Storage Safety Rule 4 |
+| R2-M1 | MED | Codex | Off-chain compatibility understated — events, gas profiles, deployment addresses all change, not just ABI | **ADDRESSED** in §Executive Summary — off-chain compatibility note added |
+| R2-M2 | MED | Gemini | Multisig deadlock during hackathon — velocity concern; 1-of-1 "God Key" likely in practice | **EXISTING** — §Upgrade Policy already acknowledges 1-of-1 interim option; no further doc change needed |
+| R2-L1 | LOW | Codex + Gemini | Size projections still optimistic for CoreFacet/GatheringFacet | Deferred — pre-merge size check gate in Development Invariants already addresses this |
+| R2-L2 | LOW | Codex | Delayed Phase 3 heartbeat isolation keeps fragile model during migration | Deferred — acknowledged explicitly in §Heartbeat Failure Model; same failure mode as monolith today |
+| R2-L3 | LOW | Codex + Gemini | Alternatives (minimal dispatcher, logic-only facets, data-first redesign) | Deferred — brief note in §Known Limitations |
+| R2-L4 | LOW | Gemini | `via_ir` retention for per-facet compilation | Deferred — existing Open Question #6 for Liam |
 
 ---
 

--- a/docs/architecture/diamond-pattern.md
+++ b/docs/architecture/diamond-pattern.md
@@ -95,12 +95,30 @@ Projections use ClanWorld's compiled density (~16 B/source line, `via_ir`) appli
 
 > **Mandatory size check:** Before merging any migration PR (PR 2–6), run `forge build --sizes` and confirm each facet's runtime bytes is under 20,000 B (leaving ≥4 KB headroom). If any facet approaches 20 KB, split before merging.
 
+### Cross-facet execution model
+
+EIP-2535 facets are separate deployed contracts. `CoreFacet` cannot call `GatheringFacet._settleCompletingMissions()` as an internal function. There are two patterns for cross-facet execution:
+
+**Pattern A: Shared internal library (preferred for pure/stateless helpers)**  
+Logic that is stateless or has no external-call risk moves into a `library` (e.g., `LibTravel`, `LibGathering`). Libraries are inlined by `via_ir` at the call site — no cross-contract call, no gas overhead, no reentrancy risk. Storage-touching logic in libraries is safe because libraries execute in the caller's storage context via `delegatecall`.
+
+**Pattern B: External self-call through proxy (for state-writing cross-facet dispatch)**  
+`CoreFacet.heartbeat()` calls `IClanWorld(address(this))._executeScheduledMarketActions(tick)`. Under `delegatecall`, `address(this)` is the Diamond proxy. The proxy routes the call to the correct facet. This is an external call — it adds ~700 gas overhead and is subject to reentrancy considerations (see §Heartbeat Failure Model).
+
+**Decision for ClanWorld:**
+- Pure computation helpers (`_buildPath`, `_distMatrix`, `_travelTicks`): Pattern A — move to `LibTravel`
+- Settlement core (`_settleClan`, `_settleCompletingMissions`): Pattern A — move to `LibSettlement` (if stateless enough) OR exposed as external selectors on GatheringFacet (Pattern B)
+- Market execution loop: Pattern B — `_executeScheduledMarketActions` becomes an external selector on MarketFacet, called from heartbeat via `IClanWorld(address(this))`
+- State-reading shared logic (`_poolReserves`): Pattern A — move to `LibMarket` (pure computation against treasury state)
+
+**Note:** Functions in Pattern A (library) do NOT appear in the Diamond's selector table. Functions in Pattern B (external self-calls) DO appear as selectors and can be called by anyone unless access-controlled. All Pattern B functions that modify state must be access-controlled to `address(this)` only.
+
 ### Function assignment by facet
 
 #### CoreFacet — world clock, heartbeat shell, clan lifecycle, order dispatch
 
 From `ClanWorld.sol`:
-- `heartbeat()` — calls into GatheringFacet for `_settleCompletingMissions`, delegates market loop to MarketFacet, calls `_resolveWorldEvents`
+- `heartbeat()` — calls GatheringFacet via Pattern B for `_settleCompletingMissions`, calls MarketFacet via Pattern B for market loop, calls `_resolveWorldEvents` internally
 - `_resolveWorldEvents(uint64 closedTick)`
 - `settleClan(uint32 clanId)` → delegates to `_settleClan` in GatheringFacet
 - `settleClansman(uint32 csId)` → delegates to `_settleClan` in GatheringFacet
@@ -286,12 +304,20 @@ struct AppStorage {
     uint256 reentrancyStatus;                          // 1 = not entered, 2 = entered
 
     // -------------------------------------------------------------------------
+    // Initialization guard + ownership (set atomically in DiamondInit._init())
+    // -------------------------------------------------------------------------
+    bool initialized;                                  // true after first init; prevents re-init
+    address owner;                                     // DiamondCut owner / multisig address
+
+    // -------------------------------------------------------------------------
     // Constants stored at deploy time (not in IClanWorld; inline here for Diamond)
     // -------------------------------------------------------------------------
     // Note: WHEAT_HARVEST_RATE and MAX_MARKET_ACTIONS_PER_TICK are contract-level
     // constants in ClanWorld.sol; keep as Solidity constants in a shared library,
     // not in AppStorage (constants don't occupy storage slots).
 }
+// IMPORTANT: any future field additions go HERE (after `owner`), never above.
+// Append-only — see §Storage Safety.
 ```
 
 **Storage slot:** `LibStorage.appStorage()` uses the deterministic slot:
@@ -340,14 +366,16 @@ Every PR that touches `LibStorage.sol` (or any struct used inside `AppStorage`) 
 
 ```bash
 # From packages/contracts:
-forge inspect ClanWorld storageLayout --json > test/snapshots/storage-layout.json
-# After Diamond migration, the target is the Diamond proxy:
-forge inspect Diamond storageLayout --json > test/snapshots/storage-layout.json
+# Inspect a facet that imports LibStorage — this captures the AppStorage struct layout
+# because the facet declares it as an inline type reference:
+forge inspect CoreFacet storageLayout --json > test/snapshots/storage-layout.json
 ```
 
-The snapshot file is committed to the repo at `packages/contracts/test/snapshots/storage-layout.json`. CI runs a diff check: if the snapshot diverges from `forge inspect` output, the PR fails.
+**Important:** `forge inspect Diamond storageLayout` will NOT capture `AppStorage` because the Diamond proxy accesses it via a hashed slot (`keccak256("clan.world.app.storage.v1")`), not as normal declared contract storage. Always inspect a facet (e.g., `CoreFacet`) that has the `AppStorage` struct in scope — this returns the struct's field layout, which is what matters for slot calculations.
 
-**Enforcement:** A `Makefile` target `make storage-snapshot-check` will be added in PR 2. Until then, enforce manually: every LibStorage change requires the reviewer to run `forge inspect` and confirm slot positions are unchanged for existing fields.
+The snapshot file is committed to the repo at `packages/contracts/test/snapshots/storage-layout.json`. CI runs a diff check: if the snapshot diverges from `forge inspect CoreFacet storageLayout` output, the PR fails.
+
+**Enforcement:** A `Makefile` target `make storage-snapshot-check` will be added in PR 2. Until then, enforce manually: every LibStorage change requires the reviewer to run `forge inspect CoreFacet` and confirm slot positions are unchanged for existing fields.
 
 ### Rule 3: No struct-field reordering, ever
 
@@ -429,6 +457,10 @@ Option B — `heartbeat()` IS `nonReentrant`; `_executeScheduledMarketActions` u
 More complex — avoid unless Option A has a concrete exploit path.
 
 **Recommended: Option A.** Implement in Phase 3. The Development Invariants rule (§Development Invariants) is adjusted to: "every `external` state-writing function MUST be `nonReentrant` UNLESS it is an orchestrator entry-point that is already access-controlled by role/address check."
+
+**External token callback risk with Option A:** `MarketFacet._executeScheduledMarketActions` calls external token contracts (ERC-20 transfers, pool interactions). A malicious ERC-20 token could call back into `heartbeat()` during the transfer. Since `heartbeat()` is NOT `nonReentrant` under Option A, this is a re-entry vector IF the attacker can cause a malicious token to be added to the treasury.
+
+Mitigation: the treasury token set is set at init time and can only be changed by the owner via `initTreasury`. If all treasury tokens are trusted (owner-controlled, vetted ERC-20s), the callback risk is negligible. **Production constraint: only audited ERC-20 tokens should be registered in the treasury.** If the game ever adds user-supplied token addresses, the reentrancy model must be revisited and Option B applied.
 
 **Current scope:** The `try/catch` isolation is NOT implemented in Phase 1 (skeleton) or Phase 2 (CoreFacet migration). It is a Phase 3 follow-up once the facet split is stable. Rationale: the monolith has the same failure mode today; adding isolation during the migration would conflate two architectural changes.
 
@@ -631,9 +663,12 @@ The Diamond migration is an architectural rewrite. "Tests mostly need a new depl
 6. Deploy `ViewsFacet`
 7. Deploy `BanditsFacet` (stub)
 8. Deploy `WintersFacet` (stub)
-9. Deploy `Diamond(owner, initialDiamondCut)` — all facets added in one tx
-10. Verify: call `IDiamondLoupe(diamond).facets()` to confirm all selectors registered
-11. Call `IClanWorld(diamond).initTreasury(...)` (if tokens known at deploy time)
+9. Deploy `DiamondInit` — one-shot initialization contract
+10. Assemble `initialDiamondCut` array (all facets) + encode `DiamondInit.init(owner, tokens, pools)` calldata
+11. Deploy `Diamond(owner, initialDiamondCut, address(diamondInit), initCalldata)` — all facets cut + state initialized atomically in constructor
+12. Verify: call `IDiamondLoupe(diamond).facets()` to confirm all selectors registered
+
+**Note:** `initTreasury()` is NOT called as a separate transaction. Token addresses and pool config are passed to `DiamondInit.init()` which runs atomically in the same tx as `diamondCut`. If token addresses are not known at deploy time (e.g., tokens deployed separately), pass zero addresses to init and use `initTreasury()` as a one-time setup call that checks `s.treasury.initialized == false`.
 
 **Base Sepolia:** The existing `foundry.toml` already has:
 ```toml
@@ -673,10 +708,10 @@ Every facet that imports `LibStorage` or other shared helpers gets that library'
 | PR | Branch | Content | Criteria |
 |---|---|---|---|
 | **PR 1** (this PR) | `feat/issue-337-diamond-design` | Design doc + Diamond skeleton (proxy, LibStorage, interfaces, empty facets) | Liam go/no-go on architecture |
-| **PR 2** | `feat/issue-337-core-facet` | Migrate CoreFacet (heartbeat shell, clan lifecycle, order submission, travel) + `DeployDiamond` helper + storage snapshot CI | All core tests pass; size check clean |
+| **PR 2** | `feat/issue-337-core-facet` | Migrate CoreFacet (heartbeat shell, clan lifecycle, order submission, travel) + `DeployDiamond` helper + storage snapshot CI + **selector collision tests start here** | All core tests pass; size check clean; no selector collisions |
 | **PR 3** | `feat/issue-337-market-gathering` | Migrate MarketFacet + GatheringFacet (settlement engine, gathering, market execution) + heartbeat `try/catch` isolation | Heartbeat + market tests pass; cross-facet reentrancy test passes |
 | **PR 4** | `feat/issue-337-buildings-views` | Migrate BuildingsFacet logic into GatheringFacet + ViewsFacet (all aggregators) | Full test suite passes |
-| **PR 5** | `feat/issue-337-bandits-winters` | BanditsFacet stub + WintersFacet stub with Phase 9/10 landing zones; selector collision tests; upgrade tests | Stubs deploy clean; all new test categories pass |
+| **PR 5** | `feat/issue-337-bandits-winters` | BanditsFacet stub + WintersFacet stub with Phase 9/10 landing zones; upgrade tests | Stubs deploy clean; all new test categories pass |
 | **PR 6** | `feat/issue-337-deploy-sepolia` | `DeployDiamond.s.sol`, invariant tests, Base Sepolia deploy + verification | Deployed + verified on Base Sepolia |
 
 After each PR merges to `dev`, the prior `ClanWorld.sol` monolith remains in the repo until PR 6 is merged — at that point it's archived or removed.
@@ -752,6 +787,27 @@ Both engines returned NEEDS WORK on R1 revision.
 | R2-L2 | LOW | Codex | Delayed Phase 3 heartbeat isolation keeps fragile model during migration | Deferred — acknowledged explicitly in §Heartbeat Failure Model; same failure mode as monolith today |
 | R2-L3 | LOW | Codex + Gemini | Alternatives (minimal dispatcher, logic-only facets, data-first redesign) | Deferred — brief note in §Known Limitations |
 | R2-L4 | LOW | Gemini | `via_ir` retention for per-facet compilation | Deferred — existing Open Question #6 for Liam |
+
+### Round 3 — 2026-04-30
+
+**Engines:** Codex + Gemini Pro (gemini-2.5-pro-preview-05-06)
+
+Both engines returned NEEDS WORK on R2 revision.
+
+**Findings summary:**
+
+| ID | Severity | Engine | Finding | Disposition |
+|---|---|---|---|---|
+| R3-H1 | HIGH | Codex | Cross-facet execution model unspecified — "CoreFacet calls GatheringFacet internally" is impossible across contract boundaries; must be library or external self-call | **ADDRESSED** in §Facet Boundaries — "Cross-facet execution model" subsection added; Pattern A (library) vs Pattern B (external self-call) documented; function assignment updated |
+| R3-H2 | HIGH | Codex | `forge inspect Diamond` won't capture hashed-slot `AppStorage` — wrong inspect target in §Storage Safety | **ADDRESSED** in §Storage Safety Rule 2 — `forge inspect CoreFacet` specified as correct target; rationale explained |
+| R3-H3 | HIGH | Codex | `s.initialized` and `s.owner` referenced in §8 but absent from AppStorage struct definition | **ADDRESSED** — `initialized` and `owner` fields added to AppStorage struct in §4 |
+| R3-H4 | MED→HIGH | Codex | Deploy step 11 contradicts atomic init — post-cut `initTreasury()` call violates §8's front-run protection rule | **ADDRESSED** — deploy sequence rewritten; `DiamondInit` handles treasury atomically; conditional path for unknown-token-at-deploy noted |
+| R3-H5 | HIGH | Gemini | External token callback re-entry risk with Option A (`heartbeat()` exempt from `nonReentrant`) | **ADDRESSED** in §Heartbeat Failure Model — explicit constraint: treasury tokens must be audited; user-supplied token addresses trigger revisit of reentrancy model |
+| R3-M1 | MED | Codex | Selector collision tests deferred to PR 5 — too late, collisions should be caught from PR 2 onward | **ADDRESSED** — migration plan updated; selector collision tests start in PR 2 |
+| R3-L1 | LOW | Codex + Gemini | Stack Too Deep concern (same as R2 H3) — caching mitigation insufficient | MockCoreFacet validation step already added in R2; `via_ir` genuinely helps; defer to implementation |
+| R3-L2 | LOW | Gemini | DiamondCut race condition — emergency 0h bypass could be overwritten by pending 48h cut | Deferred — operational edge case; document in DEPLOYMENT.md (PR 6) |
+| R3-L3 | LOW | Codex + Gemini | "Solve EIP-170 but not runtime scaling/liveness" | Out of scope for this PR; correct observation but architectural restructure not required here |
+| R3-L4 | LOW | Codex | Governance model aspirational not engineered | Pending Liam sign-off on multisig approach (Open Question #1); implementation deferred to PR 6 |
 
 ---
 

--- a/docs/architecture/diamond-pattern.md
+++ b/docs/architecture/diamond-pattern.md
@@ -53,35 +53,45 @@ The `ClanWorldTestHarness` (34,871 B) and `HeartbeatOrderingHarness` (35,011 B) 
 
 The goal: partition `ClanWorld.sol`'s 2,124 lines into facets each well under 24,576 bytes. Each facet gets exclusive ownership of its primary concern. All facets share `AppStorage` (see §4).
 
-### Size projection methodology
+### Actual compiled skeleton sizes (from `forge build --sizes`)
 
-`ClanWorld` = 34,792 B compiled. Rough line-count distribution:
-- Travel / path utilities (lines 103–292): ~190 lines
-- Settlement core / gathering (lines 293–860): ~570 lines
-- World progression / heartbeat (lines 863–996): ~134 lines
-- Clan lifecycle / order submission (lines 999–1356): ~358 lines
-- Market execution (lines 1358–1692): ~335 lines
-- Treasury / OTC stubs (lines 1694–1757): ~64 lines
-- Raw getters (lines 1759–1887): ~129 lines
-- Derived / aggregator views (lines 1889–2124): ~236 lines
+These are real measurements from `feat/issue-337-diamond-design` HEAD, not estimates:
 
-Diamond proxy itself (~600–800 B) + DiamondCut facet (~2–3 KB) + Loupe facet (~2–3 KB) are infrastructure overhead, not ClanWorld logic.
+| Contract | Runtime bytes | Init code bytes | Headroom vs 24,576 |
+|---|---|---|---|
+| `Diamond` (proxy) | 225 | 4,953 | 24,351 B headroom |
+| `DiamondCutFacet` | 4,800 | 4,826 | 19,776 B headroom |
+| `DiamondLoupeFacet` | 1,866 | 1,892 | 22,710 B headroom |
+| `CoreFacet` (empty shell) | 647 | 673 | 23,929 B headroom |
+| `MarketFacet` (empty shell) | 720 | 746 | 23,856 B headroom |
+| `GatheringFacet` (empty shell) | 115 | 139 | 24,461 B headroom |
+| `ViewsFacet` (read-only) | 5,617 | 5,643 | 18,959 B headroom |
+| `BanditsFacet` (stub) | 57 | 81 | 24,519 B headroom |
+| `WintersFacet` (stub) | 57 | 81 | 24,519 B headroom |
 
-| Facet | Responsibility | Est. Lines | Projected Size | Margin |
+**Key observations:**
+- `ViewsFacet` skeleton already compiles to 5,617 B because it includes real view logic from ClanWorld. This is the expected shape — views are dense.
+- Shell facets (CoreFacet, MarketFacet, GatheringFacet) are 115–720 B today. They will grow substantially when business logic migrates. See projected sizes below.
+- `via_ir` optimizer deduplication applies within a single compilation unit. Splitting facets may reduce per-facet optimization — total deployed bytecode will be higher than the 34,792 B monolith. This is expected and acceptable (EIP-170 is per-contract, not total).
+
+### Size projections after business logic migration
+
+Projections use ClanWorld's compiled density (~16 B/source line, `via_ir`) applied to function-count estimates per facet. These must be re-measured with `forge build --sizes` before merging each migration PR.
+
+| Facet | Responsibility | Est. Lines | Projected Size | Margin vs 24,576 |
 |---|---|---|---|---|
-| `CoreFacet` | World clock, heartbeat dispatch shell, clan lifecycle, order submission, travel | ~700 | ~16–18 KB | comfortable |
+| `CoreFacet` | World clock, heartbeat dispatch shell, clan lifecycle, order submission, travel | ~700 | ~16–18 KB | 6–8 KB margin |
 | `MarketFacet` | Market execution (sell/buy), treasury init/seed, pool routing, OTC stubs | ~420 | ~8–10 KB | large |
 | `GatheringFacet` | Settlement core (`_settleClan`, `_settleMissionForClansman`), all gather helpers, deposit, building upgrades | ~600 | ~13–15 KB | comfortable |
 | `ViewsFacet` | All `pure`/`view` aggregators: `getWorldSnapshot`, `getClanFullView`, `getMarketState`, `getRegionPopulation`, derived state | ~380 | ~8–10 KB | large |
-| `BanditsFacet` | Phase 9 bandit attack/defense (stub for now — `getBanditTroop`, `getActiveBanditView`, `getBanditTargetPreview`) | ~50 stub | ~2–3 KB | very large |
-| `WintersFacet` | Phase 10 winter damage, elimination, `finalizeSeason` (stub for now) | ~30 stub | ~1–2 KB | very large |
+| `BanditsFacet` | Phase 9 bandit attack/defense — full Phase 9 implementation landing zone | ~50 stub today | ~2–3 KB stub | very large |
+| `WintersFacet` | Phase 10 winter damage, elimination, `finalizeSeason` — full Phase 10 implementation landing zone | ~30 stub today | ~1–2 KB stub | very large |
 
-**Projected total post-Diamond bytecode (excluding infrastructure):** ~50–57 KB spread across 6 facets, each individually under 24,576 B.
+**CoreFacet growth risk (Phase 9/10):** CoreFacet holds ~700 lines today projecting to 16–18 KB. Phase 9 (Bandits) + Phase 10 (Winters) logic will NOT land in CoreFacet — they have dedicated facets (`BanditsFacet`, `WintersFacet`). These facets are not speculative pre-stubs; they are load-bearing separations that prevent CoreFacet from growing past the 24,576 B limit. If CoreFacet measures over 20 KB after business logic migration, extract `_buildPath` + `_distMatrix` + `_travelTicks` into a `TravelFacet` (pure functions, ~2–3 KB). This split is pre-approved — no additional design review needed.
 
-Notes:
-- Estimates are based on `ClanWorld`'s compiled density (~16 B per source line under `via_ir`). Individual facets may be measurably smaller because smaller compilation units give `via_ir` less to optimize across.
-- BanditsFacet and WintersFacet are stubs today. They act as landing zones for Phase 9 and Phase 10 code. Their current compiled size will be tiny (2–3 KB each).
-- If `CoreFacet` measures over 20 KB after splitting, move `_buildPath` + `_distMatrix` + `_travelTicks` into a small `TravelFacet` (pure functions only, ~2–3 KB).
+**Total deployed bytecode note:** All facets together (~50–57 KB of business logic) plus infrastructure (~7 KB for Diamond proxy + DiamondCut + Loupe) = ~57–64 KB total deployed across all contracts, vs. 34,792 B today. This is intentional and acceptable. EIP-170 limits each individual contract to 24,576 B; there is no limit on the total bytecode across all contracts in a deployment.
+
+> **Mandatory size check:** Before merging any migration PR (PR 2–6), run `forge build --sizes` and confirm each facet's runtime bytes is under 20,000 B (leaving ≥4 KB headroom). If any facet approaches 20 KB, split before merging.
 
 ### Function assignment by facet
 
@@ -161,9 +171,9 @@ From `ClanWorld.sol`:
 
 Storage primarily accessed: read-only access to all AppStorage fields (no writes)
 
-#### BanditsFacet — Phase 9 bandit mechanics (stub now)
+#### BanditsFacet — Phase 9 bandit mechanics
 
-Phase 9 is not yet implemented. This facet is a landing zone.
+BanditsFacet is a **load-bearing future separation**, not speculative pre-scaffolding. Phase 9 bandit logic must land here (not in CoreFacet) to prevent CoreFacet from exceeding 24,576 B. Stub shell exists now; full implementation lands in PR 5 / Phase 9 migration.
 
 Functions (stubs in ClanWorld.sol that will grow here):
 - `spawnBandit(...)` — Phase 9
@@ -172,9 +182,9 @@ Functions (stubs in ClanWorld.sol that will grow here):
 
 Storage primarily accessed: `_world.activeBanditId`, `_world.nextBanditSpawnEligibleTick`, future `_bandits` mapping
 
-#### WintersFacet — Phase 10 winter damage + elimination (stub now)
+#### WintersFacet — Phase 10 winter damage + elimination
 
-Phase 10 is not yet implemented. This facet is a landing zone.
+WintersFacet is a **load-bearing future separation** for the same reasons as BanditsFacet. Winter logic belongs here, not in CoreFacet.
 
 Functions:
 - `finalizeSeason()` — currently stub in CoreFacet, moves here when Phase 10 ships
@@ -208,6 +218,8 @@ The single `AppStorage` pattern is:
 - Simpler to audit (one source of truth for all state)
 - Consistent with the existing ClanWorld storage layout (direct mapping)
 - The dominant pattern in production Diamond contracts
+
+**Why not per-facet storage slots?** Per-facet slots (Option B) would require each reading facet to import every other facet's storage lib — or move shared state to a "common" struct anyway. ClanWorld's state is too interconnected for clean per-facet partitioning: `_clans` is written by CoreFacet, GatheringFacet, and MarketFacet. Attempting per-facet isolation would produce a single `LibSharedStorage` covering 90% of the struct, which is Option A by another name with extra verbosity. Single AppStorage is the correct choice for this architecture.
 
 ### AppStorage struct fields
 
@@ -267,6 +279,11 @@ struct AppStorage {
     mapping(uint64 => bytes32) tickSeeds;              // tick => seed
 
     // -------------------------------------------------------------------------
+    // Reentrancy guard (shared across all facets — see §Development Invariants)
+    // -------------------------------------------------------------------------
+    uint256 reentrancyStatus;                          // 1 = not entered, 2 = entered
+
+    // -------------------------------------------------------------------------
     // Constants stored at deploy time (not in IClanWorld; inline here for Diamond)
     // -------------------------------------------------------------------------
     // Note: WHEAT_HARVEST_RATE and MAX_MARKET_ACTIONS_PER_TICK are contract-level
@@ -284,7 +301,102 @@ This avoids slot 0 collision with any future inherited contracts and matches EIP
 
 ---
 
-## 5. Upgrade Policy Decision
+## 5. Storage Safety
+
+### The single most critical correctness rule for AppStorage
+
+The AppStorage struct is the shared state backbone across all facets. Corrupting it silently corrupts the entire game state. Two rules are non-negotiable:
+
+### Rule 1: Append-only struct modification
+
+**New fields MUST be added at the END of `AppStorage`. Never insert a field mid-struct. Never reorder fields.**
+
+Rationale: In a `delegatecall` context, the EVM computes storage slot positions by sequential layout of the struct. Adding a field at position N shifts every field after N to a new slot. Existing on-chain data at those slots now maps to the wrong variable. The Solidity compiler does NOT catch this — it will compile cleanly and silently corrupt state.
+
+```solidity
+// CORRECT — append at end
+struct AppStorage {
+    // ... existing fields ...
+    mapping(uint64 => bytes32) tickSeeds;   // slot N (existing)
+    uint256 reentrancyStatus;               // slot N+1 (existing)
+    // New field added in Phase 9:
+    mapping(uint32 => BanditData) bandits;  // ALWAYS append here
+}
+
+// WRONG — never do this
+struct AppStorage {
+    WorldState world;
+    mapping(uint32 => BanditData) bandits;  // inserted mid-struct — corrupts all downstream slots
+    TreasuryState treasury;
+    // ...
+}
+```
+
+### Rule 2: Storage layout snapshot in CI
+
+Every PR that touches `LibStorage.sol` (or any struct used inside `AppStorage`) MUST include an updated storage layout snapshot. Procedure:
+
+```bash
+# From packages/contracts:
+forge inspect ClanWorld storageLayout --json > test/snapshots/storage-layout.json
+# After Diamond migration, the target is the Diamond proxy:
+forge inspect Diamond storageLayout --json > test/snapshots/storage-layout.json
+```
+
+The snapshot file is committed to the repo at `packages/contracts/test/snapshots/storage-layout.json`. CI runs a diff check: if the snapshot diverges from `forge inspect` output, the PR fails.
+
+**Enforcement:** A `Makefile` target `make storage-snapshot-check` will be added in PR 2. Until then, enforce manually: every LibStorage change requires the reviewer to run `forge inspect` and confirm slot positions are unchanged for existing fields.
+
+### Rule 3: No struct-field reordering, ever
+
+Even "harmless" reordering (swapping two adjacent fields of the same type) changes slot assignments for all fields below them. There is no safe reorder. If a field is in the wrong logical position, add a comment — do not move it.
+
+<!-- TODO: add forge storage-layout snapshot CI step (Makefile target) in PR 2 -->
+
+---
+
+## 6. Heartbeat Failure Model
+
+### Current monolith behavior
+
+In `ClanWorld.sol`, `heartbeat()` is a single transaction. If any internal call reverts, the entire heartbeat reverts. This is the existing behavior — the game loop can be blocked by a bad order or bad state.
+
+### Diamond behavior under delegatecall
+
+In the Diamond, `heartbeat()` lives in CoreFacet. It calls GatheringFacet and MarketFacet via internal Diamond routing (through the proxy's fallback). All calls share the same transaction context via `delegatecall`. This means:
+
+**Revert propagation model:**
+- If `GatheringFacet._settleCompletingMissions()` reverts → entire `heartbeat()` tx reverts (same as monolith)
+- If `MarketFacet._executeScheduledMarketActions()` reverts → entire `heartbeat()` tx reverts (same as monolith)
+- The Diamond does NOT automatically isolate failures between facets. Revert behavior is **identical** to the monolith.
+
+### Isolation improvement opportunity (not in scope for PR 1–3)
+
+The original hybrid plan's heartbeat fragility (DA finding #2 in §1) applies equally here — if a bad market order causes MarketFacet to revert, the heartbeat reverts.
+
+The correct fix is a `try/catch` boundary at the CoreFacet level for the market execution loop:
+
+```solidity
+// In CoreFacet.heartbeat():
+try IClanWorld(address(this))._executeScheduledMarketActions(tick) {
+    // market execution succeeded
+} catch (bytes memory reason) {
+    emit MarketExecutionFailed(tick, reason);
+    // heartbeat continues — market orders dropped for this tick
+}
+```
+
+This requires `_executeScheduledMarketActions` to be an `external` function (called via the proxy, not as an internal call). Under `delegatecall`, `address(this)` resolves to the Diamond proxy, so this pattern is safe and standard.
+
+**Current scope:** The `try/catch` isolation is NOT implemented in Phase 1 (skeleton) or Phase 2 (CoreFacet migration). It is a Phase 3 follow-up once the facet split is stable. Rationale: the monolith has the same failure mode today; adding isolation during the migration would conflate two architectural changes.
+
+**Phase 3 action item:** When migrating MarketFacet (PR 3), add `try/catch` isolation for the market execution loop in `heartbeat()`. Document the revert vs. drop decision for each market action type.
+
+<!-- TODO: add try/catch heartbeat isolation in MarketFacet PR (Phase 3) -->
+
+---
+
+## 7. Upgrade Policy Decision
 
 ### Options compared
 
@@ -302,22 +414,89 @@ This avoids slot 0 collision with any future inherited contracts and matches EIP
 - Audit surface is smaller (no upgrade key risk)
 - Pattern used by: some DeFi protocols where immutability is the selling point
 
-### Decision: Mutable Diamond with 2-of-3 multisig + 48h timelock
+### Decision: Mutable Diamond with 2-of-3 multisig + tiered timelock
 
 ClanWorld is a live game with ongoing phase development (Phase 9 bandits, Phase 10 winter, Phase 11+). Requiring a full game reset to add bandit mechanics is not viable. The mutable pattern is appropriate.
 
-Safeguards to make the mutable pattern trustworthy:
-1. **2-of-3 multisig guardian** for `diamondCut` ownership. Three keyholders; no single-key risk.
-2. **48-hour timelock** on all cut proposals. The community can observe and react before any facet is replaced.
-3. **Loupe facet** (ERC-165 + `facets()`, `facetFunctionSelectors()`) stays in the Diamond permanently — any observer can audit the current facet set.
+**Tiered timelock policy:**
 
-This mirrors Aavegotchi's approach and is the recommended pattern for game contracts with ongoing feature development.
+| Change type | Timelock | Authorization |
+|---|---|---|
+| Functional upgrade (new facet, feature addition) | 48 hours | 2-of-3 multisig |
+| Emergency security patch | 0 hours | 2-of-3 multisig + mandatory post-mortem within 72h |
+| Immutable freeze (remove DiamondCut) | 48 hours | 2-of-3 multisig |
+
+**Emergency bypass rationale:** A 48h timelock on a live bug means 2 days of potential game state corruption or fund loss. Teams under pressure bypass governance if no emergency path exists — making the timelock theater. The 2-of-3 emergency bypass with mandatory post-mortem is the responsible pattern. It keeps accountability (all 3 keyholders know an emergency cut happened) while enabling rapid response.
+
+**Hackathon velocity note:** During active pre-mainnet development (current phase), the 48h timelock MAY be reduced to 0 via multisig vote. This must be explicitly re-enabled before any mainnet or public-testnet deployment. Document the timelock state in `packages/contracts/DEPLOYMENT.md`.
+
+Additional safeguards:
+1. **2-of-3 multisig guardian** for `diamondCut` ownership. Three keyholders; no single-key risk.
+2. **Loupe facet** (ERC-165 + `facets()`, `facetFunctionSelectors()`) stays in the Diamond permanently — any observer can audit the current facet set.
 
 **Open question for Liam:** Does the current team structure support a 2-of-3 multisig? If not, a 1-of-1 owner key + timelock is a viable interim while keeping the mutable path.
 
 ---
 
-## 6. Test Migration Strategy
+## 8. Operational Safety
+
+### Initializer locking
+
+The Diamond pattern requires an initializer function (equivalent to a constructor) that sets up initial state after all facets are cut in. This initializer MUST be callable exactly once.
+
+Implementation pattern:
+```solidity
+// In LibStorage:
+struct AppStorage {
+    // ... fields ...
+    bool initialized;
+}
+
+// In a dedicated InitializerFacet (or in CoreFacet):
+function initialize(...) external {
+    AppStorage storage s = LibStorage.appStorage();
+    require(!s.initialized, "ClanWorld: already initialized");
+    s.initialized = true;
+    // ... set initial state ...
+}
+```
+
+After `initialize()` is called, the `initialized` flag is permanently set. Re-initialization is impossible without a Diamond cut replacing the initializer facet.
+
+<!-- TODO: confirm whether InitializerFacet is a separate facet or a function in CoreFacet (decision in PR 2) -->
+
+### Emergency pause policy
+
+ClanWorld does not currently have a pause mechanism. The Diamond's `diamondCut` IS the emergency pause mechanism: replacing CoreFacet's `heartbeat()` selector with a no-op or revert function halts game progression without state migration.
+
+For a more granular pause (e.g., pause market only):
+- Replace `MarketFacet` with a `PausedMarketFacet` stub that reverts all market calls
+- This is a zero-delay emergency cut (see tiered timelock policy above)
+
+<!-- TODO: consider adding explicit `paused` flag to AppStorage for simpler per-module pause in Phase 5+ -->
+
+### Rollback procedure
+
+If a bad `diamondCut` ships (wrong function selector mapping, broken facet bytecode):
+
+1. **Identify:** `IDiamondLoupe(diamond).facets()` returns current facet set. Compare to last known-good snapshot in `packages/contracts/deployments/`.
+2. **Rollback:** Issue a new `diamondCut` that replaces the broken facet with the previous facet deployment address. Old facet deployments are immutable — they remain on-chain.
+3. **Timelock:** If timelock is active, rollback cut also requires the timelock delay. This is unavoidable with a standard timelock. The emergency bypass path (2-of-3 multisig, no delay) can be used here.
+4. **State:** Facet replacement does NOT revert state changes made by the broken facet. If the broken facet corrupted storage, state repair requires a StorageRepairFacet (custom migration — treat as incident response).
+
+### Ownership transfer
+
+Diamond owner key transfer:
+1. New owner prepares transfer via `Ownable.transferOwnership(newOwner)` (or multisig equivalent)
+2. 48h timelock applies (functional upgrade tier)
+3. New owner accepts transfer
+4. Update `packages/contracts/DEPLOYMENT.md` with new owner address
+
+Never transfer ownership to address(0) without first confirming immutable-diamond intent and removing the DiamondCut facet.
+
+---
+
+## 9. Test Migration Strategy
 
 ### Current test structure
 
@@ -331,7 +510,25 @@ This mirrors Aavegotchi's approach and is the recommended pattern for game contr
 | `Reentrancy.t.sol` | Reentrancy guard verification |
 | `RNG.t.sol` | RNG seed distribution |
 
-### How tests change post-Diamond
+### Required test categories post-Diamond
+
+The Diamond migration is an architectural rewrite. "Tests mostly need a new deploy helper" understates the requirement. The full test matrix:
+
+| Test category | What it validates | New file / existing file update |
+|---|---|---|
+| **Deploy helper** | `DeployDiamond.deploy()` returns a functioning `IClanWorld`; all 6 facets registered; all selectors present via Loupe | New: `test/helpers/DeployDiamond.sol` |
+| **Selector collision** | No two facets register the same 4-byte selector; `diamondCut` with a duplicate selector reverts | New: `test/DiamondSelectors.t.sol` |
+| **Storage layout snapshot** | `forge inspect` output matches committed `test/snapshots/storage-layout.json`; any struct reorder fails the check | New: `test/StorageLayout.t.sol` + snapshot file |
+| **Initializer idempotency** | `initialize()` succeeds on first call; reverts on second call; cannot be called by non-owner | New test in `test/DiamondUpgrade.t.sol` |
+| **Upgrade (diamondCut)** | Replacing a facet installs new selectors; old selectors removed; state persists across cut | New: `test/DiamondUpgrade.t.sol` |
+| **Cross-facet reentrancy** | Reentrancy attempt through GatheringFacet → MarketFacet path is blocked by shared `reentrancyStatus` in AppStorage | New test in `Reentrancy.t.sol` |
+| **Revert-data parity** | Key revert strings from monolith surface correctly through Diamond proxy (delegatecall revert bubbling) | New: `test/RevertParity.t.sol` |
+| **Facet replacement** | After replacing MarketFacet with a new version, behavior changes as expected; GatheringFacet + CoreFacet unaffected | `test/DiamondUpgrade.t.sol` |
+| **Heartbeat isolation** | (Phase 3 follow-up) A reverting market order does not revert the entire heartbeat when `try/catch` isolation is added | `HeartbeatOrdering.t.sol` — add after Phase 3 |
+| **Existing behavior suite** | All existing behavior tests pass unchanged (only deploy helper swap needed) | All existing `*.t.sol` files — swap `new ClanWorld()` → `DeployDiamond.deploy()` |
+| **Gas regression baseline** | `delegatecall` adds ~700 gas per external call; heartbeat gas must be measured and documented post-migration as the new baseline | New: `test/GasBaseline.t.sol` |
+
+### How existing tests change post-Diamond
 
 **ABI surface is byte-stable.** `IClanWorld` selectors don't change. The same `IClanWorld` interface can be cast to the Diamond proxy address — all existing test assertions remain valid.
 
@@ -363,13 +560,13 @@ This mirrors Aavegotchi's approach and is the recommended pattern for game contr
 | `DefendBase.t.sol` | Same deploy change |
 | `HeartbeatOrdering.t.sol` | Same deploy change + review gas assertions |
 | `MissionTiming.t.sol` | Same deploy change |
-| `Reentrancy.t.sol` | Same deploy change; verify cross-facet reentrancy guard works |
+| `Reentrancy.t.sol` | Same deploy change; verify cross-facet reentrancy guard works; add cross-facet test |
 | `RNG.t.sol` | Same deploy change |
 | `ClanWorldStub.t.sol` | No change (tests the stub, not the Diamond) |
 
 ---
 
-## 7. Deploy Script Approach
+## 10. Deploy Script Approach
 
 **File:** `packages/contracts/script/DeployDiamond.s.sol`
 
@@ -395,28 +592,49 @@ No changes needed to `foundry.toml` for the deploy script — the RPC config is 
 
 **Reference pattern:** Nick Mudgen's Diamond-3 (`github.com/mudgen/diamond-3-hardhat`) — the `scripts/deploy.js` shows the single-tx multi-facet cut pattern. The Foundry equivalent uses `IDiamondCut.FacetCut[]` assembled in the script and passed to the `Diamond` constructor.
 
+<!-- TODO: Etherscan/Basescan verification for Diamond artifacts requires per-facet `forge verify-contract` calls — standard single-contract verification flow does not work for proxies. Document verification procedure in DEPLOYMENT.md (PR 6). -->
+
 ---
 
-## 8. Migration Plan — Phased PRs
+## 11. Development Invariants
+
+These rules apply to ALL contributors on ALL PRs touching facets or LibStorage. Violation of any of these is a blocking PR review finding.
+
+### Checklist
+
+- [ ] **Storage append-only:** New fields added at END of `AppStorage` only. No mid-struct inserts. No field reordering. (See §Storage Safety.)
+- [ ] **Storage snapshot updated:** If `LibStorage.sol` or any embedded struct is modified, `test/snapshots/storage-layout.json` is regenerated and committed.
+- [ ] **`nonReentrant` on all state-writing externals:** Every `external` function that writes AppStorage state MUST use the `nonReentrant` modifier (backed by `AppStorage.reentrancyStatus`). No exceptions. If a facet reads state only (`pure`/`view`), the modifier is not required.
+- [ ] **Reentrancy guard is shared:** The `nonReentrant` implementation MUST read/write `AppStorage.reentrancyStatus`. Per-facet reentrancy guards are FORBIDDEN — they do not protect cross-facet re-entry through the Diamond proxy.
+- [ ] **Size check before merge:** Run `forge build --sizes` before opening any migration PR. Confirm each facet runtime bytes < 20,000 B (≥4 KB headroom). If any facet is 20–24 KB, split before merging.
+- [ ] **No `ClanWorld.sol` modifications during migration:** The monolith stays untouched until PR 6. All migration PRs add new facet files only.
+
+### Note on library bytecode duplication
+
+Every facet that imports `LibStorage` or other shared helpers gets that library's bytecode compiled into its deployment artifact. Total deployed bytecode across all facets will be higher than the 34,792 B monolith — approximately 57–64 KB total. This is expected and acceptable. EIP-170's 24,576 B limit applies per-contract, not to the sum of all deployed contracts. The goal is per-facet compliance, not minimizing total deployed bytes.
+
+---
+
+## 12. Migration Plan — Phased PRs
 
 | PR | Branch | Content | Criteria |
 |---|---|---|---|
 | **PR 1** (this PR) | `feat/issue-337-diamond-design` | Design doc + Diamond skeleton (proxy, LibStorage, interfaces, empty facets) | Liam go/no-go on architecture |
-| **PR 2** | `feat/issue-337-core-facet` | Migrate CoreFacet (heartbeat shell, clan lifecycle, order submission, travel) | All core tests pass |
-| **PR 3** | `feat/issue-337-market-gathering` | Migrate MarketFacet + GatheringFacet (settlement engine, gathering, market execution) | Heartbeat + market tests pass |
+| **PR 2** | `feat/issue-337-core-facet` | Migrate CoreFacet (heartbeat shell, clan lifecycle, order submission, travel) + `DeployDiamond` helper + storage snapshot CI | All core tests pass; size check clean |
+| **PR 3** | `feat/issue-337-market-gathering` | Migrate MarketFacet + GatheringFacet (settlement engine, gathering, market execution) + heartbeat `try/catch` isolation | Heartbeat + market tests pass; cross-facet reentrancy test passes |
 | **PR 4** | `feat/issue-337-buildings-views` | Migrate BuildingsFacet logic into GatheringFacet + ViewsFacet (all aggregators) | Full test suite passes |
-| **PR 5** | `feat/issue-337-bandits-winters` | BanditsFacet stub + WintersFacet stub with Phase 9/10 landing zones | Stubs deploy clean |
+| **PR 5** | `feat/issue-337-bandits-winters` | BanditsFacet stub + WintersFacet stub with Phase 9/10 landing zones; selector collision tests; upgrade tests | Stubs deploy clean; all new test categories pass |
 | **PR 6** | `feat/issue-337-deploy-sepolia` | `DeployDiamond.s.sol`, invariant tests, Base Sepolia deploy + verification | Deployed + verified on Base Sepolia |
 
 After each PR merges to `dev`, the prior `ClanWorld.sol` monolith remains in the repo until PR 6 is merged — at that point it's archived or removed.
 
 ---
 
-## 9. Open Questions for Liam
+## 13. Open Questions for Liam
 
 These decisions need explicit sign-off before code migration begins (PR 2+):
 
-1. **Multisig approach for DiamondCut.** Does the current team support a 2-of-3 multisig? If not, is a single owner key + 48h timelock acceptable for the hackathon phase? (The timelock can be removed for iteration speed during active development, re-added at mainnet.)
+1. **Multisig approach for DiamondCut.** Does the current team support a 2-of-3 multisig? If not, is a single owner key + 48h timelock acceptable for the hackathon phase? (The timelock can be reduced to 0 for iteration speed during active development, re-added at mainnet.)
 
 2. **Single AppStorage struct** — confirmed as the approach? (Recommendation: yes, see §4. The alternative adds significant complexity for no benefit given ClanWorld's shared state.)
 
@@ -427,6 +645,39 @@ These decisions need explicit sign-off before code migration begins (PR 2+):
 5. **Immutable-Diamond option.** If you prefer a simpler trust model (no upgrade key), we can deploy an immutable Diamond at PR 6 (remove DiamondCut after initial facet registration). Tradeoff: adding Phase 9 bandits requires deploying a new Diamond + migrating state. Confirm mutable vs immutable before PR 2.
 
 6. **`via_ir` flag.** Post-Diamond, each facet is a separate compilation unit. We may be able to drop `via_ir = true` on the facets (significant compile-time reduction). Confirm we should remove it from `foundry.toml` after migration, or keep it for consistency.
+
+---
+
+## 14. Known Limitations
+
+- **Bus factor / onboarding complexity:** Diamond pattern requires developers to understand EIP-2535 routing, AppStorage layout rules, and delegatecall semantics. Mitigated by this doc + Development Invariants checklist. <!-- TODO: add onboarding doc in DEPLOYMENT.md (PR 6) -->
+- **Event debugging across facets:** Events emitted by MarketFacet have `address` = Diamond proxy, not the facet. Debugging requires knowing which facet owns which selector. `IDiamondLoupe` makes this queryable. <!-- TODO: add event attribution note to DEPLOYMENT.md -->
+- **Etherscan/Basescan verification:** Per-facet verification requires separate `forge verify-contract` calls. Standard proxy verification UI may not display all facet source. Document in DEPLOYMENT.md (PR 6). <!-- TODO: PR 6 -->
+- **Alternatives considered:** Satellite pattern (one hub contract dispatching to independently-deployed contracts via interface calls) and custom dispatcher (manual selector→address mapping without EIP-2535) were evaluated. Both require explicit interface stitching that EIP-2535 + Loupe provides natively. Diamond was selected for battle-tested reference implementations and auditor familiarity.
+
+---
+
+## 15. DA History
+
+### Round 1 — 2026-04-30
+
+**Engines:** Codex + Gemini Pro
+
+**Findings summary:**
+
+| ID | Severity | Finding | Disposition |
+|---|---|---|---|
+| H1 | CRITICAL | Storage layout safety model absent — no append-only rule, no CI snapshot, silent corruption risk | **ADDRESSED** in §Storage Safety |
+| H2 | HIGH | Facet size projections are line-count based — no actual compiled measurements | **ADDRESSED** in §Facet Boundaries — actual `forge build --sizes` output added |
+| H3 | HIGH | CoreFacet growth risk: Phase 9/10 will blow past limit with zero headroom | **ADDRESSED** — BanditsFacet + WintersFacet explicitly documented as load-bearing separations, not pre-speculative stubs |
+| H4 | HIGH | Heartbeat failure isolation not addressed — same game-halt risk as hybrid plan | **ADDRESSED** in §Heartbeat Failure Model — current behavior documented, `try/catch` path specified as Phase 3 follow-up |
+| H5 | HIGH | Test plan understated — "tests mostly just need a new deploy helper" is wrong | **ADDRESSED** in §Test Migration Strategy — full 11-category test matrix added |
+| M1 | MED | Operational model incomplete — no initializer locking, pause policy, rollback, ownership transfer | **ADDRESSED** in §Operational Safety |
+| M2 | MED | Timelock vs. hackathon velocity tension — 48h timelock makes emergency response impossible | **ADDRESSED** in §Upgrade Policy — tiered timelock: 48h functional, 0h emergency with mandatory post-mortem |
+| M3 | MED | Library bytecode duplication — total deployed bytecode >80 KB, not acknowledged | **ADDRESSED** in §Development Invariants and §Facet Boundaries — explicitly noted as acceptable, EIP-170 per-contract not total |
+| M4 | MED | Reentrancy guard across facets — per-facet guard ineffective for cross-facet re-entry | **ADDRESSED** — `reentrancyStatus` added to AppStorage; invariant rule added in §Development Invariants |
+| M5 | MED | Per-facet Diamond Storage not evaluated | **ADDRESSED** in §AppStorage Decision Rationale — explicit comparison + rationale for single AppStorage |
+| L1–L5 | LOW | Etherscan verification, bus factor, event debugging, alternatives considered | **DEFERRED** — inline TODO comments added; §Known Limitations added |
 
 ---
 

--- a/docs/architecture/diamond-pattern.md
+++ b/docs/architecture/diamond-pattern.md
@@ -1,0 +1,440 @@
+# EIP-2535 Diamond Architecture — ClanWorld
+
+**Status:** Design proposal — awaiting Liam go/no-go before any code migration  
+**Author:** pm-dobot  
+**Issue:** #337  
+**Date:** 2026-04-30
+
+---
+
+## 1. Executive Summary
+
+### Why Diamond (EIP-2535) over the hybrid split plan
+
+The previous plan (`clanworld-eip170-split-plan.md`) proposed extracting internal libraries and an external `delegatecall`-linked market library to shrink `ClanWorld.sol` under the EIP-170 24,576-byte limit. Two independent DA reviews (Codex, Gemini Pro) both rejected the plan. The six core risks they identified:
+
+1. **Internal library savings are illusory.** `internal` library functions are inlined by `solc`/`via_ir`. The plan claimed 1.5–4 KB from Travel + token-routing extraction; both DAs rated this "WISHFUL THINKING" — real savings likely 0 KB.
+
+2. **`try/catch` + `delegatecall` is a game-halting footgun.** The heartbeat's `try this._executeMarketSellExternal(...)` boundary relies on exact error bubbling. With `delegatecall` in the call chain, revert data encoding changes subtly. A single failing market order could revert the entire heartbeat and freeze the game loop for all users.
+
+3. **Savings math is coupon-summed, not compound.** The plan adds 1.5 + 3 + 2.5 + 7 KB as independent credits. Compiler optimizations are not linear. If estimates are 30% off, the post-split contract lands at 25–27 KB — still over the limit after weeks of work.
+
+4. **Test coverage is inadequate for EVM-level refactors.** Existing tests cover outcomes, not call-context, revert-surface, or event-origin changes. The split introduces library linkage failures, `delegatecall` context mix-ups, and gas regressions invisible to functional tests.
+
+5. **< 1 KB post-split safety margin.** Even on the optimistic path, the plan leaves less than 1 KB headroom. The first Phase 9 feature restores the crisis.
+
+6. **Storage layout fragility.** External `delegatecall` libraries must perfectly mirror the monolith's storage layout. Adding one variable to a struct in a future phase, without recompiling + relinking every library, silently overwrites wrong storage slots — catastrophic data corruption.
+
+### Final decision: EIP-2535 Diamond with single AppStorage
+
+Diamond (EIP-2535) solves the problem at the root: each facet is an independent contract (≤24,576 B) that shares storage through a deterministic pointer. There is no `delegatecall`-over-library fragility, no inlining guesswork, no 1 KB margin. The ABI surface (`IClanWorld`) stays byte-stable. Off-chain consumers see no change.
+
+The reference implementation (Nick Mudgen's Diamond-3) is battle-tested in production (Aavegotchi, DeFi protocols). The pattern is well-understood by Solidity auditors.
+
+---
+
+## 2. Current State
+
+| Metric | Value |
+|---|---|
+| `ClanWorld` runtime bytecode | **34,792 bytes** |
+| EIP-170 limit | 24,576 bytes |
+| Deficit (must eliminate) | **10,216 bytes** |
+| `via_ir = true` already required | Yes (without it, even larger) |
+| Base Sepolia deployment | Blocked — contract cannot be deployed |
+
+The 34,792-byte measurement was taken from `forge build --sizes` on the `dev` HEAD (`6cf6f39`) with `optimizer = true, optimizer_runs = 200, via_ir = true`.
+
+The `ClanWorldTestHarness` (34,871 B) and `HeartbeatOrderingHarness` (35,011 B) are both over limit too — they inherit from `ClanWorld` and are test-only; they are not deployed to Base Sepolia.
+
+---
+
+## 3. Proposed Facet Boundaries
+
+The goal: partition `ClanWorld.sol`'s 2,124 lines into facets each well under 24,576 bytes. Each facet gets exclusive ownership of its primary concern. All facets share `AppStorage` (see §4).
+
+### Size projection methodology
+
+`ClanWorld` = 34,792 B compiled. Rough line-count distribution:
+- Travel / path utilities (lines 103–292): ~190 lines
+- Settlement core / gathering (lines 293–860): ~570 lines
+- World progression / heartbeat (lines 863–996): ~134 lines
+- Clan lifecycle / order submission (lines 999–1356): ~358 lines
+- Market execution (lines 1358–1692): ~335 lines
+- Treasury / OTC stubs (lines 1694–1757): ~64 lines
+- Raw getters (lines 1759–1887): ~129 lines
+- Derived / aggregator views (lines 1889–2124): ~236 lines
+
+Diamond proxy itself (~600–800 B) + DiamondCut facet (~2–3 KB) + Loupe facet (~2–3 KB) are infrastructure overhead, not ClanWorld logic.
+
+| Facet | Responsibility | Est. Lines | Projected Size | Margin |
+|---|---|---|---|---|
+| `CoreFacet` | World clock, heartbeat dispatch shell, clan lifecycle, order submission, travel | ~700 | ~16–18 KB | comfortable |
+| `MarketFacet` | Market execution (sell/buy), treasury init/seed, pool routing, OTC stubs | ~420 | ~8–10 KB | large |
+| `GatheringFacet` | Settlement core (`_settleClan`, `_settleMissionForClansman`), all gather helpers, deposit, building upgrades | ~600 | ~13–15 KB | comfortable |
+| `ViewsFacet` | All `pure`/`view` aggregators: `getWorldSnapshot`, `getClanFullView`, `getMarketState`, `getRegionPopulation`, derived state | ~380 | ~8–10 KB | large |
+| `BanditsFacet` | Phase 9 bandit attack/defense (stub for now — `getBanditTroop`, `getActiveBanditView`, `getBanditTargetPreview`) | ~50 stub | ~2–3 KB | very large |
+| `WintersFacet` | Phase 10 winter damage, elimination, `finalizeSeason` (stub for now) | ~30 stub | ~1–2 KB | very large |
+
+**Projected total post-Diamond bytecode (excluding infrastructure):** ~50–57 KB spread across 6 facets, each individually under 24,576 B.
+
+Notes:
+- Estimates are based on `ClanWorld`'s compiled density (~16 B per source line under `via_ir`). Individual facets may be measurably smaller because smaller compilation units give `via_ir` less to optimize across.
+- BanditsFacet and WintersFacet are stubs today. They act as landing zones for Phase 9 and Phase 10 code. Their current compiled size will be tiny (2–3 KB each).
+- If `CoreFacet` measures over 20 KB after splitting, move `_buildPath` + `_distMatrix` + `_travelTicks` into a small `TravelFacet` (pure functions only, ~2–3 KB).
+
+### Function assignment by facet
+
+#### CoreFacet — world clock, heartbeat shell, clan lifecycle, order dispatch
+
+From `ClanWorld.sol`:
+- `heartbeat()` — calls into GatheringFacet for `_settleCompletingMissions`, delegates market loop to MarketFacet, calls `_resolveWorldEvents`
+- `_resolveWorldEvents(uint64 closedTick)`
+- `settleClan(uint32 clanId)` → delegates to `_settleClan` in GatheringFacet
+- `settleClansman(uint32 csId)` → delegates to `_settleClan` in GatheringFacet
+- `finalizeSeason()` — stub, moves to WintersFacet later
+- `mintClan(address to)`
+- `submitClanOrders(uint32 clanId, ClanOrder[] calldata orders)`
+- `_processOrder(...)` 
+- `_installMission(...)`
+- `_enqueueScheduledMarketAction(...)`
+- `_registerDefender(...)`, `_clearDefender(...)`
+- `_validateAction(...)`, `_validateDefendBaseOrder(...)`
+- `_distMatrix(...)`, `_buildPath(...)`, `_travelTicks(...)`, `_addTicksClamped(...)`
+- `getActionDuration(...)`, `getTravelTicks(...)`
+
+Storage primarily accessed: `_world`, `_clans`, `_clansmen`, `_missions`, `_allClanIds`, `_clanClansmanIds`, `_nextClanId`, `_nextClansmanId`, `_scheduledMarketActions`, `_defendingClansByRegion`, `_defenderCountByRegionClan`, `_clansmanDefendingRegion`, `_wheatPlots`, `_tickSeeds`
+
+#### MarketFacet — market execution, treasury, pools, OTC stubs
+
+From `ClanWorld.sol`:
+- `_executeScheduledMarketActions(uint64 tick)` — called by heartbeat
+- `_executeMarketSellExternal(...)`, `_executeMarketSell(...)`
+- `_executeMarketBuyExternal(...)`, `_executeMarketBuy(...)`
+- `_sortScheduledMarketActionsByCommitSequence(...)`
+- `_poolFor(address token)`, `_addToVault(...)`, `_deductFromVault(...)`
+- `_poolReserves(...)` — shared with ViewsFacet (duplicate or extracted to LibMarket)
+- `initTreasury(address[6] calldata tokens, address[4] calldata pools)`
+- `seedPools(PoolSeedConfig calldata cfg)`
+- `transferGold(...)`, `transferVaultResource(...)`, `transferBlueprint(...)`, `transferBundle(...)` — OTC stubs (pure revert)
+
+Storage primarily accessed: `_treasury`, `_clans`, `_clansmen`, `_missions`, `_scheduledMarketActions`
+
+#### GatheringFacet — settlement engine, all gathering, deposit, buildings
+
+From `ClanWorld.sol`:
+- `_settleClan(uint32 clanId)`
+- `_settleMissionForClansman(...)`
+- `_settleCompletingMissions(uint64 tick)`
+- `_applyUpkeep(Clan storage clan, uint64 tick)`
+- `_isStarving(Clan storage clan)`
+- `_resolveAction(...)` — dispatch hub for gathering
+- `_gatherWood(...)`, `_gatherIron(...)`, `_rollIronGoldBonus(...)`
+- `_gatherFishDocks(...)`, `_gatherFishDeepSea(...)`
+- `_gatherWheat(...)`
+- `_doDeposit(...)`, `_doWithdraw(...)` (future)
+- `_doBuilding(...)`, `_tryBuildWall(...)`, `_tryUpgradeBase(...)`, `_tryUpgradeMonument(...)`
+- `_completeMission(...)`
+
+Storage primarily accessed: `_clans`, `_clansmen`, `_missions`, `_wheatPlots`, `_allClanIds`, `_clanClansmanIds`, `_tickSeeds`
+
+#### ViewsFacet — all pure/view aggregators
+
+From `ClanWorld.sol`:
+- `getWorldState()`, `getTreasuryState()`
+- `getClan(uint32)`, `getClansman(uint32)`, `getActiveMission(uint32)`, `getMissionTiming(...)`
+- `getBanditTroop(uint32)` — stub
+- `getWheatPlots(uint32)`
+- `getScheduledMarketActionsForTick(uint64)`
+- `getActiveDefenders(uint32)`, `getDefendingClans(uint8)`
+- `getDerivedClanState(uint32)`, `getDerivedClansmanState(uint32)`
+- `getBanditTargetPreview(uint32)` — stub
+- `quoteTravel(uint8, uint8)`
+- `quoteLootValueRaw(uint32)`, `quoteLootValueSettled(uint32)`
+- `_lootValueRaw(Clan memory)` — pure helper
+- `getWorldSnapshot()`
+- `getClanFullView(uint32)`
+- `getMarketState()`
+- `_poolReserves(...)` — pure computation against treasury state
+- `getActiveBanditView()` — stub
+- `getRegionPopulation(uint8)`
+
+Storage primarily accessed: read-only access to all AppStorage fields (no writes)
+
+#### BanditsFacet — Phase 9 bandit mechanics (stub now)
+
+Phase 9 is not yet implemented. This facet is a landing zone.
+
+Functions (stubs in ClanWorld.sol that will grow here):
+- `spawnBandit(...)` — Phase 9
+- `resolveBanditAttack(...)` — Phase 9
+- `_pickBanditTarget(...)` — Phase 9
+
+Storage primarily accessed: `_world.activeBanditId`, `_world.nextBanditSpawnEligibleTick`, future `_bandits` mapping
+
+#### WintersFacet — Phase 10 winter damage + elimination (stub now)
+
+Phase 10 is not yet implemented. This facet is a landing zone.
+
+Functions:
+- `finalizeSeason()` — currently stub in CoreFacet, moves here when Phase 10 ships
+- `_applyWinterDamage(...)` — Phase 10
+- `_eliminateClan(...)` — Phase 10
+
+Storage primarily accessed: `_world.winterActive`, `_clans`, winter-specific counters
+
+---
+
+## 4. AppStorage Layout Decision
+
+### Options compared
+
+**Option A: Single `AppStorage` struct in `LibStorage.sol`**
+- One canonical struct containing all state variables
+- Accessed via `LibStorage.appStorage()` returning a pointer at deterministic storage slot
+- All facets import `LibStorage` and call `s = LibStorage.appStorage()`
+- Pattern: Diamond-3 reference, Aavegotchi, most production Diamonds
+
+**Option B: Per-facet storage structs at deterministic slots**
+- Each facet declares its own storage struct at a unique `bytes32` slot
+- More modular, but requires careful slot management
+- More complex for shared state (clan data is read by every facet)
+
+### Decision: Option A — single AppStorage struct
+
+ClanWorld has deeply shared state. `_clans`, `_clansmen`, `_missions`, `_tickSeeds` are read and written by CoreFacet, GatheringFacet, MarketFacet, and ViewsFacet simultaneously. Per-facet storage would require duplicating access patterns or adding cross-facet read helpers, both of which are more error-prone than a single shared struct.
+
+The single `AppStorage` pattern is:
+- Simpler to audit (one source of truth for all state)
+- Consistent with the existing ClanWorld storage layout (direct mapping)
+- The dominant pattern in production Diamond contracts
+
+### AppStorage struct fields
+
+All state variables from `ClanWorld.sol` map 1:1 into `AppStorage`:
+
+```solidity
+struct AppStorage {
+    // -------------------------------------------------------------------------
+    // World state (was: WorldState private _world)
+    // -------------------------------------------------------------------------
+    WorldState world;
+
+    // -------------------------------------------------------------------------
+    // Treasury (was: TreasuryState private _treasury)
+    // -------------------------------------------------------------------------
+    TreasuryState treasury;
+
+    // -------------------------------------------------------------------------
+    // Clan registry
+    // -------------------------------------------------------------------------
+    mapping(uint32 => Clan) clans;                    // clanId => Clan
+    uint32 nextClanId;
+    uint32[] allClanIds;
+
+    // -------------------------------------------------------------------------
+    // Clansman registry
+    // -------------------------------------------------------------------------
+    mapping(uint32 => Clansman) clansmen;              // clansmanId => Clansman
+    uint32 nextClansmanId;
+    mapping(uint32 => uint32[]) clanClansmanIds;       // clanId => clansmanId[]
+
+    // -------------------------------------------------------------------------
+    // Mission state
+    // -------------------------------------------------------------------------
+    mapping(uint32 => Mission) missions;               // keyed by clansmanId
+
+    // -------------------------------------------------------------------------
+    // Wheat plots
+    // -------------------------------------------------------------------------
+    mapping(uint32 => WheatPlot[2]) wheatPlots;        // clanId => [west, east]
+
+    // -------------------------------------------------------------------------
+    // Scheduled market actions
+    // -------------------------------------------------------------------------
+    mapping(uint64 => ScheduledMarketAction[]) scheduledMarketActions; // tick => actions
+
+    // -------------------------------------------------------------------------
+    // Defense registries
+    // -------------------------------------------------------------------------
+    mapping(uint8 => uint32[]) defendingClansByRegion;             // region => clanIds
+    mapping(uint8 => mapping(uint32 => uint256)) defenderCountByRegionClan; // region => clanId => count
+    mapping(uint32 => uint8) clansmanDefendingRegion;              // clansmanId => region
+
+    // -------------------------------------------------------------------------
+    // RNG seeds
+    // -------------------------------------------------------------------------
+    mapping(uint64 => bytes32) tickSeeds;              // tick => seed
+
+    // -------------------------------------------------------------------------
+    // Constants stored at deploy time (not in IClanWorld; inline here for Diamond)
+    // -------------------------------------------------------------------------
+    // Note: WHEAT_HARVEST_RATE and MAX_MARKET_ACTIONS_PER_TICK are contract-level
+    // constants in ClanWorld.sol; keep as Solidity constants in a shared library,
+    // not in AppStorage (constants don't occupy storage slots).
+}
+```
+
+**Storage slot:** `LibStorage.appStorage()` uses the deterministic slot:
+```solidity
+bytes32 constant STORAGE_SLOT = keccak256("clan.world.app.storage.v1");
+```
+
+This avoids slot 0 collision with any future inherited contracts and matches EIP-2535 best practice.
+
+---
+
+## 5. Upgrade Policy Decision
+
+### Options compared
+
+**Mutable Diamond (cuts allowed post-deploy)**
+- `DiamondCutFacet` remains in the Diamond, guarded by an owner/multisig
+- Future phases (Phase 9 bandits, Phase 10 winter) can be added via `diamondCut` without redeployment
+- Requires a key holder (multisig) — adds governance overhead
+- Auditors must account for upgrade surface
+- Pattern used by: Aavegotchi, many production gaming contracts
+
+**Immutable Diamond (no cuts after deploy)**
+- After deploy, remove or zero-out the DiamondCut facet
+- Simpler trust model — contract is frozen at deploy bytecode
+- If a bug is found, a new Diamond must be deployed (game reset risk)
+- Audit surface is smaller (no upgrade key risk)
+- Pattern used by: some DeFi protocols where immutability is the selling point
+
+### Decision: Mutable Diamond with 2-of-3 multisig + 48h timelock
+
+ClanWorld is a live game with ongoing phase development (Phase 9 bandits, Phase 10 winter, Phase 11+). Requiring a full game reset to add bandit mechanics is not viable. The mutable pattern is appropriate.
+
+Safeguards to make the mutable pattern trustworthy:
+1. **2-of-3 multisig guardian** for `diamondCut` ownership. Three keyholders; no single-key risk.
+2. **48-hour timelock** on all cut proposals. The community can observe and react before any facet is replaced.
+3. **Loupe facet** (ERC-165 + `facets()`, `facetFunctionSelectors()`) stays in the Diamond permanently — any observer can audit the current facet set.
+
+This mirrors Aavegotchi's approach and is the recommended pattern for game contracts with ongoing feature development.
+
+**Open question for Liam:** Does the current team structure support a 2-of-3 multisig? If not, a 1-of-1 owner key + timelock is a viable interim while keeping the mutable path.
+
+---
+
+## 6. Test Migration Strategy
+
+### Current test structure
+
+| File | What it tests |
+|---|---|
+| `ClanWorld.t.sol` | Main behavior suite — deploy `ClanWorld`, cast to `IClanWorld` |
+| `ClanWorldStub.t.sol` | Stub sanity checks |
+| `DefendBase.t.sol` | Defense registration / clearing |
+| `HeartbeatOrdering.t.sol` | Market tick ordering, heartbeat sequencing |
+| `MissionTiming.t.sol` | Mission tick math |
+| `Reentrancy.t.sol` | Reentrancy guard verification |
+| `RNG.t.sol` | RNG seed distribution |
+
+### How tests change post-Diamond
+
+**ABI surface is byte-stable.** `IClanWorld` selectors don't change. The same `IClanWorld` interface can be cast to the Diamond proxy address — all existing test assertions remain valid.
+
+**What changes:**
+1. **Deploy helper.** All test files currently do:
+   ```solidity
+   ClanWorld world = new ClanWorld();
+   ```
+   Post-Diamond, this becomes a `DeployDiamond` helper that deploys all facets + Diamond proxy + runs the initial `diamondCut`. The helper is called once per test setup.
+
+2. **`DeployDiamond.t.sol` helper.** Add `packages/contracts/test/helpers/DeployDiamond.sol`:
+   - Deploys `DiamondCutFacet`, `DiamondLoupeFacet`
+   - Deploys `CoreFacet`, `MarketFacet`, `GatheringFacet`, `ViewsFacet`, `BanditsFacet`, `WintersFacet`
+   - Deploys `Diamond(owner, initialCuts)`
+   - Returns `IClanWorld(address(diamond))`
+   - Existing test `setUp()` calls are updated to use this helper
+
+3. **Gas fixtures.** `delegatecall` adds ~700 gas per external call through the Diamond. Any test that asserts exact gas consumption needs updating. Tests that only assert behavior (state changes, events) need no changes.
+
+4. **`msg.sender` checks.** The `_executeMarketSellExternal`/`_executeMarketBuyExternal` guards check `msg.sender == address(this)`. In the Diamond, these calls come from the proxy (`address(diamond)`), not the facet. The guard must be updated to check `msg.sender == address(this)` where `this` is the Diamond proxy — this is correct under `delegatecall` since `address(this)` resolves to the proxy.
+
+5. **`nonReentrant` guard.** `ReentrancyGuard` uses a storage slot. In the Diamond it must live in `AppStorage` (add a `uint256 reentrancyStatus` field) so all facets share the same guard. Otherwise each facet has its own reentrancy slot and the guard is ineffective cross-facet.
+
+### Concrete test file changes required
+
+| File | Change needed |
+|---|---|
+| `ClanWorld.t.sol` | Replace `new ClanWorld()` with `DeployDiamond.deploy()` in `setUp()` |
+| `DefendBase.t.sol` | Same deploy change |
+| `HeartbeatOrdering.t.sol` | Same deploy change + review gas assertions |
+| `MissionTiming.t.sol` | Same deploy change |
+| `Reentrancy.t.sol` | Same deploy change; verify cross-facet reentrancy guard works |
+| `RNG.t.sol` | Same deploy change |
+| `ClanWorldStub.t.sol` | No change (tests the stub, not the Diamond) |
+
+---
+
+## 7. Deploy Script Approach
+
+**File:** `packages/contracts/script/DeployDiamond.s.sol`
+
+**Sequence:**
+1. Deploy `DiamondCutFacet`
+2. Deploy `DiamondLoupeFacet`
+3. Deploy `CoreFacet`
+4. Deploy `MarketFacet`
+5. Deploy `GatheringFacet`
+6. Deploy `ViewsFacet`
+7. Deploy `BanditsFacet` (stub)
+8. Deploy `WintersFacet` (stub)
+9. Deploy `Diamond(owner, initialDiamondCut)` — all facets added in one tx
+10. Verify: call `IDiamondLoupe(diamond).facets()` to confirm all selectors registered
+11. Call `IClanWorld(diamond).initTreasury(...)` (if tokens known at deploy time)
+
+**Base Sepolia:** The existing `foundry.toml` already has:
+```toml
+[rpc_endpoints]
+base_sepolia = "${RPC_URL_PRIMARY}"
+```
+No changes needed to `foundry.toml` for the deploy script — the RPC config is already in place.
+
+**Reference pattern:** Nick Mudgen's Diamond-3 (`github.com/mudgen/diamond-3-hardhat`) — the `scripts/deploy.js` shows the single-tx multi-facet cut pattern. The Foundry equivalent uses `IDiamondCut.FacetCut[]` assembled in the script and passed to the `Diamond` constructor.
+
+---
+
+## 8. Migration Plan — Phased PRs
+
+| PR | Branch | Content | Criteria |
+|---|---|---|---|
+| **PR 1** (this PR) | `feat/issue-337-diamond-design` | Design doc + Diamond skeleton (proxy, LibStorage, interfaces, empty facets) | Liam go/no-go on architecture |
+| **PR 2** | `feat/issue-337-core-facet` | Migrate CoreFacet (heartbeat shell, clan lifecycle, order submission, travel) | All core tests pass |
+| **PR 3** | `feat/issue-337-market-gathering` | Migrate MarketFacet + GatheringFacet (settlement engine, gathering, market execution) | Heartbeat + market tests pass |
+| **PR 4** | `feat/issue-337-buildings-views` | Migrate BuildingsFacet logic into GatheringFacet + ViewsFacet (all aggregators) | Full test suite passes |
+| **PR 5** | `feat/issue-337-bandits-winters` | BanditsFacet stub + WintersFacet stub with Phase 9/10 landing zones | Stubs deploy clean |
+| **PR 6** | `feat/issue-337-deploy-sepolia` | `DeployDiamond.s.sol`, invariant tests, Base Sepolia deploy + verification | Deployed + verified on Base Sepolia |
+
+After each PR merges to `dev`, the prior `ClanWorld.sol` monolith remains in the repo until PR 6 is merged — at that point it's archived or removed.
+
+---
+
+## 9. Open Questions for Liam
+
+These decisions need explicit sign-off before code migration begins (PR 2+):
+
+1. **Multisig approach for DiamondCut.** Does the current team support a 2-of-3 multisig? If not, is a single owner key + 48h timelock acceptable for the hackathon phase? (The timelock can be removed for iteration speed during active development, re-added at mainnet.)
+
+2. **Single AppStorage struct** — confirmed as the approach? (Recommendation: yes, see §4. The alternative adds significant complexity for no benefit given ClanWorld's shared state.)
+
+3. **BanditsFacet scope.** Phase 9 code is not in the repo. Should `BanditsFacet` at PR 5 be: (a) a minimal stub with function signatures only, (b) a full Phase 9 implementation, or (c) deferred entirely to a post-hackathon PR?
+
+4. **WintersFacet scope.** Same question as bandits — Phase 10 winter damage is not yet implemented. PR 5 stub or full Phase 10 in PR 5?
+
+5. **Immutable-Diamond option.** If you prefer a simpler trust model (no upgrade key), we can deploy an immutable Diamond at PR 6 (remove DiamondCut after initial facet registration). Tradeoff: adding Phase 9 bandits requires deploying a new Diamond + migrating state. Confirm mutable vs immutable before PR 2.
+
+6. **`via_ir` flag.** Post-Diamond, each facet is a separate compilation unit. We may be able to drop `via_ir = true` on the facets (significant compile-time reduction). Confirm we should remove it from `foundry.toml` after migration, or keep it for consistency.
+
+---
+
+## References
+
+- [EIP-2535: Diamond Standard](https://eips.ethereum.org/EIPS/eip-2535)
+- [Nick Mudgen's Diamond-3 reference implementation](https://github.com/mudgen/diamond-3-hardhat)
+- [Aavegotchi Diamond deployment](https://github.com/aavegotchi/aavegotchi-contracts) — largest production Diamond
+- DA synthesis: `/home/claude/claudes-world/tmp/20260430-eip170-da-synthesis.md`
+- Codex DA raw: `/tmp/da-eip170-codex.txt`
+- Gemini Pro DA raw: `/tmp/da-eip170-gemini.txt`

--- a/packages/contracts/src/diamond/Diamond.sol
+++ b/packages/contracts/src/diamond/Diamond.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {LibDiamond} from "./LibDiamond.sol";
+import {IDiamondCut} from "./IDiamondCut.sol";
+
+/// @title Diamond
+/// @notice EIP-2535 proxy contract for ClanWorld.
+///         Routes all external calls to the appropriate facet via delegatecall.
+///         Stores selector→facet mapping in DiamondStorage (separate from AppStorage).
+///
+///         On deploy:
+///         1. Sets owner (will be transferred to multisig post-deploy)
+///         2. Accepts initial FacetCut array — all facets registered in one constructor tx
+///         3. Optionally calls an init contract (for AppStorage initialization)
+///
+///         Adapted from Nick Mudgen's diamond-3-hardhat reference.
+///         https://github.com/mudgen/diamond-3-hardhat
+contract Diamond {
+    constructor(address _contractOwner, IDiamondCut.FacetCut[] memory _diamondCut, address _init, bytes memory _calldata) payable {
+        LibDiamond.setContractOwner(_contractOwner);
+        LibDiamond.diamondCut(_diamondCut, _init, _calldata);
+    }
+
+    /// @notice Fallback: route call to the facet registered for msg.sig.
+    ///         Uses delegatecall so facets execute in Diamond's storage context.
+    fallback() external payable {
+        LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
+        address facet = ds.selectorToFacetAndPosition[msg.sig].facetAddress;
+        require(facet != address(0), "Diamond: function does not exist");
+
+        assembly {
+            // Copy calldata into memory
+            calldatacopy(0, 0, calldatasize())
+            // delegatecall: execute facet code in this contract's storage context
+            let result := delegatecall(gas(), facet, 0, calldatasize(), 0, 0)
+            // Copy returndata
+            returndatacopy(0, 0, returndatasize())
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+
+    receive() external payable {}
+}

--- a/packages/contracts/src/diamond/DiamondCutFacet.sol
+++ b/packages/contracts/src/diamond/DiamondCutFacet.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {IDiamondCut} from "./IDiamondCut.sol";
+import {LibDiamond} from "./LibDiamond.sol";
+
+/// @title DiamondCutFacet
+/// @notice Implements EIP-2535 facet management (add/replace/remove).
+///         Only the Diamond owner may call diamondCut.
+///
+///         In production: ownership should be transferred to a 2-of-3 multisig
+///         with a 48-hour timelock (see docs/architecture/diamond-pattern.md §5).
+///
+///         Adapted from Nick Mudgen's diamond-3-hardhat reference.
+///         https://github.com/mudgen/diamond-3-hardhat
+contract DiamondCutFacet is IDiamondCut {
+    /// @inheritdoc IDiamondCut
+    function diamondCut(FacetCut[] calldata _diamondCut, address _init, bytes calldata _calldata) external override {
+        LibDiamond.enforceIsContractOwner();
+        LibDiamond.diamondCut(_diamondCut, _init, _calldata);
+    }
+}

--- a/packages/contracts/src/diamond/DiamondLoupeFacet.sol
+++ b/packages/contracts/src/diamond/DiamondLoupeFacet.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {LibDiamond} from "./LibDiamond.sol";
+
+/// @title DiamondLoupeFacet
+/// @notice ERC-165 + EIP-2535 loupe functions for facet introspection.
+///         Required for tooling (Louper.dev, Diamond hardhat plugin) and
+///         for on-chain verification that all selectors are registered correctly.
+///
+///         Adapted from Nick Mudgen's diamond-3-hardhat reference.
+///         https://github.com/mudgen/diamond-3-hardhat
+contract DiamondLoupeFacet {
+    struct Facet {
+        address facetAddress;
+        bytes4[] functionSelectors;
+    }
+
+    /// @notice Returns all facet addresses and their function selectors.
+    function facets() external view returns (Facet[] memory facets_) {
+        LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
+        uint256 numFacets = ds.facetAddresses.length;
+        facets_ = new Facet[](numFacets);
+        for (uint256 i; i < numFacets; i++) {
+            address facetAddress_ = ds.facetAddresses[i];
+            facets_[i].facetAddress = facetAddress_;
+            facets_[i].functionSelectors = ds.facetFunctionSelectors[facetAddress_].functionSelectors;
+        }
+    }
+
+    /// @notice Returns all function selectors supported by a specific facet.
+    function facetFunctionSelectors(address _facet) external view returns (bytes4[] memory facetFunctionSelectors_) {
+        LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
+        facetFunctionSelectors_ = ds.facetFunctionSelectors[_facet].functionSelectors;
+    }
+
+    /// @notice Returns all facet addresses used by a diamond.
+    function facetAddresses() external view returns (address[] memory facetAddresses_) {
+        LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
+        facetAddresses_ = ds.facetAddresses;
+    }
+
+    /// @notice Returns the facet address that supports the given selector.
+    /// @param _functionSelector A function selector.
+    /// @return facetAddress_ The facet address.
+    function facetAddress(bytes4 _functionSelector) external view returns (address facetAddress_) {
+        LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
+        facetAddress_ = ds.selectorToFacetAndPosition[_functionSelector].facetAddress;
+    }
+
+    /// @notice ERC-165 support query.
+    function supportsInterface(bytes4 _interfaceId) external view returns (bool) {
+        LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
+        return ds.supportedInterfaces[_interfaceId];
+    }
+}

--- a/packages/contracts/src/diamond/IDiamondCut.sol
+++ b/packages/contracts/src/diamond/IDiamondCut.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+/// @title IDiamondCut
+/// @notice Interface for EIP-2535 Diamond facet management.
+///         Ported from Nick Mudgen's diamond-3-hardhat reference implementation.
+///         https://github.com/mudgen/diamond-3-hardhat
+interface IDiamondCut {
+    enum FacetCutAction {
+        Add,     // Add new function selectors
+        Replace, // Replace existing function selectors with new facet
+        Remove   // Remove function selectors
+    }
+
+    struct FacetCut {
+        address facetAddress;        // address(0) for Remove
+        FacetCutAction action;
+        bytes4[] functionSelectors;
+    }
+
+    /// @notice Add/replace/remove facets and optionally execute an init function.
+    /// @param _diamondCut Array of FacetCut structs.
+    /// @param _init Address of contract to call with _calldata; address(0) = skip.
+    /// @param _calldata Encoded function call for initialization; empty = skip.
+    function diamondCut(FacetCut[] calldata _diamondCut, address _init, bytes calldata _calldata) external;
+
+    event DiamondCut(FacetCut[] _diamondCut, address _init, bytes _calldata);
+}

--- a/packages/contracts/src/diamond/LibDiamond.sol
+++ b/packages/contracts/src/diamond/LibDiamond.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {IDiamondCut} from "./IDiamondCut.sol";
+
+/// @title LibDiamond
+/// @notice Internal library for Diamond selector storage and cut operations.
+///         Adapted from Nick Mudgen's diamond-3-hardhat reference.
+///         https://github.com/mudgen/diamond-3-hardhat
+library LibDiamond {
+    bytes32 constant DIAMOND_STORAGE_SLOT = keccak256("diamond.standard.diamond.storage");
+
+    struct FacetAddressAndPosition {
+        address facetAddress;
+        uint96 functionSelectorPosition; // position in facetFunctionSelectors.functionSelectors array
+    }
+
+    struct FacetFunctionSelectors {
+        bytes4[] functionSelectors;
+        uint256 facetAddressPosition; // position of facetAddress in facetAddresses array
+    }
+
+    struct DiamondStorage {
+        // Maps function selector -> facet address + position in selector array
+        mapping(bytes4 => FacetAddressAndPosition) selectorToFacetAndPosition;
+        // Maps facet address -> its function selectors + position in facetAddresses array
+        mapping(address => FacetFunctionSelectors) facetFunctionSelectors;
+        // Facet addresses for enumeration
+        address[] facetAddresses;
+        // Used to query if a contract implements an interface — ERC-165
+        mapping(bytes4 => bool) supportedInterfaces;
+        // Owner of the diamond — has permission to call diamondCut
+        address contractOwner;
+    }
+
+    function diamondStorage() internal pure returns (DiamondStorage storage ds) {
+        bytes32 slot = DIAMOND_STORAGE_SLOT;
+        assembly {
+            ds.slot := slot
+        }
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    function setContractOwner(address _newOwner) internal {
+        DiamondStorage storage ds = diamondStorage();
+        address previousOwner = ds.contractOwner;
+        ds.contractOwner = _newOwner;
+        emit OwnershipTransferred(previousOwner, _newOwner);
+    }
+
+    function contractOwner() internal view returns (address owner_) {
+        owner_ = diamondStorage().contractOwner;
+    }
+
+    function enforceIsContractOwner() internal view {
+        require(msg.sender == diamondStorage().contractOwner, "LibDiamond: caller is not owner");
+    }
+
+    event DiamondCut(IDiamondCut.FacetCut[] _diamondCut, address _init, bytes _calldata);
+
+    // Internal function version of diamondCut
+    function diamondCut(IDiamondCut.FacetCut[] memory _diamondCut, address _init, bytes memory _calldata) internal {
+        for (uint256 facetIndex; facetIndex < _diamondCut.length; facetIndex++) {
+            IDiamondCut.FacetCutAction action = _diamondCut[facetIndex].action;
+            if (action == IDiamondCut.FacetCutAction.Add) {
+                addFunctions(_diamondCut[facetIndex].facetAddress, _diamondCut[facetIndex].functionSelectors);
+            } else if (action == IDiamondCut.FacetCutAction.Replace) {
+                replaceFunctions(_diamondCut[facetIndex].facetAddress, _diamondCut[facetIndex].functionSelectors);
+            } else if (action == IDiamondCut.FacetCutAction.Remove) {
+                removeFunctions(_diamondCut[facetIndex].facetAddress, _diamondCut[facetIndex].functionSelectors);
+            } else {
+                revert("LibDiamond: incorrect FacetCutAction");
+            }
+        }
+        emit DiamondCut(_diamondCut, _init, _calldata);
+        initializeDiamondCut(_init, _calldata);
+    }
+
+    function addFunctions(address _facetAddress, bytes4[] memory _functionSelectors) internal {
+        require(_functionSelectors.length > 0, "LibDiamond: no selectors in facet to cut");
+        DiamondStorage storage ds = diamondStorage();
+        require(_facetAddress != address(0), "LibDiamond: add facet can't be address(0)");
+        uint96 selectorPosition = uint96(ds.facetFunctionSelectors[_facetAddress].functionSelectors.length);
+        // Add new facet address if it does not exist
+        if (selectorPosition == 0) {
+            addFacet(ds, _facetAddress);
+        }
+        for (uint256 selectorIndex; selectorIndex < _functionSelectors.length; selectorIndex++) {
+            bytes4 selector = _functionSelectors[selectorIndex];
+            address oldFacetAddress = ds.selectorToFacetAndPosition[selector].facetAddress;
+            require(oldFacetAddress == address(0), "LibDiamond: can't add function that already exists");
+            addFunction(ds, selector, selectorPosition, _facetAddress);
+            selectorPosition++;
+        }
+    }
+
+    function replaceFunctions(address _facetAddress, bytes4[] memory _functionSelectors) internal {
+        require(_functionSelectors.length > 0, "LibDiamond: no selectors in facet to cut");
+        DiamondStorage storage ds = diamondStorage();
+        require(_facetAddress != address(0), "LibDiamond: replace facet can't be address(0)");
+        uint96 selectorPosition = uint96(ds.facetFunctionSelectors[_facetAddress].functionSelectors.length);
+        if (selectorPosition == 0) {
+            addFacet(ds, _facetAddress);
+        }
+        for (uint256 selectorIndex; selectorIndex < _functionSelectors.length; selectorIndex++) {
+            bytes4 selector = _functionSelectors[selectorIndex];
+            address oldFacetAddress = ds.selectorToFacetAndPosition[selector].facetAddress;
+            require(oldFacetAddress != _facetAddress, "LibDiamond: can't replace function with same function");
+            removeFunction(ds, oldFacetAddress, selector);
+            addFunction(ds, selector, selectorPosition, _facetAddress);
+            selectorPosition++;
+        }
+    }
+
+    function removeFunctions(address _facetAddress, bytes4[] memory _functionSelectors) internal {
+        require(_functionSelectors.length > 0, "LibDiamond: no selectors in facet to cut");
+        DiamondStorage storage ds = diamondStorage();
+        require(_facetAddress == address(0), "LibDiamond: remove facet address must be address(0)");
+        for (uint256 selectorIndex; selectorIndex < _functionSelectors.length; selectorIndex++) {
+            bytes4 selector = _functionSelectors[selectorIndex];
+            address oldFacetAddress = ds.selectorToFacetAndPosition[selector].facetAddress;
+            removeFunction(ds, oldFacetAddress, selector);
+        }
+    }
+
+    function addFacet(DiamondStorage storage ds, address _facetAddress) internal {
+        enforceHasContractCode(_facetAddress, "LibDiamond: new facet has no code");
+        ds.facetFunctionSelectors[_facetAddress].facetAddressPosition = ds.facetAddresses.length;
+        ds.facetAddresses.push(_facetAddress);
+    }
+
+    function addFunction(
+        DiamondStorage storage ds,
+        bytes4 _selector,
+        uint96 _selectorPosition,
+        address _facetAddress
+    ) internal {
+        ds.selectorToFacetAndPosition[_selector].functionSelectorPosition = _selectorPosition;
+        ds.facetFunctionSelectors[_facetAddress].functionSelectors.push(_selector);
+        ds.selectorToFacetAndPosition[_selector].facetAddress = _facetAddress;
+    }
+
+    function removeFunction(DiamondStorage storage ds, address _facetAddress, bytes4 _selector) internal {
+        require(_facetAddress != address(0), "LibDiamond: can't remove function that doesn't exist");
+        require(_facetAddress != address(this), "LibDiamond: can't remove immutable function");
+        // Replace selector with last selector, then delete last selector
+        uint256 selectorPosition = ds.selectorToFacetAndPosition[_selector].functionSelectorPosition;
+        uint256 lastSelectorPosition = ds.facetFunctionSelectors[_facetAddress].functionSelectors.length - 1;
+        if (selectorPosition != lastSelectorPosition) {
+            bytes4 lastSelector = ds.facetFunctionSelectors[_facetAddress].functionSelectors[lastSelectorPosition];
+            ds.facetFunctionSelectors[_facetAddress].functionSelectors[selectorPosition] = lastSelector;
+            ds.selectorToFacetAndPosition[lastSelector].functionSelectorPosition = uint96(selectorPosition);
+        }
+        ds.facetFunctionSelectors[_facetAddress].functionSelectors.pop();
+        delete ds.selectorToFacetAndPosition[_selector];
+
+        // If no more selectors for facet address, delete facet address
+        if (lastSelectorPosition == 0) {
+            uint256 lastFacetAddressPosition = ds.facetAddresses.length - 1;
+            uint256 facetAddressPosition = ds.facetFunctionSelectors[_facetAddress].facetAddressPosition;
+            if (facetAddressPosition != lastFacetAddressPosition) {
+                address lastFacetAddress = ds.facetAddresses[lastFacetAddressPosition];
+                ds.facetAddresses[facetAddressPosition] = lastFacetAddress;
+                ds.facetFunctionSelectors[lastFacetAddress].facetAddressPosition = facetAddressPosition;
+            }
+            ds.facetAddresses.pop();
+            delete ds.facetFunctionSelectors[_facetAddress].facetAddressPosition;
+        }
+    }
+
+    function initializeDiamondCut(address _init, bytes memory _calldata) internal {
+        if (_init == address(0)) {
+            return;
+        }
+        enforceHasContractCode(_init, "LibDiamond: _init address has no code");
+        (bool success, bytes memory error) = _init.delegatecall(_calldata);
+        if (!success) {
+            if (error.length > 0) {
+                // Bubble up error
+                assembly {
+                    let returndata_size := mload(error)
+                    revert(add(32, error), returndata_size)
+                }
+            } else {
+                revert("LibDiamond: _init function reverted");
+            }
+        }
+    }
+
+    function enforceHasContractCode(address _contract, string memory _errorMessage) internal view {
+        uint256 contractSize;
+        assembly {
+            contractSize := extcodesize(_contract)
+        }
+        require(contractSize > 0, _errorMessage);
+    }
+}

--- a/packages/contracts/src/diamond/LibStorage.sol
+++ b/packages/contracts/src/diamond/LibStorage.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {
+    WorldState,
+    TreasuryState,
+    Clan,
+    Clansman,
+    Mission,
+    WheatPlot,
+    ScheduledMarketAction
+} from "../IClanWorld.sol";
+
+/// @title LibStorage
+/// @notice Single AppStorage struct for the ClanWorld Diamond.
+///         All facets access state through `LibStorage.appStorage()`.
+///
+///         Pattern: Diamond-3 / Aavegotchi-style single shared struct at a
+///         deterministic storage slot. Avoids slot-0 collision with any
+///         inherited contracts or future additions.
+///
+///         DO NOT add fields between existing fields — Solidity packs structs
+///         sequentially. Always append new fields at the END of AppStorage.
+library LibStorage {
+    bytes32 internal constant STORAGE_SLOT = keccak256("clan.world.app.storage.v1");
+
+    struct AppStorage {
+        // -------------------------------------------------------------------------
+        // Reentrancy guard (must be in AppStorage so all facets share one guard)
+        // ReentrancyGuard.sol status flag: 1 = not entered, 2 = entered
+        // -------------------------------------------------------------------------
+        uint256 reentrancyStatus;
+
+        // -------------------------------------------------------------------------
+        // World state (was: WorldState private _world in ClanWorld.sol)
+        // -------------------------------------------------------------------------
+        WorldState world;
+
+        // -------------------------------------------------------------------------
+        // Treasury (was: TreasuryState private _treasury in ClanWorld.sol)
+        // -------------------------------------------------------------------------
+        TreasuryState treasury;
+
+        // -------------------------------------------------------------------------
+        // Clan registry
+        // (was: mapping(uint32 => Clan) internal _clans)
+        // (was: uint32 private _nextClanId)
+        // (was: uint32[] private _allClanIds)
+        // -------------------------------------------------------------------------
+        mapping(uint32 => Clan) clans;
+        uint32 nextClanId;
+        uint32[] allClanIds;
+
+        // -------------------------------------------------------------------------
+        // Clansman registry
+        // (was: mapping(uint32 => Clansman) internal _clansmen)
+        // (was: uint32 private _nextClansmanId)
+        // (was: mapping(uint32 => uint32[]) private _clanClansmanIds)
+        // -------------------------------------------------------------------------
+        mapping(uint32 => Clansman) clansmen;
+        uint32 nextClansmanId;
+        mapping(uint32 => uint32[]) clanClansmanIds; // clanId => clansmanId[]
+
+        // -------------------------------------------------------------------------
+        // Mission state (keyed by clansmanId)
+        // (was: mapping(uint32 => Mission) private _missions)
+        // -------------------------------------------------------------------------
+        mapping(uint32 => Mission) missions;
+
+        // -------------------------------------------------------------------------
+        // Wheat plots: clanId => [west=0, east=1]
+        // (was: mapping(uint32 => WheatPlot[2]) private _wheatPlots)
+        // -------------------------------------------------------------------------
+        mapping(uint32 => WheatPlot[2]) wheatPlots;
+
+        // -------------------------------------------------------------------------
+        // Scheduled market actions: tick => actions[]
+        // (was: mapping(uint64 => ScheduledMarketAction[]) private _scheduledMarketActions)
+        // -------------------------------------------------------------------------
+        mapping(uint64 => ScheduledMarketAction[]) scheduledMarketActions;
+
+        // -------------------------------------------------------------------------
+        // Defense registries
+        // (was: mapping(uint8 => uint32[]) private _defendingClansByRegion)
+        // (was: mapping(uint8 => mapping(uint32 => uint256)) private _defenderCountByRegionClan)
+        // (was: mapping(uint32 => uint8) private _clansmanDefendingRegion)
+        // -------------------------------------------------------------------------
+        mapping(uint8 => uint32[]) defendingClansByRegion;
+        mapping(uint8 => mapping(uint32 => uint256)) defenderCountByRegionClan;
+        mapping(uint32 => uint8) clansmanDefendingRegion;
+
+        // -------------------------------------------------------------------------
+        // RNG tick seeds (was: mapping(uint64 => bytes32) private _tickSeeds)
+        // -------------------------------------------------------------------------
+        mapping(uint64 => bytes32) tickSeeds;
+
+        // -------------------------------------------------------------------------
+        // Phase 9 / 10 future fields — append here when needed
+        // (BanditsFacet, WintersFacet landing zones)
+        // -------------------------------------------------------------------------
+        // mapping(uint32 => BanditTroop) bandits;   // Phase 9 — uncomment when adding
+        // uint256[] activeBanditIds;                  // Phase 9
+    }
+
+    /// @notice Returns a storage pointer to the AppStorage struct.
+    ///         Uses inline assembly to load at the deterministic STORAGE_SLOT.
+    ///         All facets call this to get mutable access to game state.
+    function appStorage() internal pure returns (AppStorage storage s) {
+        bytes32 slot = STORAGE_SLOT;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            s.slot := slot
+        }
+    }
+}

--- a/packages/contracts/src/diamond/facets/BanditsFacet.sol
+++ b/packages/contracts/src/diamond/facets/BanditsFacet.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {LibStorage} from "../LibStorage.sol";
+
+/// @title BanditsFacet
+/// @notice Phase 9 bandit attack/defense mechanics — STUB, no business logic yet.
+///
+///         This facet is a landing zone for Phase 9 implementation.
+///         It registers the Phase 9 function selectors in the Diamond so
+///         the ABI surface is reserved even before the logic is written.
+///
+///         Functions to implement in Phase 9:
+///         - spawnBandit(uint8 region, uint8 tier)          — owner/keeper call
+///         - resolveBanditAttack(uint32 banditId)           — permissionless
+///         - _pickBanditTarget(uint32 banditId, bytes32 seed) — internal
+///         - _executeBanditSteal(uint32 banditId, uint32 targetClanId, bytes32 seed) — internal
+///         - _defeatBandit(uint32 banditId)                 — internal
+///         - _escapeBandit(uint32 banditId)                 — internal
+///
+///         Phase 9 storage fields to add to AppStorage (LibStorage.sol):
+///         - mapping(uint32 => BanditTroop) bandits
+///         - uint32[] activeBanditIds
+///         - (append to end of AppStorage struct — never insert in middle)
+///
+///         Relevant ClanWorldConstants (already in IClanWorld):
+///         - BANDIT_COOLDOWN_TICKS = 10
+///         - BANDIT_CAMP_TICKS = 3
+///         - BANDIT_REST_TICKS = 2
+///         - BANDIT_MAX_ATTACK_ATTEMPTS = 6
+///         - BANDIT_BASE_STEAL_BPS = 2000 (20%)
+///         - BANDIT_DROP_TO_DEFENDERS_BPS = 5000 (50%)
+///
+/// TODO: Phase 9 implementation — all functions are stubs
+contract BanditsFacet {
+    // Access shared state via AppStorage
+    // LibStorage.AppStorage storage s = LibStorage.appStorage();
+
+    // Phase 9 — placeholder; selectors registered in Diamond at deploy
+    // so existing function signatures are reserved in the ABI.
+}

--- a/packages/contracts/src/diamond/facets/CoreFacet.sol
+++ b/packages/contracts/src/diamond/facets/CoreFacet.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {LibStorage} from "../LibStorage.sol";
+import {
+    IClanWorld,
+    IClanWorldEvents,
+    ClanWorldConstants,
+    ClanState,
+    ClansmanState,
+    ActionType,
+    MarketExecutionMode,
+    StatusCode,
+    WorldState,
+    Clan,
+    Clansman,
+    Mission,
+    WheatPlot,
+    WheatPlotState,
+    ScheduledMarketAction,
+    ClanOrder,
+    OrderResult,
+    BanditTroop,
+    BanditState
+} from "../../IClanWorld.sol";
+
+/// @title CoreFacet
+/// @notice World clock, heartbeat dispatch shell, clan lifecycle, order submission, travel.
+///
+///         Functions to migrate from ClanWorld.sol (Phase 2 / PR):
+///         - heartbeat()
+///         - _resolveWorldEvents(uint64 closedTick)
+///         - settleClan(uint32 clanId)          — delegates to GatheringFacet._settleClan
+///         - settleClansman(uint32 csId)        — delegates to GatheringFacet._settleClan
+///         - finalizeSeason()                   — stub; moves to WintersFacet at Phase 10
+///         - mintClan(address to)
+///         - submitClanOrders(uint32, ClanOrder[] calldata)
+///         - _processOrder(uint32, Clan storage, ClanOrder calldata)
+///         - _installMission(Mission storage, ClanOrder calldata, Clansman storage, OrderCtx memory)
+///         - _enqueueScheduledMarketAction(...)
+///         - _registerDefender(uint8, uint32, uint32)
+///         - _clearDefender(uint32)
+///         - _validateAction(Clan storage, Clansman storage, ClanOrder calldata, uint8)
+///         - _validateDefendBaseOrder(Clan storage, ClanOrder calldata, uint8)
+///         - _distMatrix(uint8, uint8)  — pure travel helper
+///         - _buildPath(uint8, uint8)   — pure travel helper
+///         - _travelTicks(uint8, uint8) — pure travel helper
+///         - _addTicksClamped(uint64, uint64) — pure helper
+///         - getActionDuration(ActionType)  — pure, from IClanWorld
+///         - getTravelTicks(uint8, uint8)   — pure, from IClanWorld
+///
+///         Note: heartbeat calls into GatheringFacet for _settleCompletingMissions
+///         and into MarketFacet for _executeScheduledMarketActions.
+///         Cross-facet calls within a Diamond use the proxy address (address(this)).
+///
+/// TODO: migrate from ClanWorld.sol
+contract CoreFacet {
+    // Access shared state via AppStorage
+    // LibStorage.AppStorage storage s = LibStorage.appStorage();
+
+    // =========================================================================
+    // WORLD PROGRESSION
+    // =========================================================================
+
+    function heartbeat() external {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function settleClan(uint32 /*clanId*/) external {
+        // TODO: migrate from ClanWorld.sol
+        // Delegates to GatheringFacet._settleClan via internal call pattern
+    }
+
+    function settleClansman(uint32 /*csId*/) external {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function finalizeSeason() external {
+        // TODO: stub — Phase 10 implementation moves to WintersFacet
+    }
+
+    // =========================================================================
+    // CLAN LIFECYCLE
+    // =========================================================================
+
+    function mintClan(address /*to*/) external returns (uint32 clanId, uint256 iftTokenId) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function submitClanOrders(uint32 /*clanId*/, ClanOrder[] calldata /*orders*/)
+        external
+        returns (OrderResult[] memory results)
+    {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    // =========================================================================
+    // PURE VIEWS (no storage)
+    // =========================================================================
+
+    function getActionDuration(ActionType /*action*/) public pure returns (uint64) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getTravelTicks(uint8 /*fromRegion*/, uint8 /*toRegion*/) external pure returns (uint64) {
+        // TODO: migrate from ClanWorld.sol
+    }
+}

--- a/packages/contracts/src/diamond/facets/GatheringFacet.sol
+++ b/packages/contracts/src/diamond/facets/GatheringFacet.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {LibStorage} from "../LibStorage.sol";
+import {
+    ActionType,
+    ClanState,
+    ClansmanState,
+    Clan,
+    Clansman,
+    Mission,
+    WheatPlot,
+    WheatPlotState
+} from "../../IClanWorld.sol";
+
+/// @title GatheringFacet
+/// @notice Settlement engine, all gathering actions, deposit, building upgrades.
+///
+///         Functions to migrate from ClanWorld.sol:
+///         - _settleClan(uint32 clanId)                           — core settlement loop
+///         - _settleMissionForClansman(Clan storage, Clansman storage, uint32, uint64, uint64)
+///         - _settleCompletingMissions(uint64 tick)               — called by CoreFacet.heartbeat
+///         - _applyUpkeep(Clan storage, uint64)
+///         - _isStarving(Clan storage)
+///         - _resolveAction(Clan storage, Clansman storage, Mission storage, uint32, uint64, bytes32)
+///         - _gatherWood(Clan storage, Clansman storage, Mission storage, uint32, uint64, bool, bytes32)
+///         - _gatherIron(Clan storage, Clansman storage, Mission storage, uint32, uint64, bool, bytes32)
+///         - _rollIronGoldBonus(Clan storage, uint32, uint64, uint64, bytes32)
+///         - _gatherFishDocks(Clan storage, Clansman storage, Mission storage, uint32, uint64, bool, bytes32)
+///         - _gatherFishDeepSea(Clan storage, Clansman storage, Mission storage, uint32, uint64, bool, bytes32)
+///         - _gatherWheat(Clan storage, Clansman storage, Mission storage, uint32, uint64, bool)
+///         - _doDeposit(Clan storage, Clansman storage, Mission storage, uint32, uint64)
+///         - _doBuilding(Clan storage, Clansman storage, Mission storage, uint32, uint64, ActionType)
+///         - _tryBuildWall(Clan storage, uint32, uint64)
+///         - _tryUpgradeBase(Clan storage, uint32, uint64)
+///         - _tryUpgradeMonument(Clan storage, uint32, uint64)
+///         - _completeMission(Clansman storage, Mission storage)
+///
+///         Cross-facet calls:
+///         - CoreFacet.heartbeat calls _settleCompletingMissions via IClanWorld(address(this))
+///         - CoreFacet.settleClan / settleClansman call _settleClan via IClanWorld(address(this))
+///
+/// TODO: migrate from ClanWorld.sol
+contract GatheringFacet {
+    // Access shared state via AppStorage
+    // LibStorage.AppStorage storage s = LibStorage.appStorage();
+
+    // Constants (same as ClanWorld.sol — not in AppStorage, just Solidity constants)
+    uint256 private constant WHEAT_HARVEST_RATE = 20e18;
+    uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
+
+    // =========================================================================
+    // PUBLIC SETTLEMENT ENTRY POINTS (called via Diamond proxy)
+    // =========================================================================
+
+    // Note: settleClan and settleClansman are registered on CoreFacet as the
+    // public-facing functions. GatheringFacet exposes _settleClan as an internal
+    // helper. In the Diamond these are all in the same delegatecall context.
+
+    // =========================================================================
+    // SETTLEMENT ENGINE
+    // =========================================================================
+
+    // _settleClan, _settleMissionForClansman, _settleCompletingMissions
+    // _applyUpkeep, _isStarving, _resolveAction
+    // TODO: migrate from ClanWorld.sol
+
+    // =========================================================================
+    // GATHERING HELPERS
+    // =========================================================================
+
+    // _gatherWood, _gatherIron, _rollIronGoldBonus
+    // _gatherFishDocks, _gatherFishDeepSea, _gatherWheat
+    // _doDeposit, _doBuilding
+    // _tryBuildWall, _tryUpgradeBase, _tryUpgradeMonument
+    // _completeMission
+    // TODO: migrate from ClanWorld.sol
+}

--- a/packages/contracts/src/diamond/facets/MarketFacet.sol
+++ b/packages/contracts/src/diamond/facets/MarketFacet.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {LibStorage} from "../LibStorage.sol";
+import {
+    ActionType,
+    StatusCode,
+    ScheduledMarketAction,
+    PoolSeedConfig,
+    ResourceType
+} from "../../IClanWorld.sol";
+
+/// @title MarketFacet
+/// @notice Market execution, treasury initialization, pool seeding, OTC stubs.
+///
+///         Functions to migrate from ClanWorld.sol:
+///         - _executeScheduledMarketActions(uint64 tick)  — called by CoreFacet.heartbeat
+///         - _executeMarketSellExternal(uint64, uint32, uint32, address, uint256, uint64)
+///         - _executeMarketSell(uint64, uint32, uint32, address, uint256, uint64)
+///         - _executeMarketBuyExternal(uint64, uint32, uint32, address, uint256, uint256, uint64)
+///         - _executeMarketBuy(uint64, uint32, uint32, address, uint256, uint256, uint64)
+///         - _sortScheduledMarketActionsByCommitSequence(ScheduledMarketAction[] storage)
+///         - _poolFor(address token)
+///         - _addToVault(Clan storage, address, uint256)
+///         - _deductFromVault(Clan storage, address, uint256)
+///         - initTreasury(address[6] calldata, address[4] calldata)
+///         - seedPools(PoolSeedConfig calldata)
+///         - transferGold(uint32, uint32, uint256)       — pure revert stub
+///         - transferVaultResource(uint32, uint32, ResourceType, uint256) — pure revert stub
+///         - transferBlueprint(uint32, uint32, uint256)  — pure revert stub
+///         - transferBundle(uint32, uint32, uint256, uint256, uint256, uint256, uint256, uint256) — pure revert stub
+///
+///         Note on try/catch pattern:
+///         In ClanWorld.sol, heartbeat calls `this._executeMarketSellExternal(...)` (self-call)
+///         to create a try/catch boundary. In the Diamond, `address(this)` is the proxy.
+///         CoreFacet calls `IClanWorld(address(this))._executeMarketSellExternal(...)` —
+///         the proxy routes back to MarketFacet via delegatecall.
+///         The `require(msg.sender == address(this))` guard in the external wrapper
+///         still works because under delegatecall, address(this) = Diamond proxy.
+///
+/// TODO: migrate from ClanWorld.sol
+contract MarketFacet {
+    // Access shared state via AppStorage
+    // LibStorage.AppStorage storage s = LibStorage.appStorage();
+
+    // =========================================================================
+    // MARKET EXECUTION (called by CoreFacet.heartbeat)
+    // =========================================================================
+
+    function _executeMarketSellExternal(
+        uint64, /*closedTick*/
+        uint32, /*clanId*/
+        uint32, /*clansmanId*/
+        address, /*token*/
+        uint256, /*amount*/
+        uint64 /*commitSequence*/
+    ) external {
+        // TODO: migrate from ClanWorld.sol
+        // Guard: require(msg.sender == address(this), "ClanWorld: internal only");
+    }
+
+    function _executeMarketBuyExternal(
+        uint64, /*closedTick*/
+        uint32, /*clanId*/
+        uint32, /*clansmanId*/
+        address, /*token*/
+        uint256, /*amountOut*/
+        uint256, /*maxGoldIn*/
+        uint64 /*commitSequence*/
+    ) external {
+        // TODO: migrate from ClanWorld.sol
+        // Guard: require(msg.sender == address(this), "ClanWorld: internal only");
+    }
+
+    // =========================================================================
+    // TREASURY
+    // =========================================================================
+
+    function initTreasury(address[6] calldata /*tokens*/, address[4] calldata /*pools*/) external {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function seedPools(PoolSeedConfig calldata /*cfg*/) external {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    // =========================================================================
+    // OTC STUBS (pure revert — Phase 8+)
+    // =========================================================================
+
+    function transferGold(uint32, uint32, uint256) external pure {
+        revert("OTC transfers not implemented");
+    }
+
+    function transferVaultResource(uint32, uint32, ResourceType, uint256) external pure {
+        revert("OTC transfers not implemented");
+    }
+
+    function transferBlueprint(uint32, uint32, uint256) external pure {
+        revert("OTC transfers not implemented");
+    }
+
+    function transferBundle(uint32, uint32, uint256, uint256, uint256, uint256, uint256, uint256) external pure {
+        revert("OTC transfers not implemented");
+    }
+}

--- a/packages/contracts/src/diamond/facets/ViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/ViewsFacet.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {LibStorage} from "../LibStorage.sol";
+import {
+    WorldState,
+    TreasuryState,
+    Clan,
+    Clansman,
+    Mission,
+    BanditTroop,
+    BanditState,
+    WheatPlot,
+    ScheduledMarketAction,
+    DerivedClanState,
+    DerivedClansmanState,
+    ClansmanFullView,
+    ClanFullView,
+    WorldSnapshot,
+    LeaderboardEntry,
+    MarketState,
+    PoolReserves,
+    ActiveBanditView,
+    RegionOccupant,
+    ActionType,
+    ClansmanState
+} from "../../IClanWorld.sol";
+
+/// @title ViewsFacet
+/// @notice All pure/view aggregators — no storage writes.
+///
+///         Functions to migrate from ClanWorld.sol:
+///         RAW READ GETTERS:
+///         - getWorldState()
+///         - getTreasuryState()
+///         - getClan(uint32)
+///         - getClansman(uint32)
+///         - getActiveMission(uint32)
+///         - getMissionTiming(uint32, uint32)
+///         - getBanditTroop(uint32)               — stub (Phase 9)
+///         - getWheatPlots(uint32)
+///         - getScheduledMarketActionsForTick(uint64)
+///         - getActiveDefenders(uint32)
+///         - getDefendingClans(uint8)
+///
+///         DERIVED READ GETTERS:
+///         - getDerivedClanState(uint32)
+///         - getDerivedClansmanState(uint32)
+///         - getBanditTargetPreview(uint32)       — stub (Phase 9)
+///         - quoteTravel(uint8, uint8)
+///         - quoteLootValueRaw(uint32)
+///         - quoteLootValueSettled(uint32)
+///         - _lootValueRaw(Clan memory)           — pure helper
+///
+///         UI INDEXER AGGREGATORS (v4.4):
+///         - getWorldSnapshot()
+///         - getClanFullView(uint32)
+///         - getMarketState()
+///         - _poolReserves(address, address)      — pure computation
+///         - getActiveBanditView()                — stub (Phase 9)
+///         - getRegionPopulation(uint8)
+///
+///         Note: quoteTravel also needs _distMatrix and _buildPath (pure helpers).
+///         These will be duplicated here or extracted to a LibTravel pure library
+///         shared between CoreFacet and ViewsFacet. Decision: use LibTravel to avoid
+///         bytecode duplication.
+///
+/// TODO: migrate from ClanWorld.sol
+contract ViewsFacet {
+    // Access shared state (read-only) via AppStorage
+    // LibStorage.AppStorage storage s = LibStorage.appStorage();
+
+    // =========================================================================
+    // RAW READ GETTERS
+    // =========================================================================
+
+    function getWorldState() external view returns (WorldState memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getTreasuryState() external view returns (TreasuryState memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getClan(uint32 /*clanId*/) external view returns (Clan memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getClansman(uint32 /*clansmanId*/) external view returns (Clansman memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getActiveMission(uint32 /*clansmanId*/) external view returns (Mission memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getMissionTiming(uint32 /*clanId*/, uint32 /*clansmanId*/)
+        external
+        view
+        returns (uint64 submitted, uint64 executes, uint64 settles)
+    {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getBanditTroop(uint32 /*banditId*/) external pure returns (BanditTroop memory) {
+        // TODO: stub — Phase 9 implementation in BanditsFacet
+        return BanditTroop({
+            banditId: 0,
+            state: BanditState.NONE,
+            currentRegion: 0,
+            attackAttemptsMade: 0,
+            stateEnteredTick: 0,
+            nextActionTick: 0,
+            tier: 0,
+            attackPower: 0,
+            carryWood: 0,
+            carryIron: 0,
+            carryWheat: 0,
+            carryFish: 0
+        });
+    }
+
+    function getWheatPlots(uint32 /*clanId*/)
+        external
+        view
+        returns (WheatPlot memory west, WheatPlot memory east)
+    {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getScheduledMarketActionsForTick(uint64 /*tick*/)
+        external
+        view
+        returns (ScheduledMarketAction[] memory)
+    {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getActiveDefenders(uint32 /*targetClanId*/) external view returns (uint32[] memory clansmanIds) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getDefendingClans(uint8 /*region*/) external view returns (uint32[] memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    // =========================================================================
+    // DERIVED READ GETTERS
+    // =========================================================================
+
+    function getDerivedClanState(uint32 /*clanId*/) external view returns (DerivedClanState memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getDerivedClansmanState(uint32 /*clansmanId*/) external view returns (DerivedClansmanState memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getBanditTargetPreview(uint32 /*clansmanId*/) external pure returns (uint32) {
+        return 0; // TODO: Phase 9 stub
+    }
+
+    function quoteTravel(uint8 /*srcRegion*/, uint8 /*dstRegion*/)
+        external
+        pure
+        returns (uint8 travelTicks, bytes8 path)
+    {
+        // TODO: migrate from ClanWorld.sol — uses _distMatrix and _buildPath
+        // These pure helpers will be extracted to LibTravel to avoid duplication
+        // with CoreFacet (which also needs travel logic for order submission)
+    }
+
+    function quoteLootValueRaw(uint32 /*clanId*/) external view returns (uint256) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function quoteLootValueSettled(uint32 /*clanId*/) external view returns (uint256) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    // =========================================================================
+    // UI INDEXER AGGREGATORS
+    // =========================================================================
+
+    function getWorldSnapshot() external view returns (WorldSnapshot memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getClanFullView(uint32 /*clanId*/) external view returns (ClanFullView memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getMarketState() external view returns (MarketState memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+
+    function getActiveBanditView() external pure returns (ActiveBanditView memory) {
+        // TODO: stub — Phase 9 implementation in BanditsFacet
+        return ActiveBanditView({
+            exists: false,
+            banditId: 0,
+            state: BanditState.NONE,
+            currentRegion: 0,
+            attackAttemptsMade: 0,
+            maxAttemptsRemaining: 0,
+            stateEnteredTick: 0,
+            nextActionTick: 0,
+            tier: 0,
+            attackPower: 0,
+            carryWood: 0,
+            carryIron: 0,
+            carryWheat: 0,
+            carryFish: 0,
+            projectedTargetClanId: 0,
+            projectedTargetLootValue: 0
+        });
+    }
+
+    function getRegionPopulation(uint8 /*region*/) external view returns (RegionOccupant[] memory) {
+        // TODO: migrate from ClanWorld.sol
+    }
+}

--- a/packages/contracts/src/diamond/facets/WintersFacet.sol
+++ b/packages/contracts/src/diamond/facets/WintersFacet.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {LibStorage} from "../LibStorage.sol";
+
+/// @title WintersFacet
+/// @notice Phase 10 winter damage + clan elimination mechanics — STUB.
+///
+///         This facet is a landing zone for Phase 10 implementation.
+///         It owns the winter-mechanics functions that are currently
+///         timer-only stubs in CoreFacet._resolveWorldEvents.
+///
+///         Functions to implement in Phase 10:
+///         - _applyWinterDamage(uint64 tick)        — called each tick winter is active
+///         - _applyWinterUpkeepMultiplier(uint32 clanId, uint64 tick) — 2x upkeep
+///         - _applyWinterWoodBurn(uint32 clanId, uint64 tick) — burns wood per base level
+///         - _accumulateColdDamage(uint32 clanId)   — increments coldDamage on Clan
+///         - _eliminateClan(uint32 clanId, uint64 tick) — marks ClanState.DEAD
+///         - finalizeSeason()                       — full Phase 10 impl (CoreFacet has stub now)
+///         - _distributeSeasonPrizes()              — treasury payout at season end
+///
+///         Relevant storage fields (already in AppStorage via WorldState):
+///         - world.winterActive
+///         - world.winterStartsAtTick
+///         - world.winterEndsAtTick
+///         - clan.coldDamage (uint16 on Clan struct)
+///         - treasury.prizePotGold (on TreasuryState)
+///
+///         Relevant ClanWorldConstants (already in IClanWorld):
+///         - WINTER_WOOD_BURN_PER_BASE = 1e18
+///         - WINTER_UPKEEP_MULTIPLIER_BPS = 20000 (2x)
+///         - TICKS_PER_WINTER_CYCLE = 110
+///         - WINTER_DURATION_TICKS = 10
+///
+/// TODO: Phase 10 implementation — all functions are stubs
+contract WintersFacet {
+    // Access shared state via AppStorage
+    // LibStorage.AppStorage storage s = LibStorage.appStorage();
+
+    // Phase 10 — placeholder; finalizeSeason is currently stubbed in CoreFacet
+    // When Phase 10 ships: remove finalizeSeason from CoreFacet, register it here.
+}


### PR DESCRIPTION
## Summary

- Design doc at `docs/architecture/diamond-pattern.md` covering all architectural decisions — intended as the primary go/no-go artifact before any code migration
- Diamond skeleton: `Diamond.sol` proxy, `LibStorage.sol` (AppStorage), `IDiamondCut.sol`, `LibDiamond.sol`, `DiamondCutFacet.sol`, `DiamondLoupeFacet.sol`
- Six empty facet stubs: `CoreFacet`, `MarketFacet`, `GatheringFacet`, `ViewsFacet`, `BanditsFacet`, `WintersFacet`
- `ClanWorld.sol` untouched — all 86 tests pass

## Key architectural decisions made

| Decision | Choice | Rationale |
|---|---|---|
| Architecture | EIP-2535 Diamond | Hybrid split plan rejected by 2 independent DAs; 6 specific risks enumerated in doc §1 |
| ClanWorld compiled size | 34,792 bytes | Measured from `forge build --sizes`; 10,216 bytes over EIP-170 limit |
| AppStorage | Single struct in LibStorage.sol | Shared state across all facets; single-struct is simpler and matches production Diamond pattern |
| Upgrade policy | Mutable Diamond + 2-of-3 multisig + 48h timelock | Game needs live patching for Phase 9/10; mirrors Aavegotchi approach |
| Facet count | 6 facets (Core, Market, Gathering, Views, Bandits stub, Winters stub) | Each projected well under 24,576 B; Bandits/Winters are Phase 9/10 landing zones |
| ReentrancyGuard | In AppStorage (`reentrancyStatus`) | Cross-facet guard; per-facet guard is ineffective |

## Open questions for Liam

1. **Multisig structure** — does current team support 2-of-3 multisig? Or is single-owner + 48h timelock acceptable for the hackathon phase?
2. **Single AppStorage** — confirmed? (Recommendation: yes — see doc §4)
3. **BanditsFacet scope at PR 5** — stub with function signatures only, or full Phase 9 implementation?
4. **WintersFacet scope at PR 5** — same question for Phase 10
5. **Mutable vs immutable Diamond** — confirm mutable (recommended) before PR 2 starts
6. **`via_ir` flag** — can we drop it per-facet post-migration to reduce compile time?

## Test results

```
Ran 7 test suites: 86 tests passed, 0 failed, 0 skipped
```

ClanWorld.sol is untouched. New skeleton files compile clean alongside existing contracts.

## Partial close

Partially addresses #337 (PR 1 of 6). Full issue closes at PR 6 (deploy script + Base Sepolia).

Closes #337