### PR TITLE
test(contracts): strengthen upgrade reservation coverage (#323)

### DIFF
--- a/packages/contracts/test/BaseUpgrades.t.sol
+++ b/packages/contracts/test/BaseUpgrades.t.sol
@@ -8,6 +8,7 @@ import {
     ClanWorldConstants,
     Clan,
     ClanOrder,
+    ClansmanState,
     OrderResult,
     StatusCode,
     ActionType
@@ -19,6 +20,10 @@ contract BaseUpgradeHarness is ClanWorld {
         _clans[clanId].vaultIron = iron;
         _clans[clanId].vaultWheat = wheat;
         _clans[clanId].vaultFish = fish;
+    }
+
+    function killClansman(uint32 clansmanId) external {
+        _clansmen[clansmanId].state = ClansmanState.DEAD;
     }
 
     function setCurrentTick(uint64 tick) external {
@@ -215,5 +220,93 @@ contract BaseUpgradesTest is Test {
         assertEq(baseLevel, 2, "real refunds stale level-3 reservation");
         assertEq(realLoot, simLoot, "sim and real loot match");
         assertEq(realScore, simScore, "sim and real score match");
+    }
+
+    function test_upgradeBase_deadClansmanReleasesReservationAndAllowsRequeue() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 csId = _firstCs(clanId);
+        world.setVault(clanId, 100e18, 100e18, 100e18, 100e18);
+
+        OrderResult[] memory first = _submitOrder(elder, clanId, csId, ActionType.UpgradeBase);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first queue status");
+
+        world.killClansman(csId);
+        _advanceTick();
+        world.settleClan(clanId);
+
+        assertEq(world.getClan(clanId).vaultWood, 100e18, "wood still in vault");
+        assertFalse(world.getActiveMission(csId).active, "dead mission invalidated");
+
+        uint32 replacementCsId = _csAt(clanId, 1);
+        _advanceTicks(2);
+        OrderResult[] memory second = _submitOrder(elder, clanId, replacementCsId, ActionType.UpgradeBase);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "reservation released for requeue");
+    }
+
+    function test_upgradeBase_invalidatesFutureReservationAfterEarlierReservationCancelled() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 firstCsId = _csAt(clanId, 0);
+        uint32 secondCsId = _csAt(clanId, 1);
+        world.setVault(clanId, 500e18, 500e18, 500e18, 100e18);
+
+        OrderResult[] memory batch = _submitUpgradeBatch(elder, clanId, 2);
+        assertEq(uint8(batch[0].status), uint8(StatusCode.OK), "first queue");
+        assertEq(uint8(batch[1].status), uint8(StatusCode.OK), "second queue");
+
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS);
+        OrderResult[] memory cancelFirst = _submitOrder(elder, clanId, firstCsId, ActionType.Wait);
+        assertEq(uint8(cancelFirst[0].status), uint8(StatusCode.OK), "cancel first");
+
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeBase) + 1);
+
+        assertEq(world.getClan(clanId).baseLevel, 1, "future-level reservation does not reprice");
+        assertTrue(world.getActiveMission(secondCsId).active, "stale mission stays pending for retry pass");
+
+        _advanceTicks(2);
+        OrderResult[] memory next = _submitOrder(elder, clanId, firstCsId, ActionType.UpgradeBase);
+        assertEq(uint8(next[0].status), uint8(StatusCode.OK), "pending count released");
+    }
+
+    function test_upgradeBase_reversedClansmanSettlementInvalidatesFutureReservation() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 firstCsId = _csAt(clanId, 0);
+        uint32 secondCsId = _csAt(clanId, 1);
+        world.setVault(clanId, 500e18, 500e18, 500e18, 100e18);
+
+        OrderResult[] memory second = _submitOrder(elder, clanId, secondCsId, ActionType.UpgradeBase);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "second clansman queues level 1");
+        OrderResult[] memory first = _submitOrder(elder, clanId, firstCsId, ActionType.UpgradeBase);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first clansman queues level 2");
+
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeBase) + 2);
+
+        assertEq(world.getClan(clanId).baseLevel, 2, "only current-level reservation settles");
+    }
+
+    function test_upgradeBase_simAndRealScoresMatchAfterOutOfOrderCancellation() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 firstCsId = _csAt(clanId, 0);
+        uint32 secondCsId = _csAt(clanId, 1);
+        world.setVault(clanId, 500e18, 500e18, 500e18, 100e18);
+
+        OrderResult[] memory second = _submitOrder(elder, clanId, secondCsId, ActionType.UpgradeBase);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "second clansman queues level 1");
+        OrderResult[] memory first = _submitOrder(elder, clanId, firstCsId, ActionType.UpgradeBase);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first clansman queues level 2");
+
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS);
+        OrderResult[] memory cancelSecond = _submitOrder(elder, clanId, secondCsId, ActionType.Wait);
+        assertEq(uint8(cancelSecond[0].status), uint8(StatusCode.OK), "cancel current-level reservation");
+
+        world.setCurrentTick(2);
+        uint256 simLoot = world.quoteLootValueSettled(clanId);
+        (uint256 simScore,,) = world.getClanScore(clanId);
+
+        (uint256 realScore, uint256 realLoot, uint8 baseLevel) = world.settleClanAndGetStoredScore(clanId);
+
+        assertEq(realLoot, simLoot, "sim and real loot match");
+        assertEq(realScore, simScore, "sim and real score match");
+        assertEq(baseLevel, 1, "stale future reservation did not apply");
+        assertTrue(world.getActiveMission(firstCsId).active, "failed upgrade remains pending for retry pass");
     }
 }

