### PR TITLE
Phase 9D — v4 bandit restoration (medium items)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -46,8 +46,9 @@ VITE_CLAN_WORLD_USE_STUB_LLM=true
 VITE_WORLD_APP_ID=
 VITE_WORLD_ACTION_ID=
 
-# Set to 'true' to bypass the "Open in World App" guard (for demo recording / judges testing in regular browser)
-VITE_DEMO_BYPASS_WORLD_GUARD=
+# Require the World App gate (Open in World App context + verification).
+# Set to 'true' for production/World App-only flows. Leave unset or 'false' for browser/demo.
+VITE_REQUIRE_WORLD_APP_GUARD=
 
 # ============================================================
 # Runner daemon (packages/runner) — Cycle A + Cycle B per Elder

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -14,8 +14,9 @@ VITE_WORLD_APP_ID=
 VITE_WORLD_ACTION_ID=
 VITE_WORLD_RP_ID=
 
-# Set to 'true' to bypass the "Open in World App" guard (for demo recording / judges testing in regular browser)
-VITE_DEMO_BYPASS_WORLD_GUARD=
+# Require the World App gate (Open in World App context + verification).
+# Set to 'true' for production/World App-only flows. Leave unset or 'false' for browser/demo.
+VITE_REQUIRE_WORLD_APP_GUARD=
 
 # Demo/dev mode: true = show mock clans, bandits, walls, canned travel (dev UX preserved)
 #                false = empty world with "no chain data yet" placeholder

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "VITE_DEMO_BYPASS_WORLD_GUARD=true vite",
+    "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
     stderr: 'pipe',
     env: {
       VITE_CLANWORLD_DEMO_MODE: process.env.VITE_CLANWORLD_DEMO_MODE ?? 'true',
-      VITE_DEMO_BYPASS_WORLD_GUARD: process.env.VITE_DEMO_BYPASS_WORLD_GUARD ?? 'true',
+      VITE_REQUIRE_WORLD_APP_GUARD: process.env.VITE_REQUIRE_WORLD_APP_GUARD ?? 'false',
     },
   },
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -39,7 +39,7 @@ const IDKIT_CONFIG: IDKitRequestHookConfig = {
 // Env flags moved to ./config/env to break the WorldMap ↔ App circular
 // dependency (PR #133 review MUST FIX #3). Re-exported here for any external
 // callers; new internal callers should import directly from ./config/env.
-import { DEMO_MODE, DEMO_BYPASS_WORLD_GUARD } from './config/env';
+import { DEMO_MODE, REQUIRE_WORLD_APP_GUARD } from './config/env';
 export { DEMO_MODE };
 
 /**
@@ -69,10 +69,10 @@ export function App() {
 
 function MainApp() {
   // When the demo bypass env is set, start verified=true so the WorldMap canvas
-  // renders immediately without an IDKit verify round-trip (which can't complete
-  // outside World App). Production default (env unset) keeps the full gate.
-  const [verified, setVerified] = useState(DEMO_BYPASS_WORLD_GUARD);
-  const isInWorldApp = MiniKit.isInstalled() || DEMO_BYPASS_WORLD_GUARD;
+  // When the guard is required, start verified=false and prompt for verification;
+  // otherwise render directly in browser/dev.
+  const [verified, setVerified] = useState(!REQUIRE_WORLD_APP_GUARD);
+  const isInWorldApp = MiniKit.isInstalled() || !REQUIRE_WORLD_APP_GUARD;
 
   const { open: openIDKit, result, isSuccess } = useIDKitRequest(IDKIT_CONFIG);
 
@@ -145,7 +145,7 @@ function MainApp() {
           Don't have World App? <a href="https://world.org/download" target="_blank" rel="noopener noreferrer" style={{ color: '#9bbf6f', textDecoration: 'underline' }}>Get it here</a>.
         </p>
         <p style={{ fontSize: '0.7rem', opacity: 0.4, textAlign: 'center', marginTop: '24px', fontFamily: 'monospace' }}>
-          For local dev: set <code>VITE_DEMO_BYPASS_WORLD_GUARD=true</code> or run <code>pnpm dev</code> (already set).
+          Set <code>VITE_REQUIRE_WORLD_APP_GUARD=true</code> to enforce the World App gate.
         </p>
       </main>
     );

--- a/apps/web/src/config/env.ts
+++ b/apps/web/src/config/env.ts
@@ -29,11 +29,11 @@
 export const DEMO_MODE = import.meta.env.VITE_CLANWORLD_DEMO_MODE !== 'false';
 
 /**
- * DEMO_BYPASS_WORLD_GUARD — bypass the "Open in World App" gate.
+ * REQUIRE_WORLD_APP_GUARD — require the user to be in World App context.
  *
- * When true, App.tsx skips the MiniKit.isInstalled() check and renders the
- * canvas directly. Set to 'true' permanently by `pnpm dev` script (see
- * `apps/web/package.json`); production builds default to false.
+ * true  (VITE_REQUIRE_WORLD_APP_GUARD='true'): render the Open-in-World-App
+ * gate unless the app is already installed in MiniKit.
+ * false/unset: bypass the gate and render directly in browser/dev.
  */
-export const DEMO_BYPASS_WORLD_GUARD =
-  import.meta.env.VITE_DEMO_BYPASS_WORLD_GUARD === 'true';
+export const REQUIRE_WORLD_APP_GUARD =
+  import.meta.env.VITE_REQUIRE_WORLD_APP_GUARD === 'true';

--- a/apps/web/tests/e2e/02-demo-mode.spec.ts
+++ b/apps/web/tests/e2e/02-demo-mode.spec.ts
@@ -40,10 +40,9 @@ test.describe('DEMO_MODE flag — mock clans (demo mode ON)', () => {
   );
 
   test('demo mode ON: mock clan names visible in scoreboard panel', async ({ page }) => {
-    // The app requires World App context OR VITE_DEMO_BYPASS_WORLD_GUARD=true to render
-    // past the "Open in World App to play" gate. The webServer config in
-    // playwright.config.ts sets VITE_DEMO_BYPASS_WORLD_GUARD=true at build time,
-    // so the gate is already bypassed in test builds — no querystring trick needed.
+    // The app requires the World App gate only when
+    // `VITE_REQUIRE_WORLD_APP_GUARD=true`. In this test environment,
+    // Playwright sets it to false so the page renders in browser directly.
     await page.goto('/');
 
     // Scoreboard pulse panel is rendered only in DEMO_MODE with scoreboardClans > 0.

--- a/docs/planning/DEMO_DRIFT.md
+++ b/docs/planning/DEMO_DRIFT.md
@@ -32,7 +32,7 @@ Enumerates every demo/fake/stub component in the codebase. Each entry notes: wha
 | `apps/web/src/WorldMap.tsx` — `DEMO_BANDIT` (line 198) | Hardcoded bandit state: region, `attacksAtTick`, attack power. Drives bandit sprite, danger pulse, countdown UI. | Phase 4 — replace with `getActiveBanditView()` result |
 | `apps/web/src/WorldMap.tsx` — `MOCK_WALL_LEVELS` (line 208) | Hardcoded wall levels per clan (indexed by `MOCK_CLANS` position). | Phase 4 — replace with `getClanFullView().clan.wallLevel` |
 | `apps/web/src/WorldMap.tsx` — canned travel loop (lines ~1176–1200) | Spawns continuous random travel dots between `MOCK_CLANS` home regions so the map always has motion. Not driven by real mission state. | Phase 4 — gate behind `VITE_CLANWORLD_DEMO_MODE`; real dots come from `getClanFullView().clansmen[].activeMission` |
-| `apps/web/src/App.tsx` — `VITE_DEMO_BYPASS_WORLD_GUARD` (line 41) | Build-time env flag. When `true`, skips the "Open in World App to play" MiniKit guard and starts in `verified=true` state. Allows local dev and submission demo to bypass World ID verification. | Phase 4 — remove flag and bypass; require real MiniKit install check |
+| `apps/web/src/App.tsx` — `VITE_REQUIRE_WORLD_APP_GUARD` (line 41) | Build-time env flag. When `true`, enforces the "Open in World App to play" MiniKit gate; when false, starts in `verified=true` and bypasses the gate for dev/demo browser runs. | Phase 4 — remove flag and bypass; require real MiniKit install check |
 
 ---
 
@@ -70,4 +70,4 @@ Enumerates every demo/fake/stub component in the codebase. Each entry notes: wha
 - Entries marked "Phase 4" correspond to the WorldMap canvas chain-wiring phase.
 - Entries marked "Phase 1" correspond to the Convex + chain client wiring phase.
 - `ClanWorldStub.sol` is intentionally kept indefinitely as a test double; "Phase 4" only means the stub is no longer the live deployment target.
-- The `VITE_DEMO_BYPASS_WORLD_GUARD` flag must be absent (or `false`) in any Submission 2 production build.
+- The `VITE_REQUIRE_WORLD_APP_GUARD` flag must be set to `true` to keep the World App gate in any Submission 2 production build.

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -296,6 +296,31 @@
               "name": "strength",
               "type": "uint32",
               "internalType": "uint32"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryGold",
+              "type": "uint256",
+              "internalType": "uint256"
             }
           ]
         }
@@ -366,6 +391,31 @@
               "name": "strength",
               "type": "uint32",
               "internalType": "uint32"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryGold",
+              "type": "uint256",
+              "internalType": "uint256"
             }
           ]
         }
@@ -3102,6 +3152,85 @@
           "type": "uint64",
           "indexed": false,
           "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "LootDistributed",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clanIdsRewarded",
