### PR TITLE
fix(p10c): orchestrator REGION_FOREST + starvation NatSpec + submitOrders sim semantics

### DIFF
--- a/apps/orchestrator/src/main.ts
+++ b/apps/orchestrator/src/main.ts
@@ -1,4 +1,4 @@
-import type { ClanOrder } from '@clan-world/shared';
+import { REGION_FOREST, type ClanOrder } from '@clan-world/shared';
 import { createChainClient, createConvexClient } from '@clan-world/shared/adapters';
 
 const CLAN_ID = process.env.CLAN_ID || '1';
@@ -15,22 +15,22 @@ async function main(): Promise<void> {
   const orders: ClanOrder[] = [
     {
       kind: 'mission',
-      payload: { clansmanId: 1, gotoRegion: 0, action: 1 }, // action=1 is ChopWood
+      payload: { clansmanId: 1, gotoRegion: REGION_FOREST, action: 1 }, // action=1 is ChopWood
     },
   ];
 
   console.error(`[orchestrator] submitting orders for clan-${CLAN_ID}...`);
-  const { txHash, results } = await chain.submitOrders(CLAN_ID, orders);
-  const failedResults = results.filter(result => result.status !== 0);
-  console.error(`[orchestrator] tx submitted: ${txHash}; results=${JSON.stringify(results)}`);
-  if (failedResults.length > 0) {
-    console.error(`[orchestrator] ${failedResults.length} order(s) returned non-OK status`);
+  const { txHash, results: simulationResults } = await chain.submitOrders(CLAN_ID, orders);
+  const failedSimulationResults = simulationResults.filter(result => result.status !== 0);
+  console.error(`[orchestrator] tx submitted: ${txHash}; [sim] results=${JSON.stringify(simulationResults)}`);
+  if (failedSimulationResults.length > 0) {
+    console.error(`[orchestrator] [sim] ${failedSimulationResults.length} order(s) returned non-OK status`);
   }
 
   try {
     await convex.postLog(
-      failedResults.length > 0 ? 'warn' : 'info',
-      `Elder Aldric (clan-${CLAN_ID}): ChopWood submitted — txHash=${txHash} tick=${tick} results=${JSON.stringify(results)}`,
+      failedSimulationResults.length > 0 ? 'warn' : 'info',
+      `Elder Aldric (clan-${CLAN_ID}): ChopWood submitted — txHash=${txHash} tick=${tick} [sim] results=${JSON.stringify(simulationResults)}`,
     );
   } catch (err) {
     console.error('[orchestrator] convex log failed (non-fatal):', err);
@@ -38,7 +38,11 @@ async function main(): Promise<void> {
 
   // Print final JSON summary to stdout
   process.stdout.write(
-    JSON.stringify({ tick, txHash, results, clan: CLAN_ID, mission: 'ChopWood-Forest' }, null, 2) + '\n',
+    JSON.stringify(
+      { tick, txHash, simulationResults, resultSemantics: 'simulation-only', clan: CLAN_ID, mission: 'ChopWood-Forest' },
+      null,
+      2,
+    ) + '\n',
   );
 }
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -444,6 +444,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         bool starving = !hadEnoughWheat || !hadEnoughFish;
         if (starving && clan.starvationStartsAtTick == 0) {
+            /// @dev Same-tick onset is canonical; see docs/planning/clanworld_v4_6_phase5_economy_alignment.md §5.2.
+            ///      This also makes bandit-defense starvation effects apply on the upkeep-failure tick.
             clan.starvationStartsAtTick = tick;
             emit ClanStarvationChanged(clan.clanId, true, tick);
         } else if (!starving && clan.starvationStartsAtTick != 0) {

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -13,6 +13,11 @@ export interface OrderResult {
 
 export interface SubmitOrdersResult {
   txHash: string;
+  /**
+   * Per-order statuses returned by pre-send contract simulation.
+   * These are useful for client-side expectations, but are not chain-authoritative
+   * finalized outcomes for the submitted transaction.
+   */
   results: OrderResult[];
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -4,6 +4,9 @@
 
 export type Tick = number;
 
+/** Mirrors ClanWorldConstants.REGION_FOREST in packages/contracts/src/IClanWorld.sol. */
+export const REGION_FOREST = 1;
+
 export interface TickEpoch {
   /** Unix seconds when this tick window started. */
   startedAt: number;


### PR DESCRIPTION
## Summary

3 Phase 10 follow-up issues from PR #250 reviews.

**Closes #331 #332 #334**

- #331: orchestrator now uses explicit `REGION_FOREST` for ChopWood (was REGION_NOOP, fragile)
- #332: NatSpec comment at `ClanWorld.sol:445` referencing v4.6 Phase 5 §5.2 for same-tick starvation rationale (no code change)
- #334: `submitOrders.results` JSDoc'd as simulation-only; orchestrator logs labeled `[sim]`

## Test plan

- Local 3-tier swarm review pending
- Liam UAT after orchestrator gate

## Workflow

- No cloud reviews triggered
- Merge target: `dev-phase-10c-followups` ONLY
- Authored by codex 5.5; orchestrator rescue-committed