### PR TITLE
feat(contracts): Phase 5C v4 restoration — wood cap 15e18 + starvation next-tick (Closes #347 items 10, 14)

### DIFF
--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -416,7 +416,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         bool starving = !hadEnoughWheat || !hadEnoughFish;
         if (starving && clan.starvationStartsAtTick == 0) {
-            clan.starvationStartsAtTick = tick;
+            clan.starvationStartsAtTick = tick + 1;
             emit ClanStarvationChanged(clan.clanId, true, tick);
         } else if (!starving && clan.starvationStartsAtTick != 0) {
             clan.starvationStartsAtTick = 0;
@@ -484,12 +484,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         bool starving,
         bytes32 tickSeed
     ) internal {
-        if (cs.carryWood >= ClanWorldConstants.CLANSMAN_CARRY_CAP) {
+        if (cs.carryWood >= ClanWorldConstants.WOOD_CAP) {
             _completeMission(cs, m);
             return;
         }
 
-        uint256 remaining = ClanWorldConstants.CLANSMAN_CARRY_CAP - cs.carryWood;
+        uint256 remaining = ClanWorldConstants.WOOD_CAP - cs.carryWood;
         uint256 yield = ClanWorldConstants.WOOD_YIELD_PER_TICK * uint256(getActionDuration(ActionType.ChopWood));
         bytes32 woodRng = keccak256(abi.encode("wood_crit", tickSeed, cs.clansmanId, m.nonce, tick));
         if (uint256(woodRng) % 10000 < ClanWorldConstants.WOOD_CRIT_BPS) {
@@ -502,7 +502,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         emit ResourcesGathered(clanId, cs.clansmanId, ActionType.ChopWood, yield, 0, 0, 0, 0, tick);
 
-        if (cs.carryWood >= ClanWorldConstants.CLANSMAN_CARRY_CAP) {
+        if (cs.carryWood >= ClanWorldConstants.WOOD_CAP) {
             _completeMission(cs, m);
         }
     }

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -40,8 +40,8 @@ library ClanWorldConstants {
     uint64 internal constant CLANSMAN_COOLDOWN_SECONDS = 60;
 
     // Carry caps (per clansman)
-    uint256 internal constant CLANSMAN_CARRY_CAP = 10e18; // only enforced for wood gather
-    uint256 internal constant WOOD_CAP = CLANSMAN_CARRY_CAP;
+    uint256 internal constant CLANSMAN_CARRY_CAP = 10e18; // legacy generic cap; wood uses WOOD_CAP
+    uint256 internal constant WOOD_CAP = 15e18;
     uint256 internal constant IRON_CAP = 5e18;
     uint256 internal constant WHEAT_CAP = 40e18;
     uint256 internal constant FISH_CAP = 8e18;

--- a/packages/contracts/test/Gathering.t.sol
+++ b/packages/contracts/test/Gathering.t.sol
@@ -19,6 +19,11 @@ contract GatheringHarness is ClanWorld {
     function setCarryWood(uint32 csId, uint256 wood) external {
         _clansmen[csId].carryWood = wood;
     }
+
+    function setVaultFood(uint32 clanId, uint256 wheat, uint256 fish) external {
+        _clans[clanId].vaultWheat = wheat;
+        _clans[clanId].vaultFish = fish;
+    }
 }
 
 contract GatheringTest is Test {
@@ -114,11 +119,29 @@ contract GatheringTest is Test {
     function test_chopWoodClampsToCarryCap() public {
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
-        world.setCarryWood(csId, ClanWorldConstants.CLANSMAN_CARRY_CAP - 1e18);
+        world.setCarryWood(csId, ClanWorldConstants.WOOD_CAP - 1e18);
 
         Clansman memory cs = _settleChopWood(clanId, csId);
 
-        assertEq(cs.carryWood, ClanWorldConstants.CLANSMAN_CARRY_CAP, "wood carry cap");
+        assertEq(cs.carryWood, ClanWorldConstants.WOOD_CAP, "wood carry cap");
+    }
+
+    function test_starvationBeginsOnNextTickAfterUpkeepFailure() public {
+        uint32 clanId = _mintClan();
+        uint64 failureTick = world.getWorldState().currentTick;
+        world.setVaultFood(clanId, 0, 0);
+
+        _advanceTick();
+        world.settleClan(clanId);
+
+        ClanFullView memory failed = world.getClanFullView(clanId);
+        assertEq(failed.clan.clan.starvationStartsAtTick, failureTick + 1, "starvation starts next tick");
+        assertTrue(failed.clan.isStarving, "starving once next tick is current");
+
+        _advanceTick();
+
+        ClanFullView memory nextTick = world.getClanFullView(clanId);
+        assertTrue(nextTick.clan.isStarving, "starvation remains active without food");
     }
 
     function test_chopWoodAppliesCooldownPostSettle() public {


### PR DESCRIPTION
## Summary

2 v4-spec items from #347 deferred list (cost: tiny/small).

### Items shipped
- **#347 item 10** — Wood cap restored to 15e18 (was 10e18 via CLANSMAN_CARRY_CAP alias)
- **#347 item 14** — Starvation onset next-tick (starvationStartsAtTick = tick + 1; was same-tick)

### BLOCKED-PARTIAL
- Items 2-9 (yield constants per spec §4.7) — entangled with item 1 (continuous-vs-batched lifecycle); out of small-restoration scope.
- Items 11-13 (winter mechanics: wheat plot WinterLocked, upkeep 2× multiplier, wood burn) — deferred to Phase 10D (separate dispatch to gstack-dobot in flight).

### Notes
- Walks back v4.6 phase 5 economy alignment §5.2 same-tick starvation ratification → restored to v4 §4.11 next-tick semantics.
- Bandit defense path consumer audited: now correctly fires next-tick after upkeep failure.
- Authored by codex 5.5 high-reasoning. Orchestrator rescue-committed.

### Test plan
- [ ] forge test (couldn't run in worktree — CI will validate)
- [ ] Local 3-tier swarm review (orchestrator dispatching)
- [ ] Liam UAT

Closes #347 partial (items 10, 14)