--- a/packages/contracts/test/MonumentUpgrades.t.sol
+++ b/packages/contracts/test/MonumentUpgrades.t.sol
@@ -8,6 +8,7 @@ import {
     ClanWorldConstants,
     Clan,
     ClanOrder,
+    ClansmanState,
     OrderResult,
     StatusCode,
     ActionType
@@ -27,6 +28,10 @@ contract MonumentUpgradeHarness is ClanWorld {
 
     function setMonumentLevel(uint32 clanId, uint8 level) external {
         _clans[clanId].monumentLevel = level;
+    }
+
+    function killClansman(uint32 clansmanId) external {
+        _clansmen[clansmanId].state = ClansmanState.DEAD;
     }
 
     function setCurrentTick(uint64 tick) external {
@@ -249,5 +254,93 @@ contract MonumentUpgradesTest is Test {
         assertEq(monumentLevel, 1, "real refunds stale level-2 reservation");
         assertEq(realLoot, simLoot, "sim and real loot match");
         assertEq(realScore, simScore, "sim and real score match");
+    }
+
+    function test_upgradeMonument_deadClansmanReleasesReservationAndAllowsRequeue() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 csId = _firstCs(clanId);
+        world.setVault(clanId, 100e18, 0, 100e18, 0);
+
+        OrderResult[] memory first = _submitOrder(elder, clanId, csId, ActionType.UpgradeMonument);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first queue status");
+
+        world.killClansman(csId);
+        _advanceTick();
+        world.settleClan(clanId);
+
+        assertEq(world.getClan(clanId).vaultWood, 100e18, "wood still in vault");
+        assertFalse(world.getActiveMission(csId).active, "dead mission invalidated");
+
+        uint32 replacementCsId = _csAt(clanId, 1);
+        _advanceTicks(2);
+        OrderResult[] memory second = _submitOrder(elder, clanId, replacementCsId, ActionType.UpgradeMonument);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "reservation released for requeue");
+    }
+
+    function test_upgradeMonument_invalidatesFutureReservationAfterEarlierReservationCancelled() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 firstCsId = _csAt(clanId, 0);
+        uint32 secondCsId = _csAt(clanId, 1);
+        world.setVault(clanId, 500e18, 500e18, 500e18, 100e18);
+
+        OrderResult[] memory batch = _submitUpgradeBatch(elder, clanId, 2);
+        assertEq(uint8(batch[0].status), uint8(StatusCode.OK), "first queue");
+        assertEq(uint8(batch[1].status), uint8(StatusCode.OK), "second queue");
+
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS);
+        OrderResult[] memory cancelFirst = _submitOrder(elder, clanId, firstCsId, ActionType.Wait);
+        assertEq(uint8(cancelFirst[0].status), uint8(StatusCode.OK), "cancel first");
+
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeMonument) + 1);
+
+        assertEq(world.getClan(clanId).monumentLevel, 0, "future-level reservation does not reprice");
+        assertTrue(world.getActiveMission(secondCsId).active, "stale mission stays pending for retry pass");
+
+        _advanceTicks(2);
+        OrderResult[] memory next = _submitOrder(elder, clanId, firstCsId, ActionType.UpgradeMonument);
+        assertEq(uint8(next[0].status), uint8(StatusCode.OK), "pending count released");
+    }
+
+    function test_upgradeMonument_reversedClansmanSettlementInvalidatesFutureReservation() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 firstCsId = _csAt(clanId, 0);
+        uint32 secondCsId = _csAt(clanId, 1);
+        world.setVault(clanId, 500e18, 500e18, 500e18, 100e18);
+
+        OrderResult[] memory second = _submitOrder(elder, clanId, secondCsId, ActionType.UpgradeMonument);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "second clansman queues level 1");
+        OrderResult[] memory first = _submitOrder(elder, clanId, firstCsId, ActionType.UpgradeMonument);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first clansman queues level 2");
+
+        _advanceTicks(world.getActionDuration(ActionType.UpgradeMonument) + 2);
+
+        assertEq(world.getClan(clanId).monumentLevel, 1, "only current-level reservation settles");
+    }
+
+    function test_upgradeMonument_simAndRealScoresMatchAfterOutOfOrderCancellation() public {
+        uint32 clanId = _mintClan(elder);
+        uint32 firstCsId = _csAt(clanId, 0);
+        uint32 secondCsId = _csAt(clanId, 1);
+        world.setVault(clanId, 500e18, 500e18, 500e18, 100e18);
+
+        OrderResult[] memory second = _submitOrder(elder, clanId, secondCsId, ActionType.UpgradeMonument);
+        assertEq(uint8(second[0].status), uint8(StatusCode.OK), "second clansman queues level 1");
+        OrderResult[] memory first = _submitOrder(elder, clanId, firstCsId, ActionType.UpgradeMonument);
+        assertEq(uint8(first[0].status), uint8(StatusCode.OK), "first clansman queues level 2");
+
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS);
+        OrderResult[] memory cancelSecond = _submitOrder(elder, clanId, secondCsId, ActionType.Wait);
+        assertEq(uint8(cancelSecond[0].status), uint8(StatusCode.OK), "cancel current-level reservation");
+
+        world.setCurrentTick(2);
+        uint256 simLoot = world.quoteLootValueSettled(clanId);
+        (uint256 simScore,,) = world.getClanScore(clanId);
+
+        (uint256 realScore, uint256 realLoot, uint8 monumentLevel) = world.settleClanAndGetStoredScore(clanId);
+
+        assertEq(realLoot, simLoot, "sim and real loot match");
+        assertEq(realScore, simScore, "sim and real score match");
+        assertEq(monumentLevel, 0, "stale future reservation did not apply");
+        assertTrue(world.getActiveMission(firstCsId).active, "failed upgrade remains pending for retry pass");
     }
 }