+          "type": "uint32[]",
+          "indexed": false,
+          "internalType": "uint32[]"
+        },
+        {
+          "name": "perClanWood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "perClanWheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "perClanFish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "perClanIron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "perClanGold",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "burnedWood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "burnedWheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "burnedFish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "burnedIron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "burnedGold",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
         }
       ],
       "anonymous": false

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -9,6 +9,25 @@
     },
     {
       "type": "function",
+      "name": "getActionDuration",
+      "inputs": [
+        {
+          "name": "action",
+          "type": "uint8",
+          "internalType": "enum ActionType"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
       "name": "getActiveBanditView",
       "inputs": [],
       "outputs": [
@@ -234,80 +253,54 @@
     },
     {
       "type": "function",
-      "name": "getMissionTiming",
+      "name": "getBandit",
       "inputs": [
         {
-          "name": "clanId",
-          "type": "uint32",
-          "internalType": "uint32"
-        },
-        {
-          "name": "clansmanId",
+          "name": "banditId",
           "type": "uint32",
           "internalType": "uint32"
         }
       ],
       "outputs": [
         {
-          "name": "submitted",
-          "type": "uint64",
-          "internalType": "uint64"
-        },
-        {
-          "name": "executes",
-          "type": "uint64",
-          "internalType": "uint64"
-        },
-        {
-          "name": "settles",
-          "type": "uint64",
-          "internalType": "uint64"
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct BanditTroop",
+          "components": [
+            {
+              "name": "id",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "region",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum BanditState"
+            },
+            {
+              "name": "targetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "tickEnteredState",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "strength",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ]
         }
       ],
       "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "getActionDuration",
-      "inputs": [
-        {
-          "name": "action",
-          "type": "uint8",
-          "internalType": "enum ActionType"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint64",
-          "internalType": "uint64"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "getTravelTicks",
-      "inputs": [
-        {
-          "name": "fromRegion",
-          "type": "uint8",
-          "internalType": "uint8"
-        },
-        {
-          "name": "toRegion",
-          "type": "uint8",
-          "internalType": "uint8"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint64",
-          "internalType": "uint64"
-        }
-      ],
-      "stateMutability": "pure"
     },
     {
       "type": "function",
@@ -345,9 +338,14 @@
           "internalType": "struct BanditTroop",
           "components": [
             {
-              "name": "banditId",
+              "name": "id",
               "type": "uint32",
               "internalType": "uint32"
+            },
+            {
+              "name": "region",
+              "type": "uint8",
+              "internalType": "uint8"
             },
             {
               "name": "state",
@@ -355,56 +353,40 @@
               "internalType": "enum BanditState"
             },
             {
-              "name": "currentRegion",
-              "type": "uint8",
-              "internalType": "uint8"
+              "name": "targetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
             },
             {
-              "name": "attackAttemptsMade",
-              "type": "uint8",
-              "internalType": "uint8"
-            },
-            {
-              "name": "stateEnteredTick",
+              "name": "tickEnteredState",
               "type": "uint64",
               "internalType": "uint64"
             },
             {
-              "name": "nextActionTick",
-              "type": "uint64",
-              "internalType": "uint64"
-            },
-            {
-              "name": "tier",
-              "type": "uint8",
-              "internalType": "uint8"
-            },
-            {
-              "name": "attackPower",
-              "type": "uint16",
-              "internalType": "uint16"
-            },
-            {
-              "name": "carryWood",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "carryIron",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "carryWheat",
-              "type": "uint256",
-              "internalType": "uint256"
-            },
-            {
-              "name": "carryFish",
-              "type": "uint256",
-              "internalType": "uint256"
+              "name": "strength",
+              "type": "uint32",
+              "internalType": "uint32"
             }
           ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getBanditsInRegion",
+      "inputs": [
+        {
+          "name": "region",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
         }
       ],
       "stateMutability": "view"
@@ -1641,6 +1623,40 @@
     },
     {
       "type": "function",
+      "name": "getMissionTiming",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "submitted",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "executes",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "settles",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "getRegionPopulation",
       "inputs": [
         {
@@ -1750,6 +1766,30 @@
         }
       ],
       "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getTravelTicks",
+      "inputs": [
+        {
+          "name": "fromRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "toRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
     },
     {
       "type": "function",
@@ -2263,6 +2303,19 @@
       "inputs": [
         {
           "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "settleClansman",
+      "inputs": [
+        {
+          "name": "csId",
           "type": "uint32",
           "internalType": "uint32"
         }

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1970,6 +1970,16 @@
               "internalType": "bool"
             },
             {
+              "name": "currentSeasonNumber",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextHeartbeatAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
               "name": "winterActive",
               "type": "bool",
               "internalType": "bool"
@@ -2075,6 +2085,16 @@
               "name": "seasonFinalized",
               "type": "bool",
               "internalType": "bool"
+            },
+            {
+              "name": "currentSeasonNumber",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextHeartbeatAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
             },
             {
               "name": "nextHeartbeatAtTs",
@@ -2952,6 +2972,31 @@
     },
     {
       "type": "event",
+      "name": "ClansmanKilledByBandit",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
       "name": "ColdDamageApplied",
       "inputs": [
         {
@@ -3617,6 +3662,31 @@
           "type": "uint64",
           "indexed": false,
           "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WallDamagedByBandit",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "newLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
         }
       ],
       "anonymous": false

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2872,6 +2872,31 @@
     },
     {
       "type": "event",
+      "name": "BlueprintEarned",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
       "name": "BlueprintTransferred",
       "inputs": [
         {

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2912,6 +2912,12 @@
           "internalType": "uint32"
         },
         {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
           "name": "tick",
           "type": "uint64",
           "indexed": false,

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2816,6 +2816,31 @@
     },
     {
       "type": "event",
+      "name": "BanditTargetDied",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "deadClanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
       "name": "BaseLevelChanged",
       "inputs": [
         {

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1116,6 +1116,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (defeated) {
             emit BanditDefeated(banditId, targetClanId, closedTick);
             _distributeBanditLootToDefendingClans(banditId, targetClanId);
+            targetClan.blueprintBalance += 1;
+            emit BlueprintEarned(targetClanId, banditId, closedTick);
             _transitionBanditState(banditId, BanditState.Defeated);
         } else {
             _transitionBanditState(banditId, BanditState.Escaped);

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -103,6 +103,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint256 internal constant MAX_BANDIT_EAGER_SETTLE_DEFENDER_SCAN_PER_REGION = 48;
     uint32 internal constant MIN_BANDIT_SPAWN_STRENGTH = 100;
     uint32 internal constant BANDIT_SPAWN_STRENGTH_SPREAD = 151;
+    uint32 internal constant CLANSMAN_MAX_DEFENSE_DAMAGE = 100;
+    uint32 internal constant WALL_HP_PER_LEVEL = 100;
+    uint32 internal constant BASE_HP_PER_LEVEL = 25;
+    uint32 internal constant CLANSMAN_HP = 100;
 
     struct BanditSpawnState {
         uint64 lastSpawnTick;
@@ -1029,6 +1033,233 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return uint16(strength);
     }
 
+    function _resolveAttackingBandits(uint64 closedTick) internal {
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            uint32[] storage regionBandits = _banditsByRegion[region];
+            uint256 i = 0;
+            while (i < regionBandits.length) {
+                uint32 banditId = regionBandits[i];
+                BanditTroop storage bandit = _bandits[banditId];
+                bool shouldResolve =
+                    bandit.state == BanditState.Attacking && bandit.tickEnteredState == closedTick;
+                if (shouldResolve) {
+                    _resolveBanditAttack(banditId, closedTick);
+                    if (_bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) {
+                        continue;
+                    }
+                }
+                i++;
+            }
+        }
+    }
+
+    function _resolveBanditAttack(uint32 banditId, uint64 closedTick) internal {
+        require(_world.currentTick == closedTick, "ClanWorld: bandit attack tick mismatch");
+
+        BanditTroop storage bandit = _bandits[banditId];
+        if (bandit.id == ClanWorldConstants.BANDIT_ID_NULL || bandit.state != BanditState.Attacking) {
+            return;
+        }
+        if (bandit.tickEnteredState != closedTick) {
+            return;
+        }
+
+        uint32 targetClanId = bandit.targetClanId;
+        Clan storage targetClan = _clans[targetClanId];
+        if (targetClan.clanId == ClanWorldConstants.CLAN_ID_NULL || targetClan.clanState == ClanState.DEAD) {
+            _transitionBanditState(banditId, BanditState.Escaped);
+            emit BanditEscaped(banditId, closedTick);
+            return;
+        }
+
+        _settleClan(targetClanId);
+        _eagerSettleActiveDefendersForBase(targetClanId, targetClan.baseRegion);
+
+        bytes32 tickSeed = _world.currentTickSeed;
+        uint32 banditAttackPower = bandit.strength;
+        uint32 totalClansmanDefense = _totalBanditClansmanDefense(banditId, targetClanId, tickSeed);
+        bool defeated = uint256(totalClansmanDefense) >= uint256(banditAttackPower) * 2;
+
+        uint32 wallDamage;
+        uint32 baseAbsorbed;
+        uint32 clansmanDamageAbsorbed;
+        if (!defeated) {
+            uint32 incomingDamage =
+                banditAttackPower > totalClansmanDefense ? banditAttackPower - totalClansmanDefense : 0;
+            (incomingDamage, wallDamage) = _applyBanditWallDamage(targetClan, targetClanId, banditId, incomingDamage);
+            (incomingDamage, baseAbsorbed) = _applyBanditBaseDefense(targetClan, incomingDamage);
+            clansmanDamageAbsorbed =
+                _applyBanditClansmanCasualties(targetClan, targetClanId, banditId, incomingDamage, tickSeed);
+        }
+
+        uint32 totalDefense = totalClansmanDefense + wallDamage + baseAbsorbed + clansmanDamageAbsorbed;
+        emit BanditAttackResolved(
+            banditId,
+            targetClanId,
+            defeated,
+            _uint16Clamp(banditAttackPower),
+            _uint16Clamp(totalDefense),
+            targetClan.wallLevel,
+            0,
+            0,
+            0,
+            0,
+            closedTick
+        );
+
+        if (defeated) {
+            emit BanditDefeated(banditId, targetClanId, closedTick);
+            _transitionBanditState(banditId, BanditState.Defeated);
+        } else {
+            _transitionBanditState(banditId, BanditState.Escaped);
+            emit BanditEscaped(banditId, closedTick);
+        }
+    }
+
+    function _totalBanditClansmanDefense(uint32 banditId, uint32 targetClanId, bytes32 tickSeed)
+        internal
+        view
+        returns (uint32 totalDefense)
+    {
+        uint8 targetRegion = _clans[targetClanId].baseRegion;
+        uint32[] storage defendingClans = _defendingClansByRegion[targetRegion];
+
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            uint32 defenderClanId = defendingClans[i];
+            Clan storage defenderClan = _clans[defenderClanId];
+            if (defenderClan.clanState == ClanState.DEAD || _isStarving(defenderClan)) {
+                continue;
+            }
+
+            uint32[] storage clansmanIds = _clanClansmanIds[defenderClanId];
+            for (uint256 j = 0; j < clansmanIds.length; j++) {
+                uint32 clansmanId = clansmanIds[j];
+                Clansman storage cs = _clansmen[clansmanId];
+                Mission storage mission = _missions[clansmanId];
+                if (
+                    cs.state == ClansmanState.ACTING && cs.currentRegion == targetRegion && mission.active
+                        && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId
+                ) {
+                    totalDefense += _clansmanDefenseDamageRoll(tickSeed, banditId, clansmanId);
+                }
+            }
+        }
+    }
+
+    function _applyBanditWallDamage(Clan storage clan, uint32 clanId, uint32 banditId, uint32 incomingDamage)
+        internal
+        returns (uint32 remainingDamage, uint32 wallDamage)
+    {
+        remainingDamage = incomingDamage;
+        if (remainingDamage == 0 || clan.wallLevel == 0) {
+            return (remainingDamage, 0);
+        }
+
+        wallDamage = remainingDamage < WALL_HP_PER_LEVEL ? remainingDamage : WALL_HP_PER_LEVEL;
+        remainingDamage -= wallDamage;
+        if (wallDamage >= WALL_HP_PER_LEVEL) {
+            if (clan.wallLevel > 0) {
+                clan.wallLevel--;
+            }
+            emit WallDamagedByBandit(clanId, clan.wallLevel, banditId);
+        }
+    }
+
+    function _applyBanditBaseDefense(Clan storage clan, uint32 incomingDamage)
+        internal
+        view
+        returns (uint32 remainingDamage, uint32 baseAbsorbed)
+    {
+        remainingDamage = incomingDamage;
+        if (remainingDamage == 0 || clan.baseLevel == 0) {
+            return (remainingDamage, 0);
+        }
+
+        uint32 baseDefense = uint32(clan.baseLevel) * BASE_HP_PER_LEVEL;
+        baseAbsorbed = remainingDamage < baseDefense ? remainingDamage : baseDefense;
+        remainingDamage -= baseAbsorbed;
+    }
+
+    function _applyBanditClansmanCasualties(
+        Clan storage clan,
+        uint32 clanId,
+        uint32 banditId,
+        uint32 incomingDamage,
+        bytes32 tickSeed
+    ) internal returns (uint32 damageAbsorbed) {
+        uint32 remainingDamage = incomingDamage;
+        uint32 killIndex = 0;
+        while (remainingDamage > 0) {
+            uint32 victimId = _pickBanditClansmanVictim(clanId, banditId, killIndex, tickSeed);
+            if (victimId == 0) {
+                break;
+            }
+
+            Clansman storage victim = _clansmen[victimId];
+            victim.state = ClansmanState.DEAD;
+            victim.cooldownEndsAtTs = 0;
+            _clearDefender(victimId);
+            Mission storage mission = _missions[victimId];
+            mission.active = false;
+            if (clan.livingClansmen > 0) {
+                clan.livingClansmen--;
+            }
+
+            uint32 absorbed = remainingDamage < CLANSMAN_HP ? remainingDamage : CLANSMAN_HP;
+            damageAbsorbed += absorbed;
+            remainingDamage -= absorbed;
+            emit ClansmanKilledByBandit(clanId, victimId, banditId);
+            killIndex++;
+        }
+    }
+
+    function _pickBanditClansmanVictim(uint32 clanId, uint32 banditId, uint32 killIndex, bytes32 tickSeed)
+        internal
+        view
+        returns (uint32 victimId)
+    {
+        uint32[] storage clansmanIds = _clanClansmanIds[clanId];
+        uint256 livingCount;
+        for (uint256 i = 0; i < clansmanIds.length; i++) {
+            if (_clansmen[clansmanIds[i]].state != ClansmanState.DEAD) {
+                livingCount++;
+            }
+        }
+        if (livingCount == 0) {
+            return 0;
+        }
+
+        uint256 pick = uint256(keccak256(abi.encode("bandit_clansman_kill", tickSeed, banditId, clanId, killIndex)))
+            % livingCount;
+        uint256 seen;
+        for (uint256 i = 0; i < clansmanIds.length; i++) {
+            uint32 candidateId = clansmanIds[i];
+            if (_clansmen[candidateId].state == ClansmanState.DEAD) {
+                continue;
+            }
+            if (seen == pick) {
+                return candidateId;
+            }
+            seen++;
+        }
+    }
+
+    function _clansmanDefenseDamageRoll(bytes32 tickSeed, uint32 banditId, uint32 clansmanId)
+        internal
+        pure
+        returns (uint32)
+    {
+        return uint32(
+            uint256(keccak256(abi.encode("clansman_defense", tickSeed, banditId, clansmanId)))
+                % (CLANSMAN_MAX_DEFENSE_DAMAGE + 1)
+        );
+    }
+
+    function _uint16Clamp(uint32 value) internal pure returns (uint16) {
+        if (value > type(uint16).max) return type(uint16).max;
+        return uint16(value);
+    }
+
     function _evaluateBanditSpawns(bytes32 tickSeed) internal {
         uint256[] memory regionWeights = _banditSpawnRegionWeights();
         if (_activeBanditCount >= MAX_TOTAL_BANDITS) {
@@ -1269,13 +1500,16 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         // Step 3: Eager-settle bases and active defenders in bandit spawn-candidate regions.
         _eagerSettleForBandits(closedTick);
 
-        // Step 4: Evaluate deterministic bandit spawns for the closed tick.
+        // Step 4: Resolve deterministic bandit attacks for the closed tick.
+        _resolveAttackingBandits(closedTick);
+
+        // Step 5: Evaluate deterministic bandit spawns for the closed tick.
         _evaluateBanditSpawns(closedTickSeed);
 
-        // Step 5: Resolve world events (season boundary, winter transitions).
+        // Step 6: Resolve world events (season boundary, winter transitions).
         _resolveWorldEvents(closedTick);
 
-        // Step 6: Increment tick and publish the opened tick seed as one visible state transition.
+        // Step 7: Increment tick and publish the opened tick seed as one visible state transition.
         uint64 newTick = closedTick + 1;
         bytes32 newSeed = keccak256(abi.encode(block.prevrandao, closedTickSeed, closedTick));
         _world.currentTick = newTick;

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -60,10 +60,13 @@ contract ClanWorld is IClanWorld {
     mapping(uint8 => uint32[]) private _defendingClansByRegion; // home region => unique defending clanIds
     mapping(uint8 => mapping(uint32 => uint256)) private _defenderCountByRegionClan; // region => clanId => clansmen count
     mapping(uint32 => uint8) private _clansmanDefendingRegion; // clansmanId => defended home region
+    mapping(uint32 => BanditTroop) internal _bandits;
+    mapping(uint8 => uint32[]) internal _banditsByRegion; // region => bandit IDs
     mapping(uint64 => bytes32) private _tickSeeds; // tick => seed
 
     uint32 private _nextClanId;
     uint32 private _nextClansmanId;
+    uint32 internal _nextBanditId;
     uint32[] private _allClanIds;
 
     // per-clan clansman list: clanId => clansmanId[]
@@ -89,6 +92,7 @@ contract ClanWorld is IClanWorld {
         _treasury.treasuryOwner = msg.sender;
         _nextClanId = 1;
         _nextClansmanId = 1;
+        _nextBanditId = 1;
     }
 
     // =========================================================================
@@ -849,6 +853,119 @@ contract ClanWorld is IClanWorld {
         cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
         m.active = false;
         emit MissionCompleted(_clans[cs.clanId].clanId, cs.clansmanId, m.nonce, m.action);
+    }
+
+    // =========================================================================
+    // BANDIT STATE MACHINE
+    // =========================================================================
+
+    function _spawnBandit(uint8 region, uint32 strength) internal returns (uint32 id) {
+        require(
+            region >= ClanWorldConstants.REGION_FOREST && region <= ClanWorldConstants.REGION_DEEP_SEA,
+            "ClanWorld: invalid bandit region"
+        );
+        require(strength > 0, "ClanWorld: invalid bandit strength");
+
+        id = _nextBanditId++;
+        _bandits[id] = BanditTroop({
+            id: id,
+            region: region,
+            state: BanditState.Spawned,
+            targetClanId: 0,
+            tickEnteredState: _world.currentTick,
+            strength: strength
+        });
+        _banditsByRegion[region].push(id);
+
+        if (_world.activeBanditId == ClanWorldConstants.BANDIT_ID_NULL) {
+            _world.activeBanditId = id;
+        }
+
+        emit BanditSpawned(id, region, 0, _banditStrengthForLegacyEvent(strength));
+    }
+
+    function _transitionBanditToAttacking(uint32 id, uint32 targetClanId) internal {
+        require(targetClanId != ClanWorldConstants.CLAN_ID_NULL, "ClanWorld: invalid bandit target");
+        _bandits[id].targetClanId = targetClanId;
+        _transitionBanditState(id, BanditState.Attacking);
+    }
+
+    function _transitionBanditState(uint32 id, BanditState newState) internal {
+        BanditTroop storage bandit = _bandits[id];
+        require(bandit.id != ClanWorldConstants.BANDIT_ID_NULL, "ClanWorld: bandit not found");
+        require(newState != BanditState.None, "ClanWorld: invalid bandit transition");
+
+        BanditState oldState = bandit.state;
+        require(_isValidBanditTransition(bandit, newState), "ClanWorld: invalid bandit transition");
+
+        if (newState == BanditState.Defeated) {
+            emit BanditStateChanged(id, oldState, newState, bandit.region, _world.currentTick);
+            _deleteBandit(id);
+            return;
+        }
+
+        bandit.state = newState;
+        bandit.tickEnteredState = _world.currentTick;
+        if (newState != BanditState.Attacking) {
+            bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
+        }
+
+        emit BanditStateChanged(id, oldState, newState, bandit.region, _world.currentTick);
+    }
+
+    function _isValidBanditTransition(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
+        if (bandit.state == BanditState.Spawned) return _canBanditLeaveSpawned(bandit, newState);
+        if (bandit.state == BanditState.Camped) return _canBanditLeaveCamped(bandit, newState);
+        if (bandit.state == BanditState.Attacking) return _canBanditLeaveAttacking(newState);
+        if (bandit.state == BanditState.Escaped) return _canBanditLeaveEscaped(newState);
+        if (bandit.state == BanditState.Resting) return _canBanditLeaveResting(bandit, newState);
+        return false;
+    }
+
+    function _canBanditLeaveSpawned(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
+        return newState == BanditState.Camped && _world.currentTick >= bandit.tickEnteredState + 1;
+    }
+
+    function _canBanditLeaveCamped(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
+        return newState == BanditState.Attacking && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
+            && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
+    }
+
+    function _canBanditLeaveAttacking(BanditState newState) internal pure returns (bool) {
+        return newState == BanditState.Defeated || newState == BanditState.Escaped;
+    }
+
+    function _canBanditLeaveEscaped(BanditState newState) internal pure returns (bool) {
+        return newState == BanditState.Resting;
+    }
+
+    function _canBanditLeaveResting(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
+        return newState == BanditState.Camped
+            && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS;
+    }
+
+    function _deleteBandit(uint32 id) internal {
+        BanditTroop storage bandit = _bandits[id];
+        uint8 region = bandit.region;
+        uint32[] storage regionBandits = _banditsByRegion[region];
+        for (uint256 i = 0; i < regionBandits.length; i++) {
+            if (regionBandits[i] == id) {
+                regionBandits[i] = regionBandits[regionBandits.length - 1];
+                regionBandits.pop();
+                break;
+            }
+        }
+
+        delete _bandits[id];
+        if (_world.activeBanditId == id) {
+            _world.activeBanditId = ClanWorldConstants.BANDIT_ID_NULL;
+        }
+    }
+
+    function _banditStrengthForLegacyEvent(uint32 strength) internal pure returns (uint16) {
+        if (strength > type(uint16).max) return type(uint16).max;
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint16(strength);
     }
 
     // =========================================================================
@@ -1716,21 +1833,23 @@ contract ClanWorld is IClanWorld {
         return uint64(_travelTicks(fromRegion, toRegion));
     }
 
-    function getBanditTroop(uint32) external pure override returns (BanditTroop memory) {
-        return BanditTroop({
-            banditId: 0,
-            state: BanditState.NONE,
-            currentRegion: 0,
-            attackAttemptsMade: 0,
-            stateEnteredTick: 0,
-            nextActionTick: 0,
-            tier: 0,
-            attackPower: 0,
-            carryWood: 0,
-            carryIron: 0,
-            carryWheat: 0,
-            carryFish: 0
-        });
+    function getBandit(uint32 banditId) public view override returns (BanditTroop memory) {
+        BanditTroop memory bandit = _bandits[banditId];
+        if (bandit.id == ClanWorldConstants.BANDIT_ID_NULL || bandit.state == BanditState.None) {
+            return
+                BanditTroop({
+                    id: 0, region: 0, state: BanditState.None, targetClanId: 0, tickEnteredState: 0, strength: 0
+                });
+        }
+        return bandit;
+    }
+
+    function getBanditTroop(uint32 banditId) external view override returns (BanditTroop memory) {
+        return getBandit(banditId);
+    }
+
+    function getBanditsInRegion(uint8 region) external view override returns (uint32[] memory) {
+        return _banditsByRegion[region];
     }
 
     function getWheatPlots(uint32 clanId)
@@ -1815,8 +1934,8 @@ contract ClanWorld is IClanWorld {
         });
     }
 
-    function getBanditTargetPreview(uint32) external pure override returns (uint32) {
-        return 0; // Phase 3
+    function getBanditTargetPreview(uint32 banditId) external view override returns (uint32) {
+        return _bandits[banditId].targetClanId;
     }
 
     function quoteTravel(uint8 srcRegion, uint8 dstRegion)
@@ -1960,23 +2079,34 @@ contract ClanWorld is IClanWorld {
         pr.spotPriceGoldPerResource = rA > 0 ? (rB * 1e18) / rA : 0;
     }
 
-    function getActiveBanditView() external pure override returns (ActiveBanditView memory) {
+    function getActiveBanditView() external view override returns (ActiveBanditView memory) {
+        BanditTroop memory bandit = _bandits[_world.activeBanditId];
+        uint64 nextActionTick = 0;
+        bool exists = bandit.id != ClanWorldConstants.BANDIT_ID_NULL && bandit.state != BanditState.None;
+        if (exists) {
+            if (bandit.state == BanditState.Camped) {
+                nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
+            } else if (bandit.state == BanditState.Resting) {
+                nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS;
+            }
+        }
+
         return ActiveBanditView({
-            exists: false,
-            banditId: 0,
-            state: BanditState.NONE,
-            currentRegion: 0,
+            exists: exists,
+            banditId: bandit.id,
+            state: bandit.state,
+            currentRegion: bandit.region,
             attackAttemptsMade: 0,
             maxAttemptsRemaining: 0,
-            stateEnteredTick: 0,
-            nextActionTick: 0,
+            stateEnteredTick: bandit.tickEnteredState,
+            nextActionTick: nextActionTick,
             tier: 0,
-            attackPower: 0,
+            attackPower: _banditStrengthForLegacyEvent(bandit.strength),
             carryWood: 0,
             carryIron: 0,
             carryWheat: 0,
             carryFish: 0,
-            projectedTargetClanId: 0,
+            projectedTargetClanId: bandit.targetClanId,
             projectedTargetLootValue: 0
         });
     }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -114,6 +114,13 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint16 probabilityAccum;
     }
 
+    struct SettlementSimulation {
+        Clan clan;
+        Clansman[] clansmen;
+        Mission[] missions;
+        WheatPlot[2] wheatPlots;
+    }
+
     // =========================================================================
     // CONSTRUCTOR
     // =========================================================================
@@ -1017,6 +1024,486 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
         m.active = false;
         emit MissionCompleted(_clans[cs.clanId].clanId, cs.clansmanId, m.nonce, m.action);
+    }
+
+    // -------------------------------------------------------------------------
+    // View-only settlement simulation
+    // -------------------------------------------------------------------------
+
+    function _simulateSettleToTick(uint32 clanId, uint64 toTick)
+        internal
+        view
+        returns (SettlementSimulation memory sim)
+    {
+        sim.clan = _clans[clanId];
+        if (sim.clan.clanId == ClanWorldConstants.CLAN_ID_NULL) return sim;
+
+        uint32[] storage clansmanIds = _clanClansmanIds[clanId];
+        sim.clansmen = new Clansman[](clansmanIds.length);
+        sim.missions = new Mission[](clansmanIds.length);
+        for (uint256 i = 0; i < clansmanIds.length; i++) {
+            uint32 clansmanId = clansmanIds[i];
+            sim.clansmen[i] = _clansmen[clansmanId];
+            sim.missions[i] = _missions[clansmanId];
+        }
+        sim.wheatPlots[0] = _wheatPlots[clanId][0];
+        sim.wheatPlots[1] = _wheatPlots[clanId][1];
+
+        uint64 fromTick = sim.clan.lastSettledTick;
+        if (fromTick >= toTick) return sim;
+
+        for (uint64 tick = fromTick; tick < toTick; tick++) {
+            _simulateApplyUpkeep(sim, tick);
+            if (sim.clan.clanState == ClanState.DEAD) break;
+
+            _simulateRegrowWheatPlots(sim, tick);
+
+            for (uint256 i = 0; i < sim.clansmen.length; i++) {
+                _simulateSettleMissionForClansman(sim, i, tick, tick + 1);
+            }
+        }
+
+        sim.clan.lastSettledTick = toTick;
+    }
+
+    function _simulateApplyUpkeep(SettlementSimulation memory sim, uint64 tick) internal view {
+        if (sim.clan.livingClansmen == 0) return;
+
+        uint256 wheatNeeded = uint256(sim.clan.livingClansmen) * ClanWorldConstants.WHEAT_UPKEEP_PER_CLANSMAN;
+        uint256 fishNeeded = uint256(sim.clan.livingClansmen) * ClanWorldConstants.FISH_UPKEEP_PER_CLANSMAN;
+
+        bool hadEnoughWheat = sim.clan.vaultWheat >= wheatNeeded;
+        bool hadEnoughFish = sim.clan.vaultFish >= fishNeeded;
+
+        sim.clan.vaultWheat = hadEnoughWheat ? sim.clan.vaultWheat - wheatNeeded : 0;
+        sim.clan.vaultFish = hadEnoughFish ? sim.clan.vaultFish - fishNeeded : 0;
+
+        bool starving = !hadEnoughWheat || !hadEnoughFish;
+        if (starving && sim.clan.starvationStartsAtTick == 0) {
+            sim.clan.starvationStartsAtTick = tick;
+        } else if (!starving && sim.clan.starvationStartsAtTick != 0) {
+            sim.clan.starvationStartsAtTick = 0;
+        }
+
+        if (starving && _world.winterActive && sim.clan.starvationStartsAtTick >= _world.winterStartsAtTick) {
+            _simulateKillNextClansmanFromStarvation(sim);
+        }
+    }
+
+    function _simulateKillNextClansmanFromStarvation(SettlementSimulation memory sim) internal pure {
+        if (sim.clan.livingClansmen == 0) return;
+
+        for (uint256 i = 0; i < sim.clansmen.length; i++) {
+            if (sim.clansmen[i].state == ClansmanState.DEAD) continue;
+
+            _simulateMarkClansmanDead(sim, i);
+            if (sim.clan.livingClansmen == 0) {
+                _simulateMarkClanDead(sim);
+            }
+            return;
+        }
+    }
+
+    function _simulateMarkClansmanDead(SettlementSimulation memory sim, uint256 index) internal pure {
+        if (sim.clansmen[index].state == ClansmanState.DEAD) return;
+
+        sim.clansmen[index].state = ClansmanState.DEAD;
+        sim.clansmen[index].cooldownEndsAtTs = 0;
+        if (sim.clan.livingClansmen > 0) {
+            sim.clan.livingClansmen--;
+        }
+        if (sim.missions[index].active) {
+            sim.missions[index].active = false;
+        }
+    }
+
+    function _simulateMarkClanDead(SettlementSimulation memory sim) internal pure {
+        if (sim.clan.clanId == ClanWorldConstants.CLAN_ID_NULL || sim.clan.clanState == ClanState.DEAD) return;
+
+        sim.clan.clanState = ClanState.DEAD;
+        sim.clan.vaultWood = 0;
+        sim.clan.vaultWheat = 0;
+        sim.clan.vaultFish = 0;
+        sim.clan.vaultIron = 0;
+        sim.clan.starvationStartsAtTick = 0;
+        sim.clan.livingClansmen = 0;
+
+        for (uint256 i = 0; i < sim.clansmen.length; i++) {
+            sim.clansmen[i].state = ClansmanState.DEAD;
+            sim.clansmen[i].cooldownEndsAtTs = 0;
+            if (sim.missions[i].active) {
+                sim.missions[i].active = false;
+            }
+        }
+    }
+
+    function _simulateRegrowWheatPlots(SettlementSimulation memory sim, uint64 tick) internal pure {
+        for (uint256 pi = 0; pi < 2; pi++) {
+            WheatPlot memory plot = sim.wheatPlots[pi];
+            if (plot.state == WheatPlotState.Regrowing && tick >= plot.regrowUntilTick) {
+                plot.state = WheatPlotState.Harvestable;
+                plot.remainingWheat = ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT;
+                plot.regrowUntilTick = 0;
+                sim.wheatPlots[pi] = plot;
+            }
+        }
+    }
+
+    function _simulateSettleMissionForClansman(
+        SettlementSimulation memory sim,
+        uint256 index,
+        uint64 fromTick,
+        uint64 toTick
+    ) internal view {
+        Clansman memory cs = sim.clansmen[index];
+        Mission memory m = sim.missions[index];
+
+        if (cs.state == ClansmanState.DEAD) {
+            if (m.active) {
+                m.active = false;
+            }
+            sim.missions[index] = m;
+            return;
+        }
+
+        if (!m.active) return;
+
+        for (uint64 tick = fromTick; tick < toTick; tick++) {
+            bytes32 tickSeed = _tickSeeds[tick];
+
+            if (cs.state == ClansmanState.TRAVELING && tick >= m.arrivalTick) {
+                cs.state = ClansmanState.ACTING;
+                cs.currentRegion = m.targetRegion;
+            }
+
+            if (m.action == ActionType.DefendBase) continue;
+
+            if (cs.state == ClansmanState.ACTING && tick >= m.settlesAtTick) {
+                (cs, m) = _simulateResolveAction(sim, cs, m, tick, tickSeed);
+                if (m.active && getActionDuration(m.action) > 0) {
+                    (cs, m) = _simulateCompleteMission(cs, m);
+                }
+            }
+
+            if (!m.active) break;
+        }
+
+        sim.clansmen[index] = cs;
+        sim.missions[index] = m;
+    }
+
+    function _simulateResolveAction(
+        SettlementSimulation memory sim,
+        Clansman memory cs,
+        Mission memory m,
+        uint64 tick,
+        bytes32 tickSeed
+    ) internal view returns (Clansman memory, Mission memory) {
+        bool starving =
+            sim.clan.starvationStartsAtTick != 0 && sim.clan.starvationStartsAtTick <= _world.currentTick;
+        ActionType action = m.action;
+
+        if (action == ActionType.ChopWood) {
+            (cs, m) = _simulateGatherWood(cs, m, tick, starving, tickSeed);
+        } else if (action == ActionType.MineIron) {
+            (cs, m) = _simulateGatherIron(sim, cs, m, tick, starving, tickSeed);
+        } else if (action == ActionType.FishDocks) {
+            (cs, m) = _simulateGatherFish(cs, m, tick, starving, tickSeed, ClanWorldConstants.FISH_DOCKS_BPS);
+        } else if (action == ActionType.FishDeepSea) {
+            (cs, m) = _simulateGatherFish(cs, m, tick, starving, tickSeed, ClanWorldConstants.FISH_DEEP_BPS);
+        } else if (action == ActionType.HarvestWheat) {
+            (cs, m) = _simulateGatherWheat(sim, cs, m, tick, starving);
+        } else if (action == ActionType.DepositResources) {
+            (cs, m) = _simulateDoDeposit(sim, cs, m);
+        } else if (
+            action == ActionType.BuildWall || action == ActionType.UpgradeBase || action == ActionType.UpgradeMonument
+        ) {
+            (cs, m) = _simulateDoBuilding(sim, cs, m, action);
+        } else if (action == ActionType.MarketBuy || action == ActionType.MarketSell) {
+            (cs, m) = _simulateCompleteMission(cs, m);
+        }
+
+        return (cs, m);
+    }
+
+    function _simulateGatherWood(Clansman memory cs, Mission memory m, uint64 tick, bool starving, bytes32 tickSeed)
+        internal
+        view
+        returns (Clansman memory, Mission memory)
+    {
+        uint256 remaining = ClanWorldConstants.WOOD_CAP - cs.carryWood;
+        if (remaining == 0) return _simulateCompleteMission(cs, m);
+
+        uint256 yield = ClanWorldConstants.WOOD_BASE_YIELD;
+        bytes32 critRng = keccak256(abi.encode("wood_crit", tickSeed, cs.clansmanId, m.nonce, tick));
+        if (uint256(critRng) % 10000 < ClanWorldConstants.WOOD_CRIT_BPS) {
+            yield += ClanWorldConstants.WOOD_CRIT_BONUS;
+        }
+        if (starving) yield = yield / 2;
+        if (yield > remaining) yield = remaining;
+        cs.carryWood += yield;
+
+        if (cs.carryWood >= ClanWorldConstants.WOOD_CAP) {
+            return _simulateCompleteMission(cs, m);
+        }
+        return (cs, m);
+    }
+
+    function _simulateGatherIron(
+        SettlementSimulation memory sim,
+        Clansman memory cs,
+        Mission memory m,
+        uint64 tick,
+        bool starving,
+        bytes32 tickSeed
+    ) internal view returns (Clansman memory, Mission memory) {
+        uint256 remaining = ClanWorldConstants.IRON_CAP - cs.carryIron;
+        if (remaining == 0) return _simulateCompleteMission(cs, m);
+
+        uint256 yield = ClanWorldConstants.IRON_BASE_YIELD;
+        if (starving) yield = yield / 2;
+        if (yield > remaining) yield = remaining;
+        cs.carryIron += yield;
+
+        bytes32 goldRng = keccak256(abi.encode("iron_gold_bonus", tickSeed, cs.clansmanId, m.nonce, tick));
+        if (uint256(goldRng) % 10000 < ClanWorldConstants.GOLD_FROM_IRON_BPS) {
+            sim.clan.goldBalance += ClanWorldConstants.GOLD_FROM_IRON_AMOUNT;
+        }
+
+        if (cs.carryIron >= ClanWorldConstants.IRON_CAP) {
+            return _simulateCompleteMission(cs, m);
+        }
+        return (cs, m);
+    }
+
+    function _simulateGatherFish(
+        Clansman memory cs,
+        Mission memory m,
+        uint64 tick,
+        bool starving,
+        bytes32 tickSeed,
+        uint256 successBps
+    ) internal view returns (Clansman memory, Mission memory) {
+        uint256 remaining = ClanWorldConstants.FISH_CAP - cs.carryFish;
+        if (remaining == 0) return _simulateCompleteMission(cs, m);
+
+        bytes32 fishRng = keccak256(abi.encode("fish_roll", tickSeed, cs.clansmanId, m.nonce, tick));
+        uint256 yield = uint256(fishRng) % 10000 < successBps ? RESOURCE_UNIT : 0;
+        if (starving) yield = yield / 2;
+        if (yield > remaining) yield = remaining;
+        if (yield > 0) {
+            cs.carryFish += yield;
+        }
+
+        if (cs.carryFish >= ClanWorldConstants.FISH_CAP) {
+            return _simulateCompleteMission(cs, m);
+        }
+        return (cs, m);
+    }
+
+    function _simulateGatherWheat(
+        SettlementSimulation memory sim,
+        Clansman memory cs,
+        Mission memory m,
+        uint64 tick,
+        bool starving
+    ) internal view returns (Clansman memory, Mission memory) {
+        uint256 remaining = ClanWorldConstants.WHEAT_CAP - cs.carryWheat;
+        if (remaining == 0) return _simulateCompleteMission(cs, m);
+
+        uint256 plotIdx;
+        if (m.targetRegion == ClanWorldConstants.REGION_WEST_FARMS) {
+            plotIdx = 0;
+        } else if (m.targetRegion == ClanWorldConstants.REGION_EAST_FARMS) {
+            plotIdx = 1;
+        } else {
+            return _simulateCompleteMission(cs, m);
+        }
+
+        WheatPlot memory plot = sim.wheatPlots[plotIdx];
+        if (plot.state != WheatPlotState.Harvestable || plot.remainingWheat == 0) {
+            return _simulateCompleteMission(cs, m);
+        }
+
+        uint256 yield = WHEAT_HARVEST_RATE;
+        if (starving) yield = yield / 2;
+        if (yield > remaining) yield = remaining;
+        if (yield > plot.remainingWheat) yield = plot.remainingWheat;
+
+        cs.carryWheat += yield;
+        plot.remainingWheat -= yield;
+
+        if (plot.remainingWheat == 0) {
+            plot.state = WheatPlotState.Regrowing;
+            plot.regrowUntilTick = _addTicksClamped(tick, ClanWorldConstants.WHEAT_PLOT_REGROW_TICKS);
+        }
+        sim.wheatPlots[plotIdx] = plot;
+
+        if (cs.carryWheat >= ClanWorldConstants.WHEAT_CAP || plot.remainingWheat == 0) {
+            return _simulateCompleteMission(cs, m);
+        }
+        return (cs, m);
+    }
+
+    function _simulateDoDeposit(SettlementSimulation memory sim, Clansman memory cs, Mission memory m)
+        internal
+        view
+        returns (Clansman memory, Mission memory)
+    {
+        if (cs.currentRegion != sim.clan.baseRegion) return _simulateCompleteMission(cs, m);
+
+        bool hasAnything = cs.carryWood > 0 || cs.carryIron > 0 || cs.carryWheat > 0 || cs.carryFish > 0;
+        if (!hasAnything) return _simulateCompleteMission(cs, m);
+
+        sim.clan.vaultWood += cs.carryWood;
+        sim.clan.vaultIron += cs.carryIron;
+        sim.clan.vaultWheat += cs.carryWheat;
+        sim.clan.vaultFish += cs.carryFish;
+
+        cs.carryWood = 0;
+        cs.carryIron = 0;
+        cs.carryWheat = 0;
+        cs.carryFish = 0;
+
+        return _simulateCompleteMission(cs, m);
+    }
+
+    function _simulateDoBuilding(
+        SettlementSimulation memory sim,
+        Clansman memory cs,
+        Mission memory m,
+        ActionType action
+    ) internal view returns (Clansman memory, Mission memory) {
+        if (cs.currentRegion == sim.clan.baseRegion) {
+            if (action == ActionType.BuildWall) {
+                _simulateTryBuildWall(sim);
+            } else if (action == ActionType.UpgradeBase) {
+                _simulateTryUpgradeBase(sim);
+            } else if (action == ActionType.UpgradeMonument) {
+                _simulateTryUpgradeMonument(sim);
+            }
+        }
+        return _simulateCompleteMission(cs, m);
+    }
+
+    function _simulateTryBuildWall(SettlementSimulation memory sim) internal pure {
+        uint8 nextLevel = sim.clan.wallLevel + 1;
+        if (nextLevel > 5) return;
+
+        uint256 woodCost;
+        uint256 ironCost;
+        if (nextLevel == 1) {
+            woodCost = 20e18;
+        } else if (nextLevel == 2) {
+            woodCost = 35e18;
+        } else if (nextLevel == 3) {
+            woodCost = 30e18;
+            ironCost = 5e18;
+        } else if (nextLevel == 4) {
+            woodCost = 40e18;
+            ironCost = 10e18;
+        } else {
+            woodCost = 50e18;
+            ironCost = 15e18;
+        }
+
+        if (sim.clan.vaultWood < woodCost || sim.clan.vaultIron < ironCost) return;
+        sim.clan.vaultWood -= woodCost;
+        sim.clan.vaultIron -= ironCost;
+        sim.clan.wallLevel = nextLevel;
+    }
+
+    function _simulateTryUpgradeBase(SettlementSimulation memory sim) internal pure {
+        uint8 nextLevel = sim.clan.baseLevel + 1;
+        if (nextLevel > 5) return;
+
+        uint256 woodCost;
+        uint256 ironCost;
+        uint256 wheatCost;
+        if (nextLevel == 2) {
+            woodCost = 40e18;
+            wheatCost = 20e18;
+        } else if (nextLevel == 3) {
+            woodCost = 60e18;
+            ironCost = 5e18;
+            wheatCost = 30e18;
+        } else if (nextLevel == 4) {
+            woodCost = 80e18;
+            ironCost = 10e18;
+            wheatCost = 40e18;
+        } else {
+            woodCost = 100e18;
+            ironCost = 15e18;
+            wheatCost = 50e18;
+        }
+
+        if (sim.clan.vaultWood < woodCost || sim.clan.vaultIron < ironCost || sim.clan.vaultWheat < wheatCost) {
+            return;
+        }
+        sim.clan.vaultWood -= woodCost;
+        sim.clan.vaultIron -= ironCost;
+        sim.clan.vaultWheat -= wheatCost;
+        sim.clan.baseLevel = nextLevel;
+    }
+
+    function _simulateTryUpgradeMonument(SettlementSimulation memory sim) internal pure {
+        uint8 nextLevel = sim.clan.monumentLevel + 1;
+        if (nextLevel > 10) return;
+
+        uint256 woodCost;
+        uint256 wheatCost;
+        uint256 ironCost;
+        uint256 blueprintCost;
+        if (nextLevel == 1) {
+            woodCost = 30e18;
+            wheatCost = 20e18;
+        } else if (nextLevel == 2) {
+            woodCost = 50e18;
+            wheatCost = 30e18;
+        } else if (nextLevel == 3) {
+            woodCost = 70e18;
+            wheatCost = 40e18;
+            ironCost = 5e18;
+        } else if (nextLevel == 4) {
+            woodCost = 90e18;
+            wheatCost = 50e18;
+            ironCost = 10e18;
+        } else if (nextLevel == 5) {
+            woodCost = 120e18;
+            wheatCost = 60e18;
+            ironCost = 15e18;
+        } else if (nextLevel == 6) {
+            woodCost = 150e18;
+            wheatCost = 80e18;
+            ironCost = 20e18;
+        } else {
+            woodCost = 200e18;
+            wheatCost = 100e18;
+            ironCost = 25e18;
+            blueprintCost = 1e18;
+        }
+
+        if (
+            sim.clan.vaultWood < woodCost || sim.clan.vaultWheat < wheatCost || sim.clan.vaultIron < ironCost
+                || sim.clan.blueprintBalance < blueprintCost
+        ) return;
+
+        sim.clan.vaultWood -= woodCost;
+        sim.clan.vaultWheat -= wheatCost;
+        sim.clan.vaultIron -= ironCost;
+        sim.clan.blueprintBalance -= blueprintCost;
+        sim.clan.monumentLevel = nextLevel;
+    }
+
+    function _simulateCompleteMission(Clansman memory cs, Mission memory m)
+        internal
+        view
+        returns (Clansman memory, Mission memory)
+    {
+        cs.state = ClansmanState.WAITING;
+        cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
+        m.active = false;
+        return (cs, m);
     }
 
     // =========================================================================
@@ -2747,30 +3234,39 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     // DERIVED READ GETTERS (read-only, no storage mutation)
     // =========================================================================
 
-    /// @dev Returns last-settled state; starvation check uses currentTick (live).
-    ///      Carry amounts lag until next settleClan().
     function getDerivedClanState(uint32 clanId) external view override returns (DerivedClanState memory) {
-        Clan memory clan = _clans[clanId];
-        bool starving = clan.starvationStartsAtTick != 0 && clan.starvationStartsAtTick <= _world.currentTick;
-        uint256 lootVal = _lootValueRaw(clan);
-        return
-            DerivedClanState({clan: clan, isStarving: starving, lootValue: lootVal, derivedAtTick: _world.currentTick});
+        SettlementSimulation memory sim = _simulateSettleToTick(clanId, _world.currentTick);
+        return _derivedClanStateFromSimulation(sim.clan);
     }
 
     function getDerivedClansmanState(uint32 clansmanId) external view override returns (DerivedClansmanState memory) {
         Clansman memory cs = _clansmen[clansmanId];
-        Mission memory m = _missions[clansmanId];
-        uint8 effectiveRegion = cs.currentRegion;
-        if (cs.state == ClansmanState.TRAVELING && m.active) {
-            // Simplified: if past arrivalTick, they're at target; else at start
-            if (_world.currentTick >= m.arrivalTick) {
-                effectiveRegion = m.targetRegion;
-            } else {
-                effectiveRegion = m.startRegion;
-            }
+        if (cs.clansmanId == 0) {
+            Mission memory emptyMission;
+            return DerivedClansmanState({
+                clansman: cs, activeMission: emptyMission, effectiveRegion: 0, derivedAtTick: _world.currentTick
+            });
         }
+
+        SettlementSimulation memory sim = _simulateSettleToTick(cs.clanId, _world.currentTick);
+        (bool found, uint256 index) = _findSimulatedClansman(sim, clansmanId);
+        if (found) {
+            cs = sim.clansmen[index];
+            Mission memory m = sim.missions[index];
+            return DerivedClansmanState({
+                clansman: cs,
+                activeMission: m,
+                effectiveRegion: _effectiveRegion(cs, m, _world.currentTick),
+                derivedAtTick: _world.currentTick
+            });
+        }
+
+        Mission memory fallbackMission = _missions[clansmanId];
         return DerivedClansmanState({
-            clansman: cs, activeMission: m, effectiveRegion: effectiveRegion, derivedAtTick: _world.currentTick
+            clansman: cs,
+            activeMission: fallbackMission,
+            effectiveRegion: _effectiveRegion(cs, fallbackMission, _world.currentTick),
+            derivedAtTick: _world.currentTick
         });
     }
 
@@ -2801,13 +3297,39 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     function quoteLootValueSettled(uint32 clanId) external view override returns (uint256) {
-        // Phase 1: return raw value (no simulation)
-        return _lootValueRaw(_clans[clanId]);
+        SettlementSimulation memory sim = _simulateSettleToTick(clanId, _world.currentTick);
+        return _lootValueRaw(sim.clan);
     }
 
     /// @dev Compute loot value per v4 spec §6.9: wood=1, wheat=1, fish=2, iron=4 points.
     function _lootValueRaw(Clan memory clan) internal pure returns (uint256) {
         return clan.vaultWood + clan.vaultWheat + clan.vaultFish * 2 + clan.vaultIron * 4;
+    }
+
+    function _derivedClanStateFromSimulation(Clan memory clan) internal view returns (DerivedClanState memory) {
+        bool starving = clan.starvationStartsAtTick != 0 && clan.starvationStartsAtTick <= _world.currentTick;
+        return DerivedClanState({
+            clan: clan, isStarving: starving, lootValue: _lootValueRaw(clan), derivedAtTick: _world.currentTick
+        });
+    }
+
+    function _findSimulatedClansman(SettlementSimulation memory sim, uint32 clansmanId)
+        internal
+        pure
+        returns (bool found, uint256 index)
+    {
+        for (uint256 i = 0; i < sim.clansmen.length; i++) {
+            if (sim.clansmen[i].clansmanId == clansmanId) {
+                return (true, i);
+            }
+        }
+    }
+
+    function _effectiveRegion(Clansman memory cs, Mission memory m, uint64 tick) internal pure returns (uint8) {
+        if (cs.state == ClansmanState.TRAVELING && m.active) {
+            return tick >= m.arrivalTick ? m.targetRegion : m.startRegion;
+        }
+        return cs.currentRegion;
     }
 
     // =========================================================================
@@ -2851,49 +3373,50 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         });
     }
 
-    /// @dev Returns last-settled storage state. Vault contents and starvation flag are
-    ///      current; carry amounts and wheat progress lag until next settleClan() call.
-    ///      Full view-only settlement simulation is deferred (tracked issue).
     function getClanFullView(uint32 clanId) external view override returns (ClanFullView memory) {
-        Clan storage clan = _clans[clanId];
-        bool starving = clan.starvationStartsAtTick != 0 && clan.starvationStartsAtTick <= _world.currentTick;
-        uint256 lootVal = _lootValueRaw(clan);
+        SettlementSimulation memory sim = _simulateSettleToTick(clanId, _world.currentTick);
+        DerivedClanState memory derivedClan = _derivedClanStateFromSimulation(sim.clan);
 
-        DerivedClanState memory derivedClan =
-            DerivedClanState({clan: clan, isStarving: starving, lootValue: lootVal, derivedAtTick: _world.currentTick});
-
-        uint32[] storage csIds = _clanClansmanIds[clanId];
-        ClansmanFullView[] memory clansmen = new ClansmanFullView[](csIds.length);
-        for (uint256 i = 0; i < csIds.length; i++) {
-            uint32 csId = csIds[i];
-            Clansman memory cs = _clansmen[csId];
-            Mission memory m = _missions[csId];
-            uint8 effRegion = cs.currentRegion;
-            if (cs.state == ClansmanState.TRAVELING && m.active) {
-                effRegion = _world.currentTick >= m.arrivalTick ? m.targetRegion : m.startRegion;
-            }
+        ClansmanFullView[] memory clansmen = new ClansmanFullView[](sim.clansmen.length);
+        for (uint256 i = 0; i < sim.clansmen.length; i++) {
+            Clansman memory cs = sim.clansmen[i];
+            Mission memory m = sim.missions[i];
             DerivedClansmanState memory dcs = DerivedClansmanState({
-                clansman: cs, activeMission: m, effectiveRegion: effRegion, derivedAtTick: _world.currentTick
+                clansman: cs,
+                activeMission: m,
+                effectiveRegion: _effectiveRegion(cs, m, _world.currentTick),
+                derivedAtTick: _world.currentTick
             });
             clansmen[i] = ClansmanFullView({clansman: dcs, activeMission: m});
         }
 
-        // Find if any of this clan's clansmen is defending a home region.
         uint32 thisClanDefendingBaseId = 0;
-        for (uint256 i = 0; i < csIds.length; i++) {
-            uint8 region = _clansmanDefendingRegion[csIds[i]];
-            if (region != 0) {
-                thisClanDefendingBaseId = region;
+        for (uint256 i = 0; i < sim.clansmen.length; i++) {
+            if (
+                sim.missions[i].active && sim.missions[i].action == ActionType.DefendBase
+                    && sim.clansmen[i].state == ClansmanState.ACTING
+            ) {
+                thisClanDefendingBaseId = sim.missions[i].targetRegion;
                 break;
+            }
+        }
+        if (thisClanDefendingBaseId == 0) {
+            uint32[] storage csIds = _clanClansmanIds[clanId];
+            for (uint256 i = 0; i < csIds.length; i++) {
+                uint8 region = _clansmanDefendingRegion[csIds[i]];
+                if (region != 0) {
+                    thisClanDefendingBaseId = region;
+                    break;
+                }
             }
         }
 
         return ClanFullView({
             clan: derivedClan,
             clansmen: clansmen,
-            westPlot: _wheatPlots[clanId][0],
-            eastPlot: _wheatPlots[clanId][1],
-            incomingDefenderIds: _defendingClansByRegion[clan.baseRegion],
+            westPlot: sim.wheatPlots[0],
+            eastPlot: sim.wheatPlots[1],
+            incomingDefenderIds: _defendingClansByRegion[sim.clan.baseRegion],
             thisClanDefendingBaseId: thisClanDefendingBaseId
         });
     }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1164,25 +1164,19 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     /// @notice Permissionless heartbeat. Closes the current tick, advances tick counter.
     ///         Execution order per spec §4.2 (CEI-safe):
     ///         CEI guard: nextHeartbeatAtTs written first to close reentrancy window.
-    ///         Seed:      closedTick seed derived and published before step 1 so
-    ///                    settlement RNG reads real entropy, not zero.
     ///         1. Settle missions completing this tick.
     ///         2. Execute scheduled market actions for closedTick (external calls).
-    ///         3. Eager-settle clans touched by world events (Phase 3 stub).
-    ///         4. Resolve world events (season boundary, winter transitions).
-    ///         5. Increment tick and publish (seed already written above).
+    ///         3. Eager-settle clans touched by world events (Phase 9 stub).
+    ///         4. Resolve closed-tick bandit/world events.
+    ///         5. Increment tick and publish the next tick seed atomically.
     function heartbeat() external override nonReentrant {
         require(block.timestamp >= _world.nextHeartbeatAtTs, "ClanWorld: heartbeat rate limited");
 
         uint64 closedTick = _world.currentTick;
+        bytes32 closedTickSeed = _world.currentTickSeed;
 
         // CEI: update rate-limit guard before any external calls
         _world.nextHeartbeatAtTs = uint64(block.timestamp) + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS;
-
-        // Derive and publish seed for closedTick before step 1 (settlement reads it for RNG)
-        bytes32 newSeed = keccak256(abi.encode(block.prevrandao, _world.currentTickSeed, closedTick));
-        _tickSeeds[closedTick] = newSeed;
-        _world.currentTickSeed = newSeed;
 
         // Step 1: Settle missions that complete this tick (settlesAtTick == closedTick).
         // Bounded by 12-clan cap x 4 clansmen = 48 max iterations.
@@ -1191,18 +1185,21 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         // Step 2: Execute scheduled market actions for closedTick (may make external calls).
         _executeScheduledMarketActions(closedTick);
 
-        // Step 3: Eager-settle clans touched by world events (Phase 3 bandit — stub).
-        // TODO Phase 3: _settleClansNearBandit(closedTick);
+        // Step 3: Eager-settle clans touched by world events (Phase 9 bandit — stub).
+        // TODO Phase 9: _settleClansNearBandit(closedTick);
 
         // Step 4: Evaluate deterministic bandit spawns for the closed tick.
-        _evaluateBanditSpawns(newSeed);
+        _evaluateBanditSpawns(closedTickSeed);
 
         // Step 5: Resolve world events (season boundary, winter transitions).
         _resolveWorldEvents(closedTick);
 
-        // Step 6: Increment tick and publish (seed already written above; complete the atomic pair).
+        // Step 6: Increment tick and publish the opened tick seed as one visible state transition.
         uint64 newTick = closedTick + 1;
+        bytes32 newSeed = keccak256(abi.encode(block.prevrandao, closedTickSeed, closedTick));
         _world.currentTick = newTick;
+        _tickSeeds[newTick] = newSeed;
+        _world.currentTickSeed = newSeed;
         _world.nextHeartbeatAtTick = newTick + 1;
 
         emit TickAdvanced(closedTick, newTick, newSeed);

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -37,6 +37,7 @@ import {
     ActiveBanditView,
     RegionOccupant
 } from "./IClanWorld.sol";
+import {RNG} from "./lib/RNG.sol";
 import {StubPool} from "./StubPool.sol";
 import {ReentrancyGuard} from "./util/ReentrancyGuard.sol";
 
@@ -63,11 +64,13 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     mapping(uint32 => uint8) private _clansmanDefendingRegion; // clansmanId => defended home region
     mapping(uint32 => BanditTroop) internal _bandits;
     mapping(uint8 => uint32[]) internal _banditsByRegion; // region => bandit IDs
+    mapping(uint8 => BanditSpawnState) internal _banditSpawnByRegion;
     mapping(uint64 => bytes32) private _tickSeeds; // tick => seed
 
     uint32 private _nextClanId;
     uint32 private _nextClansmanId;
     uint32 internal _nextBanditId;
+    uint32 internal _activeBanditCount;
     uint32[] private _allClanIds;
 
     // per-clan clansman list: clanId => clansmanId[]
@@ -80,6 +83,24 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
+    uint256 internal constant DOMAIN_BANDIT_SPAWN = uint256(keccak256("clanworld.bandit.spawn.v1"));
+    uint64 internal constant MIN_SPAWN_COOLDOWN_TICKS = ClanWorldConstants.BANDIT_COOLDOWN_TICKS;
+    uint16 internal constant BANDIT_SPAWN_PROBABILITY_INCREMENT_BPS = 1000;
+    uint16 internal constant BANDIT_SPAWN_MAX_PROBABILITY_BPS = 8000;
+    uint8 internal constant MAX_BANDITS_PER_REGION = 3;
+    uint8 internal constant MAX_TOTAL_BANDITS = 8;
+    /// @dev Bandit spawn weights are a heartbeat-time heuristic. Bound the scan
+    ///      and rotate the starting clan by tick so larger worlds do not turn
+    ///      spawn preview/selection into an unbounded heartbeat cost.
+    uint256 internal constant MAX_BANDIT_SPAWN_SCAN_PER_REGION = 8;
+    uint256 internal constant MAX_BANDIT_SPAWN_CLANSMEN_SCAN_PER_REGION = MAX_BANDIT_SPAWN_SCAN_PER_REGION * 4;
+    uint32 internal constant MIN_BANDIT_SPAWN_STRENGTH = 100;
+    uint32 internal constant BANDIT_SPAWN_STRENGTH_SPREAD = 151;
+
+    struct BanditSpawnState {
+        uint64 lastSpawnTick;
+        uint16 probabilityAccum;
+    }
 
     // =========================================================================
     // CONSTRUCTOR
@@ -885,6 +906,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             strength: strength
         });
         _banditsByRegion[region].push(id);
+        _activeBanditCount += 1;
+
+        BanditSpawnState storage spawnState = _banditSpawnByRegion[region];
+        spawnState.lastSpawnTick = _world.currentTick;
+        spawnState.probabilityAccum = 0;
 
         if (_world.activeBanditId == ClanWorldConstants.BANDIT_ID_NULL) {
             _world.activeBanditId = id;
@@ -966,8 +992,27 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         delete _bandits[id];
+        if (_activeBanditCount > 0) {
+            _activeBanditCount -= 1;
+        }
         if (_world.activeBanditId == id) {
-            _world.activeBanditId = ClanWorldConstants.BANDIT_ID_NULL;
+            _world.activeBanditId = _findOldestActiveBandit();
+        }
+    }
+
+    function _findOldestActiveBandit() internal view returns (uint32 oldestBanditId) {
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            uint32[] storage regionBandits = _banditsByRegion[region];
+            for (uint256 i = 0; i < regionBandits.length; i++) {
+                uint32 candidateId = regionBandits[i];
+                BanditTroop storage candidate = _bandits[candidateId];
+                if (candidate.id == ClanWorldConstants.BANDIT_ID_NULL || candidate.state == BanditState.None) {
+                    continue;
+                }
+                if (oldestBanditId == ClanWorldConstants.BANDIT_ID_NULL || candidateId < oldestBanditId) {
+                    oldestBanditId = candidateId;
+                }
+            }
         }
     }
 
@@ -975,6 +1020,141 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (strength > type(uint16).max) return type(uint16).max;
         // forge-lint: disable-next-line(unsafe-typecast)
         return uint16(strength);
+    }
+
+    function _evaluateBanditSpawns(bytes32 tickSeed) internal {
+        uint256[] memory regionWeights = _banditSpawnRegionWeights();
+        if (_activeBanditCount >= MAX_TOTAL_BANDITS) {
+            _refreshBanditSpawnWorldPreview(regionWeights);
+            return;
+        }
+
+        uint256[] memory candidateWeights = new uint256[](8);
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            uint256 weight = regionWeights[region - 1];
+            if (weight == 0 || _banditsByRegion[region].length >= MAX_BANDITS_PER_REGION) {
+                continue;
+            }
+
+            BanditSpawnState storage spawnState = _banditSpawnByRegion[region];
+            if (_world.currentTick < spawnState.lastSpawnTick + MIN_SPAWN_COOLDOWN_TICKS) {
+                continue;
+            }
+
+            spawnState.probabilityAccum = _incrementBanditSpawnProbability(spawnState.probabilityAccum);
+            if (_banditSpawnRollPasses(tickSeed, region, spawnState.probabilityAccum)) {
+                candidateWeights[region - 1] = weight;
+            }
+        }
+
+        uint8 selectedRegion = _selectBanditSpawnRegion(tickSeed, candidateWeights);
+        if (selectedRegion != ClanWorldConstants.REGION_NOOP) {
+            _spawnBandit(selectedRegion, _banditSpawnStrength(tickSeed, selectedRegion));
+        }
+
+        _refreshBanditSpawnWorldPreview(regionWeights);
+    }
+
+    function _incrementBanditSpawnProbability(uint16 probabilityAccum) internal pure returns (uint16) {
+        uint256 next = uint256(probabilityAccum) + BANDIT_SPAWN_PROBABILITY_INCREMENT_BPS;
+        if (next > BANDIT_SPAWN_MAX_PROBABILITY_BPS) {
+            return BANDIT_SPAWN_MAX_PROBABILITY_BPS;
+        }
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint16(next);
+    }
+
+    function _banditSpawnRollPasses(bytes32 tickSeed, uint8 region, uint16 probabilityAccum)
+        internal
+        pure
+        returns (bool)
+    {
+        return _banditSpawnRoll(tickSeed, region) < uint256(probabilityAccum);
+    }
+
+    function _banditSpawnRoll(bytes32 tickSeed, uint8 region) internal pure returns (uint256) {
+        uint256 nonce = uint256(keccak256(abi.encodePacked("bandit_spawn", region)));
+        return RNG.rngBounded(tickSeed, DOMAIN_BANDIT_SPAWN, nonce, 10000);
+    }
+
+    function _selectBanditSpawnRegion(bytes32 tickSeed, uint256[] memory weights) internal pure returns (uint8) {
+        uint256 selected = RNG.rngWeightedPick(
+            tickSeed, DOMAIN_BANDIT_SPAWN, uint256(keccak256(abi.encodePacked("bandit_spawn_region"))), weights
+        );
+        if (weights.length == 0 || weights[selected] == 0) {
+            return ClanWorldConstants.REGION_NOOP;
+        }
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint8(selected + 1);
+    }
+
+    function _banditSpawnStrength(bytes32 tickSeed, uint8 region) internal pure returns (uint32) {
+        uint256 nonce = uint256(keccak256(abi.encodePacked("bandit_spawn_strength", region)));
+        uint256 roll = RNG.rngBounded(tickSeed, DOMAIN_BANDIT_SPAWN, nonce, BANDIT_SPAWN_STRENGTH_SPREAD);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return MIN_BANDIT_SPAWN_STRENGTH + uint32(roll);
+    }
+
+    function _banditSpawnRegionWeights() internal view returns (uint256[] memory weights) {
+        weights = new uint256[](8);
+        uint256 clanCount = _allClanIds.length;
+        if (clanCount == 0) {
+            return weights;
+        }
+
+        uint256 scanCount =
+            clanCount < MAX_BANDIT_SPAWN_SCAN_PER_REGION ? clanCount : MAX_BANDIT_SPAWN_SCAN_PER_REGION;
+        uint256 startIndex = uint256(_world.currentTick) % clanCount;
+        uint256 clansmenScanned;
+        for (uint256 i = 0; i < scanCount; i++) {
+            Clan storage clan = _clans[_allClanIds[(startIndex + i) % clanCount]];
+            if (clan.clanState == ClanState.DEAD) {
+                continue;
+            }
+
+            if (clan.baseRegion >= ClanWorldConstants.REGION_FOREST && clan.baseRegion <= ClanWorldConstants.REGION_DEEP_SEA) {
+                weights[clan.baseRegion - 1] += 100 + (_lootValueRaw(clan) / 1e18);
+            }
+
+            uint32[] storage clansmanIds = _clanClansmanIds[clan.clanId];
+            for (
+                uint256 j = 0;
+                j < clansmanIds.length && clansmenScanned < MAX_BANDIT_SPAWN_CLANSMEN_SCAN_PER_REGION;
+                j++
+            ) {
+                clansmenScanned += 1;
+                Clansman storage cs = _clansmen[clansmanIds[j]];
+                if (
+                    cs.state != ClansmanState.DEAD && cs.currentRegion >= ClanWorldConstants.REGION_FOREST
+                        && cs.currentRegion <= ClanWorldConstants.REGION_DEEP_SEA
+                ) {
+                    weights[cs.currentRegion - 1] += 25;
+                }
+            }
+        }
+    }
+
+    function _refreshBanditSpawnWorldPreview(uint256[] memory regionWeights) internal {
+        uint64 nextEligibleTick = type(uint64).max;
+        uint16 maxChance = 0;
+
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            BanditSpawnState storage spawnState = _banditSpawnByRegion[region];
+            uint64 eligibleTick = spawnState.lastSpawnTick + MIN_SPAWN_COOLDOWN_TICKS;
+            if (
+                _activeBanditCount < MAX_TOTAL_BANDITS && regionWeights[region - 1] > 0
+                    && _banditsByRegion[region].length < MAX_BANDITS_PER_REGION
+                    && eligibleTick < nextEligibleTick
+            ) {
+                nextEligibleTick = eligibleTick;
+            }
+            if (spawnState.probabilityAccum > maxChance) {
+                maxChance = spawnState.probabilityAccum;
+            }
+        }
+
+        _world.nextBanditSpawnEligibleTick = nextEligibleTick == type(uint64).max ? 0 : nextEligibleTick;
+        _world.currentBanditSpawnChanceBps = maxChance;
     }
 
     // =========================================================================
@@ -1014,10 +1194,13 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         // Step 3: Eager-settle clans touched by world events (Phase 3 bandit — stub).
         // TODO Phase 3: _settleClansNearBandit(closedTick);
 
-        // Step 4: Resolve world events (season boundary, winter transitions).
+        // Step 4: Evaluate deterministic bandit spawns for the closed tick.
+        _evaluateBanditSpawns(newSeed);
+
+        // Step 5: Resolve world events (season boundary, winter transitions).
         _resolveWorldEvents(closedTick);
 
-        // Step 5: Increment tick and publish (seed already written above; complete the atomic pair).
+        // Step 6: Increment tick and publish (seed already written above; complete the atomic pair).
         uint64 newTick = closedTick + 1;
         _world.currentTick = newTick;
         _world.nextHeartbeatAtTick = newTick + 1;

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -408,6 +408,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         for (uint64 tick = fromTick; tick < curTick; tick++) {
             // 1. Apply upkeep for this tick
             _applyUpkeep(clan, tick);
+            if (clan.clanState == ClanState.DEAD) break;
 
             // 2. Wheat plot regrow check (lazy, per tick)
             for (uint256 pi = 0; pi < 2; pi++) {
@@ -458,6 +459,127 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         } else if (!starving && clan.starvationStartsAtTick != 0) {
             clan.starvationStartsAtTick = 0;
             emit ClanStarvationChanged(clan.clanId, false, tick);
+        }
+
+        if (starving && _world.winterActive && clan.starvationStartsAtTick >= _world.winterStartsAtTick) {
+            _killNextClansmanFromStarvation(clan, tick);
+        }
+    }
+
+    function _killNextClansmanFromStarvation(Clan storage clan, uint64 tick) internal {
+        if (clan.livingClansmen == 0) return;
+
+        uint32[] storage csIds = _clanClansmanIds[clan.clanId];
+        for (uint256 i = 0; i < csIds.length; i++) {
+            Clansman storage cs = _clansmen[csIds[i]];
+            if (cs.state == ClansmanState.DEAD) continue;
+
+            _markClansmanDead(clan, cs);
+            if (clan.livingClansmen == 0) {
+                _markClanDead(clan.clanId, "starvation", tick);
+            }
+            return;
+        }
+    }
+
+    function _markClansmanDead(Clan storage clan, Clansman storage cs) internal {
+        if (cs.state == ClansmanState.DEAD) return;
+
+        cs.state = ClansmanState.DEAD;
+        cs.cooldownEndsAtTs = 0;
+        if (clan.livingClansmen > 0) {
+            clan.livingClansmen--;
+        }
+
+        Mission storage mission = _missions[cs.clansmanId];
+        if (mission.active) {
+            if (mission.action == ActionType.DefendBase) {
+                _clearDefender(cs.clansmanId);
+            }
+            mission.active = false;
+        }
+    }
+
+    function _markClanDead(uint32 clanId) internal {
+        _markClanDead(clanId, "unknown", _world.currentTick, ClanWorldConstants.BANDIT_ID_NULL);
+    }
+
+    function _markClanDead(uint32 clanId, string memory reason, uint64 tick) internal {
+        _markClanDead(clanId, reason, tick, ClanWorldConstants.BANDIT_ID_NULL);
+    }
+
+    function _markClanDead(uint32 clanId, string memory, uint64 tick, uint32 excludedBanditId) internal {
+        Clan storage clan = _clans[clanId];
+        if (clan.clanId == ClanWorldConstants.CLAN_ID_NULL || clan.clanState == ClanState.DEAD) return;
+
+        uint8 baseRegion = clan.baseRegion;
+        clan.clanState = ClanState.DEAD;
+        clan.vaultWood = 0;
+        clan.vaultWheat = 0;
+        clan.vaultFish = 0;
+        clan.vaultIron = 0;
+        clan.starvationStartsAtTick = 0;
+        clan.livingClansmen = 0;
+
+        uint32[] storage csIds = _clanClansmanIds[clanId];
+        for (uint256 i = 0; i < csIds.length; i++) {
+            Clansman storage cs = _clansmen[csIds[i]];
+            cs.state = ClansmanState.DEAD;
+            cs.cooldownEndsAtTs = 0;
+            Mission storage mission = _missions[csIds[i]];
+            if (mission.active) {
+                if (mission.action == ActionType.DefendBase) {
+                    _clearDefender(csIds[i]);
+                }
+                mission.active = false;
+            }
+        }
+
+        _releaseDefendersForDeadTarget(clanId, baseRegion);
+        _abortBanditAttacksForDeadTarget(clanId, tick, excludedBanditId);
+
+        emit ClanEliminated(clanId, tick);
+    }
+
+    function _releaseDefendersForDeadTarget(uint32 deadClanId, uint8 baseRegion) internal {
+        for (uint256 i = 0; i < _allClanIds.length; i++) {
+            uint32 defenderClanId = _allClanIds[i];
+            if (defenderClanId == deadClanId) continue;
+
+            uint32[] storage csIds = _clanClansmanIds[defenderClanId];
+            for (uint256 j = 0; j < csIds.length; j++) {
+                uint32 clansmanId = csIds[j];
+                Mission storage mission = _missions[clansmanId];
+                if (
+                    mission.active && mission.action == ActionType.DefendBase
+                        && mission.targetClanId == deadClanId && _clansmanDefendingRegion[clansmanId] == baseRegion
+                ) {
+                    _clearDefender(clansmanId);
+                    mission.active = false;
+
+                    Clansman storage defender = _clansmen[clansmanId];
+                    if (defender.state != ClansmanState.DEAD) {
+                        defender.state = ClansmanState.WAITING;
+                    }
+                }
+            }
+        }
+    }
+
+    function _abortBanditAttacksForDeadTarget(uint32 deadClanId, uint64 tick, uint32 excludedBanditId) internal {
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            uint32[] storage regionBandits = _banditsByRegion[region];
+            for (uint256 i = 0; i < regionBandits.length; i++) {
+                uint32 banditId = regionBandits[i];
+                if (banditId == excludedBanditId) continue;
+
+                BanditTroop storage bandit = _bandits[banditId];
+                if (bandit.state == BanditState.Attacking && bandit.targetClanId == deadClanId) {
+                    _transitionBanditState(banditId, BanditState.Escaped);
+                    emit BanditEscaped(banditId, tick);
+                    emit BanditTargetDied(banditId, deadClanId, tick);
+                }
+            }
         }
     }
 
@@ -975,12 +1097,16 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     function _canBanditLeaveSpawned(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
-        return newState == BanditState.Camped && _world.currentTick >= bandit.tickEnteredState + 1;
+        return newState == BanditState.Escaped
+            || (newState == BanditState.Camped && _world.currentTick >= bandit.tickEnteredState + 1);
     }
 
     function _canBanditLeaveCamped(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
-        return newState == BanditState.Attacking && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
-            && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
+        return newState == BanditState.Escaped
+            || (
+                newState == BanditState.Attacking && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
+                    && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS
+            );
     }
 
     function _canBanditLeaveAttacking(BanditState newState) internal pure returns (bool) {
@@ -992,8 +1118,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     function _canBanditLeaveResting(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
-        return newState == BanditState.Camped
-            && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS;
+        return newState == BanditState.Escaped
+            || (
+                newState == BanditState.Camped
+                    && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
+            );
     }
 
     function _deleteBandit(uint32 id) internal {
@@ -1301,20 +1430,18 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             }
 
             Clansman storage victim = _clansmen[victimId];
-            victim.state = ClansmanState.DEAD;
-            victim.cooldownEndsAtTs = 0;
-            _clearDefender(victimId);
-            Mission storage mission = _missions[victimId];
-            mission.active = false;
-            if (clan.livingClansmen > 0) {
-                clan.livingClansmen--;
-            }
+            _markClansmanDead(clan, victim);
 
             uint32 absorbed = remainingDamage < CLANSMAN_HP ? remainingDamage : CLANSMAN_HP;
             damageAbsorbed += absorbed;
             remainingDamage -= absorbed;
             emit ClansmanKilledByBandit(clanId, victimId, banditId);
             killIndex++;
+
+            if (clan.livingClansmen == 0) {
+                _markClanDead(clanId, "bandit", _world.currentTick, banditId);
+                break;
+            }
         }
     }
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -94,6 +94,13 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     ///      spawn preview/selection into an unbounded heartbeat cost.
     uint256 internal constant MAX_BANDIT_SPAWN_SCAN_PER_REGION = 8;
     uint256 internal constant MAX_BANDIT_SPAWN_CLANSMEN_SCAN_PER_REGION = MAX_BANDIT_SPAWN_SCAN_PER_REGION * 4;
+    /// @dev Eager settlement scans the clan-indexed bases in each spawn-candidate
+    ///      region, not every clan globally per region forever. The current world
+    ///      caps minting at 12 clans, so this settles all possible bases today
+    ///      while keeping the heartbeat loop explicitly bounded if that cap grows.
+    uint256 internal constant MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION = 12;
+    uint256 internal constant MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION = 12;
+    uint256 internal constant MAX_BANDIT_EAGER_SETTLE_DEFENDER_SCAN_PER_REGION = 48;
     uint32 internal constant MIN_BANDIT_SPAWN_STRENGTH = 100;
     uint32 internal constant BANDIT_SPAWN_STRENGTH_SPREAD = 151;
 
@@ -1095,6 +1102,80 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return MIN_BANDIT_SPAWN_STRENGTH + uint32(roll);
     }
 
+    function _eagerSettleForBandits(uint64 closedTick) internal {
+        require(_world.currentTick == closedTick, "ClanWorld: eager settle tick mismatch");
+        if (_activeBanditCount >= MAX_TOTAL_BANDITS) return;
+
+        uint256[] memory regionWeights = _banditSpawnRegionWeights();
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            if (!_isBanditSpawnRegionCandidate(regionWeights, region)) {
+                continue;
+            }
+            _eagerSettleBanditCandidateRegion(region);
+        }
+    }
+
+    function _isBanditSpawnRegionCandidate(uint256[] memory regionWeights, uint8 region) internal view returns (bool) {
+        if (regionWeights[region - 1] == 0 || _banditsByRegion[region].length >= MAX_BANDITS_PER_REGION) {
+            return false;
+        }
+
+        BanditSpawnState storage spawnState = _banditSpawnByRegion[region];
+        if (_world.currentTick < spawnState.lastSpawnTick + MIN_SPAWN_COOLDOWN_TICKS) {
+            return false;
+        }
+
+        uint16 nextProbability = _incrementBanditSpawnProbability(spawnState.probabilityAccum);
+        return _banditSpawnRollPasses(_world.currentTickSeed, region, nextProbability);
+    }
+
+    function _eagerSettleBanditCandidateRegion(uint8 region) internal {
+        uint256 clanScanCount = _allClanIds.length < MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION
+            ? _allClanIds.length
+            : MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION;
+
+        for (uint256 i = 0; i < clanScanCount; i++) {
+            uint32 clanId = _allClanIds[i];
+            Clan storage clan = _clans[clanId];
+            if (clan.clanState == ClanState.DEAD || clan.baseRegion != region) {
+                continue;
+            }
+
+            _settleClan(clanId);
+            _eagerSettleActiveDefendersForBase(clanId, region);
+        }
+    }
+
+    function _eagerSettleActiveDefendersForBase(uint32 targetClanId, uint8 region) internal {
+        uint32[] storage defendingClans = _defendingClansByRegion[region];
+        uint256 defendingClanScanCount = defendingClans.length < MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION
+            ? defendingClans.length
+            : MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION;
+        uint256 defendersScanned;
+
+        for (uint256 i = 0; i < defendingClanScanCount; i++) {
+            uint32 defenderClanId = defendingClans[i];
+            uint32[] storage clansmanIds = _clanClansmanIds[defenderClanId];
+
+            for (
+                uint256 j = 0;
+                j < clansmanIds.length && defendersScanned < MAX_BANDIT_EAGER_SETTLE_DEFENDER_SCAN_PER_REGION;
+                j++
+            ) {
+                defendersScanned += 1;
+                Mission storage mission = _missions[clansmanIds[j]];
+                if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId) {
+                    _settleClan(defenderClanId);
+                    break;
+                }
+            }
+
+            if (defendersScanned >= MAX_BANDIT_EAGER_SETTLE_DEFENDER_SCAN_PER_REGION) {
+                break;
+            }
+        }
+    }
+
     function _banditSpawnRegionWeights() internal view returns (uint256[] memory weights) {
         weights = new uint256[](8);
         uint256 clanCount = _allClanIds.length;
@@ -1185,8 +1266,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         // Step 2: Execute scheduled market actions for closedTick (may make external calls).
         _executeScheduledMarketActions(closedTick);
 
-        // Step 3: Eager-settle clans touched by world events (Phase 9 bandit — stub).
-        // TODO Phase 9: _settleClansNearBandit(closedTick);
+        // Step 3: Eager-settle bases and active defenders in bandit spawn-candidate regions.
+        _eagerSettleForBandits(closedTick);
 
         // Step 4: Evaluate deterministic bandit spawns for the closed tick.
         _evaluateBanditSpawns(closedTickSeed);

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -81,6 +81,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     // =========================================================================
 
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
+    uint256 private constant RESOURCE_UNIT = 1e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
     uint256 internal constant DOMAIN_BANDIT_SPAWN = uint256(keccak256("clanworld.bandit.spawn.v1"));
@@ -914,7 +915,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             state: BanditState.Spawned,
             targetClanId: 0,
             tickEnteredState: _world.currentTick,
-            strength: strength
+            strength: strength,
+            carryWood: 0,
+            carryIron: 0,
+            carryWheat: 0,
+            carryFish: 0,
+            carryGold: 0
         });
         _banditsByRegion[region].push(id);
         _activeBanditCount += 1;
@@ -1109,11 +1115,108 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         if (defeated) {
             emit BanditDefeated(banditId, targetClanId, closedTick);
+            _distributeBanditLootToDefendingClans(banditId, targetClanId);
             _transitionBanditState(banditId, BanditState.Defeated);
         } else {
             _transitionBanditState(banditId, BanditState.Escaped);
             emit BanditEscaped(banditId, closedTick);
         }
+    }
+
+    function _distributeBanditLootToDefendingClans(uint32 banditId, uint32 targetClanId) internal {
+        BanditTroop storage bandit = _bandits[banditId];
+        uint32[] memory rewardedClanIds = _activeDefendingClanIds(targetClanId);
+        uint256 nDefendingClans = rewardedClanIds.length;
+
+        uint256 perWood;
+        uint256 perIron;
+        uint256 perWheat;
+        uint256 perFish;
+        uint256 perGold;
+        if (nDefendingClans > 0) {
+            perWood = _perClanBanditLootShare(bandit.carryWood, nDefendingClans);
+            perIron = _perClanBanditLootShare(bandit.carryIron, nDefendingClans);
+            perWheat = _perClanBanditLootShare(bandit.carryWheat, nDefendingClans);
+            perFish = _perClanBanditLootShare(bandit.carryFish, nDefendingClans);
+            perGold = _perClanBanditLootShare(bandit.carryGold, nDefendingClans);
+
+            for (uint256 i = 0; i < rewardedClanIds.length; i++) {
+                Clan storage defenderClan = _clans[rewardedClanIds[i]];
+                defenderClan.vaultWood += perWood;
+                defenderClan.vaultIron += perIron;
+                defenderClan.vaultWheat += perWheat;
+                defenderClan.vaultFish += perFish;
+                defenderClan.goldBalance += perGold;
+            }
+        }
+
+        emit LootDistributed(
+            banditId,
+            rewardedClanIds,
+            perWood,
+            perWheat,
+            perFish,
+            perIron,
+            perGold,
+            bandit.carryWood - (perWood * nDefendingClans),
+            bandit.carryWheat - (perWheat * nDefendingClans),
+            bandit.carryFish - (perFish * nDefendingClans),
+            bandit.carryIron - (perIron * nDefendingClans),
+            bandit.carryGold - (perGold * nDefendingClans)
+        );
+    }
+
+    function _perClanBanditLootShare(uint256 loot, uint256 nDefendingClans) internal pure returns (uint256) {
+        if (nDefendingClans == 1) {
+            return loot;
+        }
+        return ((loot / RESOURCE_UNIT) / nDefendingClans) * RESOURCE_UNIT;
+    }
+
+    function _activeDefendingClanIds(uint32 targetClanId) internal view returns (uint32[] memory clanIds) {
+        uint8 targetRegion = _clans[targetClanId].baseRegion;
+        uint32[] storage defendingClans = _defendingClansByRegion[targetRegion];
+        uint256 count;
+
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            if (_clanHasActiveDefenderForTarget(defendingClans[i], targetClanId, targetRegion)) {
+                count++;
+            }
+        }
+
+        clanIds = new uint32[](count);
+        uint256 out;
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            uint32 defenderClanId = defendingClans[i];
+            if (_clanHasActiveDefenderForTarget(defenderClanId, targetClanId, targetRegion)) {
+                clanIds[out++] = defenderClanId;
+            }
+        }
+    }
+
+    function _clanHasActiveDefenderForTarget(uint32 defenderClanId, uint32 targetClanId, uint8 targetRegion)
+        internal
+        view
+        returns (bool)
+    {
+        Clan storage defenderClan = _clans[defenderClanId];
+        if (defenderClan.clanState == ClanState.DEAD || _isStarving(defenderClan)) {
+            return false;
+        }
+
+        uint32[] storage clansmanIds = _clanClansmanIds[defenderClanId];
+        for (uint256 i = 0; i < clansmanIds.length; i++) {
+            uint32 clansmanId = clansmanIds[i];
+            Clansman storage cs = _clansmen[clansmanId];
+            Mission storage mission = _missions[clansmanId];
+            if (
+                cs.state == ClansmanState.ACTING && cs.currentRegion == targetRegion && mission.active
+                    && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId
+            ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     function _totalBanditClansmanDefense(uint32 banditId, uint32 targetClanId, bytes32 tickSeed)
@@ -1794,7 +1897,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         ctx.targetClanId =
             order.action == ActionType.DefendBase && order.targetClanId == 0 ? clanId : order.targetClanId;
 
-        // NOOP bypass: treat 0 as "stay here"; DefendBase requires explicit home region.
+        // NOOP bypass: treat 0 as "stay here"; DefendBase requires the defended base region.
         ctx.isNoop = order.action != ActionType.DefendBase
             && (ctx.gotoRegion == ClanWorldConstants.REGION_NOOP || ctx.gotoRegion == ctx.fromRegion);
         if (ctx.isNoop) {
@@ -2298,8 +2401,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         view
         returns (StatusCode)
     {
-        if (gotoRegion != clan.baseRegion) return StatusCode.ERR_INVALID_REGION;
-        if (order.targetClanId != 0 && order.targetClanId != clan.clanId) return StatusCode.ERR_INVALID_TARGET;
+        uint32 targetClanId = order.targetClanId == 0 ? clan.clanId : order.targetClanId;
+        Clan storage targetClan = _clans[targetClanId];
+        if (targetClan.clanId == ClanWorldConstants.CLAN_ID_NULL || targetClan.clanState == ClanState.DEAD) {
+            return StatusCode.ERR_INVALID_TARGET;
+        }
+        if (gotoRegion != targetClan.baseRegion) return StatusCode.ERR_INVALID_REGION;
         return StatusCode.OK;
     }
 
@@ -2431,10 +2538,19 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     function getBandit(uint32 banditId) public view override returns (BanditTroop memory) {
         BanditTroop memory bandit = _bandits[banditId];
         if (bandit.id == ClanWorldConstants.BANDIT_ID_NULL || bandit.state == BanditState.None) {
-            return
-                BanditTroop({
-                    id: 0, region: 0, state: BanditState.None, targetClanId: 0, tickEnteredState: 0, strength: 0
-                });
+            return BanditTroop({
+                id: 0,
+                region: 0,
+                state: BanditState.None,
+                targetClanId: 0,
+                tickEnteredState: 0,
+                strength: 0,
+                carryWood: 0,
+                carryIron: 0,
+                carryWheat: 0,
+                carryFish: 0,
+                carryGold: 0
+            });
         }
         return bandit;
     }
@@ -2699,10 +2815,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             nextActionTick: nextActionTick,
             tier: 0,
             attackPower: _banditStrengthForLegacyEvent(bandit.strength),
-            carryWood: 0,
-            carryIron: 0,
-            carryWheat: 0,
-            carryFish: 0,
+            carryWood: bandit.carryWood,
+            carryIron: bandit.carryIron,
+            carryWheat: bandit.carryWheat,
+            carryFish: bandit.carryFish,
             projectedTargetClanId: bandit.targetClanId,
             projectedTargetLootValue: 0
         });

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -82,9 +82,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     uint256 private constant RESOURCE_UNIT = 1e18;
+    uint256 internal constant BLUEPRINT_UNIT = 1e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
     uint256 internal constant DOMAIN_BANDIT_SPAWN = uint256(keccak256("clanworld.bandit.spawn.v1"));
+    uint256 internal constant DOMAIN_BANDIT_TARGET_PICK = uint256(keccak256("bandit_target_pick"));
     uint64 internal constant MIN_SPAWN_COOLDOWN_TICKS = ClanWorldConstants.BANDIT_COOLDOWN_TICKS;
     uint16 internal constant BANDIT_SPAWN_PROBABILITY_INCREMENT_BPS = 1000;
     uint16 internal constant BANDIT_SPAWN_MAX_PROBABILITY_BPS = 8000;
@@ -468,9 +470,21 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             emit ClanStarvationChanged(clan.clanId, false, tick);
         }
 
-        if (starving && _world.winterActive && clan.starvationStartsAtTick >= _world.winterStartsAtTick) {
+        if (starving && _isWinterTick(tick) && clan.starvationStartsAtTick <= tick) {
             _killNextClansmanFromStarvation(clan, tick);
         }
+    }
+
+    function _isWinterTick(uint64 tick) internal pure returns (bool) {
+        uint64 seasonOffset = tick % ClanWorldConstants.SEASON_DURATION_TICKS;
+        uint64 cycleOffset = seasonOffset % ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
+        uint64 cycleStart = seasonOffset - cycleOffset;
+        uint64 winterStart =
+            cycleStart + ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS;
+        uint64 winterEnd = cycleStart + ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
+
+        return winterStart < ClanWorldConstants.SEASON_DURATION_TICKS && seasonOffset >= winterStart
+            && seasonOffset < winterEnd;
     }
 
     function _killNextClansmanFromStarvation(Clan storage clan, uint64 tick) internal {
@@ -1088,7 +1102,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             sim.clan.starvationStartsAtTick = 0;
         }
 
-        if (starving && _world.winterActive && sim.clan.starvationStartsAtTick >= _world.winterStartsAtTick) {
+        if (starving && _isWinterTick(tick) && sim.clan.starvationStartsAtTick <= tick) {
             _simulateKillNextClansmanFromStarvation(sim);
         }
     }
@@ -1661,6 +1675,22 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 if (bandit.state == BanditState.Spawned && closedTick > bandit.tickEnteredState) {
                     _transitionBanditState(banditId, BanditState.Camped);
                 } else if (
+                    bandit.state == BanditState.Camped
+                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS
+                ) {
+                    uint32 targetClanId = _pickBanditAttackTarget(bandit);
+                    if (targetClanId == ClanWorldConstants.CLAN_ID_NULL) {
+                        _transitionBanditState(banditId, BanditState.Escaped);
+                        emit BanditEscaped(banditId, closedTick);
+                    } else {
+                        _transitionBanditToAttacking(banditId, targetClanId);
+                    }
+                } else if (
+                    bandit.state == BanditState.Escaped
+                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
+                ) {
+                    _transitionBanditState(banditId, BanditState.Resting);
+                } else if (
                     bandit.state == BanditState.Resting
                         && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
                 ) {
@@ -1668,6 +1698,40 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 }
             }
         }
+    }
+
+    function _pickBanditAttackTarget(BanditTroop storage bandit) internal view returns (uint32 targetClanId) {
+        uint32[MAX_CLANS] memory tiedClanIds;
+        uint256 tiedCount;
+        uint256 bestLootValue;
+
+        for (uint256 i = 0; i < _allClanIds.length; i++) {
+            uint32 clanId = _allClanIds[i];
+            Clan storage clan = _clans[clanId];
+            if (clan.clanState == ClanState.DEAD || clan.baseRegion != bandit.region || clan.livingClansmen == 0) {
+                continue;
+            }
+
+            uint256 lootValue = _lootValueRaw(clan);
+            if (tiedCount == 0 || lootValue > bestLootValue) {
+                bestLootValue = lootValue;
+                tiedClanIds[0] = clanId;
+                tiedCount = 1;
+            } else if (lootValue == bestLootValue) {
+                tiedClanIds[tiedCount] = clanId;
+                tiedCount++;
+            }
+        }
+
+        if (tiedCount == 0) {
+            return ClanWorldConstants.CLAN_ID_NULL;
+        }
+        if (tiedCount == 1) {
+            return tiedClanIds[0];
+        }
+
+        uint256 selected = RNG.rngBounded(_world.currentTickSeed, DOMAIN_BANDIT_TARGET_PICK, bandit.id, tiedCount);
+        return tiedClanIds[selected];
     }
 
     function _banditStrengthForLegacyEvent(uint32 strength) internal pure returns (uint16) {
@@ -1715,7 +1779,22 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         _settleClan(targetClanId);
+        if (bandit.state != BanditState.Attacking || bandit.targetClanId != targetClanId) {
+            return;
+        }
+        if (targetClan.clanState == ClanState.DEAD) {
+            _transitionBanditState(banditId, BanditState.Escaped);
+            emit BanditEscaped(banditId, closedTick);
+            return;
+        }
+
         _eagerSettleActiveDefendersForBase(targetClanId, targetClan.baseRegion);
+        if (
+            bandit.state != BanditState.Attacking || bandit.targetClanId != targetClanId
+                || targetClan.clanState == ClanState.DEAD
+        ) {
+            return;
+        }
 
         bytes32 tickSeed = _world.currentTickSeed;
         uint32 banditAttackPower = bandit.strength;
@@ -1752,8 +1831,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (defeated) {
             emit BanditDefeated(banditId, targetClanId, closedTick);
             _distributeBanditLootToDefendingClans(banditId, targetClanId);
-            targetClan.blueprintBalance += 1;
-            emit BlueprintEarned(targetClanId, banditId, closedTick);
+            targetClan.blueprintBalance += BLUEPRINT_UNIT;
+            emit BlueprintEarned(targetClanId, banditId, BLUEPRINT_UNIT, closedTick);
             _transitionBanditState(banditId, BanditState.Defeated);
         } else {
             _transitionBanditState(banditId, BanditState.Escaped);

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -90,15 +90,16 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint16 internal constant BANDIT_SPAWN_MAX_PROBABILITY_BPS = 8000;
     uint8 internal constant MAX_BANDITS_PER_REGION = 3;
     uint8 internal constant MAX_TOTAL_BANDITS = 8;
-    /// @dev Bandit spawn weights are a heartbeat-time heuristic. Bound the scan
-    ///      and rotate the starting clan by tick so larger worlds do not turn
-    ///      spawn preview/selection into an unbounded heartbeat cost.
+    uint8 internal constant MAX_CLANS = 12;
+    /// @dev Bandit spawn weights are a heartbeat-time heuristic. V1 has
+    ///      MAX_CLANS = 12, so scanning 8 clans per tick covers the live cap in
+    ///      at most two rotating heartbeats while keeping heartbeat gas bounded.
     uint256 internal constant MAX_BANDIT_SPAWN_SCAN_PER_REGION = 8;
     uint256 internal constant MAX_BANDIT_SPAWN_CLANSMEN_SCAN_PER_REGION = MAX_BANDIT_SPAWN_SCAN_PER_REGION * 4;
     /// @dev Eager settlement scans the clan-indexed bases in each spawn-candidate
-    ///      region, not every clan globally per region forever. The current world
-    ///      caps minting at 12 clans, so this settles all possible bases today
-    ///      while keeping the heartbeat loop explicitly bounded if that cap grows.
+    ///      region, not every clan globally per region forever. MAX_CLANS = 12,
+    ///      so this settles all possible bases today while keeping the heartbeat
+    ///      loop explicitly bounded if that cap grows.
     uint256 internal constant MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION = 12;
     uint256 internal constant MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION = 12;
     uint256 internal constant MAX_BANDIT_EAGER_SETTLE_DEFENDER_SCAN_PER_REGION = 48;
@@ -134,8 +135,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _world.nextHeartbeatAtTick = 1; // first heartbeat will open tick 1
         // First winter: last WINTER_DURATION_TICKS of first TICKS_PER_WINTER_CYCLE cycle
         // i.e. ticks [100, 110)
-        _world.winterStartsAtTick =
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
+        _world.winterStartsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
         _world.winterEndsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE; // = 110
         _world.winterActive = false;
         _treasury.treasuryOwner = msg.sender;
@@ -543,7 +543,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         _releaseDefendersForDeadTarget(clanId, baseRegion);
-        _abortBanditAttacksForDeadTarget(clanId, tick, excludedBanditId);
+        _abortBanditAttacksForDeadTarget(clanId, excludedBanditId);
 
         emit ClanEliminated(clanId, tick);
     }
@@ -558,8 +558,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 uint32 clansmanId = csIds[j];
                 Mission storage mission = _missions[clansmanId];
                 if (
-                    mission.active && mission.action == ActionType.DefendBase
-                        && mission.targetClanId == deadClanId && _clansmanDefendingRegion[clansmanId] == baseRegion
+                    mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == deadClanId
+                        && _clansmanDefendingRegion[clansmanId] == baseRegion
                 ) {
                     _clearDefender(clansmanId);
                     mission.active = false;
@@ -573,7 +573,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
     }
 
-    function _abortBanditAttacksForDeadTarget(uint32 deadClanId, uint64 tick, uint32 excludedBanditId) internal {
+    function _abortBanditAttacksForDeadTarget(uint32 deadClanId, uint32 excludedBanditId) internal {
+        // Match _transitionBanditState's event stamp; heartbeat keeps currentTick
+        // equal to the closed tick while aborting linked bandit attacks.
+        uint64 currentTick = _world.currentTick;
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
             uint32[] storage regionBandits = _banditsByRegion[region];
             for (uint256 i = 0; i < regionBandits.length; i++) {
@@ -583,8 +586,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 BanditTroop storage bandit = _bandits[banditId];
                 if (bandit.state == BanditState.Attacking && bandit.targetClanId == deadClanId) {
                     _transitionBanditState(banditId, BanditState.Escaped);
-                    emit BanditEscaped(banditId, tick);
-                    emit BanditTargetDied(banditId, deadClanId, tick);
+                    emit BanditEscaped(banditId, currentTick);
+                    emit BanditTargetDied(banditId, deadClanId, currentTick);
                 }
             }
         }
@@ -1590,10 +1593,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     function _canBanditLeaveCamped(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
         return newState == BanditState.Escaped
-            || (
-                newState == BanditState.Attacking && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
-                    && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS
-            );
+            || (newState == BanditState.Attacking
+                && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
+                && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS);
     }
 
     function _canBanditLeaveAttacking(BanditState newState) internal pure returns (bool) {
@@ -1606,10 +1608,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     function _canBanditLeaveResting(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
         return newState == BanditState.Escaped
-            || (
-                newState == BanditState.Camped
-                    && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
-            );
+            || (newState == BanditState.Camped
+                && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS);
     }
 
     function _deleteBandit(uint32 id) internal {
@@ -1634,6 +1634,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     function _findOldestActiveBandit() internal view returns (uint32 oldestBanditId) {
+        // V1 caps live troops at MAX_TOTAL_BANDITS = 8, so scanning the region
+        // indexes is bounded even though storage mappings cannot be enumerated.
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
             uint32[] storage regionBandits = _banditsByRegion[region];
             for (uint256 i = 0; i < regionBandits.length; i++) {
@@ -1644,6 +1646,25 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 }
                 if (oldestBanditId == ClanWorldConstants.BANDIT_ID_NULL || candidateId < oldestBanditId) {
                     oldestBanditId = candidateId;
+                }
+            }
+        }
+    }
+
+    function _advanceBanditStates(uint64 closedTick) internal {
+        require(_world.currentTick == closedTick, "ClanWorld: bandit advance tick mismatch");
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            uint32[] storage regionBandits = _banditsByRegion[region];
+            for (uint256 i = 0; i < regionBandits.length; i++) {
+                uint32 banditId = regionBandits[i];
+                BanditTroop storage bandit = _bandits[banditId];
+                if (bandit.state == BanditState.Spawned && closedTick > bandit.tickEnteredState) {
+                    _transitionBanditState(banditId, BanditState.Camped);
+                } else if (
+                    bandit.state == BanditState.Resting
+                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
+                ) {
+                    _transitionBanditState(banditId, BanditState.Camped);
                 }
             }
         }
@@ -1662,8 +1683,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             while (i < regionBandits.length) {
                 uint32 banditId = regionBandits[i];
                 BanditTroop storage bandit = _bandits[banditId];
-                bool shouldResolve =
-                    bandit.state == BanditState.Attacking && bandit.tickEnteredState == closedTick;
+                bool shouldResolve = bandit.state == BanditState.Attacking && bandit.tickEnteredState == closedTick;
                 if (shouldResolve) {
                     _resolveBanditAttack(banditId, closedTick);
                     if (_bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) {
@@ -1948,8 +1968,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             return 0;
         }
 
-        uint256 pick = uint256(keccak256(abi.encode("bandit_clansman_kill", tickSeed, banditId, clanId, killIndex)))
-            % livingCount;
+        uint256 pick =
+            uint256(keccak256(abi.encode("bandit_clansman_kill", tickSeed, banditId, clanId, killIndex))) % livingCount;
         uint256 seen;
         for (uint256 i = 0; i < clansmanIds.length; i++) {
             uint32 candidateId = clansmanIds[i];
@@ -2006,6 +2026,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         uint8 selectedRegion = _selectBanditSpawnRegion(tickSeed, candidateWeights);
         if (selectedRegion != ClanWorldConstants.REGION_NOOP) {
+            // _spawnBandit resets only the selected region's accumulator; other
+            // eligible regions retain their accumulated pressure for later ticks.
             _spawnBandit(selectedRegion, _banditSpawnStrength(tickSeed, selectedRegion));
         }
 
@@ -2133,8 +2155,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             return weights;
         }
 
-        uint256 scanCount =
-            clanCount < MAX_BANDIT_SPAWN_SCAN_PER_REGION ? clanCount : MAX_BANDIT_SPAWN_SCAN_PER_REGION;
+        uint256 scanCount = clanCount < MAX_BANDIT_SPAWN_SCAN_PER_REGION ? clanCount : MAX_BANDIT_SPAWN_SCAN_PER_REGION;
         uint256 startIndex = uint256(_world.currentTick) % clanCount;
         uint256 clansmenScanned;
         for (uint256 i = 0; i < scanCount; i++) {
@@ -2143,7 +2164,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 continue;
             }
 
-            if (clan.baseRegion >= ClanWorldConstants.REGION_FOREST && clan.baseRegion <= ClanWorldConstants.REGION_DEEP_SEA) {
+            if (
+                clan.baseRegion >= ClanWorldConstants.REGION_FOREST
+                    && clan.baseRegion <= ClanWorldConstants.REGION_DEEP_SEA
+            ) {
                 weights[clan.baseRegion - 1] += 100 + (_lootValueRaw(clan) / 1e18);
             }
 
@@ -2174,8 +2198,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             uint64 eligibleTick = spawnState.lastSpawnTick + MIN_SPAWN_COOLDOWN_TICKS;
             if (
                 _activeBanditCount < MAX_TOTAL_BANDITS && regionWeights[region - 1] > 0
-                    && _banditsByRegion[region].length < MAX_BANDITS_PER_REGION
-                    && eligibleTick < nextEligibleTick
+                    && _banditsByRegion[region].length < MAX_BANDITS_PER_REGION && eligibleTick < nextEligibleTick
             ) {
                 nextEligibleTick = eligibleTick;
             }
@@ -2198,7 +2221,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     ///         1. Settle missions completing this tick.
     ///         2. Execute scheduled market actions for closedTick (external calls).
     ///         3. Eager-settle clans touched by world events (Phase 9 stub).
-    ///         4. Resolve closed-tick bandit/world events.
+    ///         4. Advance bandit timers and resolve closed-tick bandit/world events.
     ///         5. Increment tick and publish the next tick seed atomically.
     function heartbeat() external override nonReentrant {
         require(block.timestamp >= _world.nextHeartbeatAtTs, "ClanWorld: heartbeat rate limited");
@@ -2219,16 +2242,19 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         // Step 3: Eager-settle bases and active defenders in bandit spawn-candidate regions.
         _eagerSettleForBandits(closedTick);
 
-        // Step 4: Resolve deterministic bandit attacks for the closed tick.
+        // Step 4: Advance deterministic bandit timers for the closed tick.
+        _advanceBanditStates(closedTick);
+
+        // Step 5: Resolve deterministic bandit attacks for the closed tick.
         _resolveAttackingBandits(closedTick);
 
-        // Step 5: Evaluate deterministic bandit spawns for the closed tick.
+        // Step 6: Evaluate deterministic bandit spawns for the closed tick.
         _evaluateBanditSpawns(closedTickSeed);
 
-        // Step 6: Resolve world events (season boundary, winter transitions).
+        // Step 7: Resolve world events (season boundary, winter transitions).
         _resolveWorldEvents(closedTick);
 
-        // Step 7: Increment tick and publish the opened tick seed as one visible state transition.
+        // Step 8: Increment tick and publish the opened tick seed as one visible state transition.
         uint64 newTick = closedTick + 1;
         bytes32 newSeed = keccak256(abi.encode(block.prevrandao, closedTickSeed, closedTick));
         _world.currentTick = newTick;
@@ -2333,7 +2359,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     /// @notice Mint a new clan and spawn its homebase.
     function mintClan(address to) external override nonReentrant returns (uint32 clanId, uint256 iftTokenId) {
         require(to != address(0), "ClanWorld: zero address");
-        require(_allClanIds.length < 12, "ClanWorld: max clans");
+        require(_allClanIds.length < MAX_CLANS, "ClanWorld: max clans");
         clanId = _nextClanId++;
         iftTokenId = uint256(clanId); // Phase 1 placeholder; real iNFT is Phase 7
 
@@ -3449,7 +3475,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint64 nextActionTick = 0;
         bool exists = bandit.id != ClanWorldConstants.BANDIT_ID_NULL && bandit.state != BanditState.None;
         if (exists) {
-            if (bandit.state == BanditState.Camped) {
+            if (bandit.state == BanditState.Spawned) {
+                nextActionTick = bandit.tickEnteredState + 1;
+            } else if (bandit.state == BanditState.Camped) {
                 nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
             } else if (bandit.state == BanditState.Resting) {
                 nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS;

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -65,6 +65,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     mapping(uint32 => BanditTroop) internal _bandits;
     mapping(uint8 => uint32[]) internal _banditsByRegion; // region => bandit IDs
     mapping(uint8 => BanditSpawnState) internal _banditSpawnByRegion;
+    mapping(uint32 => uint8) private _banditAttackAttempts;
     mapping(uint64 => bytes32) private _tickSeeds; // tick => seed
 
     uint32 private _nextClanId;
@@ -91,7 +92,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint16 internal constant BANDIT_SPAWN_PROBABILITY_INCREMENT_BPS = 1000;
     uint16 internal constant BANDIT_SPAWN_MAX_PROBABILITY_BPS = 8000;
     uint8 internal constant MAX_BANDITS_PER_REGION = 3;
-    uint8 internal constant MAX_TOTAL_BANDITS = 8;
+    uint8 internal constant MAX_TOTAL_BANDITS = 1;
     uint8 internal constant MAX_CLANS = 12;
     /// @dev Bandit spawn weights are a heartbeat-time heuristic. V1 has
     ///      MAX_CLANS = 12, so scanning 8 clans per tick covers the live cap in
@@ -107,6 +108,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint256 internal constant MAX_BANDIT_EAGER_SETTLE_DEFENDER_SCAN_PER_REGION = 48;
     uint32 internal constant MIN_BANDIT_SPAWN_STRENGTH = 100;
     uint32 internal constant BANDIT_SPAWN_STRENGTH_SPREAD = 151;
+    uint32 internal constant DEFEND_BASE_DEFENSE = 10;
+    uint32 internal constant WAITING_HOME_DEFENSE = 5;
     uint32 internal constant CLANSMAN_MAX_DEFENSE_DAMAGE = 100;
     uint32 internal constant WALL_HP_PER_LEVEL = 100;
     uint32 internal constant BASE_HP_PER_LEVEL = 25;
@@ -1589,6 +1592,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         emit BanditStateChanged(id, oldState, newState, bandit.region, _world.currentTick);
+
+        if (oldState == BanditState.Resting && newState == BanditState.Camped) {
+            _moveBanditToRampageNextRegion(id);
+        }
     }
 
     function _isValidBanditTransition(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
@@ -1607,13 +1614,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     function _canBanditLeaveCamped(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
         return newState == BanditState.Escaped
+            || newState == BanditState.Resting
             || (newState == BanditState.Attacking
                 && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
                 && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS);
     }
 
     function _canBanditLeaveAttacking(BanditState newState) internal pure returns (bool) {
-        return newState == BanditState.Defeated || newState == BanditState.Escaped;
+        return newState == BanditState.Defeated || newState == BanditState.Escaped || newState == BanditState.Resting;
     }
 
     function _canBanditLeaveEscaped(BanditState newState) internal pure returns (bool) {
@@ -1624,6 +1632,39 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return newState == BanditState.Escaped
             || (newState == BanditState.Camped
                 && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS);
+    }
+
+    function _moveBanditToRampageNextRegion(uint32 id) internal {
+        BanditTroop storage bandit = _bandits[id];
+        uint8 fromRegion = bandit.region;
+        uint8 toRegion = _nextRampageRegion(fromRegion);
+        if (fromRegion == toRegion) {
+            return;
+        }
+
+        uint32[] storage fromBandits = _banditsByRegion[fromRegion];
+        for (uint256 i = 0; i < fromBandits.length; i++) {
+            if (fromBandits[i] == id) {
+                fromBandits[i] = fromBandits[fromBandits.length - 1];
+                fromBandits.pop();
+                break;
+            }
+        }
+
+        bandit.region = toRegion;
+        _banditsByRegion[toRegion].push(id);
+        emit BanditMoved(id, fromRegion, toRegion, _world.currentTick);
+
+        _eagerSettleBanditCandidateRegion(toRegion);
+    }
+
+    function _nextRampageRegion(uint8 currentRegion) internal pure returns (uint8) {
+        if (currentRegion == ClanWorldConstants.REGION_FOREST) return ClanWorldConstants.REGION_MOUNTAINS;
+        if (currentRegion == ClanWorldConstants.REGION_MOUNTAINS) return ClanWorldConstants.REGION_EAST_FARMS;
+        if (currentRegion == ClanWorldConstants.REGION_EAST_FARMS) return ClanWorldConstants.REGION_EAST_DOCKS;
+        if (currentRegion == ClanWorldConstants.REGION_EAST_DOCKS) return ClanWorldConstants.REGION_WEST_DOCKS;
+        if (currentRegion == ClanWorldConstants.REGION_WEST_DOCKS) return ClanWorldConstants.REGION_WEST_FARMS;
+        return ClanWorldConstants.REGION_FOREST;
     }
 
     function _deleteBandit(uint32 id) internal {
@@ -1639,6 +1680,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         delete _bandits[id];
+        delete _banditAttackAttempts[id];
         if (_activeBanditCount > 0) {
             _activeBanditCount -= 1;
         }
@@ -1648,7 +1690,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     function _findOldestActiveBandit() internal view returns (uint32 oldestBanditId) {
-        // V1 caps live troops at MAX_TOTAL_BANDITS = 8, so scanning the region
+        // V1 caps live troops at MAX_TOTAL_BANDITS, so scanning the region
         // indexes is bounded even though storage mappings cannot be enumerated.
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
             uint32[] storage regionBandits = _banditsByRegion[region];
@@ -1669,9 +1711,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         require(_world.currentTick == closedTick, "ClanWorld: bandit advance tick mismatch");
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
             uint32[] storage regionBandits = _banditsByRegion[region];
-            for (uint256 i = 0; i < regionBandits.length; i++) {
+            uint256 i = 0;
+            while (i < regionBandits.length) {
                 uint32 banditId = regionBandits[i];
                 BanditTroop storage bandit = _bandits[banditId];
+                uint8 regionBefore = bandit.region;
                 if (bandit.state == BanditState.Spawned && closedTick > bandit.tickEnteredState) {
                     _transitionBanditState(banditId, BanditState.Camped);
                 } else if (
@@ -1680,8 +1724,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 ) {
                     uint32 targetClanId = _pickBanditAttackTarget(bandit);
                     if (targetClanId == ClanWorldConstants.CLAN_ID_NULL) {
-                        _transitionBanditState(banditId, BanditState.Escaped);
-                        emit BanditEscaped(banditId, closedTick);
+                        if (_recordBanditAttackAttempt(banditId) >= ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
+                            _terminalEscapeBandit(banditId, closedTick);
+                            continue;
+                        }
+                        _transitionBanditState(banditId, BanditState.Resting);
                     } else {
                         _transitionBanditToAttacking(banditId, targetClanId);
                     }
@@ -1696,6 +1743,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 ) {
                     _transitionBanditState(banditId, BanditState.Camped);
                 }
+
+                if (_bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) {
+                    continue;
+                }
+                if (regionBefore != _bandits[banditId].region) {
+                    continue;
+                }
+                i++;
             }
         }
     }
@@ -1732,6 +1787,20 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         uint256 selected = RNG.rngBounded(_world.currentTickSeed, DOMAIN_BANDIT_TARGET_PICK, bandit.id, tiedCount);
         return tiedClanIds[selected];
+    }
+
+    function _recordBanditAttackAttempt(uint32 banditId) internal returns (uint8 attemptsMade) {
+        attemptsMade = _banditAttackAttempts[banditId] + 1;
+        _banditAttackAttempts[banditId] = attemptsMade;
+    }
+
+    function _terminalEscapeBandit(uint32 banditId, uint64 closedTick) internal {
+        BanditTroop storage bandit = _bandits[banditId];
+        BanditState oldState = bandit.state;
+        emit BanditStateChanged(banditId, oldState, BanditState.Escaped, bandit.region, closedTick);
+        _burnBanditCarry(banditId);
+        emit BanditEscaped(banditId, closedTick);
+        _deleteBandit(banditId);
     }
 
     function _banditStrengthForLegacyEvent(uint32 strength) internal pure returns (uint16) {
@@ -1798,13 +1867,18 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         bytes32 tickSeed = _world.currentTickSeed;
         uint32 banditAttackPower = bandit.strength;
-        uint32 totalClansmanDefense = _totalBanditClansmanDefense(banditId, targetClanId, tickSeed);
+        uint32 totalClansmanDefense = _totalBanditClansmanDefense(targetClanId);
         bool defeated = uint256(totalClansmanDefense) >= uint256(banditAttackPower) * 2;
 
         uint32 wallDamage;
         uint32 baseAbsorbed;
         uint32 clansmanDamageAbsorbed;
+        uint256 stolenWood;
+        uint256 stolenIron;
+        uint256 stolenWheat;
+        uint256 stolenFish;
         if (!defeated) {
+            (stolenWood, stolenIron, stolenWheat, stolenFish) = _stealBanditVaultLoot(bandit, targetClan);
             uint32 incomingDamage =
                 banditAttackPower > totalClansmanDefense ? banditAttackPower - totalClansmanDefense : 0;
             (incomingDamage, wallDamage) = _applyBanditWallDamage(targetClan, targetClanId, banditId, incomingDamage);
@@ -1821,10 +1895,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             _uint16Clamp(banditAttackPower),
             _uint16Clamp(totalDefense),
             targetClan.wallLevel,
-            0,
-            0,
-            0,
-            0,
+            stolenWood,
+            stolenIron,
+            stolenWheat,
+            stolenFish,
             closedTick
         );
 
@@ -1835,35 +1909,70 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             emit BlueprintEarned(targetClanId, banditId, BLUEPRINT_UNIT, closedTick);
             _transitionBanditState(banditId, BanditState.Defeated);
         } else {
-            _transitionBanditState(banditId, BanditState.Escaped);
-            emit BanditEscaped(banditId, closedTick);
+            if (_recordBanditAttackAttempt(banditId) >= ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
+                _terminalEscapeBandit(banditId, closedTick);
+            } else {
+                _transitionBanditState(banditId, BanditState.Resting);
+            }
         }
     }
 
     function _distributeBanditLootToDefendingClans(uint32 banditId, uint32 targetClanId) internal {
         BanditTroop storage bandit = _bandits[banditId];
-        uint32[] memory rewardedClanIds = _activeDefendingClanIds(targetClanId);
-        uint256 nDefendingClans = rewardedClanIds.length;
+        DefenseContribution[] memory contributions = _banditDefenseContributions(targetClanId);
+        uint256 nDefenders = contributions.length;
+        uint32[] memory rewardedClanIds = new uint32[](nDefenders);
+
+        uint256 dropWood = _banditLootDrop(bandit.carryWood);
+        uint256 dropIron = _banditLootDrop(bandit.carryIron);
+        uint256 dropWheat = _banditLootDrop(bandit.carryWheat);
+        uint256 dropFish = _banditLootDrop(bandit.carryFish);
+        uint256 dropGold = _banditLootDrop(bandit.carryGold);
 
         uint256 perWood;
         uint256 perIron;
         uint256 perWheat;
         uint256 perFish;
         uint256 perGold;
-        if (nDefendingClans > 0) {
-            perWood = _perClanBanditLootShare(bandit.carryWood, nDefendingClans);
-            perIron = _perClanBanditLootShare(bandit.carryIron, nDefendingClans);
-            perWheat = _perClanBanditLootShare(bandit.carryWheat, nDefendingClans);
-            perFish = _perClanBanditLootShare(bandit.carryFish, nDefendingClans);
-            perGold = _perClanBanditLootShare(bandit.carryGold, nDefendingClans);
+        uint256 distributedWood;
+        uint256 distributedIron;
+        uint256 distributedWheat;
+        uint256 distributedFish;
+        uint256 distributedGold;
+        if (nDefenders > 0) {
+            perWood = _perDefenderBanditLootShare(dropWood, nDefenders);
+            perIron = _perDefenderBanditLootShare(dropIron, nDefenders);
+            perWheat = _perDefenderBanditLootShare(dropWheat, nDefenders);
+            perFish = _perDefenderBanditLootShare(dropFish, nDefenders);
+            perGold = _perDefenderBanditLootShare(dropGold, nDefenders);
 
-            for (uint256 i = 0; i < rewardedClanIds.length; i++) {
-                Clan storage defenderClan = _clans[rewardedClanIds[i]];
-                defenderClan.vaultWood += perWood;
-                defenderClan.vaultIron += perIron;
-                defenderClan.vaultWheat += perWheat;
-                defenderClan.vaultFish += perFish;
-                defenderClan.goldBalance += perGold;
+            for (uint256 i = 0; i < contributions.length; i++) {
+                uint32 clansmanId = contributions[i].clansmanId;
+                uint32 clanId = contributions[i].clanId;
+                rewardedClanIds[i] = clanId;
+
+                Clansman storage defender = _clansmen[clansmanId];
+                uint256 addedWood = _addClansmanCarryCapped(defender.carryWood, perWood, ClanWorldConstants.WOOD_CAP);
+                uint256 addedIron = _addClansmanCarryCapped(defender.carryIron, perIron, ClanWorldConstants.IRON_CAP);
+                uint256 addedWheat =
+                    _addClansmanCarryCapped(defender.carryWheat, perWheat, ClanWorldConstants.WHEAT_CAP);
+                uint256 addedFish = _addClansmanCarryCapped(defender.carryFish, perFish, ClanWorldConstants.FISH_CAP);
+
+                defender.carryWood += addedWood;
+                defender.carryIron += addedIron;
+                defender.carryWheat += addedWheat;
+                defender.carryFish += addedFish;
+                _clans[clanId].goldBalance += perGold;
+
+                distributedWood += addedWood;
+                distributedIron += addedIron;
+                distributedWheat += addedWheat;
+                distributedFish += addedFish;
+                distributedGold += perGold;
+
+                emit LootDistributedToDefender(
+                    banditId, clanId, clansmanId, addedWood, addedIron, addedWheat, addedFish
+                );
             }
         }
 
@@ -1875,19 +1984,76 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             perFish,
             perIron,
             perGold,
-            bandit.carryWood - (perWood * nDefendingClans),
-            bandit.carryWheat - (perWheat * nDefendingClans),
-            bandit.carryFish - (perFish * nDefendingClans),
-            bandit.carryIron - (perIron * nDefendingClans),
-            bandit.carryGold - (perGold * nDefendingClans)
+            bandit.carryWood - distributedWood,
+            bandit.carryWheat - distributedWheat,
+            bandit.carryFish - distributedFish,
+            bandit.carryIron - distributedIron,
+            bandit.carryGold - distributedGold
         );
     }
 
-    function _perClanBanditLootShare(uint256 loot, uint256 nDefendingClans) internal pure returns (uint256) {
-        if (nDefendingClans == 1) {
+    function _burnBanditCarry(uint32 banditId) internal {
+        BanditTroop storage bandit = _bandits[banditId];
+        uint32[] memory rewardedClanIds = new uint32[](0);
+        emit LootDistributed(
+            banditId,
+            rewardedClanIds,
+            0,
+            0,
+            0,
+            0,
+            0,
+            bandit.carryWood,
+            bandit.carryWheat,
+            bandit.carryFish,
+            bandit.carryIron,
+            bandit.carryGold
+        );
+    }
+
+    function _stealBanditVaultLoot(BanditTroop storage bandit, Clan storage targetClan)
+        internal
+        returns (uint256 stolenWood, uint256 stolenIron, uint256 stolenWheat, uint256 stolenFish)
+    {
+        stolenWood = _banditStealAmount(targetClan.vaultWood);
+        stolenIron = _banditStealAmount(targetClan.vaultIron);
+        stolenWheat = _banditStealAmount(targetClan.vaultWheat);
+        stolenFish = _banditStealAmount(targetClan.vaultFish);
+
+        targetClan.vaultWood -= stolenWood;
+        targetClan.vaultIron -= stolenIron;
+        targetClan.vaultWheat -= stolenWheat;
+        targetClan.vaultFish -= stolenFish;
+
+        bandit.carryWood += stolenWood;
+        bandit.carryIron += stolenIron;
+        bandit.carryWheat += stolenWheat;
+        bandit.carryFish += stolenFish;
+    }
+
+    function _banditStealAmount(uint256 vaultAmount) internal pure returns (uint256) {
+        return (vaultAmount * ClanWorldConstants.BANDIT_BASE_STEAL_BPS) / 10000;
+    }
+
+    function _banditLootDrop(uint256 carryAmount) internal pure returns (uint256) {
+        return (carryAmount * ClanWorldConstants.BANDIT_DROP_TO_DEFENDERS_BPS) / 10000;
+    }
+
+    function _perDefenderBanditLootShare(uint256 loot, uint256 nDefenders) internal pure returns (uint256) {
+        if (nDefenders == 1) {
             return loot;
         }
-        return ((loot / RESOURCE_UNIT) / nDefendingClans) * RESOURCE_UNIT;
+        return ((loot / RESOURCE_UNIT) / nDefenders) * RESOURCE_UNIT;
+    }
+
+    function _addClansmanCarryCapped(uint256 currentCarry, uint256 amount, uint256 carryCap)
+        internal
+        pure
+        returns (uint256)
+    {
+        if (currentCarry >= carryCap) return 0;
+        uint256 remaining = carryCap - currentCarry;
+        return amount < remaining ? amount : remaining;
     }
 
     function _activeDefendingClanIds(uint32 targetClanId) internal view returns (uint32[] memory clanIds) {
@@ -1911,6 +2077,90 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
     }
 
+    function _banditDefenseContributions(uint32 targetClanId)
+        internal
+        view
+        returns (DefenseContribution[] memory contributions)
+    {
+        uint256 count = _countBanditDefenseContributions(targetClanId);
+        contributions = new DefenseContribution[](count);
+        uint256 out;
+
+        uint8 targetRegion = _clans[targetClanId].baseRegion;
+        uint32[] storage defendingClans = _defendingClansByRegion[targetRegion];
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            uint32 defenderClanId = defendingClans[i];
+            Clan storage defenderClan = _clans[defenderClanId];
+            if (defenderClan.clanState == ClanState.DEAD || _isStarving(defenderClan)) {
+                continue;
+            }
+
+            uint32[] storage clansmanIds = _clanClansmanIds[defenderClanId];
+            for (uint256 j = 0; j < clansmanIds.length; j++) {
+                uint32 clansmanId = clansmanIds[j];
+                Clansman storage cs = _clansmen[clansmanId];
+                Mission storage mission = _missions[clansmanId];
+                if (_isExplicitBanditDefender(cs, mission, targetClanId, targetRegion)) {
+                    contributions[out++] = DefenseContribution({
+                        clansmanId: clansmanId,
+                        clanId: defenderClanId,
+                        defensePoints: uint16(DEFEND_BASE_DEFENSE)
+                    });
+                }
+            }
+        }
+
+        Clan storage targetClan = _clans[targetClanId];
+        if (targetClan.clanState != ClanState.DEAD && !_isStarving(targetClan)) {
+            uint32[] storage targetClansmen = _clanClansmanIds[targetClanId];
+            for (uint256 i = 0; i < targetClansmen.length; i++) {
+                uint32 clansmanId = targetClansmen[i];
+                Clansman storage cs = _clansmen[clansmanId];
+                if (cs.state == ClansmanState.WAITING && cs.currentRegion == targetRegion) {
+                    contributions[out++] = DefenseContribution({
+                        clansmanId: clansmanId,
+                        clanId: targetClanId,
+                        defensePoints: uint16(WAITING_HOME_DEFENSE)
+                    });
+                }
+            }
+        }
+    }
+
+    function _countBanditDefenseContributions(uint32 targetClanId) internal view returns (uint256 count) {
+        uint8 targetRegion = _clans[targetClanId].baseRegion;
+        uint32[] storage defendingClans = _defendingClansByRegion[targetRegion];
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            uint32 defenderClanId = defendingClans[i];
+            Clan storage defenderClan = _clans[defenderClanId];
+            if (defenderClan.clanState == ClanState.DEAD || _isStarving(defenderClan)) {
+                continue;
+            }
+
+            uint32[] storage clansmanIds = _clanClansmanIds[defenderClanId];
+            for (uint256 j = 0; j < clansmanIds.length; j++) {
+                Clansman storage cs = _clansmen[clansmanIds[j]];
+                Mission storage mission = _missions[clansmanIds[j]];
+                if (_isExplicitBanditDefender(cs, mission, targetClanId, targetRegion)) {
+                    count++;
+                }
+            }
+        }
+
+        Clan storage targetClan = _clans[targetClanId];
+        if (targetClan.clanState == ClanState.DEAD || _isStarving(targetClan)) {
+            return count;
+        }
+
+        uint32[] storage targetClansmen = _clanClansmanIds[targetClanId];
+        for (uint256 i = 0; i < targetClansmen.length; i++) {
+            Clansman storage cs = _clansmen[targetClansmen[i]];
+            if (cs.state == ClansmanState.WAITING && cs.currentRegion == targetRegion) {
+                count++;
+            }
+        }
+    }
+
     function _clanHasActiveDefenderForTarget(uint32 defenderClanId, uint32 targetClanId, uint8 targetRegion)
         internal
         view
@@ -1926,43 +2176,27 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             uint32 clansmanId = clansmanIds[i];
             Clansman storage cs = _clansmen[clansmanId];
             Mission storage mission = _missions[clansmanId];
-            if (
-                cs.state == ClansmanState.ACTING && cs.currentRegion == targetRegion && mission.active
-                    && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId
-            ) {
+            if (_isExplicitBanditDefender(cs, mission, targetClanId, targetRegion)) {
                 return true;
             }
         }
         return false;
     }
 
-    function _totalBanditClansmanDefense(uint32 banditId, uint32 targetClanId, bytes32 tickSeed)
-        internal
-        view
-        returns (uint32 totalDefense)
-    {
-        uint8 targetRegion = _clans[targetClanId].baseRegion;
-        uint32[] storage defendingClans = _defendingClansByRegion[targetRegion];
+    function _isExplicitBanditDefender(
+        Clansman storage cs,
+        Mission storage mission,
+        uint32 targetClanId,
+        uint8 targetRegion
+    ) internal view returns (bool) {
+        return cs.state == ClansmanState.ACTING && cs.currentRegion == targetRegion && mission.active
+            && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId;
+    }
 
-        for (uint256 i = 0; i < defendingClans.length; i++) {
-            uint32 defenderClanId = defendingClans[i];
-            Clan storage defenderClan = _clans[defenderClanId];
-            if (defenderClan.clanState == ClanState.DEAD || _isStarving(defenderClan)) {
-                continue;
-            }
-
-            uint32[] storage clansmanIds = _clanClansmanIds[defenderClanId];
-            for (uint256 j = 0; j < clansmanIds.length; j++) {
-                uint32 clansmanId = clansmanIds[j];
-                Clansman storage cs = _clansmen[clansmanId];
-                Mission storage mission = _missions[clansmanId];
-                if (
-                    cs.state == ClansmanState.ACTING && cs.currentRegion == targetRegion && mission.active
-                        && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId
-                ) {
-                    totalDefense += _clansmanDefenseDamageRoll(tickSeed, banditId, clansmanId);
-                }
-            }
+    function _totalBanditClansmanDefense(uint32 targetClanId) internal view returns (uint32 totalDefense) {
+        DefenseContribution[] memory contributions = _banditDefenseContributions(targetClanId);
+        for (uint256 i = 0; i < contributions.length; i++) {
+            totalDefense += contributions[i].defensePoints;
         }
     }
 
@@ -3553,6 +3787,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         BanditTroop memory bandit = _bandits[_world.activeBanditId];
         uint64 nextActionTick = 0;
         bool exists = bandit.id != ClanWorldConstants.BANDIT_ID_NULL && bandit.state != BanditState.None;
+        uint8 attemptsMade = exists ? _banditAttackAttempts[bandit.id] : 0;
+        uint8 maxAttemptsRemaining =
+            exists ? ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS - attemptsMade : 0;
         if (exists) {
             if (bandit.state == BanditState.Spawned) {
                 nextActionTick = bandit.tickEnteredState + 1;
@@ -3568,8 +3805,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             banditId: bandit.id,
             state: bandit.state,
             currentRegion: bandit.region,
-            attackAttemptsMade: 0,
-            maxAttemptsRemaining: 0,
+            attackAttemptsMade: attemptsMade,
+            maxAttemptsRemaining: maxAttemptsRemaining,
             stateEnteredTick: bandit.tickEnteredState,
             nextActionTick: nextActionTick,
             tier: 0,

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -216,8 +216,19 @@ contract ClanWorldStub is IClanWorld {
     }
 
     function getBandit(uint32) public pure override returns (BanditTroop memory) {
-        return
-            BanditTroop({id: 0, region: 0, state: BanditState.None, targetClanId: 0, tickEnteredState: 0, strength: 0});
+        return BanditTroop({
+            id: 0,
+            region: 0,
+            state: BanditState.None,
+            targetClanId: 0,
+            tickEnteredState: 0,
+            strength: 0,
+            carryWood: 0,
+            carryIron: 0,
+            carryWheat: 0,
+            carryFish: 0,
+            carryGold: 0
+        });
     }
 
     function getBanditTroop(uint32 banditId) external pure override returns (BanditTroop memory) {

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -206,21 +206,17 @@ contract ClanWorldStub is IClanWorld {
         return 0;
     }
 
-    function getBanditTroop(uint32) external pure override returns (BanditTroop memory) {
-        return BanditTroop({
-            banditId: 0,
-            state: BanditState.NONE,
-            currentRegion: 0,
-            attackAttemptsMade: 0,
-            stateEnteredTick: 0,
-            nextActionTick: 0,
-            tier: 0,
-            attackPower: 0,
-            carryWood: 0,
-            carryIron: 0,
-            carryWheat: 0,
-            carryFish: 0
-        });
+    function getBandit(uint32) public pure override returns (BanditTroop memory) {
+        return
+            BanditTroop({id: 0, region: 0, state: BanditState.None, targetClanId: 0, tickEnteredState: 0, strength: 0});
+    }
+
+    function getBanditTroop(uint32 banditId) external pure override returns (BanditTroop memory) {
+        return getBandit(banditId);
+    }
+
+    function getBanditsInRegion(uint8) external pure override returns (uint32[] memory) {
+        return new uint32[](0);
     }
 
     function getWheatPlots(uint32) external pure override returns (WheatPlot memory west, WheatPlot memory east) {
@@ -330,7 +326,7 @@ contract ClanWorldStub is IClanWorld {
         return ActiveBanditView({
             exists: false,
             banditId: 0,
-            state: BanditState.NONE,
+            state: BanditState.None,
             currentRegion: 0,
             attackAttemptsMade: 0,
             maxAttemptsRemaining: 0,

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -601,7 +601,7 @@ interface IClanWorldEvents {
     event WallDamagedByBandit(uint32 indexed clanId, uint8 newLevel, uint32 indexed banditId);
     event ClansmanKilledByBandit(uint32 indexed clanId, uint32 indexed clansmanId, uint32 indexed banditId);
     event BlueprintAwarded(uint32 indexed clanId, uint32 indexed banditId, uint256 amount);
-    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint64 tick);
+    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint256 amount, uint64 tick);
     event LootDistributed(
         uint32 indexed banditId,
         uint32[] clanIdsRewarded,

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -103,6 +103,7 @@ enum ClansmanState {
     DEAD
 }
 
+// v1 ABI: Bandit state machine redesigned in Phase 9. ABI consumers must regenerate.
 enum BanditState {
     None,
     Spawned,
@@ -189,8 +190,8 @@ struct WorldState {
     uint64 seasonStartTick;
     uint64 seasonEndTick;
     bool seasonFinalized;
-    uint64 currentSeasonNumber;   // 1-indexed; incremented each time seasonEndTick is crossed
-    uint64 nextHeartbeatAtTick;   // estimated tick that will be opened by the next heartbeat (for off-chain UI)
+    uint64 currentSeasonNumber; // 1-indexed; incremented each time seasonEndTick is crossed
+    uint64 nextHeartbeatAtTick; // estimated tick that will be opened by the next heartbeat (for off-chain UI)
 
     uint64 nextHeartbeatAtTs;
     uint64 nextBanditSpawnEligibleTick;
@@ -298,6 +299,7 @@ struct Mission {
     uint256 maxGoldIn; // market_buy only, 0 otherwise
 }
 
+// v1 ABI: Bandit troop layout redesigned in Phase 9. ABI consumers must regenerate.
 struct BanditTroop {
     uint32 id;
     uint8 region;

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -598,6 +598,7 @@ interface IClanWorldEvents {
     event WallDamagedByBandit(uint32 indexed clanId, uint8 newLevel, uint32 indexed banditId);
     event ClansmanKilledByBandit(uint32 indexed clanId, uint32 indexed clansmanId, uint32 indexed banditId);
     event BlueprintAwarded(uint32 indexed clanId, uint32 indexed banditId, uint256 amount);
+    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint64 tick);
     event LootDistributed(
         uint32 indexed banditId,
         uint32[] clanIdsRewarded,

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -595,6 +595,7 @@ interface IClanWorldEvents {
     );
     event BanditDefeated(uint32 indexed banditId, uint32 indexed targetClanId, uint64 atTick);
     event BanditEscaped(uint32 indexed banditId, uint64 atTick);
+    event BanditTargetDied(uint32 indexed banditId, uint32 indexed deadClanId, uint64 tick);
     event WallDamagedByBandit(uint32 indexed clanId, uint8 newLevel, uint32 indexed banditId);
     event ClansmanKilledByBandit(uint32 indexed clanId, uint32 indexed clansmanId, uint32 indexed banditId);
     event BlueprintAwarded(uint32 indexed clanId, uint32 indexed banditId, uint256 amount);

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -590,6 +590,8 @@ interface IClanWorldEvents {
     );
     event BanditDefeated(uint32 indexed banditId, uint32 indexed targetClanId, uint64 atTick);
     event BanditEscaped(uint32 indexed banditId, uint64 atTick);
+    event WallDamagedByBandit(uint32 indexed clanId, uint8 newLevel, uint32 indexed banditId);
+    event ClansmanKilledByBandit(uint32 indexed clanId, uint32 indexed clansmanId, uint32 indexed banditId);
     event BlueprintAwarded(uint32 indexed clanId, uint32 indexed banditId, uint256 amount);
     event LootDistributedToDefender(
         uint32 indexed banditId,

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -104,12 +104,13 @@ enum ClansmanState {
 }
 
 enum BanditState {
-    NONE,
-    CAMPING,
-    RESTING,
-    ATTACKING,
-    DEFEATED,
-    ESCAPED
+    None,
+    Spawned,
+    Camped,
+    Resting,
+    Attacking,
+    Defeated,
+    Escaped
 }
 
 enum WheatPlotState {
@@ -296,21 +297,12 @@ struct Mission {
 }
 
 struct BanditTroop {
-    uint32 banditId;
+    uint32 id;
+    uint8 region;
     BanditState state;
-
-    uint8 currentRegion;
-    uint8 attackAttemptsMade;
-    uint64 stateEnteredTick;
-    uint64 nextActionTick;
-
-    uint8 tier;
-    uint16 attackPower; // derived from tier; tier is canonical (v4.3 §G)
-
-    uint256 carryWood;
-    uint256 carryIron;
-    uint256 carryWheat;
-    uint256 carryFish;
+    uint32 targetClanId; // 0 if not attacking
+    uint64 tickEnteredState;
+    uint32 strength; // hp / combat power
 }
 
 struct ScheduledMarketAction {
@@ -710,7 +702,11 @@ interface IClanWorld is IClanWorldEvents {
 
     function getTravelTicks(uint8 fromRegion, uint8 toRegion) external pure returns (uint64);
 
+    function getBandit(uint32 banditId) external view returns (BanditTroop memory);
+
     function getBanditTroop(uint32 banditId) external view returns (BanditTroop memory);
+
+    function getBanditsInRegion(uint8 region) external view returns (uint32[] memory);
 
     function getWheatPlots(uint32 clanId) external view returns (WheatPlot memory west, WheatPlot memory east);
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -305,6 +305,11 @@ struct BanditTroop {
     uint32 targetClanId; // 0 if not attacking
     uint64 tickEnteredState;
     uint32 strength; // hp / combat power
+    uint256 carryWood;
+    uint256 carryIron;
+    uint256 carryWheat;
+    uint256 carryFish;
+    uint256 carryGold;
 }
 
 struct ScheduledMarketAction {
@@ -593,6 +598,20 @@ interface IClanWorldEvents {
     event WallDamagedByBandit(uint32 indexed clanId, uint8 newLevel, uint32 indexed banditId);
     event ClansmanKilledByBandit(uint32 indexed clanId, uint32 indexed clansmanId, uint32 indexed banditId);
     event BlueprintAwarded(uint32 indexed clanId, uint32 indexed banditId, uint256 amount);
+    event LootDistributed(
+        uint32 indexed banditId,
+        uint32[] clanIdsRewarded,
+        uint256 perClanWood,
+        uint256 perClanWheat,
+        uint256 perClanFish,
+        uint256 perClanIron,
+        uint256 perClanGold,
+        uint256 burnedWood,
+        uint256 burnedWheat,
+        uint256 burnedFish,
+        uint256 burnedIron,
+        uint256 burnedGold
+    );
     event LootDistributedToDefender(
         uint32 indexed banditId,
         uint32 indexed clanId,

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {ClanWorldConstants, BanditState, BanditTroop, WorldState} from "../src/IClanWorld.sol";
+
+contract BanditHarness is ClanWorld {
+    function spawnBandit(uint8 region, uint32 strength) external returns (uint32) {
+        return _spawnBandit(region, strength);
+    }
+
+    function transitionBandit(uint32 id, BanditState newState) external {
+        _transitionBanditState(id, newState);
+    }
+
+    function transitionBanditToAttacking(uint32 id, uint32 targetClanId) external {
+        _transitionBanditToAttacking(id, targetClanId);
+    }
+}
+
+contract BanditTest is Test {
+    BanditHarness world;
+
+    function setUp() public {
+        world = new BanditHarness();
+    }
+
+    function _advanceTick() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+    }
+
+    function _advanceTicks(uint64 ticks) internal {
+        for (uint64 i = 0; i < ticks; i++) {
+            _advanceTick();
+        }
+    }
+
+    function _spawnAndCamp() internal returns (uint32 id) {
+        id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        _advanceTick();
+        world.transitionBandit(id, BanditState.Camped);
+    }
+
+    function _spawnCampAndAttack(uint32 targetClanId) internal returns (uint32 id) {
+        id = _spawnAndCamp();
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        world.transitionBanditToAttacking(id, targetClanId);
+    }
+
+    function test_spawnBandit_recordsSpawnedTroopAndRegionIndex() public {
+        uint32 id = world.spawnBandit(ClanWorldConstants.REGION_MOUNTAINS, 250);
+
+        assertEq(id, 1, "first bandit id");
+        BanditTroop memory bandit = world.getBandit(id);
+        assertEq(bandit.id, id, "bandit id");
+        assertEq(bandit.region, ClanWorldConstants.REGION_MOUNTAINS, "region");
+        assertEq(uint8(bandit.state), uint8(BanditState.Spawned), "state");
+        assertEq(bandit.targetClanId, 0, "no target while spawned");
+        assertEq(bandit.tickEnteredState, world.getWorldState().currentTick, "entered tick");
+        assertEq(bandit.strength, 250, "strength");
+
+        uint32[] memory regionBandits = world.getBanditsInRegion(ClanWorldConstants.REGION_MOUNTAINS);
+        assertEq(regionBandits.length, 1, "region index length");
+        assertEq(regionBandits[0], id, "region index id");
+
+        WorldState memory state = world.getWorldState();
+        assertEq(state.activeBanditId, id, "active bandit");
+    }
+
+    function test_getBanditMissingIdReturnsNoneState() public view {
+        BanditTroop memory bandit = world.getBandit(999);
+
+        assertEq(bandit.id, 0, "missing id");
+        assertEq(uint8(bandit.state), uint8(BanditState.None), "missing state");
+    }
+
+    function test_defaultBanditTroopStateIsNone() public pure {
+        BanditTroop memory bandit;
+
+        assertEq(uint8(bandit.state), uint8(BanditState.None), "default state");
+    }
+
+    function test_spawnedToCampedTransitionSucceedsAfterNextHeartbeat() public {
+        uint32 id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+
+        _advanceTick();
+        world.transitionBandit(id, BanditState.Camped);
+
+        BanditTroop memory bandit = world.getBandit(id);
+        assertEq(uint8(bandit.state), uint8(BanditState.Camped), "state");
+        assertEq(bandit.tickEnteredState, world.getWorldState().currentTick, "entered camp tick");
+    }
+
+    function test_campedToAttackingTransitionSucceedsWithTargetAfterCampDuration() public {
+        uint32 id = _spawnAndCamp();
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+
+        world.transitionBanditToAttacking(id, 77);
+
+        BanditTroop memory bandit = world.getBandit(id);
+        assertEq(uint8(bandit.state), uint8(BanditState.Attacking), "state");
+        assertEq(bandit.targetClanId, 77, "target");
+        assertEq(bandit.tickEnteredState, world.getWorldState().currentTick, "entered attack tick");
+    }
+
+    function test_attackingToDefeatedDeletesBanditAndRegionIndex() public {
+        uint32 id = _spawnCampAndAttack(77);
+
+        world.transitionBandit(id, BanditState.Defeated);
+
+        BanditTroop memory deletedBandit = world.getBandit(id);
+        assertEq(deletedBandit.id, 0, "deleted id");
+        assertEq(deletedBandit.region, 0, "deleted region");
+        assertEq(uint8(deletedBandit.state), uint8(BanditState.None), "deleted state");
+        assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, 0, "removed from region");
+        assertEq(world.getWorldState().activeBanditId, 0, "active bandit cleared");
+    }
+
+    function test_attackingToEscapedRestingCampedCycleWorks() public {
+        uint32 id = _spawnCampAndAttack(77);
+
+        world.transitionBandit(id, BanditState.Escaped);
+        BanditTroop memory escaped = world.getBandit(id);
+        assertEq(uint8(escaped.state), uint8(BanditState.Escaped), "escaped");
+        assertEq(escaped.targetClanId, 0, "target cleared on escape");
+
+        world.transitionBandit(id, BanditState.Resting);
+        BanditTroop memory resting = world.getBandit(id);
+        assertEq(uint8(resting.state), uint8(BanditState.Resting), "resting");
+        assertEq(resting.tickEnteredState, world.getWorldState().currentTick, "resting tick");
+
+        _advanceTicks(ClanWorldConstants.BANDIT_REST_TICKS);
+        world.transitionBandit(id, BanditState.Camped);
+
+        BanditTroop memory camped = world.getBandit(id);
+        assertEq(uint8(camped.state), uint8(BanditState.Camped), "camped again");
+        assertEq(camped.targetClanId, 0, "target remains clear");
+    }
+
+    function test_invalidTransitionsRevert() public {
+        uint32 id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+
+        vm.expectRevert("ClanWorld: invalid bandit transition");
+        world.transitionBandit(id, BanditState.Defeated);
+
+        _advanceTick();
+        world.transitionBandit(id, BanditState.Camped);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+
+        vm.expectRevert("ClanWorld: invalid bandit transition");
+        world.transitionBandit(id, BanditState.Attacking);
+
+        vm.expectRevert("ClanWorld: invalid bandit transition");
+        world.transitionBandit(id, BanditState.None);
+    }
+
+    function test_getBanditsInRegionReturnsListAndUpdatesAfterDelete() public {
+        uint32 id1 = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        uint32 id2 = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 200);
+        uint32 id3 = world.spawnBandit(ClanWorldConstants.REGION_MOUNTAINS, 300);
+
+        uint32[] memory forestBandits = world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST);
+        assertEq(forestBandits.length, 2, "forest count");
+        assertEq(forestBandits[0], id1, "first forest bandit");
+        assertEq(forestBandits[1], id2, "second forest bandit");
+
+        uint32[] memory mountainBandits = world.getBanditsInRegion(ClanWorldConstants.REGION_MOUNTAINS);
+        assertEq(mountainBandits.length, 1, "mountain count");
+        assertEq(mountainBandits[0], id3, "mountain bandit");
+
+        _advanceTick();
+        world.transitionBandit(id1, BanditState.Camped);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        world.transitionBanditToAttacking(id1, 77);
+        world.transitionBandit(id1, BanditState.Defeated);
+
+        forestBandits = world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST);
+        assertEq(forestBandits.length, 1, "forest count after delete");
+        assertEq(forestBandits[0], id2, "remaining forest bandit");
+    }
+}

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -118,6 +118,21 @@ contract BanditTest is Test {
         assertEq(world.getWorldState().activeBanditId, 0, "active bandit cleared");
     }
 
+    function test_defeatingActiveBanditPromotesOldestRemainingBandit() public {
+        uint32 id1 = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        uint32 id2 = world.spawnBandit(ClanWorldConstants.REGION_MOUNTAINS, 200);
+        uint32 id3 = world.spawnBandit(ClanWorldConstants.REGION_WEST_FARMS, 300);
+
+        _advanceTick();
+        world.transitionBandit(id1, BanditState.Camped);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        world.transitionBanditToAttacking(id1, 77);
+        world.transitionBandit(id1, BanditState.Defeated);
+
+        assertEq(world.getWorldState().activeBanditId, id2, "oldest remaining promoted");
+        assertEq(world.getBandit(id3).id, id3, "newer bandit remains live");
+    }
+
     function test_attackingToEscapedRestingCampedCycleWorks() public {
         uint32 id = _spawnCampAndAttack(77);
 

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
 import {ClanWorld} from "../src/ClanWorld.sol";
-import {ClanWorldConstants, BanditState, BanditTroop, WorldState} from "../src/IClanWorld.sol";
+import {ActiveBanditView, ClanWorldConstants, BanditState, BanditTroop, WorldState} from "../src/IClanWorld.sol";
 
 contract BanditHarness is ClanWorld {
     function spawnBandit(uint8 region, uint32 strength) external returns (uint32) {
@@ -27,7 +27,7 @@ contract BanditTest is Test {
     }
 
     function _advanceTick() internal {
-        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        vm.warp(world.getWorldState().nextHeartbeatAtTs);
         world.heartbeat();
     }
 
@@ -39,8 +39,7 @@ contract BanditTest is Test {
 
     function _spawnAndCamp() internal returns (uint32 id) {
         id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
-        _advanceTick();
-        world.transitionBandit(id, BanditState.Camped);
+        _advanceTicks(2);
     }
 
     function _spawnCampAndAttack(uint32 targetClanId) internal returns (uint32 id) {
@@ -82,15 +81,24 @@ contract BanditTest is Test {
         assertEq(uint8(bandit.state), uint8(BanditState.None), "default state");
     }
 
-    function test_spawnedToCampedTransitionSucceedsAfterNextHeartbeat() public {
+    function test_spawnedToCampedTransitionAdvancesAfterSpawnDelay() public {
         uint32 id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
 
-        _advanceTick();
-        world.transitionBandit(id, BanditState.Camped);
+        _advanceTicks(2);
 
         BanditTroop memory bandit = world.getBandit(id);
         assertEq(uint8(bandit.state), uint8(BanditState.Camped), "state");
-        assertEq(bandit.tickEnteredState, world.getWorldState().currentTick, "entered camp tick");
+        assertEq(bandit.tickEnteredState, world.getWorldState().currentTick - 1, "entered camp tick");
+    }
+
+    function test_spawnedActiveBanditViewReportsNextActionTick() public {
+        uint32 id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+
+        ActiveBanditView memory view_ = world.getActiveBanditView();
+
+        assertEq(view_.banditId, id, "active bandit");
+        assertEq(uint8(view_.state), uint8(BanditState.Spawned), "state");
+        assertEq(view_.nextActionTick, world.getWorldState().currentTick + 1, "spawn delay tick");
     }
 
     function test_campedToAttackingTransitionSucceedsWithTargetAfterCampDuration() public {
@@ -123,8 +131,7 @@ contract BanditTest is Test {
         uint32 id2 = world.spawnBandit(ClanWorldConstants.REGION_MOUNTAINS, 200);
         uint32 id3 = world.spawnBandit(ClanWorldConstants.REGION_WEST_FARMS, 300);
 
-        _advanceTick();
-        world.transitionBandit(id1, BanditState.Camped);
+        _advanceTicks(2);
         _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
         world.transitionBanditToAttacking(id1, 77);
         world.transitionBandit(id1, BanditState.Defeated);
@@ -146,8 +153,7 @@ contract BanditTest is Test {
         assertEq(uint8(resting.state), uint8(BanditState.Resting), "resting");
         assertEq(resting.tickEnteredState, world.getWorldState().currentTick, "resting tick");
 
-        _advanceTicks(ClanWorldConstants.BANDIT_REST_TICKS);
-        world.transitionBandit(id, BanditState.Camped);
+        _advanceTicks(ClanWorldConstants.BANDIT_REST_TICKS + 1);
 
         BanditTroop memory camped = world.getBandit(id);
         assertEq(uint8(camped.state), uint8(BanditState.Camped), "camped again");
@@ -160,8 +166,7 @@ contract BanditTest is Test {
         vm.expectRevert("ClanWorld: invalid bandit transition");
         world.transitionBandit(id, BanditState.Defeated);
 
-        _advanceTick();
-        world.transitionBandit(id, BanditState.Camped);
+        _advanceTicks(2);
         _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
 
         vm.expectRevert("ClanWorld: invalid bandit transition");
@@ -185,8 +190,7 @@ contract BanditTest is Test {
         assertEq(mountainBandits.length, 1, "mountain count");
         assertEq(mountainBandits[0], id3, "mountain bandit");
 
-        _advanceTick();
-        world.transitionBandit(id1, BanditState.Camped);
+        _advanceTicks(2);
         _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
         world.transitionBanditToAttacking(id1, 77);
         world.transitionBandit(id1, BanditState.Defeated);

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -44,7 +44,7 @@ contract BanditTest is Test {
 
     function _spawnCampAndAttack(uint32 targetClanId) internal returns (uint32 id) {
         id = _spawnAndCamp();
-        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS - 1);
         world.transitionBanditToAttacking(id, targetClanId);
     }
 
@@ -103,7 +103,7 @@ contract BanditTest is Test {
 
     function test_campedToAttackingTransitionSucceedsWithTargetAfterCampDuration() public {
         uint32 id = _spawnAndCamp();
-        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS - 1);
 
         world.transitionBanditToAttacking(id, 77);
 
@@ -132,7 +132,7 @@ contract BanditTest is Test {
         uint32 id3 = world.spawnBandit(ClanWorldConstants.REGION_WEST_FARMS, 300);
 
         _advanceTicks(2);
-        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS - 1);
         world.transitionBanditToAttacking(id1, 77);
         world.transitionBandit(id1, BanditState.Defeated);
 
@@ -167,7 +167,7 @@ contract BanditTest is Test {
         world.transitionBandit(id, BanditState.Defeated);
 
         _advanceTicks(2);
-        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS - 1);
 
         vm.expectRevert("ClanWorld: invalid bandit transition");
         world.transitionBandit(id, BanditState.Attacking);
@@ -191,7 +191,7 @@ contract BanditTest is Test {
         assertEq(mountainBandits[0], id3, "mountain bandit");
 
         _advanceTicks(2);
-        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS - 1);
         world.transitionBanditToAttacking(id1, 77);
         world.transitionBandit(id1, BanditState.Defeated);
 

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -158,6 +158,22 @@ contract BanditTest is Test {
         BanditTroop memory camped = world.getBandit(id);
         assertEq(uint8(camped.state), uint8(BanditState.Camped), "camped again");
         assertEq(camped.targetClanId, 0, "target remains clear");
+        assertEq(camped.region, ClanWorldConstants.REGION_MOUNTAINS, "rampaged to next region");
+        assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, 0, "left forest index");
+        assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_MOUNTAINS)[0], id, "entered mountain index");
+    }
+
+    function test_restingToCampedFollowsRampagePath() public {
+        uint32 id = _spawnCampAndAttack(77);
+        world.transitionBandit(id, BanditState.Escaped);
+        world.transitionBandit(id, BanditState.Resting);
+
+        _advanceTicks(ClanWorldConstants.BANDIT_REST_TICKS + 1);
+        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_MOUNTAINS, "forest to mountains");
+
+        world.transitionBandit(id, BanditState.Resting);
+        _advanceTicks(ClanWorldConstants.BANDIT_REST_TICKS + 1);
+        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_EAST_FARMS, "mountains to east farms");
     }
 
     function test_invalidTransitionsRevert() public {

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
 import {ClanWorld} from "../src/ClanWorld.sol";
 import {
     ClanWorldConstants,
@@ -29,6 +30,16 @@ contract BanditAttackHarness is ClanWorld {
 
     function setStarvationStartsAt(uint32 clanId, uint64 tick) external {
         _clans[clanId].starvationStartsAtTick = tick;
+    }
+
+    function setClanUpkeepState(uint32 clanId, uint64 lastSettledTick, uint256 vaultWheat, uint256 vaultFish)
+        external
+    {
+        Clan storage clan = _clans[clanId];
+        clan.lastSettledTick = lastSettledTick;
+        clan.vaultWheat = vaultWheat;
+        clan.vaultFish = vaultFish;
+        clan.starvationStartsAtTick = 0;
     }
 
     function setBanditStrength(uint32 banditId, uint32 strength) external {
@@ -69,6 +80,7 @@ contract BanditAttackResolutionTest is Test {
     );
     event BanditDefeated(uint32 indexed banditId, uint32 indexed targetClanId, uint64 atTick);
     event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint64 tick);
+    event BanditTargetDied(uint32 indexed banditId, uint32 indexed deadClanId, uint64 tick);
     event LootDistributed(
         uint32 indexed banditId,
         uint32[] clanIdsRewarded,
@@ -153,6 +165,33 @@ contract BanditAttackResolutionTest is Test {
         }
     }
 
+    function _advanceUntil(uint64 tick) internal {
+        while (world.getWorldState().currentTick < tick) {
+            _advanceTick();
+        }
+    }
+
+    function _assertBanditTargetDiedLog(
+        Vm.Log[] memory logs,
+        uint32 expectedBanditId,
+        uint32 expectedDeadClanId,
+        uint64 expectedTick
+    ) internal {
+        bytes32 eventSig = keccak256("BanditTargetDied(uint32,uint32,uint64)");
+        bytes32 expectedBanditTopic = bytes32(uint256(expectedBanditId));
+        bytes32 expectedClanTopic = bytes32(uint256(expectedDeadClanId));
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (
+                logs[i].topics.length == 3 && logs[i].topics[0] == eventSig
+                    && logs[i].topics[1] == expectedBanditTopic && logs[i].topics[2] == expectedClanTopic
+            ) {
+                uint64 tick = abi.decode(logs[i].data, (uint64));
+                if (tick == expectedTick) return;
+            }
+        }
+        fail("expected BanditTargetDied log");
+    }
+
     function _activateTargetDefenders(uint32 targetClanId, uint32[] memory defenderClanIds, uint256 countEach)
         internal
     {
@@ -220,6 +259,56 @@ contract BanditAttackResolutionTest is Test {
         _advanceTick();
 
         assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore + 1, "target blueprint awarded");
+    }
+
+    function test_deadTargetCleanupReleasesDefendersAndEscapesBandit() public {
+        uint32[] memory clanIds = _mintClans(3);
+        uint32 defenderClanId = clanIds[0];
+        uint32 targetClanId = clanIds[1];
+        uint32 unaffectedClanId = clanIds[2];
+
+        uint64 defenderExecutesAtTick = _submitTargetDefenders(defenderClanId, targetClanId, 1);
+        _advanceUntilAfter(defenderExecutesAtTick);
+        world.settleClan(defenderClanId);
+
+        uint32 defenderId = _csId(defenderClanId, 0);
+        ClansmanState defenderStateBefore = world.getClansman(defenderId).state;
+        uint64 defenderCooldownBefore = world.getClansman(defenderId).cooldownEndsAtTs;
+        assertEq(uint8(defenderStateBefore), uint8(ClansmanState.ACTING), "defender active before target death");
+        assertEq(world.getActiveDefenders(targetClanId).length, 1, "target has active defender");
+
+        uint64 winterStart = world.getWorldState().winterStartsAtTick;
+        _advanceUntil(winterStart + 4);
+        uint64 deathFromTick = winterStart;
+        world.setClanUpkeepState(targetClanId, deathFromTick, 0, 0);
+
+        Clan memory unaffectedBefore = world.getClan(unaffectedClanId);
+        uint32 banditId = _forceAttack(targetClanId, 100);
+        uint64 expectedDeathTick = deathFromTick + 3;
+
+        vm.recordLogs();
+        world.settleClan(targetClanId);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        _assertBanditTargetDiedLog(logs, banditId, targetClanId, expectedDeathTick);
+
+        Clan memory targetAfter = world.getClan(targetClanId);
+        assertEq(uint8(targetAfter.clanState), uint8(ClanState.DEAD), "target clan dead");
+        assertEq(targetAfter.livingClansmen, 0, "target living count");
+
+        ClansmanState defenderStateAfter = world.getClansman(defenderId).state;
+        assertEq(uint8(defenderStateAfter), uint8(ClansmanState.WAITING), "defender released to waiting");
+        assertEq(world.getClansman(defenderId).cooldownEndsAtTs, defenderCooldownBefore, "cooldown unchanged");
+        assertFalse(world.getActiveMission(defenderId).active, "defender mission cleared");
+        assertEq(world.getActiveDefenders(targetClanId).length, 0, "target defender registry cleared");
+
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
+        assertEq(world.getBandit(banditId).targetClanId, 0, "bandit target cleared");
+
+        Clan memory unaffectedAfter = world.getClan(unaffectedClanId);
+        assertEq(uint8(unaffectedAfter.clanState), uint8(unaffectedBefore.clanState), "clan C state unaffected");
+        assertEq(unaffectedAfter.livingClansmen, unaffectedBefore.livingClansmen, "clan C living unaffected");
+        assertEq(unaffectedAfter.vaultWheat, unaffectedBefore.vaultWheat, "clan C wheat unaffected");
+        assertEq(unaffectedAfter.vaultFish, unaffectedBefore.vaultFish, "clan C fish unaffected");
     }
 
     function test_defeatedBanditLootSplitsEquallyAcrossFourDefendingClans() public {
@@ -420,7 +509,7 @@ contract BanditAttackResolutionTest is Test {
         assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
     }
 
-    function test_allClansmenDeadLeavesClanActiveButVulnerable() public {
+    function test_allClansmenDeadMarksClanDead() public {
         uint32 clanId = _mintClan();
         _forceAttack(clanId, 425);
 
@@ -428,7 +517,11 @@ contract BanditAttackResolutionTest is Test {
 
         Clan memory clan = world.getClan(clanId);
         assertEq(clan.livingClansmen, 0, "all clansmen dead");
-        assertEq(uint8(clan.clanState), uint8(ClanState.ACTIVE), "phase 10.5 handles elimination");
+        assertEq(uint8(clan.clanState), uint8(ClanState.DEAD), "target clan dead");
+        assertEq(clan.vaultWood, 0, "dead target wood burned");
+        assertEq(clan.vaultWheat, 0, "dead target wheat burned");
+        assertEq(clan.vaultFish, 0, "dead target fish burned");
+        assertEq(clan.vaultIron, 0, "dead target iron burned");
     }
 
     function test_starvingDefenderContributesZeroDefense() public {

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -11,6 +11,7 @@ import {
     ActionType,
     StatusCode,
     Clan,
+    Mission,
     ClanOrder,
     OrderResult
 } from "../src/IClanWorld.sol";
@@ -34,6 +35,16 @@ contract BanditAttackHarness is ClanWorld {
         _bandits[banditId].strength = strength;
     }
 
+    function setBanditCarry(uint32 banditId, uint256 wood, uint256 wheat, uint256 fish, uint256 iron, uint256 gold)
+        external
+    {
+        _bandits[banditId].carryWood = wood;
+        _bandits[banditId].carryWheat = wheat;
+        _bandits[banditId].carryFish = fish;
+        _bandits[banditId].carryIron = iron;
+        _bandits[banditId].carryGold = gold;
+    }
+
     function defenseRoll(bytes32 tickSeed, uint32 banditId, uint32 clansmanId) external pure returns (uint32) {
         return _clansmanDefenseDamageRoll(tickSeed, banditId, clansmanId);
     }
@@ -42,6 +53,35 @@ contract BanditAttackHarness is ClanWorld {
 contract BanditAttackResolutionTest is Test {
     BanditAttackHarness world;
     address elder = address(0xA1);
+
+    event BanditAttackResolved(
+        uint32 indexed banditId,
+        uint32 indexed targetClanId,
+        bool defended,
+        uint16 attackPower,
+        uint16 totalDefense,
+        uint16 wallLevelAfter,
+        uint256 stolenWood,
+        uint256 stolenIron,
+        uint256 stolenWheat,
+        uint256 stolenFish,
+        uint64 atTick
+    );
+    event BanditDefeated(uint32 indexed banditId, uint32 indexed targetClanId, uint64 atTick);
+    event LootDistributed(
+        uint32 indexed banditId,
+        uint32[] clanIdsRewarded,
+        uint256 perClanWood,
+        uint256 perClanWheat,
+        uint256 perClanFish,
+        uint256 perClanIron,
+        uint256 perClanGold,
+        uint256 burnedWood,
+        uint256 burnedWheat,
+        uint256 burnedFish,
+        uint256 burnedIron,
+        uint256 burnedGold
+    );
 
     function setUp() public {
         world = new BanditAttackHarness();
@@ -58,13 +98,21 @@ contract BanditAttackResolutionTest is Test {
 
     function _defendOrders(uint32 clanId, uint256 count) internal view returns (ClanOrder[] memory orders) {
         Clan memory clan = world.getClan(clanId);
+        return _defendTargetOrders(clanId, clanId, clan.baseRegion, count);
+    }
+
+    function _defendTargetOrders(uint32 clanId, uint32 targetClanId, uint8 targetRegion, uint256 count)
+        internal
+        view
+        returns (ClanOrder[] memory orders)
+    {
         orders = new ClanOrder[](count);
         for (uint256 i = 0; i < count; i++) {
             orders[i] = ClanOrder({
                 clansmanId: _csId(clanId, i),
-                gotoRegion: clan.baseRegion,
+                gotoRegion: targetRegion,
                 action: ActionType.DefendBase,
-                targetClanId: 0,
+                targetClanId: targetClanId,
                 marketToken: address(0),
                 marketAmount: 0,
                 maxGoldIn: 0
@@ -73,11 +121,23 @@ contract BanditAttackResolutionTest is Test {
     }
 
     function _submitDefenders(uint32 clanId, uint256 count) internal {
-        ClanOrder[] memory orders = _defendOrders(clanId, count);
+        _submitTargetDefenders(clanId, clanId, count);
+    }
+
+    function _submitTargetDefenders(uint32 defenderClanId, uint32 targetClanId, uint256 count)
+        internal
+        returns (uint64 maxExecutesAtTick)
+    {
+        Clan memory targetClan = world.getClan(targetClanId);
+        ClanOrder[] memory orders = _defendTargetOrders(defenderClanId, targetClanId, targetClan.baseRegion, count);
         vm.prank(elder);
-        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+        OrderResult[] memory results = world.submitClanOrders(defenderClanId, orders);
         for (uint256 i = 0; i < count; i++) {
             assertEq(uint8(results[i].status), uint8(StatusCode.OK), "defender order status");
+            Mission memory mission = world.getActiveMission(orders[i].clansmanId);
+            if (mission.executesAtTick > maxExecutesAtTick) {
+                maxExecutesAtTick = mission.executesAtTick;
+            }
         }
     }
 
@@ -86,9 +146,170 @@ contract BanditAttackResolutionTest is Test {
         world.heartbeat();
     }
 
+    function _advanceUntilAfter(uint64 tick) internal {
+        while (world.getWorldState().currentTick <= tick) {
+            _advanceTick();
+        }
+    }
+
+    function _activateTargetDefenders(uint32 targetClanId, uint32[] memory defenderClanIds, uint256 countEach)
+        internal
+    {
+        uint64 maxExecutesAtTick;
+        for (uint256 i = 0; i < defenderClanIds.length; i++) {
+            uint64 executesAtTick = _submitTargetDefenders(defenderClanIds[i], targetClanId, countEach);
+            if (executesAtTick > maxExecutesAtTick) {
+                maxExecutesAtTick = executesAtTick;
+            }
+        }
+
+        _advanceUntilAfter(maxExecutesAtTick);
+        for (uint256 i = 0; i < defenderClanIds.length; i++) {
+            world.settleClan(defenderClanIds[i]);
+        }
+    }
+
     function _forceAttack(uint32 clanId, uint32 strength) internal returns (uint32 banditId) {
         Clan memory clan = world.getClan(clanId);
         return world.forceAttackingBandit(clan.baseRegion, strength, clanId);
+    }
+
+    function _mintClans(uint256 count) internal returns (uint32[] memory clanIds) {
+        clanIds = new uint32[](count);
+        for (uint256 i = 0; i < count; i++) {
+            clanIds[i] = _mintClan();
+        }
+    }
+
+    function test_defeatedBanditLootSingleDefendingClanGetsFullCarry() public {
+        uint32 clanId = _mintClan();
+        uint32[] memory defenders = new uint32[](1);
+        defenders[0] = clanId;
+        _activateTargetDefenders(clanId, defenders, 4);
+
+        Clan memory beforeClan = world.getClan(clanId);
+        uint32 banditId = _forceAttack(clanId, 1);
+        world.setBanditCarry(banditId, 7e18, 11e18, 13e18, 17e18, 19e18);
+        world.setBanditStrength(banditId, 0);
+
+        _advanceTick();
+
+        Clan memory afterClan = world.getClan(clanId);
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood + 7e18, "wood full carry");
+        assertEq(afterClan.vaultWheat, beforeClan.vaultWheat + 11e18, "wheat full carry");
+        assertEq(afterClan.vaultFish, beforeClan.vaultFish + 13e18, "fish full carry");
+        assertEq(afterClan.vaultIron, beforeClan.vaultIron + 17e18, "iron full carry");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance + 19e18, "gold full carry");
+        assertEq(world.getBandit(banditId).id, 0, "defeated bandit deleted");
+    }
+
+    function test_defeatedBanditLootSplitsEquallyAcrossFourDefendingClans() public {
+        uint32[] memory clanIds = _mintClans(4);
+        _activateTargetDefenders(clanIds[0], clanIds, 1);
+
+        uint256[4] memory woodBefore;
+        uint256[4] memory wheatBefore;
+        uint256[4] memory fishBefore;
+        uint256[4] memory ironBefore;
+        uint256[4] memory goldBefore;
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            Clan memory clan = world.getClan(clanIds[i]);
+            woodBefore[i] = clan.vaultWood;
+            wheatBefore[i] = clan.vaultWheat;
+            fishBefore[i] = clan.vaultFish;
+            ironBefore[i] = clan.vaultIron;
+            goldBefore[i] = clan.goldBalance;
+        }
+
+        uint32 banditId = _forceAttack(clanIds[0], 1);
+        world.setBanditCarry(banditId, 100e18, 100e18, 100e18, 100e18, 100e18);
+        world.setBanditStrength(banditId, 0);
+
+        _advanceTick();
+
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            Clan memory clan = world.getClan(clanIds[i]);
+            assertEq(clan.vaultWood, woodBefore[i] + 25e18, "wood share");
+            assertEq(clan.vaultWheat, wheatBefore[i] + 25e18, "wheat share");
+            assertEq(clan.vaultFish, fishBefore[i] + 25e18, "fish share");
+            assertEq(clan.vaultIron, ironBefore[i] + 25e18, "iron share");
+            assertEq(clan.goldBalance, goldBefore[i] + 25e18, "gold share");
+        }
+    }
+
+    function test_defeatedBanditLootBurnsWholeTokenOverflowAcrossThreeDefendingClans() public {
+        uint32[] memory clanIds = _mintClans(3);
+        _activateTargetDefenders(clanIds[0], clanIds, 1);
+
+        uint256 woodBeforeTotal;
+        uint256 goldBeforeTotal;
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            Clan memory clan = world.getClan(clanIds[i]);
+            woodBeforeTotal += clan.vaultWood;
+            goldBeforeTotal += clan.goldBalance;
+        }
+
+        uint32 banditId = _forceAttack(clanIds[0], 1);
+        world.setBanditCarry(banditId, 100e18, 100e18, 100e18, 100e18, 100e18);
+        world.setBanditStrength(banditId, 0);
+
+        vm.expectEmit(true, true, false, false, address(world));
+        emit BanditAttackResolved(banditId, clanIds[0], true, 0, 0, 0, 0, 0, 0, 0, world.getWorldState().currentTick);
+        vm.expectEmit(true, true, false, true, address(world));
+        emit BanditDefeated(banditId, clanIds[0], world.getWorldState().currentTick);
+        vm.expectEmit(true, false, false, true, address(world));
+        emit LootDistributed(banditId, clanIds, 33e18, 33e18, 33e18, 33e18, 33e18, 1e18, 1e18, 1e18, 1e18, 1e18);
+
+        _advanceTick();
+
+        uint256 woodAfterTotal;
+        uint256 goldAfterTotal;
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            Clan memory clan = world.getClan(clanIds[i]);
+            assertEq(clan.vaultWood, 20e18 + 33e18, "wood share");
+            assertEq(clan.goldBalance, 3e18 + 33e18, "gold share");
+            woodAfterTotal += clan.vaultWood;
+            goldAfterTotal += clan.goldBalance;
+        }
+        assertEq(woodAfterTotal - woodBeforeTotal, 99e18, "wood overflow burned");
+        assertEq(goldAfterTotal - goldBeforeTotal, 99e18, "gold overflow burned");
+    }
+
+    function test_multipleDefendersFromSameClanStillReceiveOneClanShare() public {
+        uint32[] memory clanIds = _mintClans(2);
+        uint64 firstExecutesAtTick = _submitTargetDefenders(clanIds[0], clanIds[0], 3);
+        uint64 secondExecutesAtTick = _submitTargetDefenders(clanIds[1], clanIds[0], 1);
+        _advanceUntilAfter(firstExecutesAtTick > secondExecutesAtTick ? firstExecutesAtTick : secondExecutesAtTick);
+        world.settleClan(clanIds[0]);
+        world.settleClan(clanIds[1]);
+
+        uint256 targetWoodBefore = world.getClan(clanIds[0]).vaultWood;
+        uint256 helperWoodBefore = world.getClan(clanIds[1]).vaultWood;
+        uint32 banditId = _forceAttack(clanIds[0], 1);
+        world.setBanditCarry(banditId, 100e18, 100e18, 100e18, 100e18, 100e18);
+        world.setBanditStrength(banditId, 0);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanIds[0]).vaultWood, targetWoodBefore + 50e18, "target clan one share");
+        assertEq(world.getClan(clanIds[1]).vaultWood, helperWoodBefore + 50e18, "helper clan one share");
+    }
+
+    function test_escapedBanditDoesNotDistributeCarry() public {
+        uint32 clanId = _mintClan();
+        Clan memory beforeClan = world.getClan(clanId);
+        uint32 banditId = _forceAttack(clanId, 100);
+        world.setBanditCarry(banditId, 100e18, 100e18, 100e18, 100e18, 100e18);
+
+        _advanceTick();
+
+        Clan memory afterClan = world.getClan(clanId);
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "wood unchanged");
+        assertEq(afterClan.vaultWheat, beforeClan.vaultWheat, "wheat unchanged");
+        assertEq(afterClan.vaultFish, beforeClan.vaultFish, "fish unchanged");
+        assertEq(afterClan.vaultIron, beforeClan.vaultIron, "iron unchanged");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "gold unchanged");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
     }
 
     function test_twoAliveDefendersWithSufficientDefenseDefeatBanditWithoutWallChip() public {

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -68,6 +68,7 @@ contract BanditAttackResolutionTest is Test {
         uint64 atTick
     );
     event BanditDefeated(uint32 indexed banditId, uint32 indexed targetClanId, uint64 atTick);
+    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint64 tick);
     event LootDistributed(
         uint32 indexed banditId,
         uint32[] clanIdsRewarded,
@@ -203,6 +204,24 @@ contract BanditAttackResolutionTest is Test {
         assertEq(world.getBandit(banditId).id, 0, "defeated bandit deleted");
     }
 
+    function test_defeatedBanditAwardsBlueprintToTargetClan() public {
+        uint32 clanId = _mintClan();
+        uint32[] memory defenders = new uint32[](1);
+        defenders[0] = clanId;
+        _activateTargetDefenders(clanId, defenders, 4);
+
+        uint256 blueprintBefore = world.getClan(clanId).blueprintBalance;
+        uint32 banditId = _forceAttack(clanId, 1);
+        world.setBanditStrength(banditId, 0);
+
+        vm.expectEmit(true, true, false, true, address(world));
+        emit BlueprintEarned(clanId, banditId, world.getWorldState().currentTick);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore + 1, "target blueprint awarded");
+    }
+
     function test_defeatedBanditLootSplitsEquallyAcrossFourDefendingClans() public {
         uint32[] memory clanIds = _mintClans(4);
         _activateTargetDefenders(clanIds[0], clanIds, 1);
@@ -235,6 +254,43 @@ contract BanditAttackResolutionTest is Test {
             assertEq(clan.vaultIron, ironBefore[i] + 25e18, "iron share");
             assertEq(clan.goldBalance, goldBefore[i] + 25e18, "gold share");
         }
+    }
+
+    function test_mixedClanDefenseAwardsBlueprintOnlyToBaseOwner() public {
+        uint32[] memory clanIds = _mintClans(4);
+        _activateTargetDefenders(clanIds[0], clanIds, 1);
+
+        uint256[4] memory blueprintBefore;
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            blueprintBefore[i] = world.getClan(clanIds[i]).blueprintBalance;
+        }
+
+        uint32 banditId = _forceAttack(clanIds[0], 1);
+        world.setBanditStrength(banditId, 0);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanIds[0]).blueprintBalance, blueprintBefore[0] + 1, "base owner blueprint");
+        for (uint256 i = 1; i < clanIds.length; i++) {
+            assertEq(world.getClan(clanIds[i]).blueprintBalance, blueprintBefore[i], "helper clan no blueprint");
+        }
+    }
+
+    function test_multipleDefeatedBanditsEachAwardBlueprint() public {
+        uint32 clanId = _mintClan();
+        uint32[] memory defenders = new uint32[](1);
+        defenders[0] = clanId;
+        _activateTargetDefenders(clanId, defenders, 4);
+
+        uint256 blueprintBefore = world.getClan(clanId).blueprintBalance;
+        uint32 firstBanditId = _forceAttack(clanId, 1);
+        uint32 secondBanditId = _forceAttack(clanId, 1);
+        world.setBanditStrength(firstBanditId, 0);
+        world.setBanditStrength(secondBanditId, 0);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore + 2, "one blueprint per defeated bandit");
     }
 
     function test_defeatedBanditLootBurnsWholeTokenOverflowAcrossThreeDefendingClans() public {
@@ -309,6 +365,17 @@ contract BanditAttackResolutionTest is Test {
         assertEq(afterClan.vaultFish, beforeClan.vaultFish, "fish unchanged");
         assertEq(afterClan.vaultIron, beforeClan.vaultIron, "iron unchanged");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "gold unchanged");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
+    }
+
+    function test_escapedBanditDoesNotAwardBlueprint() public {
+        uint32 clanId = _mintClan();
+        uint256 blueprintBefore = world.getClan(clanId).blueprintBalance;
+        uint32 banditId = _forceAttack(clanId, 100);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore, "blueprint unchanged");
         assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
     }
 

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -284,12 +284,12 @@ contract BanditAttackResolutionTest is Test {
 
         Clan memory unaffectedBefore = world.getClan(unaffectedClanId);
         uint32 banditId = _forceAttack(targetClanId, 100);
-        uint64 expectedDeathTick = deathFromTick + 3;
+        uint64 expectedBanditAbortTick = world.getWorldState().currentTick;
 
         vm.recordLogs();
         world.settleClan(targetClanId);
         Vm.Log[] memory logs = vm.getRecordedLogs();
-        _assertBanditTargetDiedLog(logs, banditId, targetClanId, expectedDeathTick);
+        _assertBanditTargetDiedLog(logs, banditId, targetClanId, expectedBanditAbortTick);
 
         Clan memory targetAfter = world.getClan(targetClanId);
         assertEq(uint8(targetAfter.clanState), uint8(ClanState.DEAD), "target clan dead");

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {
+    ClanWorldConstants,
+    ClanState,
+    ClansmanState,
+    BanditState,
+    ActionType,
+    StatusCode,
+    Clan,
+    ClanOrder,
+    OrderResult
+} from "../src/IClanWorld.sol";
+
+contract BanditAttackHarness is ClanWorld {
+    function forceAttackingBandit(uint8 region, uint32 strength, uint32 targetClanId) external returns (uint32 id) {
+        id = _spawnBandit(region, strength);
+        _bandits[id].state = BanditState.Attacking;
+        _bandits[id].targetClanId = targetClanId;
+    }
+
+    function setWallLevel(uint32 clanId, uint8 wallLevel) external {
+        _clans[clanId].wallLevel = wallLevel;
+    }
+
+    function setStarvationStartsAt(uint32 clanId, uint64 tick) external {
+        _clans[clanId].starvationStartsAtTick = tick;
+    }
+
+    function setBanditStrength(uint32 banditId, uint32 strength) external {
+        _bandits[banditId].strength = strength;
+    }
+
+    function defenseRoll(bytes32 tickSeed, uint32 banditId, uint32 clansmanId) external pure returns (uint32) {
+        return _clansmanDefenseDamageRoll(tickSeed, banditId, clansmanId);
+    }
+}
+
+contract BanditAttackResolutionTest is Test {
+    BanditAttackHarness world;
+    address elder = address(0xA1);
+
+    function setUp() public {
+        world = new BanditAttackHarness();
+    }
+
+    function _mintClan() internal returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
+    }
+
+    function _csId(uint32 clanId, uint256 index) internal view returns (uint32) {
+        return world.getClanFullView(clanId).clansmen[index].clansman.clansman.clansmanId;
+    }
+
+    function _defendOrders(uint32 clanId, uint256 count) internal view returns (ClanOrder[] memory orders) {
+        Clan memory clan = world.getClan(clanId);
+        orders = new ClanOrder[](count);
+        for (uint256 i = 0; i < count; i++) {
+            orders[i] = ClanOrder({
+                clansmanId: _csId(clanId, i),
+                gotoRegion: clan.baseRegion,
+                action: ActionType.DefendBase,
+                targetClanId: 0,
+                marketToken: address(0),
+                marketAmount: 0,
+                maxGoldIn: 0
+            });
+        }
+    }
+
+    function _submitDefenders(uint32 clanId, uint256 count) internal {
+        ClanOrder[] memory orders = _defendOrders(clanId, count);
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+        for (uint256 i = 0; i < count; i++) {
+            assertEq(uint8(results[i].status), uint8(StatusCode.OK), "defender order status");
+        }
+    }
+
+    function _advanceTick() internal {
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        world.heartbeat();
+    }
+
+    function _forceAttack(uint32 clanId, uint32 strength) internal returns (uint32 banditId) {
+        Clan memory clan = world.getClan(clanId);
+        return world.forceAttackingBandit(clan.baseRegion, strength, clanId);
+    }
+
+    function test_twoAliveDefendersWithSufficientDefenseDefeatBanditWithoutWallChip() public {
+        uint32 clanId = _mintClan();
+        _submitDefenders(clanId, 2);
+        world.setWallLevel(clanId, 1);
+
+        uint32 banditId = _forceAttack(clanId, 1);
+        bytes32 tickSeed = world.getWorldState().currentTickSeed;
+        uint32 defense = world.defenseRoll(tickSeed, banditId, _csId(clanId, 0))
+            + world.defenseRoll(tickSeed, banditId, _csId(clanId, 1));
+        uint32 strength = defense / 2;
+        if (strength == 0) strength = 1;
+        world.setBanditStrength(banditId, strength);
+        _advanceTick();
+
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.None), "defeated bandit deleted");
+        assertEq(world.getClan(clanId).wallLevel, 1, "wall was not chipped");
+        assertEq(world.getClan(clanId).livingClansmen, 4, "no casualties");
+    }
+
+    function test_weakDefenseChipsWallOneLevel() public {
+        uint32 clanId = _mintClan();
+        world.setWallLevel(clanId, 1);
+        uint32 banditId = _forceAttack(clanId, 100);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanId).wallLevel, 0, "wall level decreased");
+        assertEq(world.getClan(clanId).livingClansmen, 4, "wall absorbed full hit");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
+    }
+
+    function test_wallZeroWeakDefenseKillsClansmanDeterministically() public {
+        uint32 clanId = _mintClan();
+        uint32 banditId = _forceAttack(clanId, 100);
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanId).livingClansmen, 3, "one clansman died");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
+    }
+
+    function test_allClansmenDeadLeavesClanActiveButVulnerable() public {
+        uint32 clanId = _mintClan();
+        _forceAttack(clanId, 425);
+
+        _advanceTick();
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(clan.livingClansmen, 0, "all clansmen dead");
+        assertEq(uint8(clan.clanState), uint8(ClanState.ACTIVE), "phase 10.5 handles elimination");
+    }
+
+    function test_starvingDefenderContributesZeroDefense() public {
+        uint32 clanId = _mintClan();
+        _submitDefenders(clanId, 1);
+        _advanceTick();
+        world.settleClan(clanId);
+        world.setWallLevel(clanId, 1);
+        world.setStarvationStartsAt(clanId, 1);
+
+        uint32 banditId = _forceAttack(clanId, 100);
+        uint32 nonStarvingRoll =
+            world.defenseRoll(world.getWorldState().currentTickSeed, banditId, _csId(clanId, 0));
+        assertGt(nonStarvingRoll, 0, "test setup needs nonzero roll");
+
+        _advanceTick();
+
+        assertEq(world.getClan(clanId).wallLevel, 0, "starving defender did not reduce incoming wall hit");
+        assertEq(world.getClan(clanId).livingClansmen, 4, "wall absorbed full hit");
+    }
+
+    function test_twoAttacksSameTickDeterminismAcrossReplay() public {
+        BanditAttackHarness a = new BanditAttackHarness();
+        BanditAttackHarness b = new BanditAttackHarness();
+
+        uint32 aFirst;
+        uint32 aSecond;
+        uint32 bFirst;
+        uint32 bSecond;
+        (aFirst, aSecond) = _setupTwoAttackWorld(a);
+        (bFirst, bSecond) = _setupTwoAttackWorld(b);
+
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        a.heartbeat();
+        b.heartbeat();
+
+        assertEq(a.getClan(aFirst).livingClansmen, b.getClan(bFirst).livingClansmen, "first target deterministic");
+        assertEq(a.getClan(aSecond).livingClansmen, b.getClan(bSecond).livingClansmen, "second target deterministic");
+        assertEq(uint8(a.getBandit(1).state), uint8(b.getBandit(1).state), "first bandit state deterministic");
+        assertEq(uint8(a.getBandit(2).state), uint8(b.getBandit(2).state), "second bandit state deterministic");
+    }
+
+    function _setupTwoAttackWorld(BanditAttackHarness target) internal returns (uint32 firstClanId, uint32 secondClanId) {
+        vm.prank(elder);
+        (firstClanId,) = target.mintClan(elder);
+        vm.prank(elder);
+        (secondClanId,) = target.mintClan(elder);
+
+        target.forceAttackingBandit(target.getClan(firstClanId).baseRegion, 100, firstClanId);
+        target.forceAttackingBandit(target.getClan(secondClanId).baseRegion, 100, secondClanId);
+    }
+}

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -12,6 +12,7 @@ import {
     ActionType,
     StatusCode,
     Clan,
+    ClanFullView,
     Mission,
     ClanOrder,
     OrderResult
@@ -32,14 +33,27 @@ contract BanditAttackHarness is ClanWorld {
         _clans[clanId].starvationStartsAtTick = tick;
     }
 
-    function setClanUpkeepState(uint32 clanId, uint64 lastSettledTick, uint256 vaultWheat, uint256 vaultFish)
-        external
-    {
+    function setClanUpkeepState(uint32 clanId, uint64 lastSettledTick, uint256 vaultWheat, uint256 vaultFish) external {
         Clan storage clan = _clans[clanId];
         clan.lastSettledTick = lastSettledTick;
         clan.vaultWheat = vaultWheat;
         clan.vaultFish = vaultFish;
         clan.starvationStartsAtTick = 0;
+    }
+
+    function setLivingClansmenForTest(uint32 clanId, uint8 livingClansmen) external {
+        _clans[clanId].livingClansmen = livingClansmen;
+    }
+
+    function blockBanditSpawnsForTest() external {
+        uint64 currentTick = this.getWorldState().currentTick;
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            _banditSpawnByRegion[region].lastSpawnTick = currentTick;
+        }
+    }
+
+    function blueprintUnit() external pure returns (uint256) {
+        return BLUEPRINT_UNIT;
     }
 
     function setBanditStrength(uint32 banditId, uint32 strength) external {
@@ -79,7 +93,7 @@ contract BanditAttackResolutionTest is Test {
         uint64 atTick
     );
     event BanditDefeated(uint32 indexed banditId, uint32 indexed targetClanId, uint64 atTick);
-    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint64 tick);
+    event BlueprintEarned(uint32 indexed clanId, uint32 indexed banditId, uint256 amount, uint64 tick);
     event BanditTargetDied(uint32 indexed banditId, uint32 indexed deadClanId, uint64 tick);
     event LootDistributed(
         uint32 indexed banditId,
@@ -182,14 +196,33 @@ contract BanditAttackResolutionTest is Test {
         bytes32 expectedClanTopic = bytes32(uint256(expectedDeadClanId));
         for (uint256 i = 0; i < logs.length; i++) {
             if (
-                logs[i].topics.length == 3 && logs[i].topics[0] == eventSig
-                    && logs[i].topics[1] == expectedBanditTopic && logs[i].topics[2] == expectedClanTopic
+                logs[i].topics.length == 3 && logs[i].topics[0] == eventSig && logs[i].topics[1] == expectedBanditTopic
+                    && logs[i].topics[2] == expectedClanTopic
             ) {
                 uint64 tick = abi.decode(logs[i].data, (uint64));
                 if (tick == expectedTick) return;
             }
         }
         fail("expected BanditTargetDied log");
+    }
+
+    function _assertBanditAttackResolvedLog(Vm.Log[] memory logs, uint32 expectedBanditId, uint32 expectedTargetClanId)
+        internal
+    {
+        bytes32 eventSig = keccak256(
+            "BanditAttackResolved(uint32,uint32,bool,uint16,uint16,uint16,uint256,uint256,uint256,uint256,uint64)"
+        );
+        bytes32 expectedBanditTopic = bytes32(uint256(expectedBanditId));
+        bytes32 expectedClanTopic = bytes32(uint256(expectedTargetClanId));
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (
+                logs[i].topics.length == 3 && logs[i].topics[0] == eventSig && logs[i].topics[1] == expectedBanditTopic
+                    && logs[i].topics[2] == expectedClanTopic
+            ) {
+                return;
+            }
+        }
+        fail("expected BanditAttackResolved log");
     }
 
     function _activateTargetDefenders(uint32 targetClanId, uint32[] memory defenderClanIds, uint256 countEach)
@@ -254,15 +287,55 @@ contract BanditAttackResolutionTest is Test {
         world.setBanditStrength(banditId, 0);
 
         vm.expectEmit(true, true, false, true, address(world));
-        emit BlueprintEarned(clanId, banditId, world.getWorldState().currentTick);
+        emit BlueprintEarned(clanId, banditId, world.blueprintUnit(), world.getWorldState().currentTick);
 
         _advanceTick();
 
-        assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore + 1, "target blueprint awarded");
+        assertEq(
+            world.getClan(clanId).blueprintBalance, blueprintBefore + world.blueprintUnit(), "target blueprint awarded"
+        );
+    }
+
+    function test_e2e_banditLifecycle_throughHeartbeat() public {
+        uint32 clanId = _mintClan();
+
+        uint32 banditId;
+        for (uint256 i = 0; i < 64; i++) {
+            vm.prevrandao(keccak256(abi.encodePacked("bandit-lifecycle", i)));
+            _advanceTick();
+            banditId = world.getWorldState().activeBanditId;
+            if (banditId != 0) break;
+        }
+        assertGt(banditId, 0, "bandit spawned through heartbeat");
+
+        _advanceTick();
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "spawned to camped");
+
+        uint64 campedAt = world.getBandit(banditId).tickEnteredState;
+        while (world.getWorldState().currentTick < campedAt + ClanWorldConstants.BANDIT_CAMP_TICKS) {
+            _advanceTick();
+        }
+
+        vm.recordLogs();
+        _advanceTick();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        _assertBanditAttackResolvedLog(logs, banditId, clanId);
+
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "attack resolved to escaped");
+
+        for (uint64 i = 0; i < ClanWorldConstants.BANDIT_REST_TICKS; i++) {
+            _advanceTick();
+        }
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "escaped recovered to resting");
     }
 
     function test_deadTargetCleanupReleasesDefendersAndEscapesBandit() public {
+        uint64 winterStart = world.getWorldState().winterStartsAtTick;
+        _advanceUntil(winterStart + 4);
+
         uint32[] memory clanIds = _mintClans(3);
+        world.blockBanditSpawnsForTest();
+
         uint32 defenderClanId = clanIds[0];
         uint32 targetClanId = clanIds[1];
         uint32 unaffectedClanId = clanIds[2];
@@ -277,8 +350,6 @@ contract BanditAttackResolutionTest is Test {
         assertEq(uint8(defenderStateBefore), uint8(ClansmanState.ACTING), "defender active before target death");
         assertEq(world.getActiveDefenders(targetClanId).length, 1, "target has active defender");
 
-        uint64 winterStart = world.getWorldState().winterStartsAtTick;
-        _advanceUntil(winterStart + 4);
         uint64 deathFromTick = winterStart;
         world.setClanUpkeepState(targetClanId, deathFromTick, 0, 0);
 
@@ -359,7 +430,11 @@ contract BanditAttackResolutionTest is Test {
 
         _advanceTick();
 
-        assertEq(world.getClan(clanIds[0]).blueprintBalance, blueprintBefore[0] + 1, "base owner blueprint");
+        assertEq(
+            world.getClan(clanIds[0]).blueprintBalance,
+            blueprintBefore[0] + world.blueprintUnit(),
+            "base owner blueprint"
+        );
         for (uint256 i = 1; i < clanIds.length; i++) {
             assertEq(world.getClan(clanIds[i]).blueprintBalance, blueprintBefore[i], "helper clan no blueprint");
         }
@@ -379,7 +454,47 @@ contract BanditAttackResolutionTest is Test {
 
         _advanceTick();
 
-        assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore + 2, "one blueprint per defeated bandit");
+        assertEq(
+            world.getClan(clanId).blueprintBalance,
+            blueprintBefore + 2 * world.blueprintUnit(),
+            "one blueprint per defeated bandit"
+        );
+    }
+
+    function test_winterStarvationReplayUsesHistoricalWinterTicks() public {
+        uint64 winterStart = world.getWorldState().winterStartsAtTick;
+        _advanceUntil(winterStart + 30);
+        assertFalse(world.getWorldState().winterActive, "test settles after winter");
+
+        uint32 clanId = _mintClan();
+        world.setClanUpkeepState(clanId, winterStart, 0, 0);
+
+        ClanFullView memory preview = world.getClanFullView(clanId);
+        assertEq(uint8(preview.clan.clan.clanState), uint8(ClanState.DEAD), "derived view replays winter deaths");
+        assertEq(preview.clan.clan.livingClansmen, 0, "derived living count");
+
+        world.settleClan(clanId);
+
+        Clan memory settled = world.getClan(clanId);
+        assertEq(uint8(settled.clanState), uint8(ClanState.DEAD), "settlement replays winter deaths");
+        assertEq(settled.livingClansmen, 0, "settled living count");
+    }
+
+    function test_resolveBanditAttackReturnsWhenTargetDiesDuringSettlement() public {
+        uint64 winterStart = world.getWorldState().winterStartsAtTick;
+        _advanceUntil(winterStart + 1);
+
+        uint32 targetClanId = _mintClan();
+        world.setClanUpkeepState(targetClanId, winterStart, 0, 0);
+        world.setLivingClansmenForTest(targetClanId, 1);
+
+        uint32 banditId = _forceAttack(targetClanId, 100);
+
+        _advanceTick();
+
+        assertEq(uint8(world.getClan(targetClanId).clanState), uint8(ClanState.DEAD), "target starved");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped once");
+        assertEq(world.getBandit(banditId).targetClanId, 0, "bandit target cleared");
     }
 
     function test_defeatedBanditLootBurnsWholeTokenOverflowAcrossThreeDefendingClans() public {
@@ -533,8 +648,7 @@ contract BanditAttackResolutionTest is Test {
         world.setStarvationStartsAt(clanId, 1);
 
         uint32 banditId = _forceAttack(clanId, 100);
-        uint32 nonStarvingRoll =
-            world.defenseRoll(world.getWorldState().currentTickSeed, banditId, _csId(clanId, 0));
+        uint32 nonStarvingRoll = world.defenseRoll(world.getWorldState().currentTickSeed, banditId, _csId(clanId, 0));
         assertGt(nonStarvingRoll, 0, "test setup needs nonzero roll");
 
         _advanceTick();
@@ -564,7 +678,10 @@ contract BanditAttackResolutionTest is Test {
         assertEq(uint8(a.getBandit(2).state), uint8(b.getBandit(2).state), "second bandit state deterministic");
     }
 
-    function _setupTwoAttackWorld(BanditAttackHarness target) internal returns (uint32 firstClanId, uint32 secondClanId) {
+    function _setupTwoAttackWorld(BanditAttackHarness target)
+        internal
+        returns (uint32 firstClanId, uint32 secondClanId)
+    {
         vm.prank(elder);
         (firstClanId,) = target.mintClan(elder);
         vm.prank(elder);

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -254,7 +254,7 @@ contract BanditAttackResolutionTest is Test {
         }
     }
 
-    function test_defeatedBanditLootSingleDefendingClanGetsFullCarry() public {
+    function test_defeatedBanditLootDropsHalfCarryAcrossContributingDefenders() public {
         uint32 clanId = _mintClan();
         uint32[] memory defenders = new uint32[](1);
         defenders[0] = clanId;
@@ -262,17 +262,23 @@ contract BanditAttackResolutionTest is Test {
 
         Clan memory beforeClan = world.getClan(clanId);
         uint32 banditId = _forceAttack(clanId, 1);
-        world.setBanditCarry(banditId, 7e18, 11e18, 13e18, 17e18, 19e18);
+        world.setBanditCarry(banditId, 8e18, 8e18, 8e18, 8e18, 8e18);
         world.setBanditStrength(banditId, 0);
 
         _advanceTick();
 
         Clan memory afterClan = world.getClan(clanId);
-        assertEq(afterClan.vaultWood, beforeClan.vaultWood + 7e18, "wood full carry");
-        assertEq(afterClan.vaultWheat, beforeClan.vaultWheat + 11e18, "wheat full carry");
-        assertEq(afterClan.vaultFish, beforeClan.vaultFish + 13e18, "fish full carry");
-        assertEq(afterClan.vaultIron, beforeClan.vaultIron + 17e18, "iron full carry");
-        assertEq(afterClan.goldBalance, beforeClan.goldBalance + 19e18, "gold full carry");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "wood stays in defender carry");
+        assertEq(afterClan.vaultWheat, beforeClan.vaultWheat, "wheat stays in defender carry");
+        assertEq(afterClan.vaultFish, beforeClan.vaultFish, "fish stays in defender carry");
+        assertEq(afterClan.vaultIron, beforeClan.vaultIron, "iron stays in defender carry");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance + 4e18, "gold half carry");
+        for (uint256 i = 0; i < 4; i++) {
+            assertEq(world.getClansman(_csId(clanId, i)).carryWood, 1e18, "wood defender share");
+            assertEq(world.getClansman(_csId(clanId, i)).carryWheat, 1e18, "wheat defender share");
+            assertEq(world.getClansman(_csId(clanId, i)).carryFish, 1e18, "fish defender share");
+            assertEq(world.getClansman(_csId(clanId, i)).carryIron, 1e18, "iron defender share");
+        }
         assertEq(world.getBandit(banditId).id, 0, "defeated bandit deleted");
     }
 
@@ -321,12 +327,13 @@ contract BanditAttackResolutionTest is Test {
         Vm.Log[] memory logs = vm.getRecordedLogs();
         _assertBanditAttackResolvedLog(logs, banditId, clanId);
 
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "attack resolved to escaped");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "attack resolved to resting");
 
         for (uint64 i = 0; i < ClanWorldConstants.BANDIT_REST_TICKS; i++) {
             _advanceTick();
         }
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "escaped recovered to resting");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "resting recovered to camped");
+        assertEq(world.getBandit(banditId).region, ClanWorldConstants.REGION_MOUNTAINS, "rampaged after rest");
     }
 
     function test_deadTargetCleanupReleasesDefendersAndEscapesBandit() public {
@@ -382,7 +389,7 @@ contract BanditAttackResolutionTest is Test {
         assertEq(unaffectedAfter.vaultFish, unaffectedBefore.vaultFish, "clan C fish unaffected");
     }
 
-    function test_defeatedBanditLootSplitsEquallyAcrossFourDefendingClans() public {
+    function test_defeatedBanditLootSplitsEquallyAcrossContributingClansmen() public {
         uint32[] memory clanIds = _mintClans(4);
         _activateTargetDefenders(clanIds[0], clanIds, 1);
 
@@ -408,11 +415,20 @@ contract BanditAttackResolutionTest is Test {
 
         for (uint256 i = 0; i < clanIds.length; i++) {
             Clan memory clan = world.getClan(clanIds[i]);
-            assertEq(clan.vaultWood, woodBefore[i] + 25e18, "wood share");
-            assertEq(clan.vaultWheat, wheatBefore[i] + 25e18, "wheat share");
-            assertEq(clan.vaultFish, fishBefore[i] + 25e18, "fish share");
-            assertEq(clan.vaultIron, ironBefore[i] + 25e18, "iron share");
-            assertEq(clan.goldBalance, goldBefore[i] + 25e18, "gold share");
+            assertEq(clan.vaultWood, woodBefore[i], "wood stays out of vault");
+            assertEq(clan.vaultWheat, wheatBefore[i], "wheat stays out of vault");
+            assertEq(clan.vaultFish, fishBefore[i], "fish stays out of vault");
+            assertEq(clan.vaultIron, ironBefore[i], "iron stays out of vault");
+            assertEq(clan.goldBalance, goldBefore[i] + (i == 0 ? 28e18 : 7e18), "gold share");
+        }
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            assertEq(world.getClansman(_csId(clanIds[i], 0)).carryWood, 7e18, "explicit wood share");
+        }
+        assertEq(world.getClansman(_csId(clanIds[0], 1)).carryWood, 7e18, "waiting wood share 1");
+        assertEq(world.getClansman(_csId(clanIds[0], 2)).carryWood, 7e18, "waiting wood share 2");
+        assertEq(world.getClansman(_csId(clanIds[0], 3)).carryWood, 7e18, "waiting wood share 3");
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            assertEq(world.getClansman(_csId(clanIds[i], 0)).carryIron, 5e18, "iron capped");
         }
     }
 
@@ -461,6 +477,36 @@ contract BanditAttackResolutionTest is Test {
         );
     }
 
+    function test_waitingAtHomeClansmenContributePassiveDefense() public {
+        uint32 clanId = _mintClan();
+        uint256 blueprintBefore = world.getClan(clanId).blueprintBalance;
+        uint32 banditId = _forceAttack(clanId, 10);
+
+        _advanceTick();
+
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.None), "passive defenders defeated bandit");
+        assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore + world.blueprintUnit(), "blueprint awarded");
+        assertEq(world.getClan(clanId).livingClansmen, 4, "no casualties");
+    }
+
+    function test_failedDefenseStealsTwentyPercentAndAccumulatesCarry() public {
+        uint32 clanId = _mintClan();
+        uint32 banditId = _forceAttack(clanId, 100);
+        world.setBanditCarry(banditId, 1e18, 2e18, 3e18, 4e18, 0);
+
+        _advanceTick();
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(clan.vaultWood, 16e18, "wood drained");
+        assertEq(clan.vaultWheat, 16e18, "wheat drained");
+        assertEq(clan.vaultFish, 16e17, "fish drained");
+
+        assertEq(world.getBandit(banditId).carryWood, 5e18, "wood carry accumulated");
+        assertEq(world.getBandit(banditId).carryWheat, 6e18, "wheat carry accumulated");
+        assertEq(world.getBandit(banditId).carryFish, 34e17, "fish carry accumulated");
+        assertEq(world.getBandit(banditId).carryIron, 4e18, "iron carry unchanged without vault iron");
+    }
+
     function test_winterStarvationReplayUsesHistoricalWinterTicks() public {
         uint64 winterStart = world.getWorldState().winterStartsAtTick;
         _advanceUntil(winterStart + 30);
@@ -497,15 +543,13 @@ contract BanditAttackResolutionTest is Test {
         assertEq(world.getBandit(banditId).targetClanId, 0, "bandit target cleared");
     }
 
-    function test_defeatedBanditLootBurnsWholeTokenOverflowAcrossThreeDefendingClans() public {
+    function test_defeatedBanditLootBurnsDropRemainderAndCarryOverflow() public {
         uint32[] memory clanIds = _mintClans(3);
         _activateTargetDefenders(clanIds[0], clanIds, 1);
 
-        uint256 woodBeforeTotal;
         uint256 goldBeforeTotal;
         for (uint256 i = 0; i < clanIds.length; i++) {
             Clan memory clan = world.getClan(clanIds[i]);
-            woodBeforeTotal += clan.vaultWood;
             goldBeforeTotal += clan.goldBalance;
         }
 
@@ -517,25 +561,22 @@ contract BanditAttackResolutionTest is Test {
         emit BanditAttackResolved(banditId, clanIds[0], true, 0, 0, 0, 0, 0, 0, 0, world.getWorldState().currentTick);
         vm.expectEmit(true, true, false, true, address(world));
         emit BanditDefeated(banditId, clanIds[0], world.getWorldState().currentTick);
-        vm.expectEmit(true, false, false, true, address(world));
-        emit LootDistributed(banditId, clanIds, 33e18, 33e18, 33e18, 33e18, 33e18, 1e18, 1e18, 1e18, 1e18, 1e18);
 
         _advanceTick();
 
-        uint256 woodAfterTotal;
         uint256 goldAfterTotal;
         for (uint256 i = 0; i < clanIds.length; i++) {
             Clan memory clan = world.getClan(clanIds[i]);
-            assertEq(clan.vaultWood, 20e18 + 33e18, "wood share");
-            assertEq(clan.goldBalance, 3e18 + 33e18, "gold share");
-            woodAfterTotal += clan.vaultWood;
+            assertEq(clan.goldBalance, 3e18 + (i == 0 ? 32e18 : 8e18), "gold share");
             goldAfterTotal += clan.goldBalance;
         }
-        assertEq(woodAfterTotal - woodBeforeTotal, 99e18, "wood overflow burned");
-        assertEq(goldAfterTotal - goldBeforeTotal, 99e18, "gold overflow burned");
+        assertEq(goldAfterTotal - goldBeforeTotal, 48e18, "undropped gold burned");
+        assertEq(world.getClansman(_csId(clanIds[0], 0)).carryWood, 8e18, "target explicit wood");
+        assertEq(world.getClansman(_csId(clanIds[0], 1)).carryIron, 5e18, "target waiting iron capped");
+        assertEq(world.getClansman(_csId(clanIds[1], 0)).carryFish, 8e18, "helper fish capped");
     }
 
-    function test_multipleDefendersFromSameClanStillReceiveOneClanShare() public {
+    function test_multipleDefendersFromSameClanEachReceiveDefenderShare() public {
         uint32[] memory clanIds = _mintClans(2);
         uint64 firstExecutesAtTick = _submitTargetDefenders(clanIds[0], clanIds[0], 3);
         uint64 secondExecutesAtTick = _submitTargetDefenders(clanIds[1], clanIds[0], 1);
@@ -551,25 +592,31 @@ contract BanditAttackResolutionTest is Test {
 
         _advanceTick();
 
-        assertEq(world.getClan(clanIds[0]).vaultWood, targetWoodBefore + 50e18, "target clan one share");
-        assertEq(world.getClan(clanIds[1]).vaultWood, helperWoodBefore + 50e18, "helper clan one share");
+        assertEq(world.getClan(clanIds[0]).vaultWood, targetWoodBefore, "target vault unchanged");
+        assertEq(world.getClan(clanIds[1]).vaultWood, helperWoodBefore, "helper vault unchanged");
+        for (uint256 i = 0; i < 4; i++) {
+            assertEq(world.getClansman(_csId(clanIds[0], i)).carryWood, 10e18, "target defender share");
+        }
+        assertEq(world.getClansman(_csId(clanIds[1], 0)).carryWood, 10e18, "helper defender share");
     }
 
-    function test_escapedBanditDoesNotDistributeCarry() public {
+    function test_failedDefenseStealsVaultLootAndKeepsCarryWhileResting() public {
         uint32 clanId = _mintClan();
         Clan memory beforeClan = world.getClan(clanId);
         uint32 banditId = _forceAttack(clanId, 100);
-        world.setBanditCarry(banditId, 100e18, 100e18, 100e18, 100e18, 100e18);
 
         _advanceTick();
 
         Clan memory afterClan = world.getClan(clanId);
-        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "wood unchanged");
-        assertEq(afterClan.vaultWheat, beforeClan.vaultWheat, "wheat unchanged");
-        assertEq(afterClan.vaultFish, beforeClan.vaultFish, "fish unchanged");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood - 4e18, "wood stolen");
+        assertEq(afterClan.vaultWheat, beforeClan.vaultWheat - 4e18, "wheat stolen");
+        assertEq(afterClan.vaultFish, beforeClan.vaultFish - 4e17, "fish stolen");
         assertEq(afterClan.vaultIron, beforeClan.vaultIron, "iron unchanged");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "gold unchanged");
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
+        assertEq(world.getBandit(banditId).carryWood, 4e18, "bandit carry wood");
+        assertEq(world.getBandit(banditId).carryWheat, 4e18, "bandit carry wheat");
+        assertEq(world.getBandit(banditId).carryFish, 4e17, "bandit carry fish");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "bandit resting");
     }
 
     function test_escapedBanditDoesNotAwardBlueprint() public {
@@ -580,7 +627,7 @@ contract BanditAttackResolutionTest is Test {
         _advanceTick();
 
         assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore, "blueprint unchanged");
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "bandit resting");
     }
 
     function test_twoAliveDefendersWithSufficientDefenseDefeatBanditWithoutWallChip() public {
@@ -589,12 +636,7 @@ contract BanditAttackResolutionTest is Test {
         world.setWallLevel(clanId, 1);
 
         uint32 banditId = _forceAttack(clanId, 1);
-        bytes32 tickSeed = world.getWorldState().currentTickSeed;
-        uint32 defense = world.defenseRoll(tickSeed, banditId, _csId(clanId, 0))
-            + world.defenseRoll(tickSeed, banditId, _csId(clanId, 1));
-        uint32 strength = defense / 2;
-        if (strength == 0) strength = 1;
-        world.setBanditStrength(banditId, strength);
+        world.setBanditStrength(banditId, 15);
         _advanceTick();
 
         assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.None), "defeated bandit deleted");
@@ -606,12 +648,13 @@ contract BanditAttackResolutionTest is Test {
         uint32 clanId = _mintClan();
         world.setWallLevel(clanId, 1);
         uint32 banditId = _forceAttack(clanId, 100);
+        world.setBanditStrength(banditId, 130);
 
         _advanceTick();
 
         assertEq(world.getClan(clanId).wallLevel, 0, "wall level decreased");
         assertEq(world.getClan(clanId).livingClansmen, 4, "wall absorbed full hit");
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "bandit resting");
     }
 
     function test_wallZeroWeakDefenseKillsClansmanDeterministically() public {
@@ -621,7 +664,7 @@ contract BanditAttackResolutionTest is Test {
         _advanceTick();
 
         assertEq(world.getClan(clanId).livingClansmen, 3, "one clansman died");
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "bandit resting");
     }
 
     function test_allClansmenDeadMarksClanDead() public {
@@ -648,8 +691,6 @@ contract BanditAttackResolutionTest is Test {
         world.setStarvationStartsAt(clanId, 1);
 
         uint32 banditId = _forceAttack(clanId, 100);
-        uint32 nonStarvingRoll = world.defenseRoll(world.getWorldState().currentTickSeed, banditId, _csId(clanId, 0));
-        assertGt(nonStarvingRoll, 0, "test setup needs nonzero roll");
 
         _advanceTick();
 

--- a/packages/contracts/test/BanditSpawn.t.sol
+++ b/packages/contracts/test/BanditSpawn.t.sol
@@ -3,7 +3,19 @@ pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
 import {ClanWorld} from "../src/ClanWorld.sol";
-import {BanditState, BanditTroop, ClanWorldConstants, WorldState} from "../src/IClanWorld.sol";
+import {
+    ActionType,
+    BanditState,
+    BanditTroop,
+    Clan,
+    ClanOrder,
+    ClanWorldConstants,
+    ClansmanState,
+    Mission,
+    OrderResult,
+    StatusCode,
+    WorldState
+} from "../src/IClanWorld.sol";
 
 contract BanditSpawnHarness is ClanWorld {
     function spawnBandit(uint8 region, uint32 strength) external returns (uint32) {
@@ -48,12 +60,19 @@ contract BanditSpawnHarness is ClanWorld {
         return MAX_BANDIT_SPAWN_SCAN_PER_REGION;
     }
 
+    function maxBanditEagerSettleBaseScanPerRegion() external pure returns (uint256) {
+        return MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION;
+    }
+
     function banditSpawnRoll(bytes32 tickSeed, uint8 region) external pure returns (uint256) {
         return _banditSpawnRoll(tickSeed, region);
     }
 }
 
 contract BanditSpawnTest is Test {
+    event ClanSettled(uint32 indexed clanId, uint64 settledToTick);
+    event BanditSpawned(uint32 indexed banditId, uint8 region, uint8 tier, uint16 attackPower);
+
     BanditSpawnHarness world;
 
     function setUp() public {
@@ -77,6 +96,86 @@ contract BanditSpawnTest is Test {
 
     function _mintForestClan(BanditSpawnHarness target) internal {
         target.mintClan(address(this));
+    }
+
+    function _mintUntilTwoForestClans(BanditSpawnHarness target) internal returns (uint32 first, uint32 second) {
+        for (uint256 i = 0; i < target.maxBanditEagerSettleBaseScanPerRegion(); i++) {
+            (uint32 clanId,) = target.mintClan(address(this));
+            if (target.getClan(clanId).baseRegion == ClanWorldConstants.REGION_FOREST) {
+                if (first == 0) {
+                    first = clanId;
+                } else {
+                    second = clanId;
+                    return (first, second);
+                }
+            }
+        }
+        revert("missing second forest clan");
+    }
+
+    function _csId(BanditSpawnHarness target, uint32 clanId, uint256 index) internal view returns (uint32) {
+        return target.getClanFullView(clanId).clansmen[index].clansman.clansman.clansmanId;
+    }
+
+    function _ordersForPendingWorkerAndDefender(uint32 workerId, uint32 defenderId, uint8 baseRegion)
+        internal
+        pure
+        returns (ClanOrder[] memory orders)
+    {
+        orders = new ClanOrder[](2);
+        orders[0] = ClanOrder({
+            clansmanId: workerId,
+            gotoRegion: ClanWorldConstants.REGION_FOREST,
+            action: ActionType.ChopWood,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+        orders[1] = ClanOrder({
+            clansmanId: defenderId,
+            gotoRegion: baseRegion,
+            action: ActionType.DefendBase,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+    }
+
+    function _submitPendingWorkerAndDefender(BanditSpawnHarness target, uint32 clanId)
+        internal
+        returns (uint32 workerId, uint32 defenderId)
+    {
+        Clan memory clan = target.getClan(clanId);
+        workerId = _csId(target, clanId, 0);
+        defenderId = _csId(target, clanId, 1);
+
+        OrderResult[] memory results =
+            target.submitClanOrders(clanId, _ordersForPendingWorkerAndDefender(workerId, defenderId, clan.baseRegion));
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "worker order accepted");
+        assertEq(uint8(results[1].status), uint8(StatusCode.OK), "defender order accepted");
+    }
+
+    function _blockNonForestSpawnRegions(BanditSpawnHarness target) internal {
+        uint64 currentTick = target.getWorldState().currentTick;
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            if (region != ClanWorldConstants.REGION_FOREST) {
+                target.setBanditSpawnState(region, currentTick, 0);
+            }
+        }
+    }
+
+    function _prevrandaoForNextForestSpawn(BanditSpawnHarness target) internal view returns (bytes32) {
+        WorldState memory state = target.getWorldState();
+        for (uint256 i = 1; i < 256; i++) {
+            bytes32 nextRandao = keccak256(abi.encodePacked("forest-spawn-randao", i));
+            bytes32 nextSeed = keccak256(abi.encode(nextRandao, state.currentTickSeed, state.currentTick));
+            if (target.banditSpawnRoll(nextSeed, ClanWorldConstants.REGION_FOREST) < 8000) {
+                return nextRandao;
+            }
+        }
+        revert("missing forest spawn randao");
     }
 
     function _missSeed(uint8 region, uint16 probability) internal view returns (bytes32) {
@@ -169,6 +268,56 @@ contract BanditSpawnTest is Test {
         _advanceTick(world);
 
         assertEq(world.getWorldState().currentTick, 1, "heartbeat advanced");
+    }
+
+    function test_heartbeatEagerSettlesCandidateRegionBasesAndDefendersBeforeBanditSpawn() public {
+        _advancePastInitialCooldown(world);
+        (uint32 clanId1, uint32 clanId2) = _mintUntilTwoForestClans(world);
+
+        (uint32 workerId1, uint32 defenderId1) = _submitPendingWorkerAndDefender(world, clanId1);
+        (uint32 workerId2, uint32 defenderId2) = _submitPendingWorkerAndDefender(world, clanId2);
+
+        _blockNonForestSpawnRegions(world);
+        world.setBanditSpawnState(ClanWorldConstants.REGION_FOREST, world.getWorldState().currentTick, 0);
+        vm.prevrandao(_prevrandaoForNextForestSpawn(world));
+        _advanceTick(world);
+
+        uint64 closedTick = world.getWorldState().currentTick;
+        assertEq(world.getClan(clanId1).lastSettledTick, closedTick - 1, "clan 1 setup: unsettled");
+        assertEq(world.getClan(clanId2).lastSettledTick, closedTick - 1, "clan 2 setup: unsettled");
+        assertTrue(world.getActiveMission(workerId1).active, "clan 1 worker has pending mission");
+        assertTrue(world.getActiveMission(workerId2).active, "clan 2 worker has pending mission");
+        assertEq(world.getActiveDefenders(clanId1)[0], defenderId1, "clan 1 defender registered");
+        assertEq(world.getActiveDefenders(clanId2)[0], defenderId2, "clan 2 defender registered");
+
+        _blockNonForestSpawnRegions(world);
+        world.setBanditSpawnState(ClanWorldConstants.REGION_FOREST, 0, 10000);
+
+        vm.expectEmit(true, false, false, true);
+        emit ClanSettled(clanId1, closedTick);
+        vm.expectEmit(true, false, false, true);
+        emit ClanSettled(clanId2, closedTick);
+        vm.expectEmit(true, false, false, false);
+        emit BanditSpawned(1, 0, 0, 0);
+
+        _advanceTick(world);
+
+        assertEq(world.getClan(clanId1).lastSettledTick, closedTick, "clan 1 eager-settled");
+        assertEq(world.getClan(clanId2).lastSettledTick, closedTick, "clan 2 eager-settled");
+
+        Mission memory defenderMission1 = world.getActiveMission(defenderId1);
+        Mission memory defenderMission2 = world.getActiveMission(defenderId2);
+        assertTrue(defenderMission1.active, "clan 1 defender remains active");
+        assertTrue(defenderMission2.active, "clan 2 defender remains active");
+        assertEq(uint8(defenderMission1.action), uint8(ActionType.DefendBase), "clan 1 defender action");
+        assertEq(uint8(defenderMission2.action), uint8(ActionType.DefendBase), "clan 2 defender action");
+        assertEq(uint8(world.getClansman(defenderId1).state), uint8(ClansmanState.ACTING), "clan 1 defender settled");
+        assertEq(uint8(world.getClansman(defenderId2).state), uint8(ClansmanState.ACTING), "clan 2 defender settled");
+
+        BanditTroop memory bandit = world.getBandit(1);
+        assertEq(uint8(bandit.state), uint8(BanditState.Spawned), "bandit spawned");
+        assertEq(bandit.region, ClanWorldConstants.REGION_FOREST, "forest selected after eager settle");
+        assertEq(bandit.tickEnteredState, closedTick, "spawn used closed tick");
     }
 
     function test_regionSelectionDeterministicForSameSeed() public {

--- a/packages/contracts/test/BanditSpawn.t.sol
+++ b/packages/contracts/test/BanditSpawn.t.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {BanditState, BanditTroop, ClanWorldConstants, WorldState} from "../src/IClanWorld.sol";
+
+contract BanditSpawnHarness is ClanWorld {
+    function spawnBandit(uint8 region, uint32 strength) external returns (uint32) {
+        return _spawnBandit(region, strength);
+    }
+
+    function evaluateBanditSpawns(bytes32 tickSeed) external {
+        _evaluateBanditSpawns(tickSeed);
+    }
+
+    function setBanditSpawnState(uint8 region, uint64 lastSpawnTick, uint16 probabilityAccum) external {
+        _banditSpawnByRegion[region].lastSpawnTick = lastSpawnTick;
+        _banditSpawnByRegion[region].probabilityAccum = probabilityAccum;
+    }
+
+    function getBanditSpawnState(uint8 region) external view returns (uint64 lastSpawnTick, uint16 probabilityAccum) {
+        lastSpawnTick = _banditSpawnByRegion[region].lastSpawnTick;
+        probabilityAccum = _banditSpawnByRegion[region].probabilityAccum;
+    }
+
+    function activeBanditCount() external view returns (uint32) {
+        return _activeBanditCount;
+    }
+
+    function minSpawnCooldownTicks() external pure returns (uint64) {
+        return MIN_SPAWN_COOLDOWN_TICKS;
+    }
+
+    function spawnProbabilityIncrementBps() external pure returns (uint16) {
+        return BANDIT_SPAWN_PROBABILITY_INCREMENT_BPS;
+    }
+
+    function maxBanditsPerRegion() external pure returns (uint8) {
+        return MAX_BANDITS_PER_REGION;
+    }
+
+    function maxTotalBandits() external pure returns (uint8) {
+        return MAX_TOTAL_BANDITS;
+    }
+
+    function maxBanditSpawnScanPerRegion() external pure returns (uint256) {
+        return MAX_BANDIT_SPAWN_SCAN_PER_REGION;
+    }
+
+    function banditSpawnRoll(bytes32 tickSeed, uint8 region) external pure returns (uint256) {
+        return _banditSpawnRoll(tickSeed, region);
+    }
+}
+
+contract BanditSpawnTest is Test {
+    BanditSpawnHarness world;
+
+    function setUp() public {
+        world = new BanditSpawnHarness();
+    }
+
+    function _advanceTick(BanditSpawnHarness target) internal {
+        vm.warp(target.getWorldState().nextHeartbeatAtTs);
+        target.heartbeat();
+    }
+
+    function _advanceTicks(BanditSpawnHarness target, uint64 ticks) internal {
+        for (uint64 i = 0; i < ticks; i++) {
+            _advanceTick(target);
+        }
+    }
+
+    function _advancePastInitialCooldown(BanditSpawnHarness target) internal {
+        _advanceTicks(target, target.minSpawnCooldownTicks());
+    }
+
+    function _mintForestClan(BanditSpawnHarness target) internal {
+        target.mintClan(address(this));
+    }
+
+    function _missSeed(uint8 region, uint16 probability) internal view returns (bytes32) {
+        for (uint256 i = 0; i < 256; i++) {
+            bytes32 seed = keccak256(abi.encodePacked("miss", i));
+            if (world.banditSpawnRoll(seed, region) >= probability) {
+                return seed;
+            }
+        }
+        revert("missing miss seed");
+    }
+
+    function test_cooldownEnforcedAfterSpawn() public {
+        _mintForestClan(world);
+        world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+
+        _advanceTicks(world, world.minSpawnCooldownTicks() - 1);
+
+        assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, 1, "cooldown blocks second spawn");
+        (, uint16 probabilityAccum) = world.getBanditSpawnState(ClanWorldConstants.REGION_FOREST);
+        assertEq(probabilityAccum, 0, "cooldown does not accumulate chance");
+    }
+
+    function test_probabilityRisesAfterCooldown() public {
+        _advancePastInitialCooldown(world);
+        _mintForestClan(world);
+
+        uint16 increment = world.spawnProbabilityIncrementBps();
+        world.evaluateBanditSpawns(_missSeed(ClanWorldConstants.REGION_FOREST, increment));
+
+        (, uint16 probabilityAccum) = world.getBanditSpawnState(ClanWorldConstants.REGION_FOREST);
+        assertEq(probabilityAccum, increment, "first eligible tick increments accumulator");
+    }
+
+    function test_perRegionCapEnforced() public {
+        _advancePastInitialCooldown(world);
+        _mintForestClan(world);
+
+        uint8 maxPerRegion = world.maxBanditsPerRegion();
+        for (uint8 i = 0; i < maxPerRegion; i++) {
+            world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100 + i);
+        }
+        world.setBanditSpawnState(ClanWorldConstants.REGION_FOREST, 0, 10000);
+
+        world.evaluateBanditSpawns(keccak256("per-region-cap"));
+
+        assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, maxPerRegion, "region cap");
+    }
+
+    function test_globalCapEnforced() public {
+        _advancePastInitialCooldown(world);
+        _mintForestClan(world);
+
+        uint8 maxTotal = world.maxTotalBandits();
+        for (uint8 i = 0; i < maxTotal; i++) {
+            world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100 + i);
+        }
+        world.setBanditSpawnState(ClanWorldConstants.REGION_FOREST, 0, 10000);
+
+        world.evaluateBanditSpawns(keccak256("global-cap"));
+
+        assertEq(world.activeBanditCount(), maxTotal, "global cap");
+    }
+
+    function test_globalCapRefreshesPreviewOnHeartbeat() public {
+        _mintForestClan(world);
+
+        uint8 maxTotal = world.maxTotalBandits();
+        for (uint8 i = 0; i < maxTotal; i++) {
+            world.spawnBandit(uint8(ClanWorldConstants.REGION_FOREST + (i % 8)), 100 + i);
+        }
+        world.setBanditSpawnState(ClanWorldConstants.REGION_FOREST, 0, 4321);
+
+        _advanceTick(world);
+
+        WorldState memory state = world.getWorldState();
+        assertEq(world.activeBanditCount(), maxTotal, "still at cap");
+        assertEq(state.nextBanditSpawnEligibleTick, 0, "no eligible tick while capped");
+        assertEq(state.currentBanditSpawnChanceBps, 4321, "preview chance refreshed");
+    }
+
+    function test_heartbeatCompletesWhenClanCountExceedsBanditSpawnScanCap() public {
+        uint256 clanCount = world.maxBanditSpawnScanPerRegion() + 1;
+        uint160 ownerId = 1;
+        for (uint256 i = 0; i < clanCount; i++) {
+            world.mintClan(address(ownerId));
+            ownerId += 1;
+        }
+
+        _advanceTick(world);
+
+        assertEq(world.getWorldState().currentTick, 1, "heartbeat advanced");
+    }
+
+    function test_regionSelectionDeterministicForSameSeed() public {
+        BanditSpawnHarness a = new BanditSpawnHarness();
+        BanditSpawnHarness b = new BanditSpawnHarness();
+        _advancePastInitialCooldown(a);
+        _advancePastInitialCooldown(b);
+        a.mintClan(address(0xA11CE));
+        a.mintClan(address(0xB0B));
+        b.mintClan(address(0xA11CE));
+        b.mintClan(address(0xB0B));
+        a.setBanditSpawnState(ClanWorldConstants.REGION_FOREST, 0, 10000);
+        a.setBanditSpawnState(ClanWorldConstants.REGION_MOUNTAINS, 0, 10000);
+        b.setBanditSpawnState(ClanWorldConstants.REGION_FOREST, 0, 10000);
+        b.setBanditSpawnState(ClanWorldConstants.REGION_MOUNTAINS, 0, 10000);
+
+        bytes32 seed = keccak256("deterministic-region");
+        a.evaluateBanditSpawns(seed);
+        b.evaluateBanditSpawns(seed);
+
+        assertEq(a.getBandit(1).region, b.getBandit(1).region, "same seed selects same region");
+    }
+
+    function test_rngNoncePerRegionIsIndependent() public view {
+        bytes32 seed = keccak256("region-nonce");
+
+        uint256 forestRoll = world.banditSpawnRoll(seed, ClanWorldConstants.REGION_FOREST);
+        uint256 mountainRoll = world.banditSpawnRoll(seed, ClanWorldConstants.REGION_MOUNTAINS);
+
+        assertTrue(forestRoll != mountainRoll, "region nonce changes roll");
+    }
+
+    function test_spawnedBanditEntersStateMachine() public {
+        _advancePastInitialCooldown(world);
+        _mintForestClan(world);
+        world.setBanditSpawnState(ClanWorldConstants.REGION_FOREST, 0, 10000);
+
+        world.evaluateBanditSpawns(keccak256("spawn-state-machine"));
+
+        BanditTroop memory bandit = world.getBandit(1);
+        WorldState memory state = world.getWorldState();
+        assertEq(uint8(bandit.state), uint8(BanditState.Spawned), "spawned state");
+        assertEq(bandit.tickEnteredState, state.currentTick, "entered current tick");
+        assertEq(state.activeBanditId, bandit.id, "active bandit set");
+    }
+}

--- a/packages/contracts/test/BanditSpawn.t.sol
+++ b/packages/contracts/test/BanditSpawn.t.sol
@@ -188,6 +188,19 @@ contract BanditSpawnTest is Test {
         revert("missing miss seed");
     }
 
+    function _hitBothSeed(uint8 firstRegion, uint8 secondRegion, uint16 probability) internal view returns (bytes32) {
+        for (uint256 i = 0; i < 256; i++) {
+            bytes32 seed = keccak256(abi.encodePacked("hit-both", i));
+            if (
+                world.banditSpawnRoll(seed, firstRegion) < probability
+                    && world.banditSpawnRoll(seed, secondRegion) < probability
+            ) {
+                return seed;
+            }
+        }
+        revert("missing hit seed");
+    }
+
     function test_cooldownEnforcedAfterSpawn() public {
         _mintForestClan(world);
         world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
@@ -208,6 +221,30 @@ contract BanditSpawnTest is Test {
 
         (, uint16 probabilityAccum) = world.getBanditSpawnState(ClanWorldConstants.REGION_FOREST);
         assertEq(probabilityAccum, increment, "first eligible tick increments accumulator");
+    }
+
+    function test_spawnResetsOnlySelectedRegionAccumulator() public {
+        _advancePastInitialCooldown(world);
+        world.mintClan(address(0xF0));
+        world.mintClan(address(0xB0));
+
+        uint16 oneStepBelowCap = 7000;
+        world.setBanditSpawnState(ClanWorldConstants.REGION_FOREST, 0, oneStepBelowCap);
+        world.setBanditSpawnState(ClanWorldConstants.REGION_MOUNTAINS, 0, oneStepBelowCap);
+
+        world.evaluateBanditSpawns(
+            _hitBothSeed(ClanWorldConstants.REGION_FOREST, ClanWorldConstants.REGION_MOUNTAINS, 8000)
+        );
+
+        uint8 selectedRegion = world.getBandit(1).region;
+        uint8 otherRegion = selectedRegion == ClanWorldConstants.REGION_FOREST
+            ? ClanWorldConstants.REGION_MOUNTAINS
+            : ClanWorldConstants.REGION_FOREST;
+        (, uint16 selectedAccum) = world.getBanditSpawnState(selectedRegion);
+        (, uint16 otherAccum) = world.getBanditSpawnState(otherRegion);
+
+        assertEq(selectedAccum, 0, "selected region reset");
+        assertEq(otherAccum, 8000, "unselected candidate retained accum");
     }
 
     function test_perRegionCapEnforced() public {

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -125,6 +125,12 @@ contract ClanWorldTest is Test {
         world.heartbeat();
     }
 
+    function _advanceTicks(uint256 count) internal {
+        for (uint256 i = 0; i < count; i++) {
+            _advanceTick();
+        }
+    }
+
     function _mintClan() internal returns (uint32 clanId) {
         vm.prank(elder);
         (clanId,) = world.mintClan(elder);
@@ -280,6 +286,87 @@ contract ClanWorldTest is Test {
             assertEq(cs.currentRegion, baseRegion, "clansman should be at homebase");
             assertEq(cs.clanId, clanId, "clansman.clanId should match clan");
         }
+    }
+
+    function test_issue230_derivedClanState_simulatesStarvationWithoutMutatingRaw() public {
+        uint32 clanId = _mintClan();
+
+        _advanceTicks(6);
+
+        DerivedClanState memory derived = world.getDerivedClanState(clanId);
+        assertEq(derived.derivedAtTick, 6, "derived tick");
+        assertTrue(derived.isStarving, "derived clan should be starving");
+        assertEq(derived.clan.lastSettledTick, 6, "derived clan settled to current tick");
+        assertEq(derived.clan.starvationStartsAtTick, 5, "starvation starts at first unpaid upkeep tick");
+        assertEq(derived.clan.vaultWheat, 0, "simulated wheat spent");
+        assertEq(derived.clan.vaultFish, 0, "simulated fish spent");
+
+        Clan memory raw = world.getClan(clanId);
+        assertEq(raw.lastSettledTick, 0, "raw settlement checkpoint unchanged");
+        assertEq(raw.starvationStartsAtTick, 0, "raw starvation flag unchanged");
+        assertEq(raw.vaultWheat, 20e18, "raw wheat unchanged");
+        assertEq(raw.vaultFish, 2e18, "raw fish unchanged");
+    }
+
+    function test_issue230_derivedClansmanState_simulatesArrivalWithoutMutatingRaw() public {
+        uint32 clanId = _mintClan();
+        ClanFullView memory view_ = world.getClanFullView(clanId);
+        uint32 csId = view_.clansmen[0].clansman.clansman.clansmanId;
+
+        _submitOrder(clanId, csId, ClanWorldConstants.REGION_MOUNTAINS, ActionType.MineIron);
+        _advanceTicks(2);
+
+        DerivedClansmanState memory derived = world.getDerivedClansmanState(csId);
+        assertEq(uint8(derived.clansman.state), uint8(ClansmanState.ACTING), "derived clansman arrived");
+        assertEq(derived.clansman.currentRegion, ClanWorldConstants.REGION_MOUNTAINS, "derived current region");
+        assertEq(derived.effectiveRegion, ClanWorldConstants.REGION_MOUNTAINS, "derived effective region");
+        assertTrue(derived.activeMission.active, "mission remains active before settle tick");
+
+        Clansman memory raw = world.getClansman(csId);
+        assertEq(uint8(raw.state), uint8(ClansmanState.TRAVELING), "raw clansman remains unmutated");
+        assertEq(raw.currentRegion, view_.clan.clan.baseRegion, "raw current region unchanged");
+    }
+
+    function test_issue230_fullViewAndLootQuoteUseSimulationButRawStaysCommitted() public {
+        uint32 clanId = _mintClan();
+
+        _advanceTicks(6);
+
+        ClanFullView memory view_ = world.getClanFullView(clanId);
+        assertTrue(view_.clan.isStarving, "full view clan should be starving");
+        assertEq(view_.clan.clan.vaultWheat, 0, "full view simulated wheat spent");
+        assertEq(view_.clan.clan.vaultFish, 0, "full view simulated fish spent");
+        assertEq(world.quoteLootValueSettled(clanId), 20e18, "settled loot quote uses simulated vault");
+        assertEq(world.quoteLootValueRaw(clanId), 44e18, "raw loot quote remains committed storage");
+
+        Clan memory raw = world.getClan(clanId);
+        assertEq(raw.lastSettledTick, 0, "full view did not settle raw clan");
+        assertEq(raw.vaultWheat, 20e18, "full view did not mutate raw wheat");
+        assertEq(raw.vaultFish, 2e18, "full view did not mutate raw fish");
+    }
+
+    function test_issue230_multipleClansSimulateIndependentlyFromDifferentCheckpoints() public {
+        uint32 clanId1 = _mintClan();
+        vm.prank(elder2);
+        (uint32 clanId2,) = world.mintClan(elder2);
+
+        _advanceTicks(2);
+        world.settleClan(clanId1);
+        _advanceTicks(4);
+
+        DerivedClanState memory derived1 = world.getDerivedClanState(clanId1);
+        DerivedClanState memory derived2 = world.getDerivedClanState(clanId2);
+        assertTrue(derived1.isStarving, "clan 1 simulated from later checkpoint");
+        assertTrue(derived2.isStarving, "clan 2 simulated from genesis checkpoint");
+        assertEq(derived1.clan.lastSettledTick, 6, "clan 1 derived to current");
+        assertEq(derived2.clan.lastSettledTick, 6, "clan 2 derived to current");
+
+        Clan memory raw1 = world.getClan(clanId1);
+        Clan memory raw2 = world.getClan(clanId2);
+        assertEq(raw1.lastSettledTick, 2, "clan 1 raw checkpoint unchanged after derived reads");
+        assertEq(raw2.lastSettledTick, 0, "clan 2 raw checkpoint unchanged after derived reads");
+        assertEq(raw1.starvationStartsAtTick, 0, "clan 1 raw starvation unchanged");
+        assertEq(raw2.starvationStartsAtTick, 0, "clan 2 raw starvation unchanged");
     }
 
     // -------------------------------------------------------------------------

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -496,8 +496,11 @@ contract ClanWorldTest is Test {
         ClanFullView memory view_ = world.getClanFullView(clanId);
         uint32 csId = view_.clansmen[0].clansman.clansman.clansmanId;
 
-        // Advance 201 ticks — clan is now 201 ticks behind its lastSettledTick
-        for (uint256 i = 0; i < 201; i++) {
+        // Advance until the clan is truly >200 ticks behind. Phase 9 bandit
+        // eager-settle may settle candidate-region bases on spawn ticks, so
+        // this test follows the invariant instead of assuming no heartbeat
+        // settlement ever touches the clan.
+        while (world.getWorldState().currentTick <= world.getClan(clanId).lastSettledTick + 200) {
             _advanceTick();
         }
 

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -48,6 +48,10 @@ contract ClanWorldTestHarness is ClanWorld {
     function killClansman(uint32 csId) external {
         _clansmen[csId].state = ClansmanState.DEAD;
     }
+
+    function setLastSettledTickForTest(uint32 clanId, uint64 lastSettledTick) external {
+        _clans[clanId].lastSettledTick = lastSettledTick;
+    }
 }
 
 contract ClanWorldTest is Test {
@@ -68,7 +72,7 @@ contract ClanWorldTest is Test {
     StubPool fishPool;
 
     function setUp() public {
-        world = new ClanWorld();
+        world = new ClanWorldTestHarness();
     }
 
     /// @dev Deploy tokens + pools, call initTreasury + seedPools. Returns wood token address.
@@ -579,17 +583,14 @@ contract ClanWorldTest is Test {
     // -------------------------------------------------------------------------
 
     function test_submitClanOrders_reverts_when_clan_too_far_behind() public {
+        while (world.getWorldState().currentTick <= 200) {
+            _advanceTick();
+        }
+
         uint32 clanId = _mintClan();
         ClanFullView memory view_ = world.getClanFullView(clanId);
         uint32 csId = view_.clansmen[0].clansman.clansman.clansmanId;
-
-        // Advance until the clan is truly >200 ticks behind. Phase 9 bandit
-        // eager-settle may settle candidate-region bases on spawn ticks, so
-        // this test follows the invariant instead of assuming no heartbeat
-        // settlement ever touches the clan.
-        while (world.getWorldState().currentTick <= world.getClan(clanId).lastSettledTick + 200) {
-            _advanceTick();
-        }
+        ClanWorldTestHarness(address(world)).setLastSettledTickForTest(clanId, 0);
 
         // submitClanOrders should return ERR_INVALID_ACTION (ERR_MUST_SETTLE_FIRST proxy)
         // without reverting, for every order in the batch
@@ -1904,7 +1905,11 @@ contract ClanWorldTest is Test {
         // Call settleClansman on-demand — must be idempotent (no crash, no double-credit).
         uint256 ironBefore = world.getClansman(csId).carryIron;
         world.settleClansman(csId);
-        assertEq(world.getClansman(csId).carryIron, ironBefore, "onDemand: settleClansman is idempotent after heartbeat settle");
+        assertEq(
+            world.getClansman(csId).carryIron,
+            ironBefore,
+            "onDemand: settleClansman is idempotent after heartbeat settle"
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -2011,8 +2016,7 @@ contract ClanWorldTest is Test {
         assertEq(ws.seasonStartTick, 0);
         assertEq(ws.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS);
         assertEq(
-            ws.winterStartsAtTick,
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS
+            ws.winterStartsAtTick, ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS
         );
         assertFalse(ws.winterActive);
     }
@@ -2021,8 +2025,7 @@ contract ClanWorldTest is Test {
         // winterStartsAtTick = 100; WinterStarted fires on the heartbeat that opens tick 100
         // i.e. when closedTick=99, newTick=100 >= winterStartsAtTick=100.
         // Advance 99 heartbeats so currentTick=99, then one more heartbeat fires WinterStarted at tick 100.
-        uint64 winterStart =
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
+        uint64 winterStart = ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
         for (uint64 i = 0; i < winterStart - 1; i++) {
             vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
             world.heartbeat();

--- a/packages/contracts/test/ClanWorldStub.t.sol
+++ b/packages/contracts/test/ClanWorldStub.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
 import {ClanWorldStub} from "../src/ClanWorldStub.sol";
+import {BanditState, BanditTroop} from "../src/IClanWorld.sol";
 import {MinimalERC20} from "../src/MinimalERC20.sol";
 import {StubPool} from "../src/StubPool.sol";
 
@@ -32,5 +33,12 @@ contract ClanWorldStubTest is Test {
     function test_getWorldSnapshot_returns_current_tick() public {
         stub.heartbeat();
         assertEq(stub.getWorldSnapshot().currentTick, 2);
+    }
+
+    function test_getBanditMissingIdReturnsNoneState() public view {
+        BanditTroop memory bandit = stub.getBandit(999);
+
+        assertEq(bandit.id, 0, "missing id");
+        assertEq(uint8(bandit.state), uint8(BanditState.None), "missing state");
     }
 }

--- a/packages/contracts/test/HeartbeatOrdering.t.sol
+++ b/packages/contracts/test/HeartbeatOrdering.t.sol
@@ -36,6 +36,72 @@ contract HeartbeatOrderingHarness is ClanWorld {
     }
 }
 
+contract RecordingPool {
+    address public immutable TOKEN_A;
+    address public immutable TOKEN_B;
+    address public immutable ENGINE;
+
+    uint256 public reserveA;
+    uint256 public reserveB;
+    uint64 public observedTick;
+    bytes32 public observedSeed;
+    bool public observedSell;
+    bool private _seeded;
+
+    modifier onlyEngine() {
+        require(msg.sender == ENGINE, "RecordingPool: only engine");
+        _;
+    }
+
+    constructor(address tokenA_, address tokenB_, address engine_) {
+        TOKEN_A = tokenA_;
+        TOKEN_B = tokenB_;
+        ENGINE = engine_;
+    }
+
+    function seed(uint256 amountA, uint256 amountB) external onlyEngine {
+        require(!_seeded, "RecordingPool: already seeded");
+        require(amountA > 0 && amountB > 0, "RecordingPool: zero seed");
+        reserveA = amountA;
+        reserveB = amountB;
+        _seeded = true;
+    }
+
+    function sellResource(uint256 amountIn) external onlyEngine returns (uint256 goldOut) {
+        require(amountIn > 0, "RecordingPool: zero amount");
+        require(reserveA > 0 && reserveB > 0, "RecordingPool: not seeded");
+
+        WorldState memory state = HeartbeatOrderingHarness(ENGINE).getWorldState();
+        observedTick = state.currentTick;
+        observedSeed = state.currentTickSeed;
+        observedSell = true;
+
+        goldOut = (reserveB * amountIn) / (reserveA + amountIn);
+        require(goldOut > 0, "RecordingPool: zero output");
+        reserveA += amountIn;
+        reserveB -= goldOut;
+    }
+
+    function quoteBuy(uint256 amountOut) external view returns (uint256 goldIn) {
+        require(amountOut > 0, "RecordingPool: zero amount");
+        require(amountOut < reserveA, "RecordingPool: insufficient resource reserve");
+        uint256 num = reserveB * amountOut;
+        uint256 denom_ = reserveA - amountOut;
+        goldIn = num / denom_ + (num % denom_ == 0 ? 0 : 1);
+    }
+
+    function buyResource(uint256 amountOut) external onlyEngine returns (uint256 goldIn) {
+        require(amountOut > 0, "RecordingPool: zero amount");
+        require(amountOut < reserveA, "RecordingPool: insufficient resource reserve");
+        require(reserveB > 0, "RecordingPool: not seeded");
+        uint256 num = reserveB * amountOut;
+        uint256 denom_ = reserveA - amountOut;
+        goldIn = num / denom_ + (num % denom_ == 0 ? 0 : 1);
+        reserveA -= amountOut;
+        reserveB += goldIn;
+    }
+}
+
 contract HeartbeatOrderingTest is Test {
     HeartbeatOrderingHarness world;
     address elder = address(0xA1);
@@ -51,6 +117,7 @@ contract HeartbeatOrderingTest is Test {
     StubPool ironPool;
     StubPool wheatPool;
     StubPool fishPool;
+    RecordingPool recordingWoodPool;
 
     function setUp() public {
         world = new HeartbeatOrderingHarness();
@@ -164,6 +231,46 @@ contract HeartbeatOrderingTest is Test {
         world.seedPools(cfg);
     }
 
+    function _setupRecordingMarket() internal {
+        woodToken = new MinimalERC20("Wood", "WOOD");
+        ironToken = new MinimalERC20("Iron", "IRON");
+        wheatToken = new MinimalERC20("Wheat", "WHEAT");
+        fishToken = new MinimalERC20("Fish", "FISH");
+        goldToken = new MinimalERC20("Gold", "GOLD");
+        blueprintToken = new MinimalERC20("BPRT", "BPRT");
+
+        address wAddr = address(world);
+        recordingWoodPool = new RecordingPool(address(woodToken), address(goldToken), wAddr);
+        ironPool = new StubPool(address(ironToken), address(goldToken), wAddr);
+        wheatPool = new StubPool(address(wheatToken), address(goldToken), wAddr);
+        fishPool = new StubPool(address(fishToken), address(goldToken), wAddr);
+
+        address[6] memory tokens = [
+            address(woodToken),
+            address(ironToken),
+            address(wheatToken),
+            address(fishToken),
+            address(goldToken),
+            address(blueprintToken)
+        ];
+        address[4] memory pools = [address(recordingWoodPool), address(wheatPool), address(fishPool), address(ironPool)];
+        world.initTreasury(tokens, pools);
+
+        uint256 resSeed = 1000e18;
+        uint256 goldSeed = 1000e18;
+        PoolSeedConfig memory cfg = PoolSeedConfig({
+            woodSeed: resSeed,
+            wheatSeed: resSeed,
+            fishSeed: resSeed,
+            ironSeed: resSeed,
+            goldSeedForWood: goldSeed,
+            goldSeedForWheat: goldSeed,
+            goldSeedForFish: goldSeed,
+            goldSeedForIron: goldSeed
+        });
+        world.seedPools(cfg);
+    }
+
     // -------------------------------------------------------------------------
     // test_heartbeat_settlementBeforeMarket
     //
@@ -250,6 +357,33 @@ contract HeartbeatOrderingTest is Test {
 
         assertEq(world.getWorldState().currentTick, tick2 + 1, "tick must increment again");
         assertEq(world.getWorldState().currentTickSeed, expectedSeed2, "seed must chain from prior seed");
+    }
+
+    function test_heartbeat_scheduledMarketObservesClosedTickSeedBeforeIncrement() public {
+        _setupRecordingMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, address(woodToken), 5e18, 0);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "market sell order must enqueue");
+
+        Mission memory m = world.getActiveMission(csId);
+        uint64 executeAtTick = m.actionStartTick;
+        _advanceToTick(executeAtTick);
+
+        WorldState memory beforeClose = world.getWorldState();
+        assertEq(beforeClose.currentTick, executeAtTick, "setup must be at execute tick before close");
+        bytes32 seedForClosedTick = beforeClose.currentTickSeed;
+
+        _advanceTick();
+
+        assertTrue(recordingWoodPool.observedSell(), "scheduled sell must execute");
+        assertEq(recordingWoodPool.observedTick(), executeAtTick, "market observes closed tick before increment");
+        assertEq(recordingWoodPool.observedSeed(), seedForClosedTick, "market observes seed for closed tick");
+
+        WorldState memory afterClose = world.getWorldState();
+        assertEq(afterClose.currentTick, executeAtTick + 1, "heartbeat opens next tick after market execution");
+        assertNotEq(afterClose.currentTickSeed, seedForClosedTick, "next tick seed publishes after close-tick work");
     }
 
     // -------------------------------------------------------------------------

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -4,57 +4,19 @@ import {
   createWalletClient,
   http,
   type Account,
+  type Abi,
   type PublicClient,
   type WalletClient,
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
+import IClanWorldArtifact from '../../contracts/abi/IClanWorld.json';
 import { baseSepolia } from '@clan-world/shared/adapters';
 import {
   HeartbeatRateLimitedError,
   type IHeartbeatCaller,
 } from '@clan-world/agents/seams';
 
-/**
- * Minimal ABI: only the `heartbeat()` write and the `nextHeartbeatAtTs` field
- * we read out of `getWorldState()`. We avoid pulling in the full IClanWorld
- * ABI here so the runner stays decoupled from contract-package versioning.
- */
-const HEARTBEAT_ABI = [
-  {
-    type: 'function',
-    name: 'heartbeat',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'getWorldState',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        components: [
-          { name: 'currentTick', type: 'uint64' },
-          { name: 'seasonStartTick', type: 'uint64' },
-          { name: 'seasonEndTick', type: 'uint64' },
-          { name: 'seasonFinalized', type: 'bool' },
-          { name: 'nextHeartbeatAtTs', type: 'uint64' },
-          { name: 'nextBanditSpawnEligibleTick', type: 'uint64' },
-          { name: 'currentBanditSpawnChanceBps', type: 'uint16' },
-          { name: 'currentTickSeed', type: 'bytes32' },
-          { name: 'activeBanditId', type: 'uint32' },
-          { name: 'winterActive', type: 'bool' },
-          { name: 'winterStartsAtTick', type: 'uint64' },
-          { name: 'winterEndsAtTick', type: 'uint64' },
-          { name: 'nextCommitSequence', type: 'uint64' },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-] as const;
+export const HEARTBEAT_ABI = IClanWorldArtifact.abi as Abi;
 
 export interface RunnerHeartbeatConfig {
   /** Hex-encoded 64-char private key, optionally 0x-prefixed. */

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,12 +11,14 @@
   },
   "scripts": {
     "build": "tsc -b",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'lint stub'",
     "clean": "rm -rf dist .turbo"
   },
   "devDependencies": {
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^3.2.0"
   },
   "dependencies": {
     "convex": "1.17.4",

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
 import { createPublicClient, createWalletClient, http, fallback, defineChain } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
+import IClanWorldArtifact from '../../../contracts/abi/IClanWorld.json';
 import type { ClanFullView, ClanOrder, Tick } from '../types';
+import type { Abi } from 'viem';
 import { readEnv } from './_env';
 
 export interface IChainClient {
@@ -21,221 +23,7 @@ export const baseSepolia = defineChain({
   },
 });
 
-// Minimal ABI — only the two read functions we call.
-const CLAN_WORLD_ABI = [
-  {
-    type: 'function',
-    name: 'getWorldSnapshot',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        components: [
-          { name: 'currentTick', type: 'uint64' },
-          { name: 'seasonStartTick', type: 'uint64' },
-          { name: 'seasonEndTick', type: 'uint64' },
-          { name: 'seasonFinalized', type: 'bool' },
-          { name: 'winterActive', type: 'bool' },
-          { name: 'winterStartsAtTick', type: 'uint64' },
-          { name: 'winterEndsAtTick', type: 'uint64' },
-          { name: 'activeBanditId', type: 'uint32' },
-          { name: 'currentTickSeed', type: 'bytes32' },
-          {
-            name: 'leaderboard',
-            type: 'tuple[]',
-            components: [
-              { name: 'clanId', type: 'uint32' },
-              { name: 'owner', type: 'address' },
-              { name: 'monumentLevel', type: 'uint8' },
-              { name: 'baseLevel', type: 'uint8' },
-              { name: 'wallLevel', type: 'uint8' },
-              { name: 'livingClansmen', type: 'uint8' },
-              { name: 'state', type: 'uint8' },
-              { name: 'lootValue', type: 'uint256' },
-            ],
-          },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'getClanFullView',
-    inputs: [{ name: '', type: 'uint32' }],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple',
-        components: [
-          {
-            name: 'clan',
-            type: 'tuple',
-            components: [
-              {
-                name: 'clan',
-                type: 'tuple',
-                components: [
-                  { name: 'clanId', type: 'uint32' },
-                  { name: 'iftTokenId', type: 'uint256' },
-                  { name: 'owner', type: 'address' },
-                  { name: 'clanState', type: 'uint8' },
-                  { name: 'baseRegion', type: 'uint8' },
-                  { name: 'baseLevel', type: 'uint8' },
-                  { name: 'wallLevel', type: 'uint8' },
-                  { name: 'monumentLevel', type: 'uint8' },
-                  { name: 'livingClansmen', type: 'uint8' },
-                  { name: 'lastSettledTick', type: 'uint64' },
-                  { name: 'starvationStartsAtTick', type: 'uint64' },
-                  { name: 'coldDamage', type: 'uint16' },
-                  { name: 'goldBalance', type: 'uint256' },
-                  { name: 'blueprintBalance', type: 'uint256' },
-                  { name: 'vaultWood', type: 'uint256' },
-                  { name: 'vaultIron', type: 'uint256' },
-                  { name: 'vaultWheat', type: 'uint256' },
-                  { name: 'vaultFish', type: 'uint256' },
-                ],
-              },
-              { name: 'isStarving', type: 'bool' },
-              { name: 'lootValue', type: 'uint256' },
-              { name: 'derivedAtTick', type: 'uint64' },
-            ],
-          },
-          // clansmen, westPlot, eastPlot etc. omitted — not needed for Wave 0 mapping
-          {
-            name: 'clansmen',
-            type: 'tuple[]',
-            components: [
-              {
-                name: 'clansman',
-                type: 'tuple',
-                components: [
-                  {
-                    name: 'clansman',
-                    type: 'tuple',
-                    components: [
-                      { name: 'clansmanId', type: 'uint32' },
-                      { name: 'clanId', type: 'uint32' },
-                      { name: 'state', type: 'uint8' },
-                      { name: 'currentRegion', type: 'uint8' },
-                      { name: 'cooldownEndsAtTs', type: 'uint64' },
-                      { name: 'lastMissionNonce', type: 'uint64' },
-                      { name: 'carryWood', type: 'uint256' },
-                      { name: 'carryIron', type: 'uint256' },
-                      { name: 'carryWheat', type: 'uint256' },
-                      { name: 'carryFish', type: 'uint256' },
-                    ],
-                  },
-                  {
-                    name: 'activeMission',
-                    type: 'tuple',
-                    components: [
-                      { name: 'active', type: 'bool' },
-                      { name: 'nonce', type: 'uint64' },
-                      { name: 'clansmanId', type: 'uint32' },
-                      { name: 'startRegion', type: 'uint8' },
-                      { name: 'targetRegion', type: 'uint8' },
-                      { name: 'action', type: 'uint8' },
-                      { name: 'startTick', type: 'uint64' },
-                      { name: 'arrivalTick', type: 'uint64' },
-                      { name: 'actionStartTick', type: 'uint64' },
-                      { name: 'missionSeed', type: 'bytes32' },
-                      { name: 'marketMode', type: 'uint8' },
-                      { name: 'targetClanId', type: 'uint32' },
-                      { name: 'marketToken', type: 'address' },
-                      { name: 'marketAmount', type: 'uint256' },
-                      { name: 'maxGoldIn', type: 'uint256' },
-                    ],
-                  },
-                  { name: 'effectiveRegion', type: 'uint8' },
-                  { name: 'derivedAtTick', type: 'uint64' },
-                ],
-              },
-              {
-                name: 'activeMission',
-                type: 'tuple',
-                components: [
-                  { name: 'active', type: 'bool' },
-                  { name: 'nonce', type: 'uint64' },
-                  { name: 'clansmanId', type: 'uint32' },
-                  { name: 'startRegion', type: 'uint8' },
-                  { name: 'targetRegion', type: 'uint8' },
-                  { name: 'action', type: 'uint8' },
-                  { name: 'startTick', type: 'uint64' },
-                  { name: 'arrivalTick', type: 'uint64' },
-                  { name: 'actionStartTick', type: 'uint64' },
-                  { name: 'missionSeed', type: 'bytes32' },
-                  { name: 'marketMode', type: 'uint8' },
-                  { name: 'targetClanId', type: 'uint32' },
-                  { name: 'marketToken', type: 'address' },
-                  { name: 'marketAmount', type: 'uint256' },
-                  { name: 'maxGoldIn', type: 'uint256' },
-                ],
-              },
-            ],
-          },
-          {
-            name: 'westPlot',
-            type: 'tuple',
-            components: [
-              { name: 'state', type: 'uint8' },
-              { name: 'region', type: 'uint8' },
-              { name: 'remainingWheat', type: 'uint256' },
-              { name: 'regrowUntilTick', type: 'uint64' },
-            ],
-          },
-          {
-            name: 'eastPlot',
-            type: 'tuple',
-            components: [
-              { name: 'state', type: 'uint8' },
-              { name: 'region', type: 'uint8' },
-              { name: 'remainingWheat', type: 'uint256' },
-              { name: 'regrowUntilTick', type: 'uint64' },
-            ],
-          },
-          { name: 'incomingDefenderIds', type: 'uint32[]' },
-          { name: 'thisClanDefendingBaseId', type: 'uint32' },
-        ],
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    name: 'submitClanOrders',
-    type: 'function',
-    inputs: [
-      { name: 'clanId', type: 'uint32' },
-      {
-        name: 'orders',
-        type: 'tuple[]',
-        components: [
-          { name: 'clansmanId', type: 'uint32' },
-          { name: 'gotoRegion', type: 'uint8' },
-          { name: 'action', type: 'uint8' },
-          { name: 'targetClanId', type: 'uint32' },
-          { name: 'marketToken', type: 'address' },
-          { name: 'marketAmount', type: 'uint256' },
-          { name: 'maxGoldIn', type: 'uint256' },
-        ],
-      },
-    ],
-    outputs: [
-      {
-        name: 'results',
-        type: 'tuple[]',
-        components: [
-          { name: 'clansmanId', type: 'uint32' },
-          { name: 'status', type: 'uint8' },
-          { name: 'cooldownEndsAtTs', type: 'uint64' },
-          { name: 'missionNonce', type: 'uint64' },
-        ],
-      },
-    ],
-    stateMutability: 'nonpayable',
-  },
-] as const;
+export const CLAN_WORLD_ABI = IClanWorldArtifact.abi as Abi;
 
 class StubChainClient implements IChainClient {
   async getCurrentTick(): Promise<Tick> {
@@ -282,7 +70,7 @@ class RealChainClient implements IChainClient {
       address: this.contractAddress,
       abi: CLAN_WORLD_ABI,
       functionName: 'getWorldSnapshot',
-    });
+    }) as { currentTick: bigint };
     return Number(snapshot.currentTick); // safe: tick values are small enough to fit Number precisely in Wave 0
   }
 
@@ -380,7 +168,14 @@ class RealChainClient implements IChainClient {
       abi: CLAN_WORLD_ABI,
       functionName: 'getClanFullView',
       args: [parseInt(clanId, 10)],
-    });
+    }) as {
+      clan: {
+        clan: {
+          clanId: number;
+          goldBalance: bigint;
+        };
+      };
+    };
 
     const inner = result.clan.clan;
     return {

--- a/packages/shared/test/clanWorldAbi.test.ts
+++ b/packages/shared/test/clanWorldAbi.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { decodeFunctionResult, encodeAbiParameters } from 'viem';
+import { CLAN_WORLD_ABI } from '../src/adapters/IChainClient';
+
+const ZERO_BYTES32 = `0x${'00'.repeat(32)}` as `0x${string}`;
+
+const worldStateTuple = [
+  {
+    type: 'tuple',
+    components: [
+      { name: 'currentTick', type: 'uint64' },
+      { name: 'seasonStartTick', type: 'uint64' },
+      { name: 'seasonEndTick', type: 'uint64' },
+      { name: 'seasonFinalized', type: 'bool' },
+      { name: 'currentSeasonNumber', type: 'uint64' },
+      { name: 'nextHeartbeatAtTick', type: 'uint64' },
+      { name: 'nextHeartbeatAtTs', type: 'uint64' },
+      { name: 'nextBanditSpawnEligibleTick', type: 'uint64' },
+      { name: 'currentBanditSpawnChanceBps', type: 'uint16' },
+      { name: 'currentTickSeed', type: 'bytes32' },
+      { name: 'activeBanditId', type: 'uint32' },
+      { name: 'winterActive', type: 'bool' },
+      { name: 'winterStartsAtTick', type: 'uint64' },
+      { name: 'winterEndsAtTick', type: 'uint64' },
+      { name: 'nextCommitSequence', type: 'uint64' },
+    ],
+  },
+] as const;
+
+const worldSnapshotTuple = [
+  {
+    type: 'tuple',
+    components: [
+      { name: 'currentTick', type: 'uint64' },
+      { name: 'seasonStartTick', type: 'uint64' },
+      { name: 'seasonEndTick', type: 'uint64' },
+      { name: 'seasonFinalized', type: 'bool' },
+      { name: 'currentSeasonNumber', type: 'uint64' },
+      { name: 'nextHeartbeatAtTick', type: 'uint64' },
+      { name: 'winterActive', type: 'bool' },
+      { name: 'winterStartsAtTick', type: 'uint64' },
+      { name: 'winterEndsAtTick', type: 'uint64' },
+      { name: 'activeBanditId', type: 'uint32' },
+      { name: 'currentTickSeed', type: 'bytes32' },
+      {
+        name: 'leaderboard',
+        type: 'tuple[]',
+        components: [
+          { name: 'clanId', type: 'uint32' },
+          { name: 'owner', type: 'address' },
+          { name: 'monumentLevel', type: 'uint8' },
+          { name: 'baseLevel', type: 'uint8' },
+          { name: 'wallLevel', type: 'uint8' },
+          { name: 'livingClansmen', type: 'uint8' },
+          { name: 'state', type: 'uint8' },
+          { name: 'lootValue', type: 'uint256' },
+        ],
+      },
+    ],
+  },
+] as const;
+
+describe('ClanWorld generated ABI tuple decoding', () => {
+  it('decodes a known-good getWorldState() result with the current Solidity order', () => {
+    const data = encodeAbiParameters(worldStateTuple, [
+      {
+        currentTick: 11n,
+        seasonStartTick: 1n,
+        seasonEndTick: 360n,
+        seasonFinalized: false,
+        currentSeasonNumber: 7n,
+        nextHeartbeatAtTick: 12n,
+        nextHeartbeatAtTs: 1_900_000_001n,
+        nextBanditSpawnEligibleTick: 21n,
+        currentBanditSpawnChanceBps: 3000,
+        currentTickSeed: ZERO_BYTES32,
+        activeBanditId: 42,
+        winterActive: true,
+        winterStartsAtTick: 100n,
+        winterEndsAtTick: 110n,
+        nextCommitSequence: 9n,
+      },
+    ]);
+
+    const state = decodeFunctionResult({
+      abi: CLAN_WORLD_ABI,
+      functionName: 'getWorldState',
+      data,
+    }) as Record<string, unknown>;
+
+    expect(state.currentSeasonNumber).toBe(7n);
+    expect(state.nextHeartbeatAtTick).toBe(12n);
+    expect(state.nextHeartbeatAtTs).toBe(1_900_000_001n);
+    expect(state.winterActive).toBe(true);
+  });
+
+  it('decodes a known-good getWorldSnapshot() result with season fields before winter fields', () => {
+    const data = encodeAbiParameters(worldSnapshotTuple, [
+      {
+        currentTick: 33n,
+        seasonStartTick: 0n,
+        seasonEndTick: 360n,
+        seasonFinalized: false,
+        currentSeasonNumber: 2n,
+        nextHeartbeatAtTick: 34n,
+        winterActive: true,
+        winterStartsAtTick: 100n,
+        winterEndsAtTick: 110n,
+        activeBanditId: 3,
+        currentTickSeed: ZERO_BYTES32,
+        leaderboard: [],
+      },
+    ]);
+
+    const snapshot = decodeFunctionResult({
+      abi: CLAN_WORLD_ABI,
+      functionName: 'getWorldSnapshot',
+      data,
+    }) as Record<string, unknown>;
+
+    expect(snapshot.currentSeasonNumber).toBe(2n);
+    expect(snapshot.nextHeartbeatAtTick).toBe(34n);
+    expect(snapshot.winterActive).toBe(true);
+    expect(snapshot.activeBanditId).toBe(3);
+  });
+});

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.4(@types/node@25.6.0)(lightningcss@1.32.0)
 
 packages:
 


### PR DESCRIPTION
Phase 9D b-branch consolidating remaining medium-cost v4 bandit-mechanic restorations from #340.

**Fold history:** PR #374 squash-merged.

**Closes:** #340 (combined with PR #375 P9C — items 3,4,5,7,8 there + 1,2,6 here = 8/8 done)

### Items
- **#340 item 6** — WAITING-at-home defense contribution (5 def each, vs 10 DefendBase)
- **#340 item 1** — Vault loot theft (20% steal per BANDIT_BASE_STEAL_BPS, carry accumulation, distribution on defeat or burn on terminal escape)
- **#340 item 2** — Rampage path (1→2→5→7→6→4→1 clockwise on rest-end + eager-settle bases per v4_1 A4)

3 files +409/-115. Tests added for all 3 items.