### PR TITLE
fix(p6c): Phase 6 follow-ups — schema hygiene + post-audit polish

### DIFF
--- a/apps/server/convex/README.md
+++ b/apps/server/convex/README.md
@@ -1,7 +1,26 @@
-# Welcome to your Convex functions directory!
+# ClanWorld Convex Functions
 
-Write your Convex functions here.
-See https://docs.convex.dev/functions for more.
+This directory hosts the Convex backend functions, including the heartbeat
+webhook and the future chain indexer.
+
+## Market Event Indexer Notes
+
+Phase 6 market events intentionally use compact resource ids rather than token
+addresses:
+
+- `ImmediateMarketActionExecuted`: `resourceIn` and `resourceOut` are `uint8`
+  resource ids; `4` is gold.
+- `ScheduledMarketActionExecuted`: same resource-id encoding, plus
+  `settledAtTick`.
+- `MarketActionFailed`: includes `MarketExecutionMode mode`; indexers should
+  persist it to distinguish immediate failures from scheduled queue failures.
+- `ScheduledMarketActionCommitted`: optional pending-queue signal. Indexers may
+  use it for live queue rendering, or fall back to
+  `getScheduledMarketActionsForTick`.
+
+The canonical ABI lives in `packages/contracts/abi/IClanWorld.json`.
+
+## Convex Reference
 
 A query function that takes two arguments looks like:
 

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2465,7 +2465,7 @@
       "name": "settleClansman",
       "inputs": [
         {
-          "name": "csId",
+          "name": "clansmanId",
           "type": "uint32",
           "internalType": "uint32"
         }
@@ -3205,7 +3205,7 @@
           "internalType": "uint32"
         },
         {
-          "name": "csId",
+          "name": "clansmanId",
           "type": "uint32",
           "indexed": false,
           "internalType": "uint32"
@@ -3309,7 +3309,7 @@
           "internalType": "uint32"
         },
         {
-          "name": "csId",
+          "name": "clansmanId",
           "type": "uint32",
           "indexed": false,
           "internalType": "uint32"
@@ -3795,7 +3795,7 @@
           "internalType": "uint32"
         },
         {
-          "name": "csId",
+          "name": "clansmanId",
           "type": "uint32",
           "indexed": false,
           "internalType": "uint32"

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -8,6 +8,16 @@ import {ClanWorld} from "../src/ClanWorld.sol";
 import {PoolSeedConfig} from "../src/IClanWorld.sol";
 
 contract Deploy is Script {
+    // v4 section 5.11 default pool ratios for the hackathon deployment.
+    uint256 private constant WOOD_POOL_SEED = 1_000e18;
+    uint256 private constant WHEAT_POOL_SEED = 1_000e18;
+    uint256 private constant FISH_POOL_SEED = 500e18;
+    uint256 private constant IRON_POOL_SEED = 250e18;
+    uint256 private constant GOLD_SEED_FOR_WOOD = 500e18;
+    uint256 private constant GOLD_SEED_FOR_WHEAT = 700e18;
+    uint256 private constant GOLD_SEED_FOR_FISH = 600e18;
+    uint256 private constant GOLD_SEED_FOR_IRON = 800e18;
+
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
         address treasury = vm.addr(deployerPrivateKey);
@@ -50,32 +60,30 @@ contract Deploy is Script {
 
         game.initTreasury(tokens, pools);
 
-        uint256 resSeed = game.INITIAL_RESOURCE_POOL_SEED();
-        uint256 goldSeed = game.INITIAL_GOLD_POOL_SEED();
-        uint256 totalGoldSeed = goldSeed * 4;
+        uint256 totalGoldSeed = GOLD_SEED_FOR_WOOD + GOLD_SEED_FOR_WHEAT + GOLD_SEED_FOR_FISH + GOLD_SEED_FOR_IRON;
 
-        wood.seedTreasury(treasury, resSeed);
-        wheat.seedTreasury(treasury, resSeed);
-        fish.seedTreasury(treasury, resSeed);
-        iron.seedTreasury(treasury, resSeed);
+        wood.seedTreasury(treasury, WOOD_POOL_SEED);
+        wheat.seedTreasury(treasury, WHEAT_POOL_SEED);
+        fish.seedTreasury(treasury, FISH_POOL_SEED);
+        iron.seedTreasury(treasury, IRON_POOL_SEED);
         gold.seedTreasury(treasury, totalGoldSeed);
 
-        wood.approve(address(game), resSeed);
-        wheat.approve(address(game), resSeed);
-        fish.approve(address(game), resSeed);
-        iron.approve(address(game), resSeed);
+        wood.approve(address(game), WOOD_POOL_SEED);
+        wheat.approve(address(game), WHEAT_POOL_SEED);
+        fish.approve(address(game), FISH_POOL_SEED);
+        iron.approve(address(game), IRON_POOL_SEED);
         gold.approve(address(game), totalGoldSeed);
 
         game.seedPools(
             PoolSeedConfig({
-                woodSeed: resSeed,
-                wheatSeed: resSeed,
-                fishSeed: resSeed,
-                ironSeed: resSeed,
-                goldSeedForWood: goldSeed,
-                goldSeedForWheat: goldSeed,
-                goldSeedForFish: goldSeed,
-                goldSeedForIron: goldSeed
+                woodSeed: WOOD_POOL_SEED,
+                wheatSeed: WHEAT_POOL_SEED,
+                fishSeed: FISH_POOL_SEED,
+                ironSeed: IRON_POOL_SEED,
+                goldSeedForWood: GOLD_SEED_FOR_WOOD,
+                goldSeedForWheat: GOLD_SEED_FOR_WHEAT,
+                goldSeedForFish: GOLD_SEED_FOR_FISH,
+                goldSeedForIron: GOLD_SEED_FOR_IRON
             })
         );
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1017,8 +1017,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     ///         Internally settles the entire clan (including upkeep) to guarantee
     ///         correct ordering and prevent double-settlement. Callers may call this
     ///         or settleClan interchangeably; both are safe and idempotent.
-    function settleClansman(uint32 csId) external override nonReentrant {
-        Clansman storage cs = _clansmen[csId];
+    function settleClansman(uint32 clansmanId) external override nonReentrant {
+        Clansman storage cs = _clansmen[clansmanId];
         if (cs.clansmanId == 0) return;
         _settleClan(cs.clanId);
     }
@@ -1088,9 +1088,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         // Create 4 clansmen
         for (uint256 i = 0; i < 4; i++) {
-            uint32 csId = _nextClansmanId++;
-            Clansman storage cs = _clansmen[csId];
-            cs.clansmanId = csId;
+            uint32 clansmanId = _nextClansmanId++;
+            Clansman storage cs = _clansmen[clansmanId];
+            cs.clansmanId = clansmanId;
             cs.clanId = clanId;
             cs.state = ClansmanState.WAITING;
             cs.currentRegion = baseRegion;
@@ -1100,7 +1100,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             cs.carryIron = 0;
             cs.carryWheat = 0;
             cs.carryFish = 0;
-            _clanClansmanIds[clanId].push(csId);
+            _clanClansmanIds[clanId].push(clansmanId);
         }
 
         _allClanIds.push(clanId);
@@ -1408,7 +1408,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     // =========================================================================
-    // MARKET EXECUTION (Phase 2)
+    // MARKET EXECUTION (Phase 6)
     // =========================================================================
 
     /// @dev Execute the full scheduled market queue for the given tick, then delete it.
@@ -1458,7 +1458,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 ) returns (
                     StatusCode marketStatus
                 ) {
-                    marketStatus;
+                    if (marketStatus != StatusCode.OK) continue;
                 } catch {
                     _handleMarketFailure(
                         sma.clanId,
@@ -1475,7 +1475,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 ) returns (
                     StatusCode marketStatus
                 ) {
-                    marketStatus;
+                    if (marketStatus != StatusCode.OK) continue;
                 } catch {
                     _handleMarketFailure(
                         sma.clanId,
@@ -1799,7 +1799,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             );
         }
 
-        try StubPool(poolAddr).swapExactInForOut(amount, 1) returns (uint256 goldOut) {
+        try StubPool(poolAddr).swapExactInForOut(amount, 0) returns (uint256 goldOut) {
             clan.goldBalance += goldOut;
             emit ImmediateMarketActionExecuted(
                 clanId,
@@ -1928,7 +1928,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
     }
 
-    /// @dev Execute a scheduled market sell: deduct resource from vault, credit gold.
+    /// @dev Execute a scheduled market sell: deduct resource from carry, credit clan gold.
     function _executeMarketSell(uint64 closedTick, uint32 clanId, uint32 clansmanId, address token, uint256 amount)
         internal
         returns (StatusCode)
@@ -1984,7 +1984,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return StatusCode.OK;
     }
 
-    /// @dev Execute a scheduled market buy: deduct gold from purse, credit resource to vault.
+    /// @dev Execute a scheduled market buy: deduct clan gold, credit resource to carry.
     function _executeMarketBuy(
         uint64 closedTick,
         uint32 clanId,
@@ -2557,9 +2557,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32[] storage csIds = _clanClansmanIds[clanId];
         ClansmanFullView[] memory clansmen = new ClansmanFullView[](csIds.length);
         for (uint256 i = 0; i < csIds.length; i++) {
-            uint32 csId = csIds[i];
-            Clansman memory cs = _clansmen[csId];
-            Mission memory m = _missions[csId];
+            uint32 clansmanId = csIds[i];
+            Clansman memory cs = _clansmen[clansmanId];
+            Mission memory m = _missions[clansmanId];
             uint8 effRegion = cs.currentRegion;
             if (cs.state == ClansmanState.TRAVELING && m.active) {
                 effRegion = _world.currentTick >= m.arrivalTick ? m.targetRegion : m.startRegion;
@@ -2656,12 +2656,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             uint32 cid = _allClanIds[i];
             uint32[] storage csIds = _clanClansmanIds[cid];
             for (uint256 j = 0; j < csIds.length; j++) {
-                uint32 csId = csIds[j];
-                Clansman storage cs = _clansmen[csId];
+                uint32 clansmanId = csIds[j];
+                Clansman storage cs = _clansmen[clansmanId];
                 if (cs.state != ClansmanState.DEAD && cs.currentRegion == region) {
-                    Mission storage m = _missions[csId];
+                    Mission storage m = _missions[clansmanId];
                     occupants[idx++] = RegionOccupant({
-                        clansmanId: csId,
+                        clansmanId: clansmanId,
                         clanId: cid,
                         state: cs.state,
                         currentAction: m.active ? m.action : ActionType.None,

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1458,7 +1458,16 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 ) returns (
                     StatusCode marketStatus
                 ) {
-                    if (marketStatus != StatusCode.OK) continue;
+                    if (marketStatus != StatusCode.OK) {
+                        _handleMarketFailure(
+                            sma.clanId,
+                            sma.clansmanId,
+                            sma.action,
+                            MarketExecutionMode.Scheduled,
+                            marketStatus,
+                            tick
+                        );
+                    }
                 } catch {
                     _handleMarketFailure(
                         sma.clanId,
@@ -1475,7 +1484,16 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 ) returns (
                     StatusCode marketStatus
                 ) {
-                    if (marketStatus != StatusCode.OK) continue;
+                    if (marketStatus != StatusCode.OK) {
+                        _handleMarketFailure(
+                            sma.clanId,
+                            sma.clansmanId,
+                            sma.action,
+                            MarketExecutionMode.Scheduled,
+                            marketStatus,
+                            tick
+                        );
+                    }
                 } catch {
                     _handleMarketFailure(
                         sma.clanId,
@@ -1934,38 +1952,17 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         returns (StatusCode)
     {
         if (!_treasury.poolsSeeded) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketSell,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
-                closedTick
-            );
+            return StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketSell,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
-                closedTick
-            );
+            return StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN;
         }
 
         Clan storage clan = _clans[clanId];
         Clansman storage cs = _clansmen[clansmanId];
         if (!_deductFromCarry(cs, token, amount)) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketSell,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MISSING_RESOURCES,
-                closedTick
-            );
+            return StatusCode.ERR_MISSING_RESOURCES;
         }
 
         uint256 goldOut = StubPool(poolAddr).sellResource(amount);
@@ -1994,88 +1991,39 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint256 maxGoldIn
     ) internal returns (StatusCode) {
         if (!_treasury.poolsSeeded) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
-                closedTick
-            );
+            return StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
-                closedTick
-            );
+            return StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN;
         }
 
         Clansman storage cs = _clansmen[clansmanId];
         if (amountOut > _remainingCarryForToken(cs, token)) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_CARRY_FULL,
-                closedTick
-            );
+            return StatusCode.ERR_CARRY_FULL;
         }
 
         uint256 goldIn;
         try StubPool(poolAddr).quoteBuy(amountOut) returns (uint256 quotedGoldIn) {
             goldIn = quotedGoldIn;
         } catch {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
-                closedTick
-            );
+            return StatusCode.ERR_LIQUIDITY_INSUFFICIENT;
         }
 
         Clan storage clan = _clans[clanId];
 
         if (goldIn > maxGoldIn) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MAX_GOLD_IN_EXCEEDED,
-                closedTick
-            );
+            return StatusCode.ERR_MAX_GOLD_IN_EXCEEDED;
         }
         if (clan.goldBalance < goldIn) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_NOT_ENOUGH_GOLD,
-                closedTick
-            );
+            return StatusCode.ERR_NOT_ENOUGH_GOLD;
         }
 
         uint256 actualGoldIn;
         try StubPool(poolAddr).swapExactOutForInWithMaxIn(amountOut, maxGoldIn) returns (uint256 spentGold) {
             actualGoldIn = spentGold;
         } catch {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
-                closedTick
-            );
+            return StatusCode.ERR_LIQUIDITY_INSUFFICIENT;
         }
 
         clan.goldBalance -= actualGoldIn;

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -586,7 +586,7 @@ interface IClanWorldEvents {
     // ----- market -----
     event ImmediateMarketActionExecuted(
         uint32 indexed clanId,
-        uint32 csId,
+        uint32 clansmanId,
         ActionType action,
         uint8 resourceIn,
         uint256 amountIn,
@@ -596,7 +596,7 @@ interface IClanWorldEvents {
     );
     event ScheduledMarketActionExecuted(
         uint32 indexed clanId,
-        uint32 csId,
+        uint32 clansmanId,
         ActionType action,
         uint8 resourceIn,
         uint256 amountIn,
@@ -605,7 +605,12 @@ interface IClanWorldEvents {
         uint64 settledAtTick
     );
     event MarketActionFailed(
-        uint32 indexed clanId, uint32 csId, ActionType action, MarketExecutionMode mode, StatusCode reason, uint64 tick
+        uint32 indexed clanId,
+        uint32 clansmanId,
+        ActionType action,
+        MarketExecutionMode mode,
+        StatusCode reason,
+        uint64 tick
     );
     event ScheduledMarketActionCommitted(
         uint64 indexed executeAtTick,
@@ -685,7 +690,7 @@ interface IClanWorld is IClanWorldEvents {
     function settleClan(uint32 clanId) external;
 
     /// @notice Lazily settle a single clansman's mission to current tick. Idempotent.
-    function settleClansman(uint32 csId) external;
+    function settleClansman(uint32 clansmanId) external;
 
     /// @notice Finalize the current season. Permissionless after seasonEndTick.
     function finalizeSeason() external;

--- a/packages/contracts/src/StubPool.sol
+++ b/packages/contracts/src/StubPool.sol
@@ -97,7 +97,7 @@ contract StubPool {
     /// @notice Exact-input sell: clan sells amountIn of resource, gets goldOut.
     ///         Legacy alias for Phase 6.1 scheduled-market code.
     function sellResource(uint256 amountIn) external onlyEngine returns (uint256 goldOut) {
-        goldOut = _swapExactInForOut(amountIn, 1);
+        goldOut = _swapExactInForOut(amountIn, 0);
     }
 
     /// @notice Legacy quote alias for exact-output resource buys.

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -1445,6 +1445,60 @@ contract ClanWorldTest is Test {
         assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
     }
 
+    function test_scheduledMarketSell_missingCarryEmitsFailureOnce() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        address woodAddr = _setupMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+        harness.setClansmanForTest(csId, ClansmanState.WAITING, ClanWorldConstants.REGION_FOREST, 0);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "sell order should be accepted");
+
+        Mission memory m = world.getActiveMission(csId);
+        uint64 executeAtTick = m.settlesAtTick;
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+        harness.setCarry(csId, 0, 0, 0, 0);
+
+        _advanceUntilNextHeartbeatCloses(executeAtTick);
+        bytes32 failedSig =
+            keccak256("MarketActionFailed(uint32,uint32,uint8,uint8,uint8,uint64)");
+
+        vm.recordLogs();
+        _advanceTick();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        uint256 failedCount;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != address(world) || logs[i].topics.length == 0 || logs[i].topics[0] != failedSig) {
+                continue;
+            }
+            (
+                uint32 eventCsId,
+                ActionType eventAction,
+                MarketExecutionMode eventMode,
+                StatusCode eventReason,
+                uint64 eventTick
+            ) = abi.decode(logs[i].data, (uint32, ActionType, MarketExecutionMode, StatusCode, uint64));
+            if (
+                eventCsId == csId && eventAction == ActionType.MarketSell
+                    && eventMode == MarketExecutionMode.Scheduled && eventReason == StatusCode.ERR_MISSING_RESOURCES
+                    && eventTick == executeAtTick
+            ) {
+                failedCount++;
+            }
+        }
+
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(failedCount, 1, "failed scheduled sell should emit once");
+        assertEq(world.getClan(clanId).goldBalance, goldBefore, "failed sell should not credit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed scheduled sell should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed scheduled worker waits");
+        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
+    }
+
     // -------------------------------------------------------------------------
     // Test 14: scheduledMarket_deletedAfterHeartbeat
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 6 follow-up bundle.

**Closes #319 #351**

### #319 — schema hygiene
- ABI-facing csId → clansmanId (naming consistency)
- Scheduled market try-return cleanup
- Phase 6 market NatSpec drift fixes

### #351 — post-audit polish
- Indexer accommodation notes for market event decoding
- Deploy seeding explicit with v4 §5.11 pool ratios
- MarketSell minOut literal `1` → `0` per spec §5.9

## Test plan

- [x] forge build (`--skip script --skip test` due to forge-std submodule absent in worktree; CI will run full suite)
- [ ] Local 3-tier swarm review (orchestrator dispatching)
- [ ] Liam UAT

## Notes

Codex 5.5 authored under orchestrator dispatch. `gh issue view` calls were sandboxed-blocked, so codex inferred actionable list from local audit/review artifacts. Orchestrator rescue-committed.

Merge target: `dev-phase-6c-followups` ONLY.