--- a/packages/contracts/test/UpgradeReservationSwitches.t.sol
+++ b/packages/contracts/test/UpgradeReservationSwitches.t.sol
@@ -12,6 +12,21 @@ contract UpgradeReservationSwitchHarness is ClanWorld {
         _clans[clanId].vaultWheat = wheat;
         _clans[clanId].vaultFish = fish;
     }
+
+    function getWallReservation(uint32 csId) external view returns (bool active, uint8 fromLevel) {
+        WallUpgradeReservation storage r = _wallUpgradeReservations[csId];
+        return (r.active, r.fromLevel);
+    }
+
+    function getBaseReservation(uint32 csId) external view returns (bool active, uint8 fromLevel) {
+        BaseUpgradeReservation storage r = _baseUpgradeReservations[csId];
+        return (r.active, r.fromLevel);
+    }
+
+    function getMonumentReservation(uint32 csId) external view returns (bool active, uint8 fromLevel) {
+        MonumentUpgradeReservation storage r = _monumentUpgradeReservations[csId];
+        return (r.active, r.fromLevel);
+    }
 }
 
 contract UpgradeReservationSwitchesTest is Test {
@@ -48,17 +63,51 @@ contract UpgradeReservationSwitchesTest is Test {
         return world.submitClanOrders(clanId, orders);
     }
 
+    /// @dev Returns (active, fromLevel) for the reservation corresponding to `action`.
+    function _getReservation(uint32 csId, ActionType action) internal view returns (bool active, uint8 fromLevel) {
+        if (action == ActionType.UpgradeWall) return world.getWallReservation(csId);
+        if (action == ActionType.UpgradeBase) return world.getBaseReservation(csId);
+        if (action == ActionType.UpgradeMonument) return world.getMonumentReservation(csId);
+        revert("unknown action");
+    }
+
+    /// @dev Returns the expected fromLevel for a fresh clan (level at queue time).
+    ///      wallLevel starts at 0, baseLevel starts at 1, monumentLevel starts at 0.
+    function _initialFromLevel(ActionType action) internal pure returns (uint8) {
+        if (action == ActionType.UpgradeWall) return 0;
+        if (action == ActionType.UpgradeBase) return 1;
+        if (action == ActionType.UpgradeMonument) return 0;
+        revert("unknown action");
+    }
+
     function _assertCanSwitch(ActionType first, ActionType second, uint256 wood, uint256 wheat) internal {
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
         world.setVault(clanId, wood, 0, wheat, 100e18);
 
+        // Submit first reservation
         OrderResult[] memory initial = _submit(clanId, csId, first);
         assertEq(uint8(initial[0].status), uint8(StatusCode.OK), "initial upgrade accepted");
 
+        // Assert first reservation is active with correct fromLevel
+        (bool firstActive, uint8 firstFromLevel) = _getReservation(csId, first);
+        assertTrue(firstActive, "first reservation active after initial submit");
+        assertEq(firstFromLevel, _initialFromLevel(first), "first reservation fromLevel");
+
         vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
+
+        // Submit cross-type replacement
         OrderResult[] memory replacement = _submit(clanId, csId, second);
         assertEq(uint8(replacement[0].status), uint8(StatusCode.OK), "cross-type replacement accepted");
+
+        // Old reservation must be cleared
+        (bool oldActive,) = _getReservation(csId, first);
+        assertFalse(oldActive, "old reservation cleared after switch");
+
+        // New reservation must be active
+        (bool newActive, uint8 newFromLevel) = _getReservation(csId, second);
+        assertTrue(newActive, "new reservation active after switch");
+        assertEq(newFromLevel, _initialFromLevel(second), "new reservation fromLevel");
     }
 
     function test_upgradeWallCanSwitchToBaseWithTightResources() public {


### PR DESCRIPTION
Closes #323

**UpgradeReservationSwitches:** Strengthened `_assertCanSwitch` to verify reservation state transitions (not just `OK` status):
- After initial submit: correct reservation type is active
- After cross-type switch: old reservation cleared, new reservation active

**BaseUpgrades / MonumentUpgrades:** 4 new tests each, mirroring existing WallUpgrades coverage:
- Dead clansman releases reservation and allows requeue
- Cancelled earlier reservation invalidates stale future reservation
- Reversed-order clansman settlement invalidates future reservation
- Sim and real scores match after out-of-order cancellation

All forge tests pass.