### PR TITLE
refactor(contracts): drop *Upgraded events, keep *LevelChanged (#321)

### DIFF
--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -845,9 +845,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint8 old = clan.wallLevel;
         clan.wallLevel = old + 1;
         emit WallLevelChanged(clanId, old, clan.wallLevel, tick);
-        // Phase 8 event ABI uses uint32; season tick horizons are far below this cap.
-        // forge-lint: disable-next-line(unsafe-typecast)
-        emit WallUpgraded(clanId, clan.wallLevel, uint32(tick));
         return true;
     }
 
@@ -884,9 +881,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint8 old = clan.baseLevel;
         clan.baseLevel = old + 1;
         emit BaseLevelChanged(clanId, old, clan.baseLevel, tick);
-        // Phase 8 event ABI uses uint32; season tick horizons are far below this cap.
-        // forge-lint: disable-next-line(unsafe-typecast)
-        emit BaseUpgraded(clanId, clan.baseLevel, uint32(tick));
         return true;
     }
 
@@ -933,9 +927,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         clan.monumentLevel = old + 1;
         recordMonumentReachTick(clanId, clan.monumentLevel, tick);
         emit MonumentLevelChanged(clanId, old, clan.monumentLevel, tick);
-        // Phase 8 event ABI uses uint32; season tick horizons are far below this cap.
-        // forge-lint: disable-next-line(unsafe-typecast)
-        emit MonumentUpgraded(clanId, clan.monumentLevel, uint32(tick));
         return true;
     }
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -545,11 +545,8 @@ interface IClanWorldEvents {
 
     // ----- building -----
     event WallLevelChanged(uint32 indexed clanId, uint8 oldLevel, uint8 newLevel, uint64 atTick);
-    event WallUpgraded(uint32 indexed clanId, uint8 newLevel, uint32 settledAtTick);
     event BaseLevelChanged(uint32 indexed clanId, uint8 oldLevel, uint8 newLevel, uint64 atTick);
-    event BaseUpgraded(uint32 indexed clanId, uint8 newLevel, uint32 settledAtTick);
     event MonumentLevelChanged(uint32 indexed clanId, uint8 oldLevel, uint8 newLevel, uint64 atTick);
-    event MonumentUpgraded(uint32 indexed clanId, uint8 newLevel, uint32 settledAtTick);
 
     // ----- market -----
     event ImmediateMarketActionExecuted(

--- a/packages/contracts/test/BaseUpgrades.t.sol
+++ b/packages/contracts/test/BaseUpgrades.t.sol
@@ -141,7 +141,7 @@ contract BaseUpgradesTest is Test {
 
         _advanceTicks(world.getActionDuration(ActionType.UpgradeBase));
         vm.expectEmit(true, false, false, true, address(world));
-        emit IClanWorldEvents.BaseUpgraded(clanId, 2, 1);
+        emit IClanWorldEvents.BaseLevelChanged(clanId, 1, 2, 1);
         _advanceTick();
 
         assertEq(world.getClan(clanId).baseLevel, 2, "base level after settle");

--- a/packages/contracts/test/MonumentUpgrades.t.sol
+++ b/packages/contracts/test/MonumentUpgrades.t.sol
@@ -154,7 +154,7 @@ contract MonumentUpgradesTest is Test {
 
         _advanceTicks(world.getActionDuration(ActionType.UpgradeMonument));
         vm.expectEmit(true, false, false, true, address(world));
-        emit IClanWorldEvents.MonumentUpgraded(clanId, 1, 1);
+        emit IClanWorldEvents.MonumentLevelChanged(clanId, 0, 1, 1);
         _advanceTick();
 
         assertEq(world.getClanFullView(clanId).clan.clan.monumentLevel, 1, "monument level after settle");

--- a/packages/contracts/test/WallUpgrades.t.sol
+++ b/packages/contracts/test/WallUpgrades.t.sol
@@ -170,7 +170,7 @@ contract WallUpgradesTest is Test {
 
         _advanceTicks(world.getActionDuration(ActionType.UpgradeWall));
         vm.expectEmit(true, false, false, true, address(world));
-        emit IClanWorldEvents.WallUpgraded(clanId, 1, 1);
+        emit IClanWorldEvents.WallLevelChanged(clanId, 0, 1, 1);
         _advanceTick();
 
         assertEq(world.getClan(clanId).wallLevel, 1, "wall level after settle");


### PR DESCRIPTION
Closes #321

Drops the redundant \`*Upgraded\` event family emitted alongside \`*LevelChanged\` on every upgrade settlement.

**Kept:** \`WallLevelChanged\`, \`BaseLevelChanged\`, \`MonumentLevelChanged\`
**Removed:** \`WallUpgraded\`, \`BaseUpgraded\`, \`MonumentUpgraded\`

Updated 3 test files to assert \`*LevelChanged\` events.

All forge tests pass.