### PR TITLE
Phase 6C — market follow-ups + post-audit polish

### DIFF
--- a/apps/server/convex/README.md
+++ b/apps/server/convex/README.md
@@ -1,7 +1,26 @@
-# Welcome to your Convex functions directory!
+# ClanWorld Convex Functions
 
-Write your Convex functions here.
-See https://docs.convex.dev/functions for more.
+This directory hosts the Convex backend functions, including the heartbeat
+webhook and the future chain indexer.
+
+## Market Event Indexer Notes
+
+Phase 6 market events intentionally use compact resource ids rather than token
+addresses:
+
+- `ImmediateMarketActionExecuted`: `resourceIn` and `resourceOut` are `uint8`
+  resource ids; `4` is gold.
+- `ScheduledMarketActionExecuted`: same resource-id encoding, plus
+  `settledAtTick`.
+- `MarketActionFailed`: includes `MarketExecutionMode mode`; indexers should
+  persist it to distinguish immediate failures from scheduled queue failures.
+- `ScheduledMarketActionCommitted`: optional pending-queue signal. Indexers may
+  use it for live queue rendering, or fall back to
+  `getScheduledMarketActionsForTick`.
+
+The canonical ABI lives in `packages/contracts/abi/IClanWorld.json`.
+
+## Convex Reference
 
 A query function that takes two arguments looks like:
 

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -245,6 +245,33 @@
               "name": "maxGoldIn",
               "type": "uint256",
               "internalType": "uint256"
+            },
+            {
+              "name": "withdrawResources",
+              "type": "tuple",
+              "internalType": "struct WithdrawResourcesData",
+              "components": [
+                {
+                  "name": "wood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "iron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "wheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "fish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
             }
           ]
         }
@@ -758,6 +785,33 @@
                           "name": "maxGoldIn",
                           "type": "uint256",
                           "internalType": "uint256"
+                        },
+                        {
+                          "name": "withdrawResources",
+                          "type": "tuple",
+                          "internalType": "struct WithdrawResourcesData",
+                          "components": [
+                            {
+                              "name": "wood",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            },
+                            {
+                              "name": "iron",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            },
+                            {
+                              "name": "wheat",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            },
+                            {
+                              "name": "fish",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            }
+                          ]
                         }
                       ]
                     },
@@ -867,6 +921,33 @@
                       "name": "maxGoldIn",
                       "type": "uint256",
                       "internalType": "uint256"
+                    },
+                    {
+                      "name": "withdrawResources",
+                      "type": "tuple",
+                      "internalType": "struct WithdrawResourcesData",
+                      "components": [
+                        {
+                          "name": "wood",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "iron",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "wheat",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "fish",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -1331,6 +1412,33 @@
                   "name": "maxGoldIn",
                   "type": "uint256",
                   "internalType": "uint256"
+                },
+                {
+                  "name": "withdrawResources",
+                  "type": "tuple",
+                  "internalType": "struct WithdrawResourcesData",
+                  "components": [
+                    {
+                      "name": "wood",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "iron",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "wheat",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "fish",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
                 }
               ]
             },
@@ -2413,6 +2521,33 @@
               "name": "maxGoldIn",
               "type": "uint256",
               "internalType": "uint256"
+            },
+            {
+              "name": "withdrawResources",
+              "type": "tuple",
+              "internalType": "struct WithdrawResourcesData",
+              "components": [
+                {
+                  "name": "wood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "iron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "wheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "fish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
             }
           ]
         }
@@ -3541,6 +3676,55 @@
           "type": "uint64",
           "indexed": false,
           "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ResourcesWithdrawn",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "woodDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "ironDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheatDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fishDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "tick",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
         }
       ],
       "anonymous": false

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2465,7 +2465,7 @@
       "name": "settleClansman",
       "inputs": [
         {
-          "name": "csId",
+          "name": "clansmanId",
           "type": "uint32",
           "internalType": "uint32"
         }
@@ -3205,7 +3205,7 @@
           "internalType": "uint32"
         },
         {
-          "name": "csId",
+          "name": "clansmanId",
           "type": "uint32",
           "indexed": false,
           "internalType": "uint32"
@@ -3309,7 +3309,7 @@
           "internalType": "uint32"
         },
         {
-          "name": "csId",
+          "name": "clansmanId",
           "type": "uint32",
           "indexed": false,
           "internalType": "uint32"
@@ -3795,7 +3795,7 @@
           "internalType": "uint32"
         },
         {
-          "name": "csId",
+          "name": "clansmanId",
           "type": "uint32",
           "indexed": false,
           "internalType": "uint32"

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1617,6 +1617,49 @@
     },
     {
       "type": "function",
+      "name": "getPool",
+      "inputs": [
+        {
+          "name": "resourceType",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getPrice",
+      "inputs": [
+        {
+          "name": "resourceType",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "amountIn",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "amountOut",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "getRegionPopulation",
       "inputs": [
         {
@@ -3382,7 +3425,7 @@
         {
           "name": "clansmanId",
           "type": "uint32",
-          "indexed": false,
+          "indexed": true,
           "internalType": "uint32"
         },
         {
@@ -3398,16 +3441,22 @@
           "internalType": "uint256"
         },
         {
+          "name": "wheatDelta",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
           "name": "fishDelta",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
         },
         {
-          "name": "wheatDelta",
-          "type": "uint256",
+          "name": "tick",
+          "type": "uint32",
           "indexed": false,
-          "internalType": "uint256"
+          "internalType": "uint32"
         }
       ],
       "anonymous": false

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -9,6 +9,25 @@
     },
     {
       "type": "function",
+      "name": "getActionDuration",
+      "inputs": [
+        {
+          "name": "action",
+          "type": "uint8",
+          "internalType": "enum ActionType"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
       "name": "getActiveBanditView",
       "inputs": [],
       "outputs": [
@@ -231,83 +250,6 @@
         }
       ],
       "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "getMissionTiming",
-      "inputs": [
-        {
-          "name": "clanId",
-          "type": "uint32",
-          "internalType": "uint32"
-        },
-        {
-          "name": "clansmanId",
-          "type": "uint32",
-          "internalType": "uint32"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "submitted",
-          "type": "uint64",
-          "internalType": "uint64"
-        },
-        {
-          "name": "executes",
-          "type": "uint64",
-          "internalType": "uint64"
-        },
-        {
-          "name": "settles",
-          "type": "uint64",
-          "internalType": "uint64"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "getActionDuration",
-      "inputs": [
-        {
-          "name": "action",
-          "type": "uint8",
-          "internalType": "enum ActionType"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint64",
-          "internalType": "uint64"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "getTravelTicks",
-      "inputs": [
-        {
-          "name": "fromRegion",
-          "type": "uint8",
-          "internalType": "uint8"
-        },
-        {
-          "name": "toRegion",
-          "type": "uint8",
-          "internalType": "uint8"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint64",
-          "internalType": "uint64"
-        }
-      ],
-      "stateMutability": "pure"
     },
     {
       "type": "function",
@@ -1641,6 +1583,40 @@
     },
     {
       "type": "function",
+      "name": "getMissionTiming",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "submitted",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "executes",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "settles",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "getRegionPopulation",
       "inputs": [
         {
@@ -1681,6 +1657,25 @@
               "internalType": "uint64"
             }
           ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getResourceToken",
+      "inputs": [
+        {
+          "name": "resourceType",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
         }
       ],
       "stateMutability": "view"
@@ -1750,6 +1745,30 @@
         }
       ],
       "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getTravelTicks",
+      "inputs": [
+        {
+          "name": "fromRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "toRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
     },
     {
       "type": "function",
@@ -1930,6 +1949,16 @@
               "internalType": "bool"
             },
             {
+              "name": "currentSeasonNumber",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextHeartbeatAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
               "name": "winterActive",
               "type": "bool",
               "internalType": "bool"
@@ -2035,6 +2064,16 @@
               "name": "seasonFinalized",
               "type": "bool",
               "internalType": "bool"
+            },
+            {
+              "name": "currentSeasonNumber",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextHeartbeatAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
             },
             {
               "name": "nextHeartbeatAtTs",
@@ -2263,6 +2302,19 @@
       "inputs": [
         {
           "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "settleClansman",
+      "inputs": [
+        {
+          "name": "csId",
           "type": "uint32",
           "internalType": "uint32"
         }
@@ -3269,6 +3321,56 @@
     },
     {
       "type": "event",
+      "name": "ResourceBurned",
+      "inputs": [
+        {
+          "name": "resourceType",
+          "type": "uint8",
+          "indexed": true,
+          "internalType": "uint8"
+        },
+        {
+          "name": "from",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ResourceMinted",
+      "inputs": [
+        {
+          "name": "resourceType",
+          "type": "uint8",
+          "indexed": true,
+          "internalType": "uint8"
+        },
+        {
+          "name": "to",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
       "name": "ResourcesDeposited",
       "inputs": [
         {
@@ -3280,38 +3382,32 @@
         {
           "name": "clansmanId",
           "type": "uint32",
-          "indexed": true,
+          "indexed": false,
           "internalType": "uint32"
         },
         {
-          "name": "wood",
+          "name": "woodDelta",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
         },
         {
-          "name": "iron",
+          "name": "ironDelta",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
         },
         {
-          "name": "wheat",
+          "name": "fishDelta",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
         },
         {
-          "name": "fish",
+          "name": "wheatDelta",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
-        },
-        {
-          "name": "atTick",
-          "type": "uint64",
-          "indexed": false,
-          "internalType": "uint64"
         }
       ],
       "anonymous": false

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1698,6 +1698,11 @@
               "name": "missionNonce",
               "type": "uint64",
               "internalType": "uint64"
+            },
+            {
+              "name": "marketMode",
+              "type": "uint8",
+              "internalType": "enum MarketExecutionMode"
             }
           ]
         }

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1698,11 +1698,6 @@
               "name": "missionNonce",
               "type": "uint64",
               "internalType": "uint64"
-            },
-            {
-              "name": "marketMode",
-              "type": "uint8",
-              "internalType": "enum MarketExecutionMode"
             }
           ]
         }
@@ -2447,6 +2442,11 @@
               "name": "missionNonce",
               "type": "uint64",
               "internalType": "uint64"
+            },
+            {
+              "name": "marketMode",
+              "type": "uint8",
+              "internalType": "enum MarketExecutionMode"
             }
           ]
         }
@@ -3070,22 +3070,22 @@
           "internalType": "uint32"
         },
         {
-          "name": "clansmanId",
+          "name": "csId",
           "type": "uint32",
-          "indexed": true,
+          "indexed": false,
           "internalType": "uint32"
         },
         {
-          "name": "tokenIn",
-          "type": "address",
+          "name": "action",
+          "type": "uint8",
           "indexed": false,
-          "internalType": "address"
+          "internalType": "enum ActionType"
         },
         {
-          "name": "tokenOut",
-          "type": "address",
+          "name": "resourceIn",
+          "type": "uint8",
           "indexed": false,
-          "internalType": "address"
+          "internalType": "uint8"
         },
         {
           "name": "amountIn",
@@ -3094,13 +3094,19 @@
           "internalType": "uint256"
         },
         {
+          "name": "resourceOut",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
           "name": "amountOut",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
         },
         {
-          "name": "atTick",
+          "name": "tick",
           "type": "uint64",
           "indexed": false,
           "internalType": "uint64"
@@ -3168,9 +3174,9 @@
           "internalType": "uint32"
         },
         {
-          "name": "clansmanId",
+          "name": "csId",
           "type": "uint32",
-          "indexed": true,
+          "indexed": false,
           "internalType": "uint32"
         },
         {
@@ -3180,10 +3186,22 @@
           "internalType": "enum ActionType"
         },
         {
+          "name": "mode",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum MarketExecutionMode"
+        },
+        {
           "name": "reason",
           "type": "uint8",
           "indexed": false,
           "internalType": "enum StatusCode"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
         }
       ],
       "anonymous": false
@@ -3587,40 +3605,28 @@
       "name": "ScheduledMarketActionExecuted",
       "inputs": [
         {
-          "name": "executeAtTick",
-          "type": "uint64",
-          "indexed": true,
-          "internalType": "uint64"
-        },
-        {
-          "name": "commitSequence",
-          "type": "uint64",
-          "indexed": true,
-          "internalType": "uint64"
-        },
-        {
           "name": "clanId",
           "type": "uint32",
           "indexed": true,
           "internalType": "uint32"
         },
         {
-          "name": "clansmanId",
+          "name": "csId",
           "type": "uint32",
           "indexed": false,
           "internalType": "uint32"
         },
         {
-          "name": "tokenIn",
-          "type": "address",
+          "name": "action",
+          "type": "uint8",
           "indexed": false,
-          "internalType": "address"
+          "internalType": "enum ActionType"
         },
         {
-          "name": "tokenOut",
-          "type": "address",
+          "name": "resourceIn",
+          "type": "uint8",
           "indexed": false,
-          "internalType": "address"
+          "internalType": "uint8"
         },
         {
           "name": "amountIn",
@@ -3629,10 +3635,22 @@
           "internalType": "uint256"
         },
         {
+          "name": "resourceOut",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
           "name": "amountOut",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
+        },
+        {
+          "name": "settledAtTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
         }
       ],
       "anonymous": false

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -5,7 +5,7 @@ import {Script, console} from "forge-std/Script.sol";
 import {MinimalERC20} from "../src/MinimalERC20.sol";
 import {StubPool} from "../src/StubPool.sol";
 import {ClanWorld} from "../src/ClanWorld.sol";
-import {PoolSeedConfig, ResourceType} from "../src/IClanWorld.sol";
+import {PoolSeedConfig} from "../src/IClanWorld.sol";
 
 contract Deploy is Script {
     function run() external {
@@ -32,11 +32,6 @@ contract Deploy is Script {
         // 2. Deploy ClanWorld first (needed as engine arg for pools).
         ClanWorld game = new ClanWorld();
         console.log("CLAN_WORLD_CONTRACT_ADDRESS:", address(game));
-
-        wood.configureBoundary(uint8(ResourceType.Wood), address(game));
-        iron.configureBoundary(uint8(ResourceType.Iron), address(game));
-        wheat.configureBoundary(uint8(ResourceType.Wheat), address(game));
-        fish.configureBoundary(uint8(ResourceType.Fish), address(game));
 
         // 3. Deploy 4 AMM pools (Phase 6.2: constant-product pools).
         StubPool woodGold = new StubPool(address(wood), address(gold), address(game));

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -10,6 +10,7 @@ import {PoolSeedConfig, ResourceType} from "../src/IClanWorld.sol";
 contract Deploy is Script {
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address treasury = vm.addr(deployerPrivateKey);
 
         vm.startBroadcast(deployerPrivateKey);
 
@@ -28,7 +29,7 @@ contract Deploy is Script {
         console.log("gold:     ", address(gold));
         console.log("blueprint:", address(blueprint));
 
-        // 3. Deploy ClanWorld first (needed as engine arg for pools)
+        // 2. Deploy ClanWorld first (needed as engine arg for pools).
         ClanWorld game = new ClanWorld();
         console.log("CLAN_WORLD_CONTRACT_ADDRESS:", address(game));
 
@@ -37,7 +38,7 @@ contract Deploy is Script {
         wheat.configureBoundary(uint8(ResourceType.Wheat), address(game));
         fish.configureBoundary(uint8(ResourceType.Fish), address(game));
 
-        // 2. Deploy 4 AMM pools (Phase 2: real constant-product pools)
+        // 3. Deploy 4 AMM pools (Phase 6.2: constant-product pools).
         StubPool woodGold = new StubPool(address(wood), address(gold), address(game));
         StubPool wheatGold = new StubPool(address(wheat), address(gold), address(game));
         StubPool fishGold = new StubPool(address(fish), address(gold), address(game));
@@ -54,8 +55,22 @@ contract Deploy is Script {
 
         game.initTreasury(tokens, pools);
 
-        uint256 resSeed = 1000e18;
-        uint256 goldSeed = 1000e18;
+        uint256 resSeed = game.INITIAL_RESOURCE_POOL_SEED();
+        uint256 goldSeed = game.INITIAL_GOLD_POOL_SEED();
+        uint256 totalGoldSeed = goldSeed * 4;
+
+        wood.seedTreasury(treasury, resSeed);
+        wheat.seedTreasury(treasury, resSeed);
+        fish.seedTreasury(treasury, resSeed);
+        iron.seedTreasury(treasury, resSeed);
+        gold.seedTreasury(treasury, totalGoldSeed);
+
+        wood.approve(address(game), resSeed);
+        wheat.approve(address(game), resSeed);
+        fish.approve(address(game), resSeed);
+        iron.approve(address(game), resSeed);
+        gold.approve(address(game), totalGoldSeed);
+
         game.seedPools(
             PoolSeedConfig({
                 woodSeed: resSeed,

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -5,7 +5,7 @@ import {Script, console} from "forge-std/Script.sol";
 import {MinimalERC20} from "../src/MinimalERC20.sol";
 import {StubPool} from "../src/StubPool.sol";
 import {ClanWorld} from "../src/ClanWorld.sol";
-import {PoolSeedConfig} from "../src/IClanWorld.sol";
+import {PoolSeedConfig, ResourceType} from "../src/IClanWorld.sol";
 
 contract Deploy is Script {
     function run() external {
@@ -13,12 +13,12 @@ contract Deploy is Script {
 
         vm.startBroadcast(deployerPrivateKey);
 
-        // 1. Deploy 6 resource tokens (still needed for treasury/pool references)
-        MinimalERC20 wood = new MinimalERC20("ClanWorld Wood", "WOOD");
-        MinimalERC20 iron = new MinimalERC20("ClanWorld Iron", "IRON");
-        MinimalERC20 wheat = new MinimalERC20("ClanWorld Wheat", "WHEAT");
-        MinimalERC20 fish = new MinimalERC20("ClanWorld Fish", "FISH");
-        MinimalERC20 gold = new MinimalERC20("ClanWorld Gold", "GOLD");
+        // 1. Deploy boundary tokens (gold existed in Phase 2 and is reused here).
+        MinimalERC20 wood = new MinimalERC20("Wood", "WOOD");
+        MinimalERC20 iron = new MinimalERC20("Iron", "IRON");
+        MinimalERC20 wheat = new MinimalERC20("Wheat", "WHEAT");
+        MinimalERC20 fish = new MinimalERC20("Fish", "FISH");
+        MinimalERC20 gold = new MinimalERC20("Gold", "GOLD");
         MinimalERC20 blueprint = new MinimalERC20("ClanWorld Blueprint", "BPRT");
 
         console.log("wood:     ", address(wood));
@@ -31,6 +31,11 @@ contract Deploy is Script {
         // 3. Deploy ClanWorld first (needed as engine arg for pools)
         ClanWorld game = new ClanWorld();
         console.log("CLAN_WORLD_CONTRACT_ADDRESS:", address(game));
+
+        wood.configureBoundary(uint8(ResourceType.Wood), address(game));
+        iron.configureBoundary(uint8(ResourceType.Iron), address(game));
+        wheat.configureBoundary(uint8(ResourceType.Wheat), address(game));
+        fish.configureBoundary(uint8(ResourceType.Fish), address(game));
 
         // 2. Deploy 4 AMM pools (Phase 2: real constant-product pools)
         StubPool woodGold = new StubPool(address(wood), address(gold), address(game));

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -8,6 +8,16 @@ import {ClanWorld} from "../src/ClanWorld.sol";
 import {PoolSeedConfig} from "../src/IClanWorld.sol";
 
 contract Deploy is Script {
+    // v4 section 5.11 default pool ratios for the hackathon deployment.
+    uint256 private constant WOOD_POOL_SEED = 1_000e18;
+    uint256 private constant WHEAT_POOL_SEED = 1_000e18;
+    uint256 private constant FISH_POOL_SEED = 500e18;
+    uint256 private constant IRON_POOL_SEED = 250e18;
+    uint256 private constant GOLD_SEED_FOR_WOOD = 500e18;
+    uint256 private constant GOLD_SEED_FOR_WHEAT = 700e18;
+    uint256 private constant GOLD_SEED_FOR_FISH = 600e18;
+    uint256 private constant GOLD_SEED_FOR_IRON = 800e18;
+
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
         address treasury = vm.addr(deployerPrivateKey);
@@ -50,32 +60,30 @@ contract Deploy is Script {
 
         game.initTreasury(tokens, pools);
 
-        uint256 resSeed = game.INITIAL_RESOURCE_POOL_SEED();
-        uint256 goldSeed = game.INITIAL_GOLD_POOL_SEED();
-        uint256 totalGoldSeed = goldSeed * 4;
+        uint256 totalGoldSeed = GOLD_SEED_FOR_WOOD + GOLD_SEED_FOR_WHEAT + GOLD_SEED_FOR_FISH + GOLD_SEED_FOR_IRON;
 
-        wood.seedTreasury(treasury, resSeed);
-        wheat.seedTreasury(treasury, resSeed);
-        fish.seedTreasury(treasury, resSeed);
-        iron.seedTreasury(treasury, resSeed);
+        wood.seedTreasury(treasury, WOOD_POOL_SEED);
+        wheat.seedTreasury(treasury, WHEAT_POOL_SEED);
+        fish.seedTreasury(treasury, FISH_POOL_SEED);
+        iron.seedTreasury(treasury, IRON_POOL_SEED);
         gold.seedTreasury(treasury, totalGoldSeed);
 
-        wood.approve(address(game), resSeed);
-        wheat.approve(address(game), resSeed);
-        fish.approve(address(game), resSeed);
-        iron.approve(address(game), resSeed);
+        wood.approve(address(game), WOOD_POOL_SEED);
+        wheat.approve(address(game), WHEAT_POOL_SEED);
+        fish.approve(address(game), FISH_POOL_SEED);
+        iron.approve(address(game), IRON_POOL_SEED);
         gold.approve(address(game), totalGoldSeed);
 
         game.seedPools(
             PoolSeedConfig({
-                woodSeed: resSeed,
-                wheatSeed: resSeed,
-                fishSeed: resSeed,
-                ironSeed: resSeed,
-                goldSeedForWood: goldSeed,
-                goldSeedForWheat: goldSeed,
-                goldSeedForFish: goldSeed,
-                goldSeedForIron: goldSeed
+                woodSeed: WOOD_POOL_SEED,
+                wheatSeed: WHEAT_POOL_SEED,
+                fishSeed: FISH_POOL_SEED,
+                ironSeed: IRON_POOL_SEED,
+                goldSeedForWood: GOLD_SEED_FOR_WOOD,
+                goldSeedForWheat: GOLD_SEED_FOR_WHEAT,
+                goldSeedForFish: GOLD_SEED_FOR_FISH,
+                goldSeedForIron: GOLD_SEED_FOR_IRON
             })
         );
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -96,8 +96,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _world.nextHeartbeatAtTick = 1; // first heartbeat will open tick 1
         // First winter: last WINTER_DURATION_TICKS of first TICKS_PER_WINTER_CYCLE cycle
         // i.e. ticks [100, 110)
-        _world.winterStartsAtTick =
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
+        _world.winterStartsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
         _world.winterEndsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE; // = 110
         _world.winterActive = false;
         _treasury.treasuryOwner = msg.sender;
@@ -1334,14 +1333,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         });
         _scheduledMarketActions[executeAtTick].push(sma);
         emit ScheduledMarketActionCommitted(
-            executeAtTick,
-            sma.commitSequence,
-            clanId,
-            clansmanId,
-            m.action,
-            m.marketToken,
-            m.marketAmount,
-            m.maxGoldIn
+            executeAtTick, sma.commitSequence, clanId, clansmanId, m.action, m.marketToken, m.marketAmount, m.maxGoldIn
         );
     }
 
@@ -1397,7 +1389,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // Validate clansman still belongs to the clan
             Clansman storage cs = _clansmen[sma.clansmanId];
             if (cs.clanId != sma.clanId || cs.state == ClansmanState.DEAD) {
-                emit MarketActionFailed(sma.clanId, sma.clansmanId, sma.action, StatusCode.ERR_INVALID_CLANSMAN);
+                _emitMarketActionFailed(
+                    sma.clanId,
+                    sma.clansmanId,
+                    sma.action,
+                    MarketExecutionMode.Scheduled,
+                    StatusCode.ERR_INVALID_CLANSMAN,
+                    tick
+                );
                 continue;
             }
 
@@ -1406,7 +1405,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // cannot use m.active as a validity signal here — check action type and nonce.
             Mission storage m = _missions[sma.clansmanId];
             if (m.action != sma.action || m.nonce != sma.missionNonce) {
-                emit MarketActionFailed(sma.clanId, sma.clansmanId, sma.action, StatusCode.ERR_INVALID_ACTION);
+                _emitMarketActionFailed(
+                    sma.clanId,
+                    sma.clansmanId,
+                    sma.action,
+                    MarketExecutionMode.Scheduled,
+                    StatusCode.ERR_INVALID_ACTION,
+                    tick
+                );
                 continue;
             }
 
@@ -1417,7 +1423,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 // success
                 }
                 catch {
-                    emit MarketActionFailed(sma.clanId, sma.clansmanId, sma.action, StatusCode.ERR_INVALID_ACTION);
+                    _emitMarketActionFailed(
+                        sma.clanId,
+                        sma.clansmanId,
+                        sma.action,
+                        MarketExecutionMode.Scheduled,
+                        StatusCode.ERR_INVALID_ACTION,
+                        tick
+                    );
                 }
             } else if (sma.action == ActionType.MarketBuy) {
                 try this._executeMarketBuyExternal(
@@ -1432,7 +1445,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 // success
                 }
                 catch {
-                    emit MarketActionFailed(sma.clanId, sma.clansmanId, sma.action, StatusCode.ERR_INVALID_ACTION);
+                    _emitMarketActionFailed(
+                        sma.clanId,
+                        sma.clansmanId,
+                        sma.action,
+                        MarketExecutionMode.Scheduled,
+                        StatusCode.ERR_INVALID_ACTION,
+                        tick
+                    );
                 }
             }
         }
@@ -1459,10 +1479,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clansmanId,
         address token,
         uint256 amount,
-        uint64 commitSequence
+        uint64
     ) external {
         require(msg.sender == address(this), "ClanWorld: internal only");
-        _executeMarketSell(closedTick, clanId, clansmanId, token, amount, commitSequence);
+        _executeMarketSell(closedTick, clanId, clansmanId, token, amount);
     }
 
     /// @dev External wrapper for _executeMarketBuy — enables try/catch from heartbeat loop.
@@ -1473,10 +1493,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         address token,
         uint256 amountOut,
         uint256 maxGoldIn,
-        uint64 commitSequence
+        uint64
     ) external {
         require(msg.sender == address(this), "ClanWorld: internal only");
-        _executeMarketBuy(closedTick, clanId, clansmanId, token, amountOut, maxGoldIn, commitSequence);
+        _executeMarketBuy(closedTick, clanId, clansmanId, token, amountOut, maxGoldIn);
     }
 
     /// @dev Map a resource token address to its pool address.
@@ -1486,6 +1506,27 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (token == _treasury.wheatToken) return _treasury.wheatGoldPool;
         if (token == _treasury.fishToken) return _treasury.fishGoldPool;
         return address(0);
+    }
+
+    /// @dev Map a market token address to the canonical uint8 resource id used by market events.
+    function _marketResourceForToken(address token) internal view returns (uint8) {
+        if (token == _treasury.woodToken) return uint8(ResourceType.Wood);
+        if (token == _treasury.ironToken) return uint8(ResourceType.Iron);
+        if (token == _treasury.wheatToken) return uint8(ResourceType.Wheat);
+        if (token == _treasury.fishToken) return uint8(ResourceType.Fish);
+        if (token == _treasury.goldToken) return ClanWorldConstants.RESOURCE_GOLD;
+        revert("ClanWorld: invalid market resource");
+    }
+
+    function _emitMarketActionFailed(
+        uint32 clanId,
+        uint32 clansmanId,
+        ActionType action,
+        MarketExecutionMode mode,
+        StatusCode reason,
+        uint64 tick
+    ) internal {
+        emit MarketActionFailed(clanId, clansmanId, action, mode, reason, tick);
     }
 
     /// @dev Add an amount of a resource token to the clan vault.
@@ -1552,18 +1593,39 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     function _executeImmediateMarketSell(uint32 clanId, uint32 clansmanId, address token, uint256 amount) internal {
         if (!_treasury.poolsSeeded) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                _world.currentTick
+            );
             return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                _world.currentTick
+            );
             return;
         }
 
         Clan storage clan = _clans[clanId];
         if (!_hasVaultBalance(clan, token, amount)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MISSING_RESOURCES);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MISSING_RESOURCES,
+                _world.currentTick
+            );
             return;
         }
 
@@ -1571,10 +1633,24 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             _deductFromVault(clan, token, amount);
             clan.goldBalance += goldOut;
             emit ImmediateMarketActionExecuted(
-                clanId, clansmanId, token, _treasury.goldToken, amount, goldOut, _world.currentTick
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                _marketResourceForToken(token),
+                amount,
+                ClanWorldConstants.RESOURCE_GOLD,
+                goldOut,
+                _world.currentTick
             );
         } catch {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_INVALID_ACTION);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                _world.currentTick
+            );
         }
     }
 
@@ -1586,12 +1662,26 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint256 maxGoldIn
     ) internal {
         if (!_treasury.poolsSeeded) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                _world.currentTick
+            );
             return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                _world.currentTick
+            );
             return;
         }
 
@@ -1599,19 +1689,38 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         try StubPool(poolAddr).getAmountInForExactOut(amountOut) returns (uint256 quotedGoldIn) {
             goldIn = quotedGoldIn;
         } catch {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_INVALID_ACTION);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                _world.currentTick
+            );
             return;
         }
 
         Clan storage clan = _clans[clanId];
         if (goldIn > maxGoldIn) {
-            emit MarketActionFailed(
-                clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+                _world.currentTick
             );
             return;
         }
         if (clan.goldBalance < goldIn) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_NOT_ENOUGH_GOLD);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_NOT_ENOUGH_GOLD,
+                _world.currentTick
+            );
             return;
         }
 
@@ -1619,35 +1728,65 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             clan.goldBalance -= actualGoldIn;
             _addToVault(clan, token, amountOut);
             emit ImmediateMarketActionExecuted(
-                clanId, clansmanId, _treasury.goldToken, token, actualGoldIn, amountOut, _world.currentTick
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                ClanWorldConstants.RESOURCE_GOLD,
+                actualGoldIn,
+                _marketResourceForToken(token),
+                amountOut,
+                _world.currentTick
             );
         } catch {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_INVALID_ACTION);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_INVALID_ACTION,
+                _world.currentTick
+            );
         }
     }
 
     /// @dev Execute a scheduled market sell: deduct resource from vault, credit gold.
-    function _executeMarketSell(
-        uint64 closedTick,
-        uint32 clanId,
-        uint32 clansmanId,
-        address token,
-        uint256 amount,
-        uint64 commitSequence
-    ) internal {
+    function _executeMarketSell(uint64 closedTick, uint32 clanId, uint32 clansmanId, address token, uint256 amount)
+        internal
+    {
         if (!_treasury.poolsSeeded) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                closedTick
+            );
             return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                closedTick
+            );
             return;
         }
 
         Clan storage clan = _clans[clanId];
         if (!_deductFromVault(clan, token, amount)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MISSING_RESOURCES);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MISSING_RESOURCES,
+                closedTick
+            );
             return;
         }
 
@@ -1655,7 +1794,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         clan.goldBalance += goldOut;
 
         emit ScheduledMarketActionExecuted(
-            closedTick, commitSequence, clanId, clansmanId, token, _treasury.goldToken, amount, goldOut
+            clanId,
+            clansmanId,
+            ActionType.MarketSell,
+            _marketResourceForToken(token),
+            amount,
+            ClanWorldConstants.RESOURCE_GOLD,
+            goldOut,
+            closedTick
         );
     }
 
@@ -1666,32 +1812,70 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clansmanId,
         address token,
         uint256 amountOut,
-        uint256 maxGoldIn,
-        uint64 commitSequence
+        uint256 maxGoldIn
     ) internal {
         if (!_treasury.poolsSeeded) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                closedTick
+            );
             return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
+                closedTick
+            );
             return;
         }
 
         // Quote gold cost without updating reserves
-        uint256 goldIn = StubPool(poolAddr).quoteBuy(amountOut);
+        uint256 goldIn;
+        try StubPool(poolAddr).quoteBuy(amountOut) returns (uint256 quotedGoldIn) {
+            goldIn = quotedGoldIn;
+        } catch {
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                closedTick
+            );
+            return;
+        }
 
         Clan storage clan = _clans[clanId];
 
         if (goldIn > maxGoldIn) {
-            emit MarketActionFailed(
-                clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+                closedTick
             );
             return;
         }
         if (clan.goldBalance < goldIn) {
-            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_NOT_ENOUGH_GOLD);
+            _emitMarketActionFailed(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_NOT_ENOUGH_GOLD,
+                closedTick
+            );
             return;
         }
 
@@ -1701,7 +1885,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _addToVault(clan, token, amountOut);
 
         emit ScheduledMarketActionExecuted(
-            closedTick, commitSequence, clanId, clansmanId, _treasury.goldToken, token, actualGoldIn, amountOut
+            clanId,
+            clansmanId,
+            ActionType.MarketBuy,
+            ClanWorldConstants.RESOURCE_GOLD,
+            actualGoldIn,
+            _marketResourceForToken(token),
+            amountOut,
+            closedTick
         );
     }
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -80,9 +80,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     uint256 public constant INITIAL_RESOURCE_POOL_SEED = 100_000e18;
     uint256 public constant INITIAL_GOLD_POOL_SEED = 50_000e18;
-    /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
-    uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
-
     // =========================================================================
     // CONSTRUCTOR
     // =========================================================================
@@ -488,12 +485,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         bool starving,
         bytes32 tickSeed
     ) internal {
-        if (cs.carryWood >= ClanWorldConstants.CLANSMAN_CARRY_CAP) {
+        if (cs.carryWood >= ClanWorldConstants.WOOD_CARRY_CAP) {
             _completeMission(cs, m);
             return;
         }
 
-        uint256 remaining = ClanWorldConstants.CLANSMAN_CARRY_CAP - cs.carryWood;
+        uint256 remaining = ClanWorldConstants.WOOD_CARRY_CAP - cs.carryWood;
         uint256 yield = ClanWorldConstants.WOOD_YIELD_PER_TICK * uint256(getActionDuration(ActionType.ChopWood));
         bytes32 woodRng = keccak256(abi.encode("wood_crit", tickSeed, cs.clansmanId, m.nonce, tick));
         if (uint256(woodRng) % 10000 < ClanWorldConstants.WOOD_CRIT_BPS) {
@@ -506,7 +503,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         emit ResourcesGathered(clanId, cs.clansmanId, ActionType.ChopWood, yield, 0, 0, 0, 0, tick);
 
-        if (cs.carryWood >= ClanWorldConstants.CLANSMAN_CARRY_CAP) {
+        if (cs.carryWood >= ClanWorldConstants.WOOD_CARRY_CAP) {
             _completeMission(cs, m);
         }
     }
@@ -1378,7 +1375,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     // MARKET EXECUTION (Phase 2)
     // =========================================================================
 
-    /// @dev Execute all scheduled market actions for the given tick, then delete the queue.
+    /// @dev Execute the full scheduled market queue for the given tick, then delete it.
     function _executeScheduledMarketActions(uint64 tick) internal {
         ScheduledMarketAction[] storage actions = _scheduledMarketActions[tick];
         uint256 len = actions.length;
@@ -1421,7 +1418,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
             if (sma.action == ActionType.MarketSell) {
                 try this._executeMarketSellExternal(
-                    tick, sma.clanId, sma.clansmanId, sma.marketToken, sma.marketAmount, sma.commitSequence
+                    tick, sma.clanId, sma.clansmanId, sma.marketToken, sma.marketAmount
                 ) returns (
                     StatusCode marketStatus
                 ) {
@@ -1438,13 +1435,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 }
             } else if (sma.action == ActionType.MarketBuy) {
                 try this._executeMarketBuyExternal(
-                    tick,
-                    sma.clanId,
-                    sma.clansmanId,
-                    sma.marketToken,
-                    sma.marketAmount,
-                    sma.maxGoldIn,
-                    sma.commitSequence
+                    tick, sma.clanId, sma.clansmanId, sma.marketToken, sma.marketAmount, sma.maxGoldIn
                 ) returns (
                     StatusCode marketStatus
                 ) {
@@ -1483,11 +1474,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clanId,
         uint32 clansmanId,
         address token,
-        uint256 amount,
-        uint64 commitSequence
+        uint256 amount
     ) external returns (StatusCode) {
         require(msg.sender == address(this), "ClanWorld: internal only");
-        return _executeMarketSell(closedTick, clanId, clansmanId, token, amount, commitSequence);
+        return _executeMarketSell(closedTick, clanId, clansmanId, token, amount);
     }
 
     /// @dev External wrapper for _executeMarketBuy — enables try/catch from heartbeat loop.
@@ -1497,11 +1487,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clansmanId,
         address token,
         uint256 amountOut,
-        uint256 maxGoldIn,
-        uint64 commitSequence
+        uint256 maxGoldIn
     ) external returns (StatusCode) {
         require(msg.sender == address(this), "ClanWorld: internal only");
-        return _executeMarketBuy(closedTick, clanId, clansmanId, token, amountOut, maxGoldIn, commitSequence);
+        return _executeMarketBuy(closedTick, clanId, clansmanId, token, amountOut, maxGoldIn);
     }
 
     /// @dev Map a resource token address to its pool address.
@@ -1806,14 +1795,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     /// @dev Execute a scheduled market sell: deduct resource from vault, credit gold.
-    function _executeMarketSell(
-        uint64 closedTick,
-        uint32 clanId,
-        uint32 clansmanId,
-        address token,
-        uint256 amount,
-        uint64
-    ) internal returns (StatusCode) {
+    function _executeMarketSell(uint64 closedTick, uint32 clanId, uint32 clansmanId, address token, uint256 amount)
+        internal
+        returns (StatusCode)
+    {
         if (!_treasury.poolsSeeded) {
             return _handleMarketFailure(
                 clanId,
@@ -1871,8 +1856,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clansmanId,
         address token,
         uint256 amountOut,
-        uint256 maxGoldIn,
-        uint64
+        uint256 maxGoldIn
     ) internal returns (StatusCode) {
         if (!_treasury.poolsSeeded) {
             return _handleMarketFailure(
@@ -2045,6 +2029,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                     && tok != _treasury.fishToken
             ) {
                 return StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN;
+            }
+            // Over-capacity buys are rejected at submission; no partial fills or overflow refunds.
+            if (action == ActionType.MarketBuy && order.marketAmount > _remainingCarryForToken(cs, tok)) {
+                return StatusCode.ERR_CARRY_FULL;
             }
             // Immediate market orders execute during submitClanOrders when the
             // worker is waiting in Unicorn Town and off cooldown. Other valid

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -38,7 +38,6 @@ import {
     RegionOccupant
 } from "./IClanWorld.sol";
 import {StubPool} from "./StubPool.sol";
-import {RNG} from "./lib/RNG.sol";
 import {ReentrancyGuard} from "./util/ReentrancyGuard.sol";
 
 /// @title ClanWorld
@@ -77,7 +76,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     uint64 private constant DEPOSIT_DURATION_TICKS = 1;
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
-    uint256 private constant DOMAIN_GATHER = uint256(keccak256("clanworld.gather.v1"));
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
 
@@ -455,7 +453,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         } else if (action == ActionType.HarvestWheat) {
             _gatherWheat(clan, cs, m, clanId, tick, starving);
         } else if (action == ActionType.DepositResources) {
-            _doDeposit(clan, cs, m, clanId);
+            // Deposit event ABI intentionally stores the current tick as uint32.
+            // forge-lint: disable-next-line(unsafe-typecast)
+            _doDeposit(clan, cs, m, clanId, uint32(tick));
         } else if (action == ActionType.Wait) {
             // NOOP — worker stays ACTING (continuous), no transition needed
             // Wait mission is effectively persistent until interrupted
@@ -494,11 +494,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         uint256 remaining = ClanWorldConstants.CLANSMAN_CARRY_CAP - cs.carryWood;
         uint256 yield = ClanWorldConstants.WOOD_YIELD_PER_TICK * uint256(getActionDuration(ActionType.ChopWood));
-        uint256 nonce = uint256(keccak256(abi.encodePacked(clanId, cs.clansmanId)));
-        bool critGate = RNG.rngBool(tickSeed, DOMAIN_GATHER, nonce);
-        bool isCrit = critGate
-            && RNG.rngBounded(tickSeed, DOMAIN_GATHER, nonce + 1, 5000) < ClanWorldConstants.WOOD_CRIT_BPS;
-        if (isCrit) {
+        bytes32 woodRng = keccak256(abi.encode("wood_crit", tickSeed, cs.clansmanId, m.nonce, tick));
+        if (uint256(woodRng) % 10000 < ClanWorldConstants.WOOD_CRIT_BPS) {
             yield *= 2;
         }
 
@@ -670,7 +667,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         // else continuous
     }
 
-    function _doDeposit(Clan storage clan, Clansman storage cs, Mission storage m, uint32 clanId) internal {
+    function _doDeposit(Clan storage clan, Clansman storage cs, Mission storage m, uint32 clanId, uint32 tick)
+        internal
+    {
         // Must be at homebase region
         if (cs.currentRegion != clan.baseRegion) {
             _completeMission(cs, m);
@@ -698,7 +697,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         cs.carryWheat = 0;
         cs.carryFish = 0;
 
-        emit ResourcesDeposited(clanId, cs.clansmanId, woodDelta, ironDelta, fishDelta, wheatDelta);
+        emit ResourcesDeposited(clanId, cs.clansmanId, woodDelta, ironDelta, wheatDelta, fishDelta, tick);
         _completeMission(cs, m);
     }
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -38,6 +38,7 @@ import {
     RegionOccupant
 } from "./IClanWorld.sol";
 import {StubPool} from "./StubPool.sol";
+import {RNG} from "./lib/RNG.sol";
 import {ReentrancyGuard} from "./util/ReentrancyGuard.sol";
 
 /// @title ClanWorld
@@ -76,6 +77,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     uint64 private constant DEPOSIT_DURATION_TICKS = 1;
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
+    uint256 private constant DOMAIN_GATHER = uint256(keccak256("clanworld.gather.v1"));
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
 
@@ -430,7 +432,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return clan.starvationStartsAtTick != 0 && clan.starvationStartsAtTick <= _world.currentTick;
     }
 
-    /// @dev Resolve one tick of action for a clansman that is in ACTING state.
+    /// @dev Resolve an action for a clansman that is in ACTING state.
     function _resolveAction(
         Clan storage clan,
         Clansman storage cs,
@@ -485,28 +487,30 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         bool starving,
         bytes32 tickSeed
     ) internal {
-        uint256 remaining = ClanWorldConstants.WOOD_CAP - cs.carryWood;
-        if (remaining == 0) {
+        if (cs.carryWood >= ClanWorldConstants.CLANSMAN_CARRY_CAP) {
             _completeMission(cs, m);
             return;
         }
-        uint256 yield = ClanWorldConstants.WOOD_BASE_YIELD;
-        // Crit roll: domain-separated RNG
-        bytes32 critRng = keccak256(abi.encode("wood_crit", tickSeed, cs.clansmanId, m.nonce, tick));
-        uint256 critRoll = uint256(critRng) % 10000;
-        if (critRoll < ClanWorldConstants.WOOD_CRIT_BPS) {
-            yield += ClanWorldConstants.WOOD_CRIT_BONUS;
+
+        uint256 remaining = ClanWorldConstants.CLANSMAN_CARRY_CAP - cs.carryWood;
+        uint256 yield = ClanWorldConstants.WOOD_YIELD_PER_TICK * uint256(getActionDuration(ActionType.ChopWood));
+        uint256 nonce = uint256(keccak256(abi.encodePacked(clanId, cs.clansmanId)));
+        bool critGate = RNG.rngBool(tickSeed, DOMAIN_GATHER, nonce);
+        bool isCrit = critGate
+            && RNG.rngBounded(tickSeed, DOMAIN_GATHER, nonce + 1, 5000) < ClanWorldConstants.WOOD_CRIT_BPS;
+        if (isCrit) {
+            yield *= 2;
         }
+
         if (starving) yield = yield / 2;
         if (yield > remaining) yield = remaining;
         cs.carryWood += yield;
 
         emit ResourcesGathered(clanId, cs.clansmanId, ActionType.ChopWood, yield, 0, 0, 0, 0, tick);
 
-        if (cs.carryWood >= ClanWorldConstants.WOOD_CAP) {
+        if (cs.carryWood >= ClanWorldConstants.CLANSMAN_CARRY_CAP) {
             _completeMission(cs, m);
         }
-        // else continuous — worker stays ACTING
     }
 
     function _gatherIron(

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -452,7 +452,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         } else if (action == ActionType.HarvestWheat) {
             _gatherWheat(clan, cs, m, clanId, tick, starving);
         } else if (action == ActionType.DepositResources) {
-            _doDeposit(clan, cs, m, clanId, tick);
+            _doDeposit(clan, cs, m, clanId);
         } else if (action == ActionType.Wait) {
             // NOOP — worker stays ACTING (continuous), no transition needed
             // Wait mission is effectively persistent until interrupted
@@ -665,9 +665,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         // else continuous
     }
 
-    function _doDeposit(Clan storage clan, Clansman storage cs, Mission storage m, uint32 clanId, uint64 tick)
-        internal
-    {
+    function _doDeposit(Clan storage clan, Clansman storage cs, Mission storage m, uint32 clanId) internal {
         // Must be at homebase region
         if (cs.currentRegion != clan.baseRegion) {
             _completeMission(cs, m);
@@ -675,26 +673,27 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
         bool hasAnything = cs.carryWood > 0 || cs.carryIron > 0 || cs.carryWheat > 0 || cs.carryFish > 0;
         if (!hasAnything) {
+            // Empty deposits are silent no-ops; no zero-delta event for indexers to process.
             _completeMission(cs, m);
             return;
         }
 
-        uint256 w = cs.carryWood;
-        uint256 ir = cs.carryIron;
-        uint256 wh = cs.carryWheat;
-        uint256 fi = cs.carryFish;
+        uint256 woodDelta = cs.carryWood;
+        uint256 ironDelta = cs.carryIron;
+        uint256 wheatDelta = cs.carryWheat;
+        uint256 fishDelta = cs.carryFish;
 
-        clan.vaultWood += w;
-        clan.vaultIron += ir;
-        clan.vaultWheat += wh;
-        clan.vaultFish += fi;
+        clan.vaultWood += woodDelta;
+        clan.vaultIron += ironDelta;
+        clan.vaultWheat += wheatDelta;
+        clan.vaultFish += fishDelta;
 
         cs.carryWood = 0;
         cs.carryIron = 0;
         cs.carryWheat = 0;
         cs.carryFish = 0;
 
-        emit ResourcesDeposited(clanId, cs.clansmanId, w, ir, wh, fi, tick);
+        emit ResourcesDeposited(clanId, cs.clansmanId, woodDelta, ironDelta, fishDelta, wheatDelta);
         _completeMission(cs, m);
     }
 
@@ -1610,7 +1609,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         // DepositResources: must go to homebase
         if (action == ActionType.DepositResources) {
-            if (gotoRegion != clan.baseRegion) return StatusCode.ERR_NOT_AT_HOMEBASE;
+            if (gotoRegion != clan.baseRegion) return StatusCode.ERR_INVALID_REGION;
         }
 
         // BuildWall / UpgradeBase / UpgradeMonument: must go to homebase
@@ -1802,9 +1801,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         if (
-            action == ActionType.DepositResources || action == ActionType.BuildWall || action == ActionType.UpgradeBase
-                || action == ActionType.UpgradeMonument || action == ActionType.MarketBuy
-                || action == ActionType.MarketSell
+            action == ActionType.BuildWall || action == ActionType.UpgradeBase || action == ActionType.UpgradeMonument
+                || action == ActionType.MarketBuy || action == ActionType.MarketSell
         ) {
             return 1;
         }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1174,7 +1174,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         // Cooldown check. Market orders may still fall back to the scheduled path;
         // only the immediate path requires the worker to be off cooldown.
-        if (!isMarketAction && block.timestamp < cs.cooldownEndsAtTs) {
+        if (block.timestamp < cs.cooldownEndsAtTs) {
             result.status = StatusCode.ERR_COOLDOWN_ACTIVE;
             result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
             result.missionNonce = cs.lastMissionNonce;
@@ -1457,14 +1457,23 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     function _sortScheduledMarketActionsByCommitSequence(ScheduledMarketAction[] storage actions) internal {
-        for (uint256 i = 1; i < actions.length; i++) {
-            ScheduledMarketAction memory key = actions[i];
+        uint256 len = actions.length;
+        if (len <= 1) return;
+        ScheduledMarketAction[] memory arr = new ScheduledMarketAction[](len);
+        for (uint256 i = 0; i < len; i++) {
+            arr[i] = actions[i];
+        }
+        for (uint256 i = 1; i < len; i++) {
+            ScheduledMarketAction memory key = arr[i];
             uint256 j = i;
-            while (j > 0 && actions[j - 1].commitSequence > key.commitSequence) {
-                actions[j] = actions[j - 1];
+            while (j > 0 && arr[j - 1].commitSequence > key.commitSequence) {
+                arr[j] = arr[j - 1];
                 j--;
             }
-            actions[j] = key;
+            arr[j] = key;
+        }
+        for (uint256 i = 0; i < len; i++) {
+            actions[i] = arr[i];
         }
     }
 
@@ -1568,6 +1577,45 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return false;
     }
 
+    function _hasCarryBalance(Clansman storage cs, address token, uint256 amount) internal view returns (bool) {
+        if (token == _treasury.woodToken) return cs.carryWood >= amount;
+        if (token == _treasury.ironToken) return cs.carryIron >= amount;
+        if (token == _treasury.wheatToken) return cs.carryWheat >= amount;
+        if (token == _treasury.fishToken) return cs.carryFish >= amount;
+        return false;
+    }
+
+    function _deductFromCarry(Clansman storage cs, address token, uint256 amount) internal returns (bool) {
+        if (token == _treasury.woodToken) {
+            if (cs.carryWood < amount) return false;
+            cs.carryWood -= amount;
+            return true;
+        }
+        if (token == _treasury.ironToken) {
+            if (cs.carryIron < amount) return false;
+            cs.carryIron -= amount;
+            return true;
+        }
+        if (token == _treasury.wheatToken) {
+            if (cs.carryWheat < amount) return false;
+            cs.carryWheat -= amount;
+            return true;
+        }
+        if (token == _treasury.fishToken) {
+            if (cs.carryFish < amount) return false;
+            cs.carryFish -= amount;
+            return true;
+        }
+        return false;
+    }
+
+    function _addToCarry(Clansman storage cs, address token, uint256 amount) internal {
+        if (token == _treasury.woodToken) { cs.carryWood += amount; return; }
+        if (token == _treasury.ironToken) { cs.carryIron += amount; return; }
+        if (token == _treasury.wheatToken) { cs.carryWheat += amount; return; }
+        if (token == _treasury.fishToken) { cs.carryFish += amount; return; }
+    }
+
     /// @dev Check a clan vault balance without mutating storage.
     function _hasVaultBalance(Clan storage clan, address token, uint256 amount) internal view returns (bool) {
         if (token == _treasury.woodToken) return clan.vaultWood >= amount;
@@ -1654,7 +1702,20 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         Clan storage clan = _clans[clanId];
-        if (!_hasVaultBalance(clan, token, amount)) {
+        Clansman storage cs = _clansmen[clansmanId];
+        if (!_hasCarryBalance(cs, token, amount)) {
+            return _handleMarketFailure(
+                clanId,
+                clansmanId,
+                ActionType.MarketSell,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_MISSING_RESOURCES,
+                _world.currentTick
+            );
+        }
+
+        // CEI: deduct carry before external call
+        if (!_deductFromCarry(cs, token, amount)) {
             return _handleMarketFailure(
                 clanId,
                 clansmanId,
@@ -1666,7 +1727,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         try StubPool(poolAddr).swapExactInForOut(amount, 1) returns (uint256 goldOut) {
-            _deductFromVault(clan, token, amount);
             clan.goldBalance += goldOut;
             emit ImmediateMarketActionExecuted(
                 clanId,
@@ -1680,6 +1740,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             );
             return StatusCode.OK;
         } catch {
+            _addToCarry(cs, token, amount); // restore carry on swap failure
             return _handleMarketFailure(
                 clanId,
                 clansmanId,
@@ -1770,7 +1831,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         try StubPool(poolAddr).swapExactOutForInWithMaxIn(amountOut, maxGoldIn) returns (uint256 actualGoldIn) {
             clan.goldBalance -= actualGoldIn;
-            _addToVault(clan, token, amountOut);
+            _addToCarry(cs, token, amountOut);
             emit ImmediateMarketActionExecuted(
                 clanId,
                 clansmanId,
@@ -1822,7 +1883,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         Clan storage clan = _clans[clanId];
-        if (!_deductFromVault(clan, token, amount)) {
+        Clansman storage cs = _clansmen[clansmanId];
+        if (!_deductFromCarry(cs, token, amount)) {
             return _handleMarketFailure(
                 clanId,
                 clansmanId,
@@ -1944,7 +2006,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         clan.goldBalance -= actualGoldIn;
-        _addToVault(clan, token, amountOut);
+        _addToCarry(cs, token, amountOut);
 
         emit ScheduledMarketActionExecuted(
             clanId,

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1217,9 +1217,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             ctx.newNonce = cs.lastMissionNonce + 1;
             cs.lastMissionNonce = ctx.newNonce;
 
-            _executeImmediateMarket(clanId, order, cs.clansmanId);
+            StatusCode marketStatus = _executeImmediateMarket(clanId, order, cs.clansmanId);
 
-            cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
+            if (marketStatus == StatusCode.OK) {
+                cs.state = ClansmanState.WAITING;
+                cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
+            }
             _clearDefender(cs.clansmanId);
 
             result.status = StatusCode.OK;
@@ -1419,16 +1422,17 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             if (sma.action == ActionType.MarketSell) {
                 try this._executeMarketSellExternal(
                     tick, sma.clanId, sma.clansmanId, sma.marketToken, sma.marketAmount, sma.commitSequence
+                ) returns (
+                    StatusCode marketStatus
                 ) {
-                // success
-                }
-                catch {
-                    _emitMarketActionFailed(
+                    marketStatus;
+                } catch {
+                    _handleMarketFailure(
                         sma.clanId,
                         sma.clansmanId,
                         sma.action,
                         MarketExecutionMode.Scheduled,
-                        StatusCode.ERR_INVALID_ACTION,
+                        StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                         tick
                     );
                 }
@@ -1441,16 +1445,17 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                     sma.marketAmount,
                     sma.maxGoldIn,
                     sma.commitSequence
+                ) returns (
+                    StatusCode marketStatus
                 ) {
-                // success
-                }
-                catch {
-                    _emitMarketActionFailed(
+                    marketStatus;
+                } catch {
+                    _handleMarketFailure(
                         sma.clanId,
                         sma.clansmanId,
                         sma.action,
                         MarketExecutionMode.Scheduled,
-                        StatusCode.ERR_INVALID_ACTION,
+                        StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                         tick
                     );
                 }
@@ -1479,10 +1484,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clansmanId,
         address token,
         uint256 amount,
-        uint64
-    ) external {
+        uint64 commitSequence
+    ) external returns (StatusCode) {
         require(msg.sender == address(this), "ClanWorld: internal only");
-        _executeMarketSell(closedTick, clanId, clansmanId, token, amount);
+        return _executeMarketSell(closedTick, clanId, clansmanId, token, amount, commitSequence);
     }
 
     /// @dev External wrapper for _executeMarketBuy — enables try/catch from heartbeat loop.
@@ -1493,10 +1498,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         address token,
         uint256 amountOut,
         uint256 maxGoldIn,
-        uint64
-    ) external {
+        uint64 commitSequence
+    ) external returns (StatusCode) {
         require(msg.sender == address(this), "ClanWorld: internal only");
-        _executeMarketBuy(closedTick, clanId, clansmanId, token, amountOut, maxGoldIn);
+        return _executeMarketBuy(closedTick, clanId, clansmanId, token, amountOut, maxGoldIn, commitSequence);
     }
 
     /// @dev Map a resource token address to its pool address.
@@ -1583,17 +1588,62 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return false;
     }
 
-    function _executeImmediateMarket(uint32 clanId, ClanOrder calldata order, uint32 clansmanId) internal {
-        if (order.action == ActionType.MarketSell) {
-            _executeImmediateMarketSell(clanId, clansmanId, order.marketToken, order.marketAmount);
-        } else {
-            _executeImmediateMarketBuy(clanId, clansmanId, order.marketToken, order.marketAmount, order.maxGoldIn);
+    function _handleMarketFailure(
+        uint32 clanId,
+        uint32 clansmanId,
+        ActionType action,
+        MarketExecutionMode mode,
+        StatusCode reason,
+        uint64 tick
+    ) internal returns (StatusCode) {
+        Clansman storage cs = _clansmen[clansmanId];
+        if (cs.clansmanId != 0 && cs.state != ClansmanState.DEAD) {
+            cs.state = ClansmanState.WAITING;
+            cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
         }
+        _emitMarketActionFailed(clanId, clansmanId, action, mode, reason, tick);
+        return reason;
     }
 
-    function _executeImmediateMarketSell(uint32 clanId, uint32 clansmanId, address token, uint256 amount) internal {
+    function _remainingCarryForToken(Clansman storage cs, address token) internal view returns (uint256) {
+        uint256 carried;
+        uint256 cap;
+        if (token == _treasury.woodToken) {
+            carried = cs.carryWood;
+            cap = ClanWorldConstants.WOOD_CAP;
+        } else if (token == _treasury.ironToken) {
+            carried = cs.carryIron;
+            cap = ClanWorldConstants.IRON_CAP;
+        } else if (token == _treasury.wheatToken) {
+            carried = cs.carryWheat;
+            cap = ClanWorldConstants.WHEAT_CAP;
+        } else if (token == _treasury.fishToken) {
+            carried = cs.carryFish;
+            cap = ClanWorldConstants.FISH_CAP;
+        } else {
+            return 0;
+        }
+
+        if (carried >= cap) return 0;
+        return cap - carried;
+    }
+
+    function _executeImmediateMarket(uint32 clanId, ClanOrder calldata order, uint32 clansmanId)
+        internal
+        returns (StatusCode)
+    {
+        if (order.action == ActionType.MarketSell) {
+            return _executeImmediateMarketSell(clanId, clansmanId, order.marketToken, order.marketAmount);
+        }
+        return _executeImmediateMarketBuy(clanId, clansmanId, order.marketToken, order.marketAmount, order.maxGoldIn);
+    }
+
+    function _executeImmediateMarketSell(uint32 clanId, uint32 clansmanId, address token, uint256 amount)
+        internal
+        returns (StatusCode)
+    {
         if (!_treasury.poolsSeeded) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1601,11 +1651,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 _world.currentTick
             );
-            return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1613,12 +1662,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 _world.currentTick
             );
-            return;
         }
 
         Clan storage clan = _clans[clanId];
         if (!_hasVaultBalance(clan, token, amount)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1626,7 +1674,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MISSING_RESOURCES,
                 _world.currentTick
             );
-            return;
         }
 
         try StubPool(poolAddr).swapExactInForOut(amount, 1) returns (uint256 goldOut) {
@@ -1642,13 +1689,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 goldOut,
                 _world.currentTick
             );
+            return StatusCode.OK;
         } catch {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
                 MarketExecutionMode.Immediate,
-                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                 _world.currentTick
             );
         }
@@ -1660,9 +1708,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         address token,
         uint256 amountOut,
         uint256 maxGoldIn
-    ) internal {
+    ) internal returns (StatusCode) {
         if (!_treasury.poolsSeeded) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1670,11 +1718,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 _world.currentTick
             );
-            return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1682,38 +1729,47 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 _world.currentTick
             );
-            return;
+        }
+
+        Clansman storage cs = _clansmen[clansmanId];
+        if (amountOut > _remainingCarryForToken(cs, token)) {
+            return _handleMarketFailure(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Immediate,
+                StatusCode.ERR_CARRY_FULL,
+                _world.currentTick
+            );
         }
 
         uint256 goldIn;
         try StubPool(poolAddr).getAmountInForExactOut(amountOut) returns (uint256 quotedGoldIn) {
             goldIn = quotedGoldIn;
         } catch {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
                 MarketExecutionMode.Immediate,
-                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                 _world.currentTick
             );
-            return;
         }
 
         Clan storage clan = _clans[clanId];
         if (goldIn > maxGoldIn) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
                 MarketExecutionMode.Immediate,
-                StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+                StatusCode.ERR_MAX_GOLD_IN_EXCEEDED,
                 _world.currentTick
             );
-            return;
         }
         if (clan.goldBalance < goldIn) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1721,7 +1777,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_NOT_ENOUGH_GOLD,
                 _world.currentTick
             );
-            return;
         }
 
         try StubPool(poolAddr).swapExactOutForInWithMaxIn(amountOut, maxGoldIn) returns (uint256 actualGoldIn) {
@@ -1737,24 +1792,30 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 amountOut,
                 _world.currentTick
             );
+            return StatusCode.OK;
         } catch {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
                 MarketExecutionMode.Immediate,
-                StatusCode.ERR_INVALID_ACTION,
+                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                 _world.currentTick
             );
         }
     }
 
     /// @dev Execute a scheduled market sell: deduct resource from vault, credit gold.
-    function _executeMarketSell(uint64 closedTick, uint32 clanId, uint32 clansmanId, address token, uint256 amount)
-        internal
-    {
+    function _executeMarketSell(
+        uint64 closedTick,
+        uint32 clanId,
+        uint32 clansmanId,
+        address token,
+        uint256 amount,
+        uint64
+    ) internal returns (StatusCode) {
         if (!_treasury.poolsSeeded) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1762,11 +1823,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 closedTick
             );
-            return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1774,12 +1834,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 closedTick
             );
-            return;
         }
 
         Clan storage clan = _clans[clanId];
         if (!_deductFromVault(clan, token, amount)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketSell,
@@ -1787,7 +1846,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MISSING_RESOURCES,
                 closedTick
             );
-            return;
         }
 
         uint256 goldOut = StubPool(poolAddr).sellResource(amount);
@@ -1803,6 +1861,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             goldOut,
             closedTick
         );
+        return StatusCode.OK;
     }
 
     /// @dev Execute a scheduled market buy: deduct gold from purse, credit resource to vault.
@@ -1812,10 +1871,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 clansmanId,
         address token,
         uint256 amountOut,
-        uint256 maxGoldIn
-    ) internal {
+        uint256 maxGoldIn,
+        uint64
+    ) internal returns (StatusCode) {
         if (!_treasury.poolsSeeded) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1823,11 +1883,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 closedTick
             );
-            return;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1835,40 +1894,48 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
                 closedTick
             );
-            return;
         }
 
-        // Quote gold cost without updating reserves
+        Clansman storage cs = _clansmen[clansmanId];
+        if (amountOut > _remainingCarryForToken(cs, token)) {
+            return _handleMarketFailure(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_CARRY_FULL,
+                closedTick
+            );
+        }
+
         uint256 goldIn;
         try StubPool(poolAddr).quoteBuy(amountOut) returns (uint256 quotedGoldIn) {
             goldIn = quotedGoldIn;
         } catch {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
                 MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
                 closedTick
             );
-            return;
         }
 
         Clan storage clan = _clans[clanId];
 
         if (goldIn > maxGoldIn) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
                 MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+                StatusCode.ERR_MAX_GOLD_IN_EXCEEDED,
                 closedTick
             );
-            return;
         }
         if (clan.goldBalance < goldIn) {
-            _emitMarketActionFailed(
+            return _handleMarketFailure(
                 clanId,
                 clansmanId,
                 ActionType.MarketBuy,
@@ -1876,11 +1943,22 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 StatusCode.ERR_NOT_ENOUGH_GOLD,
                 closedTick
             );
-            return;
         }
 
-        // Execute — use return value to guard against any future pool divergence
-        uint256 actualGoldIn = StubPool(poolAddr).buyResource(amountOut);
+        uint256 actualGoldIn;
+        try StubPool(poolAddr).swapExactOutForInWithMaxIn(amountOut, maxGoldIn) returns (uint256 spentGold) {
+            actualGoldIn = spentGold;
+        } catch {
+            return _handleMarketFailure(
+                clanId,
+                clansmanId,
+                ActionType.MarketBuy,
+                MarketExecutionMode.Scheduled,
+                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
+                closedTick
+            );
+        }
+
         clan.goldBalance -= actualGoldIn;
         _addToVault(clan, token, amountOut);
 
@@ -1894,6 +1972,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             amountOut,
             closedTick
         );
+        return StatusCode.OK;
     }
 
     function _validateAction(Clan storage clan, Clansman storage cs, ClanOrder calldata order, uint8 gotoRegion)

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1771,6 +1771,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return _treasury;
     }
 
+    function getResourceToken(uint8 resourceType) external view override returns (address) {
+        if (resourceType == uint8(ResourceType.Wood)) return _treasury.woodToken;
+        if (resourceType == uint8(ResourceType.Iron)) return _treasury.ironToken;
+        if (resourceType == uint8(ResourceType.Wheat)) return _treasury.wheatToken;
+        if (resourceType == uint8(ResourceType.Fish)) return _treasury.fishToken;
+        revert("ClanWorld: invalid resource");
+    }
+
     function getClan(uint32 clanId) external view override returns (Clan memory) {
         return _clans[clanId];
     }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1254,8 +1254,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             }
             _clearDefender(cs.clansmanId);
 
-            result.status =
-                order.action == ActionType.MarketSell && marketStatus != StatusCode.OK ? marketStatus : StatusCode.OK;
+            result.status = marketStatus;
             result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
             result.missionNonce = ctx.newNonce;
             result.marketMode = MarketExecutionMode.Immediate;

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1106,7 +1106,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                         clansmanId: orders[i].clansmanId,
                         status: StatusCode.ERR_INVALID_ACTION,
                         cooldownEndsAtTs: 0,
-                        missionNonce: 0
+                        missionNonce: 0,
+                        marketMode: MarketExecutionMode.None
                     });
                 }
                 return results;
@@ -1174,8 +1175,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             }
         }
 
-        // Cooldown check
-        if (block.timestamp < cs.cooldownEndsAtTs) {
+        bool isMarketAction = order.action == ActionType.MarketBuy || order.action == ActionType.MarketSell;
+
+        // Cooldown check. Market orders may still fall back to the scheduled path;
+        // only the immediate path requires the worker to be off cooldown.
+        if (!isMarketAction && block.timestamp < cs.cooldownEndsAtTs) {
             result.status = StatusCode.ERR_COOLDOWN_ACTIVE;
             result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
             result.missionNonce = cs.lastMissionNonce;
@@ -1205,6 +1209,25 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         StatusCode actionErr = _validateAction(clan, cs, order, ctx.gotoRegion);
         if (actionErr != StatusCode.OK) {
             result.status = actionErr;
+            return result;
+        }
+
+        if (
+            isMarketAction && ctx.fromRegion == ClanWorldConstants.REGION_UNICORN_TOWN
+                && cs.state == ClansmanState.WAITING && block.timestamp >= cs.cooldownEndsAtTs
+        ) {
+            ctx.newNonce = cs.lastMissionNonce + 1;
+            cs.lastMissionNonce = ctx.newNonce;
+
+            _executeImmediateMarket(clanId, order, cs.clansmanId);
+
+            cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
+            _clearDefender(cs.clansmanId);
+
+            result.status = StatusCode.OK;
+            result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
+            result.missionNonce = ctx.newNonce;
+            result.marketMode = MarketExecutionMode.Immediate;
             return result;
         }
 
@@ -1240,7 +1263,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         // v4.2 §8 L758: "executes at heartbeat closing tick T" where T = arrivalTick.
         // executeAtTick = arrivalTick (not arrivalTick+1).
-        if (order.action == ActionType.MarketBuy || order.action == ActionType.MarketSell) {
+        if (isMarketAction) {
             _enqueueScheduledMarketAction(clanId, order, cs.clansmanId, ctx.arrivalTick, ctx.newNonce);
         }
 
@@ -1266,6 +1289,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         result.status = StatusCode.OK;
         result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
         result.missionNonce = ctx.newNonce;
+        result.marketMode = isMarketAction ? MarketExecutionMode.Scheduled : MarketExecutionMode.None;
         return result;
     }
 
@@ -1526,6 +1550,99 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return false;
     }
 
+    /// @dev Check a clan vault balance without mutating storage.
+    function _hasVaultBalance(Clan storage clan, address token, uint256 amount) internal view returns (bool) {
+        if (token == _treasury.woodToken) return clan.vaultWood >= amount;
+        if (token == _treasury.ironToken) return clan.vaultIron >= amount;
+        if (token == _treasury.wheatToken) return clan.vaultWheat >= amount;
+        if (token == _treasury.fishToken) return clan.vaultFish >= amount;
+        return false;
+    }
+
+    function _executeImmediateMarket(uint32 clanId, ClanOrder calldata order, uint32 clansmanId) internal {
+        if (order.action == ActionType.MarketSell) {
+            _executeImmediateMarketSell(clanId, clansmanId, order.marketToken, order.marketAmount);
+        } else {
+            _executeImmediateMarketBuy(clanId, clansmanId, order.marketToken, order.marketAmount, order.maxGoldIn);
+        }
+    }
+
+    function _executeImmediateMarketSell(uint32 clanId, uint32 clansmanId, address token, uint256 amount) internal {
+        if (!_treasury.poolsSeeded) {
+            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            return;
+        }
+        address poolAddr = _poolFor(token);
+        if (poolAddr == address(0)) {
+            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            return;
+        }
+
+        Clan storage clan = _clans[clanId];
+        if (!_hasVaultBalance(clan, token, amount)) {
+            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_MISSING_RESOURCES);
+            return;
+        }
+
+        try StubPool(poolAddr).swapExactInForOut(amount, 1) returns (uint256 goldOut) {
+            _deductFromVault(clan, token, amount);
+            clan.goldBalance += goldOut;
+            emit ImmediateMarketActionExecuted(
+                clanId, clansmanId, token, _treasury.goldToken, amount, goldOut, _world.currentTick
+            );
+        } catch {
+            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketSell, StatusCode.ERR_INVALID_ACTION);
+        }
+    }
+
+    function _executeImmediateMarketBuy(
+        uint32 clanId,
+        uint32 clansmanId,
+        address token,
+        uint256 amountOut,
+        uint256 maxGoldIn
+    ) internal {
+        if (!_treasury.poolsSeeded) {
+            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            return;
+        }
+        address poolAddr = _poolFor(token);
+        if (poolAddr == address(0)) {
+            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN);
+            return;
+        }
+
+        uint256 goldIn;
+        try StubPool(poolAddr).getAmountInForExactOut(amountOut) returns (uint256 quotedGoldIn) {
+            goldIn = quotedGoldIn;
+        } catch {
+            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_INVALID_ACTION);
+            return;
+        }
+
+        Clan storage clan = _clans[clanId];
+        if (goldIn > maxGoldIn) {
+            emit MarketActionFailed(
+                clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+            );
+            return;
+        }
+        if (clan.goldBalance < goldIn) {
+            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_NOT_ENOUGH_GOLD);
+            return;
+        }
+
+        try StubPool(poolAddr).swapExactOutForInWithMaxIn(amountOut, maxGoldIn) returns (uint256 actualGoldIn) {
+            clan.goldBalance -= actualGoldIn;
+            _addToVault(clan, token, amountOut);
+            emit ImmediateMarketActionExecuted(
+                clanId, clansmanId, _treasury.goldToken, token, actualGoldIn, amountOut, _world.currentTick
+            );
+        } catch {
+            emit MarketActionFailed(clanId, clansmanId, ActionType.MarketBuy, StatusCode.ERR_INVALID_ACTION);
+        }
+    }
+
     /// @dev Execute a scheduled market sell: deduct resource from vault, credit gold.
     function _executeMarketSell(
         uint64 closedTick,
@@ -1676,10 +1793,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             ) {
                 return StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN;
             }
-            // Market orders are always enqueued for the arrivalTick FIFO queue.
-            // _resolveAction records mission completion but does not execute any swap.
+            // Immediate market orders execute during submitClanOrders when the
+            // worker is waiting in Unicorn Town and off cooldown. All other
+            // valid market orders are enqueued for the arrivalTick FIFO queue.
             if (cs.currentRegion == ClanWorldConstants.REGION_UNICORN_TOWN && cs.state == ClansmanState.WAITING) {
-                // Already at Unicorn Town — arrivalTick == currentTick, queued for next heartbeat.
+                // Already at Unicorn Town — immediate if off cooldown, scheduled otherwise.
             }
         }
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -37,6 +37,7 @@ import {
     ActiveBanditView,
     RegionOccupant
 } from "./IClanWorld.sol";
+import {MinimalERC20} from "./MinimalERC20.sol";
 import {StubPool} from "./StubPool.sol";
 import {ReentrancyGuard} from "./util/ReentrancyGuard.sol";
 
@@ -76,6 +77,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     uint64 private constant DEPOSIT_DURATION_TICKS = 1;
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
+    uint256 public constant INITIAL_RESOURCE_POOL_SEED = 100_000e18;
+    uint256 public constant INITIAL_GOLD_POOL_SEED = 50_000e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
 
@@ -1723,6 +1726,15 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         require(!_treasury.poolsSeeded, "ClanWorld: pools already seeded");
         require(_treasury.woodToken != address(0), "ClanWorld: treasury not init");
 
+        _transferSeed(_treasury.woodToken, _treasury.woodGoldPool, cfg.woodSeed);
+        _transferSeed(_treasury.goldToken, _treasury.woodGoldPool, cfg.goldSeedForWood);
+        _transferSeed(_treasury.wheatToken, _treasury.wheatGoldPool, cfg.wheatSeed);
+        _transferSeed(_treasury.goldToken, _treasury.wheatGoldPool, cfg.goldSeedForWheat);
+        _transferSeed(_treasury.fishToken, _treasury.fishGoldPool, cfg.fishSeed);
+        _transferSeed(_treasury.goldToken, _treasury.fishGoldPool, cfg.goldSeedForFish);
+        _transferSeed(_treasury.ironToken, _treasury.ironGoldPool, cfg.ironSeed);
+        _transferSeed(_treasury.goldToken, _treasury.ironGoldPool, cfg.goldSeedForIron);
+
         StubPool(_treasury.woodGoldPool).seed(cfg.woodSeed, cfg.goldSeedForWood);
         StubPool(_treasury.wheatGoldPool).seed(cfg.wheatSeed, cfg.goldSeedForWheat);
         StubPool(_treasury.fishGoldPool).seed(cfg.fishSeed, cfg.goldSeedForFish);
@@ -1733,6 +1745,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         emit PoolsSeeded(
             _treasury.woodGoldPool, _treasury.wheatGoldPool, _treasury.fishGoldPool, _treasury.ironGoldPool
         );
+    }
+
+    function _transferSeed(address token, address pool, uint256 amount) internal {
+        require(token != address(0) && pool != address(0), "ClanWorld: treasury not init");
+        require(MinimalERC20(token).transferFrom(msg.sender, pool, amount), "ClanWorld: seed transfer failed");
     }
 
     // =========================================================================
@@ -1776,6 +1793,22 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (resourceType == uint8(ResourceType.Iron)) return _treasury.ironToken;
         if (resourceType == uint8(ResourceType.Wheat)) return _treasury.wheatToken;
         if (resourceType == uint8(ResourceType.Fish)) return _treasury.fishToken;
+        revert("ClanWorld: invalid resource");
+    }
+
+    function getPool(uint8 resourceType) external view override returns (address) {
+        return _poolForResourceType(resourceType);
+    }
+
+    function getPrice(uint8 resourceType, uint256 amountIn) external view override returns (uint256 amountOut) {
+        amountOut = StubPool(_poolForResourceType(resourceType)).getAmountOutForExactIn(amountIn);
+    }
+
+    function _poolForResourceType(uint8 resourceType) internal view returns (address) {
+        if (resourceType == uint8(ResourceType.Wood)) return _treasury.woodGoldPool;
+        if (resourceType == uint8(ResourceType.Iron)) return _treasury.ironGoldPool;
+        if (resourceType == uint8(ResourceType.Wheat)) return _treasury.wheatGoldPool;
+        if (resourceType == uint8(ResourceType.Fish)) return _treasury.fishGoldPool;
         revert("ClanWorld: invalid resource");
     }
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -74,6 +74,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     // CONSTANTS — Wheat harvest rate (not in IClanWorld constants)
     // =========================================================================
 
+    uint64 private constant DEPOSIT_DURATION_TICKS = 1;
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
@@ -1798,6 +1799,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 || action == ActionType.FishDeepSea || action == ActionType.HarvestWheat
         ) {
             return 4;
+        }
+
+        if (action == ActionType.DepositResources) {
+            return DEPOSIT_DURATION_TICKS;
         }
 
         if (

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -26,6 +26,7 @@ import {
     DerivedClanState,
     DerivedClansmanState,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     PoolSeedConfig,
     LeaderboardEntry,
@@ -456,6 +457,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // Deposit event ABI intentionally stores the current tick as uint32.
             // forge-lint: disable-next-line(unsafe-typecast)
             _doDeposit(clan, cs, m, clanId, uint32(tick));
+        } else if (action == ActionType.WithdrawResources) {
+            // Withdraw event ABI intentionally mirrors ResourcesDeposited's uint32 tick.
+            // forge-lint: disable-next-line(unsafe-typecast)
+            _doWithdrawResources(clan, cs, m, clanId, uint32(tick));
         } else if (action == ActionType.Wait) {
             // NOOP — worker stays ACTING (continuous), no transition needed
             // Wait mission is effectively persistent until interrupted
@@ -467,7 +472,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // Phase 1 stub: check homebase, check resources; if ok, stub success
             _doBuilding(clan, cs, m, clanId, tick, action);
         } else if (action == ActionType.MarketBuy || action == ActionType.MarketSell) {
-            _enqueueScheduledMarketAction(clanId, cs.clansmanId, m);
             _completeMission(cs, m);
         }
     }
@@ -696,6 +700,34 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         cs.carryFish = 0;
 
         emit ResourcesDeposited(clanId, cs.clansmanId, woodDelta, ironDelta, wheatDelta, fishDelta, tick);
+        _completeMission(cs, m);
+    }
+
+    function _doWithdrawResources(Clan storage clan, Clansman storage cs, Mission storage m, uint32 clanId, uint32 tick)
+        internal
+    {
+        if (cs.currentRegion != clan.baseRegion) {
+            _completeMission(cs, m);
+            return;
+        }
+
+        WithdrawResourcesData memory req = m.withdrawResources;
+        if (!_hasWithdrawRequest(req) || !_hasVaultResources(clan, req) || !_hasCarryCapacityForWithdraw(cs, req)) {
+            _completeMission(cs, m);
+            return;
+        }
+
+        clan.vaultWood -= req.wood;
+        clan.vaultIron -= req.iron;
+        clan.vaultWheat -= req.wheat;
+        clan.vaultFish -= req.fish;
+
+        cs.carryWood += req.wood;
+        cs.carryIron += req.iron;
+        cs.carryWheat += req.wheat;
+        cs.carryFish += req.fish;
+
+        emit ResourcesWithdrawn(clanId, cs.clansmanId, req.wood, req.iron, req.wheat, req.fish, tick);
         _completeMission(cs, m);
     }
 
@@ -1222,7 +1254,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             }
             _clearDefender(cs.clansmanId);
 
-            result.status = StatusCode.OK;
+            result.status =
+                order.action == ActionType.MarketSell && marketStatus != StatusCode.OK ? marketStatus : StatusCode.OK;
             result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
             result.missionNonce = ctx.newNonce;
             result.marketMode = MarketExecutionMode.Immediate;
@@ -1282,6 +1315,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         result.cooldownEndsAtTs = cs.cooldownEndsAtTs;
         result.missionNonce = ctx.newNonce;
         result.marketMode = isMarketAction ? MarketExecutionMode.Scheduled : MarketExecutionMode.None;
+        if (isMarketAction) {
+            _enqueueScheduledMarketAction(clanId, cs.clansmanId, existingM);
+        }
         return result;
     }
 
@@ -1310,6 +1346,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         m.marketToken = order.marketToken;
         m.marketAmount = order.marketAmount;
         m.maxGoldIn = order.maxGoldIn;
+        m.withdrawResources = order.withdrawResources;
 
         if (m.marketMode == MarketExecutionMode.Scheduled) {
             _marketMissionCommitSequence[cs.clansmanId] = _world.nextCommitSequence++;
@@ -1610,10 +1647,22 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     function _addToCarry(Clansman storage cs, address token, uint256 amount) internal {
-        if (token == _treasury.woodToken) { cs.carryWood += amount; return; }
-        if (token == _treasury.ironToken) { cs.carryIron += amount; return; }
-        if (token == _treasury.wheatToken) { cs.carryWheat += amount; return; }
-        if (token == _treasury.fishToken) { cs.carryFish += amount; return; }
+        if (token == _treasury.woodToken) {
+            cs.carryWood += amount;
+            return;
+        }
+        if (token == _treasury.ironToken) {
+            cs.carryIron += amount;
+            return;
+        }
+        if (token == _treasury.wheatToken) {
+            cs.carryWheat += amount;
+            return;
+        }
+        if (token == _treasury.fishToken) {
+            cs.carryFish += amount;
+            return;
+        }
     }
 
     /// @dev Check a clan vault balance without mutating storage.
@@ -1623,6 +1672,31 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (token == _treasury.wheatToken) return clan.vaultWheat >= amount;
         if (token == _treasury.fishToken) return clan.vaultFish >= amount;
         return false;
+    }
+
+    function _hasWithdrawRequest(WithdrawResourcesData memory req) internal pure returns (bool) {
+        return req.wood > 0 || req.iron > 0 || req.wheat > 0 || req.fish > 0;
+    }
+
+    function _hasVaultResources(Clan storage clan, WithdrawResourcesData memory req) internal view returns (bool) {
+        return clan.vaultWood >= req.wood && clan.vaultIron >= req.iron && clan.vaultWheat >= req.wheat
+            && clan.vaultFish >= req.fish;
+    }
+
+    function _hasCarryCapacityForWithdraw(Clansman storage cs, WithdrawResourcesData memory req)
+        internal
+        view
+        returns (bool)
+    {
+        return req.wood <= _remainingCapacity(cs.carryWood, ClanWorldConstants.WOOD_CAP)
+            && req.iron <= _remainingCapacity(cs.carryIron, ClanWorldConstants.IRON_CAP)
+            && req.wheat <= _remainingCapacity(cs.carryWheat, ClanWorldConstants.WHEAT_CAP)
+            && req.fish <= _remainingCapacity(cs.carryFish, ClanWorldConstants.FISH_CAP);
+    }
+
+    function _remainingCapacity(uint256 carried, uint256 cap) internal pure returns (uint256) {
+        if (carried >= cap) return 0;
+        return cap - carried;
     }
 
     function _handleMarketFailure(
@@ -2030,9 +2104,16 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         if (action == ActionType.None) return StatusCode.ERR_INVALID_ACTION;
 
-        // DepositResources: must go to homebase
+        // DepositResources / WithdrawResources: must go to homebase
         if (action == ActionType.DepositResources) {
             if (gotoRegion != clan.baseRegion) return StatusCode.ERR_INVALID_REGION;
+        }
+        if (action == ActionType.WithdrawResources) {
+            if (gotoRegion != clan.baseRegion) return StatusCode.ERR_NOT_AT_HOMEBASE;
+            WithdrawResourcesData memory req = order.withdrawResources;
+            if (!_hasWithdrawRequest(req)) return StatusCode.ERR_EMPTY_CARGO;
+            if (!_hasVaultResources(clan, req)) return StatusCode.ERR_MISSING_RESOURCES;
+            if (!_hasCarryCapacityForWithdraw(cs, req)) return StatusCode.ERR_CARRY_FULL;
         }
 
         // BuildWall / UpgradeBase / UpgradeMonument: must go to homebase
@@ -2095,6 +2176,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // Over-capacity buys are rejected at submission; no partial fills or overflow refunds.
             if (action == ActionType.MarketBuy && order.marketAmount > _remainingCarryForToken(cs, tok)) {
                 return StatusCode.ERR_CARRY_FULL;
+            }
+            if (action == ActionType.MarketSell && !_hasCarryBalance(cs, tok, order.marketAmount)) {
+                return StatusCode.ERR_MISSING_RESOURCES;
             }
             // Immediate market orders execute during submitClanOrders when the
             // worker is waiting in Unicorn Town and off cooldown. Other valid
@@ -2266,7 +2350,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             return 4;
         }
 
-        if (action == ActionType.DepositResources) {
+        if (action == ActionType.DepositResources || action == ActionType.WithdrawResources) {
             return DEPOSIT_DURATION_TICKS;
         }
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -59,6 +59,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     mapping(uint32 => Mission) private _missions; // keyed by clansmanId
     mapping(uint32 => WheatPlot[2]) private _wheatPlots; // [0]=west [1]=east
     mapping(uint64 => ScheduledMarketAction[]) private _scheduledMarketActions; // keyed by tick
+    mapping(uint32 => uint64) private _marketMissionCommitSequence; // clansmanId => FIFO sequence captured at submit
     mapping(uint8 => uint32[]) private _defendingClansByRegion; // home region => unique defending clanIds
     mapping(uint8 => mapping(uint32 => uint256)) private _defenderCountByRegionClan; // region => clanId => clansmen count
     mapping(uint32 => uint8) private _clansmanDefendingRegion; // clansmanId => defended home region
@@ -470,9 +471,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             // Phase 1 stub: check homebase, check resources; if ok, stub success
             _doBuilding(clan, cs, m, clanId, tick, action);
         } else if (action == ActionType.MarketBuy || action == ActionType.MarketSell) {
-            // Scheduled market actions: already enqueued at submitClanOrders time.
-            // Settlement resolves this action slot — just complete the mission.
-            // (Actual execution happened or will happen at heartbeat.)
+            _enqueueScheduledMarketAction(clanId, cs.clansmanId, m);
             _completeMission(cs, m);
         }
     }
@@ -1261,12 +1260,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         _clearDefender(cs.clansmanId);
 
-        // v4.2 §8 L758: "executes at heartbeat closing tick T" where T = arrivalTick.
-        // executeAtTick = arrivalTick (not arrivalTick+1).
-        if (isMarketAction) {
-            _enqueueScheduledMarketAction(clanId, order, cs.clansmanId, ctx.arrivalTick, ctx.newNonce);
-        }
-
         if (order.action == ActionType.DefendBase && ctx.travelTicks == 0) {
             _registerDefender(ctx.gotoRegion, clanId, cs.clansmanId);
         }
@@ -1318,25 +1311,26 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         m.marketToken = order.marketToken;
         m.marketAmount = order.marketAmount;
         m.maxGoldIn = order.maxGoldIn;
+
+        if (m.marketMode == MarketExecutionMode.Scheduled) {
+            _marketMissionCommitSequence[cs.clansmanId] = _world.nextCommitSequence++;
+        } else {
+            delete _marketMissionCommitSequence[cs.clansmanId];
+        }
     }
 
-    function _enqueueScheduledMarketAction(
-        uint32 clanId,
-        ClanOrder calldata order,
-        uint32 clansmanId,
-        uint64 executeAtTick,
-        uint64 missionNonce
-    ) internal {
+    function _enqueueScheduledMarketAction(uint32 clanId, uint32 clansmanId, Mission storage m) internal {
+        uint64 executeAtTick = m.settlesAtTick;
         ScheduledMarketAction memory sma = ScheduledMarketAction({
             executeAtTick: executeAtTick,
-            commitSequence: _world.nextCommitSequence++,
-            missionNonce: missionNonce,
+            commitSequence: _marketMissionCommitSequence[clansmanId],
+            missionNonce: m.nonce,
             clanId: clanId,
             clansmanId: clansmanId,
-            action: order.action,
-            marketToken: order.marketToken,
-            marketAmount: order.marketAmount,
-            maxGoldIn: order.maxGoldIn
+            action: m.action,
+            marketToken: m.marketToken,
+            marketAmount: m.marketAmount,
+            maxGoldIn: m.maxGoldIn
         });
         _scheduledMarketActions[executeAtTick].push(sma);
         emit ScheduledMarketActionCommitted(
@@ -1344,10 +1338,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             sma.commitSequence,
             clanId,
             clansmanId,
-            order.action,
-            order.marketToken,
-            order.marketAmount,
-            order.maxGoldIn
+            m.action,
+            m.marketToken,
+            m.marketAmount,
+            m.maxGoldIn
         );
     }
 
@@ -1389,16 +1383,15 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     // MARKET EXECUTION (Phase 2)
     // =========================================================================
 
-    /// @dev Execute up to MAX_MARKET_ACTIONS_PER_TICK scheduled market actions for the given tick.
-    ///      Overflow is appended to the next tick to keep heartbeat gas bounded.
+    /// @dev Execute all scheduled market actions for the given tick, then delete the queue.
     function _executeScheduledMarketActions(uint64 tick) internal {
         ScheduledMarketAction[] storage actions = _scheduledMarketActions[tick];
         uint256 len = actions.length;
         if (len == 0) return;
 
-        uint256 processCount = len > MAX_MARKET_ACTIONS_PER_TICK ? MAX_MARKET_ACTIONS_PER_TICK : len;
+        _sortScheduledMarketActionsByCommitSequence(actions);
 
-        for (uint256 i = 0; i < processCount; i++) {
+        for (uint256 i = 0; i < len; i++) {
             ScheduledMarketAction storage sma = actions[i];
 
             // Validate clansman still belongs to the clan
@@ -1442,16 +1435,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                     emit MarketActionFailed(sma.clanId, sma.clansmanId, sma.action, StatusCode.ERR_INVALID_ACTION);
                 }
             }
-        }
-
-        if (len > processCount) {
-            ScheduledMarketAction[] storage nextActions = _scheduledMarketActions[tick + 1];
-            for (uint256 i = processCount; i < len; i++) {
-                nextActions.push(actions[i]);
-            }
-            // Invariant: each tick queue executes in global commitSequence order, including
-            // older overflow actions merged into a tick that already has native actions.
-            _sortScheduledMarketActionsByCommitSequence(nextActions);
         }
 
         delete _scheduledMarketActions[tick];
@@ -1794,8 +1777,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 return StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN;
             }
             // Immediate market orders execute during submitClanOrders when the
-            // worker is waiting in Unicorn Town and off cooldown. All other
-            // valid market orders are enqueued for the arrivalTick FIFO queue.
+            // worker is waiting in Unicorn Town and off cooldown. Other valid
+            // market orders enqueue when the scheduled mission resolves.
             if (cs.currentRegion == ClanWorldConstants.REGION_UNICORN_TOWN && cs.state == ClansmanState.WAITING) {
                 // Already at Unicorn Town — immediate if off cooldown, scheduled otherwise.
             }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1017,8 +1017,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     ///         Internally settles the entire clan (including upkeep) to guarantee
     ///         correct ordering and prevent double-settlement. Callers may call this
     ///         or settleClan interchangeably; both are safe and idempotent.
-    function settleClansman(uint32 csId) external override nonReentrant {
-        Clansman storage cs = _clansmen[csId];
+    function settleClansman(uint32 clansmanId) external override nonReentrant {
+        Clansman storage cs = _clansmen[clansmanId];
         if (cs.clansmanId == 0) return;
         _settleClan(cs.clanId);
     }
@@ -1088,9 +1088,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         // Create 4 clansmen
         for (uint256 i = 0; i < 4; i++) {
-            uint32 csId = _nextClansmanId++;
-            Clansman storage cs = _clansmen[csId];
-            cs.clansmanId = csId;
+            uint32 clansmanId = _nextClansmanId++;
+            Clansman storage cs = _clansmen[clansmanId];
+            cs.clansmanId = clansmanId;
             cs.clanId = clanId;
             cs.state = ClansmanState.WAITING;
             cs.currentRegion = baseRegion;
@@ -1100,7 +1100,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             cs.carryIron = 0;
             cs.carryWheat = 0;
             cs.carryFish = 0;
-            _clanClansmanIds[clanId].push(csId);
+            _clanClansmanIds[clanId].push(clansmanId);
         }
 
         _allClanIds.push(clanId);
@@ -1408,7 +1408,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     // =========================================================================
-    // MARKET EXECUTION (Phase 2)
+    // MARKET EXECUTION (Phase 6)
     // =========================================================================
 
     /// @dev Execute the full scheduled market queue for the given tick, then delete it.
@@ -1458,7 +1458,16 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 ) returns (
                     StatusCode marketStatus
                 ) {
-                    marketStatus;
+                    if (marketStatus != StatusCode.OK) {
+                        _handleMarketFailure(
+                            sma.clanId,
+                            sma.clansmanId,
+                            sma.action,
+                            MarketExecutionMode.Scheduled,
+                            marketStatus,
+                            tick
+                        );
+                    }
                 } catch {
                     _handleMarketFailure(
                         sma.clanId,
@@ -1475,7 +1484,16 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 ) returns (
                     StatusCode marketStatus
                 ) {
-                    marketStatus;
+                    if (marketStatus != StatusCode.OK) {
+                        _handleMarketFailure(
+                            sma.clanId,
+                            sma.clansmanId,
+                            sma.action,
+                            MarketExecutionMode.Scheduled,
+                            marketStatus,
+                            tick
+                        );
+                    }
                 } catch {
                     _handleMarketFailure(
                         sma.clanId,
@@ -1799,7 +1817,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             );
         }
 
-        try StubPool(poolAddr).swapExactInForOut(amount, 1) returns (uint256 goldOut) {
+        try StubPool(poolAddr).swapExactInForOut(amount, 0) returns (uint256 goldOut) {
             clan.goldBalance += goldOut;
             emit ImmediateMarketActionExecuted(
                 clanId,
@@ -1928,44 +1946,23 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
     }
 
-    /// @dev Execute a scheduled market sell: deduct resource from vault, credit gold.
+    /// @dev Execute a scheduled market sell: deduct resource from carry, credit clan gold.
     function _executeMarketSell(uint64 closedTick, uint32 clanId, uint32 clansmanId, address token, uint256 amount)
         internal
         returns (StatusCode)
     {
         if (!_treasury.poolsSeeded) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketSell,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
-                closedTick
-            );
+            return StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketSell,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
-                closedTick
-            );
+            return StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN;
         }
 
         Clan storage clan = _clans[clanId];
         Clansman storage cs = _clansmen[clansmanId];
         if (!_deductFromCarry(cs, token, amount)) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketSell,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MISSING_RESOURCES,
-                closedTick
-            );
+            return StatusCode.ERR_MISSING_RESOURCES;
         }
 
         uint256 goldOut = StubPool(poolAddr).sellResource(amount);
@@ -1984,7 +1981,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return StatusCode.OK;
     }
 
-    /// @dev Execute a scheduled market buy: deduct gold from purse, credit resource to vault.
+    /// @dev Execute a scheduled market buy: deduct clan gold, credit resource to carry.
     function _executeMarketBuy(
         uint64 closedTick,
         uint32 clanId,
@@ -1994,88 +1991,39 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint256 maxGoldIn
     ) internal returns (StatusCode) {
         if (!_treasury.poolsSeeded) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
-                closedTick
-            );
+            return StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN;
         }
         address poolAddr = _poolFor(token);
         if (poolAddr == address(0)) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN,
-                closedTick
-            );
+            return StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN;
         }
 
         Clansman storage cs = _clansmen[clansmanId];
         if (amountOut > _remainingCarryForToken(cs, token)) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_CARRY_FULL,
-                closedTick
-            );
+            return StatusCode.ERR_CARRY_FULL;
         }
 
         uint256 goldIn;
         try StubPool(poolAddr).quoteBuy(amountOut) returns (uint256 quotedGoldIn) {
             goldIn = quotedGoldIn;
         } catch {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
-                closedTick
-            );
+            return StatusCode.ERR_LIQUIDITY_INSUFFICIENT;
         }
 
         Clan storage clan = _clans[clanId];
 
         if (goldIn > maxGoldIn) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_MAX_GOLD_IN_EXCEEDED,
-                closedTick
-            );
+            return StatusCode.ERR_MAX_GOLD_IN_EXCEEDED;
         }
         if (clan.goldBalance < goldIn) {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_NOT_ENOUGH_GOLD,
-                closedTick
-            );
+            return StatusCode.ERR_NOT_ENOUGH_GOLD;
         }
 
         uint256 actualGoldIn;
         try StubPool(poolAddr).swapExactOutForInWithMaxIn(amountOut, maxGoldIn) returns (uint256 spentGold) {
             actualGoldIn = spentGold;
         } catch {
-            return _handleMarketFailure(
-                clanId,
-                clansmanId,
-                ActionType.MarketBuy,
-                MarketExecutionMode.Scheduled,
-                StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
-                closedTick
-            );
+            return StatusCode.ERR_LIQUIDITY_INSUFFICIENT;
         }
 
         clan.goldBalance -= actualGoldIn;
@@ -2557,9 +2505,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32[] storage csIds = _clanClansmanIds[clanId];
         ClansmanFullView[] memory clansmen = new ClansmanFullView[](csIds.length);
         for (uint256 i = 0; i < csIds.length; i++) {
-            uint32 csId = csIds[i];
-            Clansman memory cs = _clansmen[csId];
-            Mission memory m = _missions[csId];
+            uint32 clansmanId = csIds[i];
+            Clansman memory cs = _clansmen[clansmanId];
+            Mission memory m = _missions[clansmanId];
             uint8 effRegion = cs.currentRegion;
             if (cs.state == ClansmanState.TRAVELING && m.active) {
                 effRegion = _world.currentTick >= m.arrivalTick ? m.targetRegion : m.startRegion;
@@ -2656,12 +2604,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             uint32 cid = _allClanIds[i];
             uint32[] storage csIds = _clanClansmanIds[cid];
             for (uint256 j = 0; j < csIds.length; j++) {
-                uint32 csId = csIds[j];
-                Clansman storage cs = _clansmen[csId];
+                uint32 clansmanId = csIds[j];
+                Clansman storage cs = _clansmen[clansmanId];
                 if (cs.state != ClansmanState.DEAD && cs.currentRegion == region) {
-                    Mission storage m = _missions[csId];
+                    Mission storage m = _missions[clansmanId];
                     occupants[idx++] = RegionOccupant({
-                        clansmanId: csId,
+                        clansmanId: clansmanId,
                         clanId: cid,
                         state: cs.state,
                         currentAction: m.active ? m.action : ActionType.None,

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -137,6 +137,14 @@ contract ClanWorldStub is IClanWorld {
         return _treasury;
     }
 
+    function getResourceToken(uint8 resourceType) external view override returns (address) {
+        if (resourceType == uint8(ResourceType.Wood)) return _treasury.woodToken;
+        if (resourceType == uint8(ResourceType.Iron)) return _treasury.ironToken;
+        if (resourceType == uint8(ResourceType.Wheat)) return _treasury.wheatToken;
+        if (resourceType == uint8(ResourceType.Fish)) return _treasury.fishToken;
+        revert("ClanWorldStub: invalid resource");
+    }
+
     function getClan(uint32) external pure override returns (Clan memory) {
         return Clan({
             clanId: 0,

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -26,6 +26,7 @@ import {
     DerivedClanState,
     DerivedClansmanState,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     PoolSeedConfig,
     LeaderboardEntry,
@@ -51,8 +52,7 @@ contract ClanWorldStub is IClanWorld {
         _world.seasonEndTick = ClanWorldConstants.SEASON_DURATION_TICKS;
         _world.currentSeasonNumber = 1;
         _world.nextHeartbeatAtTick = _world.currentTick + 1;
-        _world.winterStartsAtTick =
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS;
+        _world.winterStartsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS;
         _world.winterEndsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
         _world.winterActive = false;
 
@@ -214,7 +214,8 @@ contract ClanWorldStub is IClanWorld {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
     }
 

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -145,6 +145,18 @@ contract ClanWorldStub is IClanWorld {
         revert("ClanWorldStub: invalid resource");
     }
 
+    function getPool(uint8 resourceType) external view override returns (address) {
+        if (resourceType == uint8(ResourceType.Wood)) return _treasury.woodGoldPool;
+        if (resourceType == uint8(ResourceType.Iron)) return _treasury.ironGoldPool;
+        if (resourceType == uint8(ResourceType.Wheat)) return _treasury.wheatGoldPool;
+        if (resourceType == uint8(ResourceType.Fish)) return _treasury.fishGoldPool;
+        revert("ClanWorldStub: invalid resource");
+    }
+
+    function getPrice(uint8, uint256) external pure override returns (uint256) {
+        return 0;
+    }
+
     function getClan(uint32) external pure override returns (Clan memory) {
         return Clan({
             clanId: 0,

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -84,6 +84,10 @@ library ClanWorldConstants {
     uint8 internal constant REGION_EAST_DOCKS = 7;
     uint8 internal constant REGION_DEEP_SEA = 8;
 
+    // Market event resource ids. ResourceType covers the four vault resources;
+    // gold is the quote asset emitted as resource id 4.
+    uint8 internal constant RESOURCE_GOLD = 4;
+
     // Sentinels
     uint32 internal constant CLAN_ID_NULL = 0; // valid clan IDs start at 1
     uint32 internal constant BANDIT_ID_NULL = 0;
@@ -178,7 +182,8 @@ enum StatusCode {
     ERR_NO_ACTIVE_BANDIT,
     ERR_SEASON_ENDED,
     ERR_NOT_ENOUGH_GOLD,
-    ERR_CARRY_FULL
+    ERR_CARRY_FULL,
+    ERR_MARKET_INSUFFICIENT_LIQUIDITY
 }
 
 // =============================================================================
@@ -190,8 +195,8 @@ struct WorldState {
     uint64 seasonStartTick;
     uint64 seasonEndTick;
     bool seasonFinalized;
-    uint64 currentSeasonNumber;   // 1-indexed; incremented each time seasonEndTick is crossed
-    uint64 nextHeartbeatAtTick;   // estimated tick that will be opened by the next heartbeat (for off-chain UI)
+    uint64 currentSeasonNumber; // 1-indexed; incremented each time seasonEndTick is crossed
+    uint64 nextHeartbeatAtTick; // estimated tick that will be opened by the next heartbeat (for off-chain UI)
 
     uint64 nextHeartbeatAtTs;
     uint64 nextBanditSpawnEligibleTick;
@@ -551,22 +556,26 @@ interface IClanWorldEvents {
     // ----- market -----
     event ImmediateMarketActionExecuted(
         uint32 indexed clanId,
-        uint32 indexed clansmanId,
-        address tokenIn,
-        address tokenOut,
+        uint32 csId,
+        ActionType action,
+        uint8 resourceIn,
         uint256 amountIn,
+        uint8 resourceOut,
         uint256 amountOut,
-        uint64 atTick
+        uint64 tick
     );
     event ScheduledMarketActionExecuted(
-        uint64 indexed executeAtTick,
-        uint64 indexed commitSequence,
         uint32 indexed clanId,
-        uint32 clansmanId,
-        address tokenIn,
-        address tokenOut,
+        uint32 csId,
+        ActionType action,
+        uint8 resourceIn,
         uint256 amountIn,
-        uint256 amountOut
+        uint8 resourceOut,
+        uint256 amountOut,
+        uint64 settledAtTick
+    );
+    event MarketActionFailed(
+        uint32 indexed clanId, uint32 csId, ActionType action, MarketExecutionMode mode, StatusCode reason, uint64 tick
     );
     event ScheduledMarketActionCommitted(
         uint64 indexed executeAtTick,
@@ -578,7 +587,6 @@ interface IClanWorldEvents {
         uint256 marketAmount,
         uint256 maxGoldIn
     );
-    event MarketActionFailed(uint32 indexed clanId, uint32 indexed clansmanId, ActionType action, StatusCode reason);
     event ResourceMinted(uint8 indexed resourceType, address indexed to, uint256 amount);
     event ResourceBurned(uint8 indexed resourceType, address indexed from, uint256 amount);
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -578,6 +578,8 @@ interface IClanWorldEvents {
         uint256 maxGoldIn
     );
     event MarketActionFailed(uint32 indexed clanId, uint32 indexed clansmanId, ActionType action, StatusCode reason);
+    event ResourceMinted(uint8 indexed resourceType, address indexed to, uint256 amount);
+    event ResourceBurned(uint8 indexed resourceType, address indexed from, uint256 amount);
 
     // ----- bandits -----
     event BanditSpawned(uint32 indexed banditId, uint8 region, uint8 tier, uint16 attackPower);
@@ -700,6 +702,8 @@ interface IClanWorld is IClanWorldEvents {
     function getWorldState() external view returns (WorldState memory);
 
     function getTreasuryState() external view returns (TreasuryState memory);
+
+    function getResourceToken(uint8 resourceType) external view returns (address);
 
     function getClan(uint32 clanId) external view returns (Clan memory);
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -534,11 +534,12 @@ interface IClanWorldEvents {
     );
     event ResourcesDeposited(
         uint32 indexed clanId,
-        uint32 clansmanId,
+        uint32 indexed clansmanId,
         uint256 woodDelta,
         uint256 ironDelta,
+        uint256 wheatDelta,
         uint256 fishDelta,
-        uint256 wheatDelta
+        uint32 tick
     );
 
     // ----- building -----

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -40,8 +40,8 @@ library ClanWorldConstants {
     uint64 internal constant CLANSMAN_COOLDOWN_SECONDS = 60;
 
     // Carry caps (per clansman)
-    uint256 internal constant CLANSMAN_CARRY_CAP = 10e18;
-    uint256 internal constant WOOD_CAP = CLANSMAN_CARRY_CAP;
+    uint256 internal constant WOOD_CARRY_CAP = 10e18;
+    uint256 internal constant WOOD_CAP = WOOD_CARRY_CAP;
     uint256 internal constant IRON_CAP = 5e18;
     uint256 internal constant WHEAT_CAP = 40e18;
     uint256 internal constant FISH_CAP = 8e18;
@@ -177,13 +177,11 @@ enum StatusCode {
     ERR_MARKET_UNSUPPORTED_TOKEN,
     ERR_IMMEDIATE_MARKET_NOT_ELIGIBLE,
     ERR_MARKET_BUY_OVER_CAPACITY,
-    ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
     ERR_WORLD_TICK_MISMATCH,
     ERR_NO_ACTIVE_BANDIT,
     ERR_SEASON_ENDED,
     ERR_NOT_ENOUGH_GOLD,
     ERR_CARRY_FULL,
-    ERR_MARKET_INSUFFICIENT_LIQUIDITY,
     ERR_LIQUIDITY_INSUFFICIENT,
     ERR_MAX_GOLD_IN_EXCEEDED
 }

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -532,12 +532,11 @@ interface IClanWorldEvents {
     );
     event ResourcesDeposited(
         uint32 indexed clanId,
-        uint32 indexed clansmanId,
-        uint256 wood,
-        uint256 iron,
-        uint256 wheat,
-        uint256 fish,
-        uint64 atTick
+        uint32 clansmanId,
+        uint256 woodDelta,
+        uint256 ironDelta,
+        uint256 fishDelta,
+        uint256 wheatDelta
     );
 
     // ----- building -----

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -178,11 +178,13 @@ enum StatusCode {
     ERR_MARKET_UNSUPPORTED_TOKEN,
     ERR_IMMEDIATE_MARKET_NOT_ELIGIBLE,
     ERR_MARKET_BUY_OVER_CAPACITY,
+    ERR_MARKET_BUY_MAX_GOLD_EXCEEDED, // Deprecated/reserved legacy ordinal (replaced by ERR_MAX_GOLD_IN_EXCEEDED); kept only to preserve enum ordinal stability.
     ERR_WORLD_TICK_MISMATCH,
     ERR_NO_ACTIVE_BANDIT,
     ERR_SEASON_ENDED,
     ERR_NOT_ENOUGH_GOLD,
     ERR_CARRY_FULL,
+    ERR_MARKET_INSUFFICIENT_LIQUIDITY, // Deprecated/reserved legacy ordinal (replaced by ERR_LIQUIDITY_INSUFFICIENT); kept only to preserve enum ordinal stability.
     ERR_LIQUIDITY_INSUFFICIENT,
     ERR_MAX_GOLD_IN_EXCEEDED
 }

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -139,6 +139,7 @@ enum ActionType {
     FishDeepSea,
     HarvestWheat,
     DepositResources,
+    WithdrawResources,
     BuildWall,
     UpgradeBase,
     UpgradeMonument,
@@ -302,6 +303,8 @@ struct Mission {
     address marketToken; // market token for buy/sell
     uint256 marketAmount; // exact-in for sell, exact-out for buy
     uint256 maxGoldIn; // market_buy only, 0 otherwise
+
+    WithdrawResourcesData withdrawResources; // WithdrawResources only
 }
 
 struct BanditTroop {
@@ -368,6 +371,20 @@ struct DerivedClansmanState {
 // WRITE INPUT / OUTPUT STRUCTS
 // =============================================================================
 
+struct DepositResourcesData {
+    uint256 wood;
+    uint256 iron;
+    uint256 wheat;
+    uint256 fish;
+}
+
+struct WithdrawResourcesData {
+    uint256 wood;
+    uint256 iron;
+    uint256 wheat;
+    uint256 fish;
+}
+
 struct ClanOrder {
     uint32 clansmanId;
     uint8 gotoRegion;
@@ -377,6 +394,8 @@ struct ClanOrder {
     address marketToken;
     uint256 marketAmount;
     uint256 maxGoldIn;
+
+    WithdrawResourcesData withdrawResources;
 }
 
 struct OrderResult {
@@ -539,6 +558,15 @@ interface IClanWorldEvents {
         uint64 atTick
     );
     event ResourcesDeposited(
+        uint32 indexed clanId,
+        uint32 indexed clansmanId,
+        uint256 woodDelta,
+        uint256 ironDelta,
+        uint256 wheatDelta,
+        uint256 fishDelta,
+        uint32 tick
+    );
+    event ResourcesWithdrawn(
         uint32 indexed clanId,
         uint32 indexed clansmanId,
         uint256 woodDelta,

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -705,6 +705,10 @@ interface IClanWorld is IClanWorldEvents {
 
     function getResourceToken(uint8 resourceType) external view returns (address);
 
+    function getPool(uint8 resourceType) external view returns (address);
+
+    function getPrice(uint8 resourceType, uint256 amountIn) external view returns (uint256 amountOut);
+
     function getClan(uint32 clanId) external view returns (Clan memory);
 
     function getClansman(uint32 clansmanId) external view returns (Clansman memory);

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -139,14 +139,14 @@ enum ActionType {
     FishDeepSea,
     HarvestWheat,
     DepositResources,
-    WithdrawResources,
     BuildWall,
     UpgradeBase,
     UpgradeMonument,
     DefendBase,
     MarketBuy,
     MarketSell,
-    Wait
+    Wait,
+    WithdrawResources
 }
 
 enum MarketExecutionMode {

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -183,7 +183,9 @@ enum StatusCode {
     ERR_SEASON_ENDED,
     ERR_NOT_ENOUGH_GOLD,
     ERR_CARRY_FULL,
-    ERR_MARKET_INSUFFICIENT_LIQUIDITY
+    ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+    ERR_LIQUIDITY_INSUFFICIENT,
+    ERR_MAX_GOLD_IN_EXCEEDED
 }
 
 // =============================================================================

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -40,15 +40,17 @@ library ClanWorldConstants {
     uint64 internal constant CLANSMAN_COOLDOWN_SECONDS = 60;
 
     // Carry caps (per clansman)
-    uint256 internal constant WOOD_CAP = 15e18;
+    uint256 internal constant CLANSMAN_CARRY_CAP = 10e18;
+    uint256 internal constant WOOD_CAP = CLANSMAN_CARRY_CAP;
     uint256 internal constant IRON_CAP = 5e18;
     uint256 internal constant WHEAT_CAP = 40e18;
     uint256 internal constant FISH_CAP = 8e18;
 
     // Gathering yields
-    uint256 internal constant WOOD_BASE_YIELD = 2e18;
-    uint256 internal constant WOOD_CRIT_BONUS = 1e18;
-    uint16 internal constant WOOD_CRIT_BPS = 2000; // 20%
+    uint256 internal constant WOOD_YIELD_PER_TICK = 1e18;
+    uint256 internal constant WOOD_BASE_YIELD = WOOD_YIELD_PER_TICK;
+    uint256 internal constant WOOD_CRIT_BONUS = WOOD_YIELD_PER_TICK;
+    uint16 internal constant WOOD_CRIT_BPS = 1000; // 10%
 
     uint256 internal constant IRON_BASE_YIELD = 5e17; // 0.5e18
     uint16 internal constant GOLD_FROM_IRON_BPS = 200; // 2%

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -379,6 +379,7 @@ struct OrderResult {
     StatusCode status;
     uint64 cooldownEndsAtTs;
     uint64 missionNonce;
+    MarketExecutionMode marketMode;
 }
 
 struct PoolSeedConfig {

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -586,7 +586,7 @@ interface IClanWorldEvents {
     // ----- market -----
     event ImmediateMarketActionExecuted(
         uint32 indexed clanId,
-        uint32 csId,
+        uint32 clansmanId,
         ActionType action,
         uint8 resourceIn,
         uint256 amountIn,
@@ -596,7 +596,7 @@ interface IClanWorldEvents {
     );
     event ScheduledMarketActionExecuted(
         uint32 indexed clanId,
-        uint32 csId,
+        uint32 clansmanId,
         ActionType action,
         uint8 resourceIn,
         uint256 amountIn,
@@ -605,7 +605,12 @@ interface IClanWorldEvents {
         uint64 settledAtTick
     );
     event MarketActionFailed(
-        uint32 indexed clanId, uint32 csId, ActionType action, MarketExecutionMode mode, StatusCode reason, uint64 tick
+        uint32 indexed clanId,
+        uint32 clansmanId,
+        ActionType action,
+        MarketExecutionMode mode,
+        StatusCode reason,
+        uint64 tick
     );
     event ScheduledMarketActionCommitted(
         uint64 indexed executeAtTick,
@@ -685,7 +690,7 @@ interface IClanWorld is IClanWorldEvents {
     function settleClan(uint32 clanId) external;
 
     /// @notice Lazily settle a single clansman's mission to current tick. Idempotent.
-    function settleClansman(uint32 csId) external;
+    function settleClansman(uint32 clansmanId) external;
 
     /// @notice Finalize the current season. Permissionless after seasonEndTick.
     function finalizeSeason() external;

--- a/packages/contracts/src/MinimalERC20.sol
+++ b/packages/contracts/src/MinimalERC20.sol
@@ -9,9 +9,6 @@ contract MinimalERC20 {
 
     uint256 public totalSupply;
     address public immutable DEPLOYER;
-    address public engine;
-    uint8 public resourceType;
-    bool public boundaryConfigured;
     bool public treasurySeeded;
 
     mapping(address => uint256) public balanceOf;
@@ -19,15 +16,11 @@ contract MinimalERC20 {
 
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner_, address indexed spender, uint256 value);
-    event BoundaryConfigured(uint8 indexed resourceType, address indexed engine);
-    event ResourceMinted(uint8 indexed resourceType, address indexed to, uint256 amount);
-    event ResourceBurned(uint8 indexed resourceType, address indexed from, uint256 amount);
 
     constructor(string memory name_, string memory symbol_) {
         name = name_;
         symbol = symbol_;
         DEPLOYER = msg.sender;
-        resourceType = type(uint8).max;
     }
 
     /// @dev Wrapped per forge-lint unwrapped-modifier-logic — keeps modifier
@@ -36,29 +29,9 @@ contract MinimalERC20 {
         require(msg.sender == DEPLOYER, "MinimalERC20: not deployer");
     }
 
-    function _onlyEngine() internal view {
-        require(boundaryConfigured && msg.sender == engine, "MinimalERC20: not engine");
-    }
-
     modifier onlyDeployer() {
         _onlyDeployer();
         _;
-    }
-
-    modifier onlyEngine() {
-        _onlyEngine();
-        _;
-    }
-
-    function configureBoundary(uint8 resourceType_, address engine_) external onlyDeployer {
-        require(!boundaryConfigured, "MinimalERC20: boundary configured");
-        require(engine_ != address(0), "MinimalERC20: zero engine");
-
-        resourceType = resourceType_;
-        engine = engine_;
-        boundaryConfigured = true;
-
-        emit BoundaryConfigured(resourceType_, engine_);
     }
 
     function seedTreasury(address treasury, uint256 amount) external onlyDeployer {
@@ -67,18 +40,6 @@ contract MinimalERC20 {
 
         treasurySeeded = true;
         _mint(treasury, amount);
-    }
-
-    function mint(address to, uint256 amount) external onlyEngine {
-        _mint(to, amount);
-        emit ResourceMinted(resourceType, to, amount);
-    }
-
-    function burn(address from, uint256 amount) external onlyEngine {
-        balanceOf[from] -= amount;
-        totalSupply -= amount;
-        emit Transfer(from, address(0), amount);
-        emit ResourceBurned(resourceType, from, amount);
     }
 
     function _mint(address to, uint256 amount) internal {

--- a/packages/contracts/src/MinimalERC20.sol
+++ b/packages/contracts/src/MinimalERC20.sol
@@ -1,39 +1,87 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.34;
 
-/// @notice Minimal ERC20 with owner-only mint. No external deps.
+/// @notice Minimal ERC20 boundary token. No external deps.
 contract MinimalERC20 {
     string public name;
     string public symbol;
     uint8 public constant decimals = 18;
 
     uint256 public totalSupply;
-    address public immutable OWNER;
+    address public immutable DEPLOYER;
+    address public engine;
+    uint8 public resourceType;
+    bool public boundaryConfigured;
+    bool public treasurySeeded;
 
     mapping(address => uint256) public balanceOf;
     mapping(address => mapping(address => uint256)) public allowance;
 
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner_, address indexed spender, uint256 value);
+    event BoundaryConfigured(uint8 indexed resourceType, address indexed engine);
+    event ResourceMinted(uint8 indexed resourceType, address indexed to, uint256 amount);
+    event ResourceBurned(uint8 indexed resourceType, address indexed from, uint256 amount);
 
     constructor(string memory name_, string memory symbol_) {
         name = name_;
         symbol = symbol_;
-        OWNER = msg.sender;
+        DEPLOYER = msg.sender;
+        resourceType = type(uint8).max;
     }
 
     /// @dev Wrapped per forge-lint unwrapped-modifier-logic — keeps modifier
     /// body slim so the require isn't duplicated at every call site.
-    function _onlyOwner() internal view {
-        require(msg.sender == OWNER, "not owner");
+    function _onlyDeployer() internal view {
+        require(msg.sender == DEPLOYER, "MinimalERC20: not deployer");
     }
 
-    modifier onlyOwner() {
-        _onlyOwner();
+    function _onlyEngine() internal view {
+        require(boundaryConfigured && msg.sender == engine, "MinimalERC20: not engine");
+    }
+
+    modifier onlyDeployer() {
+        _onlyDeployer();
         _;
     }
 
-    function mint(address to, uint256 amount) external onlyOwner {
+    modifier onlyEngine() {
+        _onlyEngine();
+        _;
+    }
+
+    function configureBoundary(uint8 resourceType_, address engine_) external onlyDeployer {
+        require(!boundaryConfigured, "MinimalERC20: boundary configured");
+        require(engine_ != address(0), "MinimalERC20: zero engine");
+
+        resourceType = resourceType_;
+        engine = engine_;
+        boundaryConfigured = true;
+
+        emit BoundaryConfigured(resourceType_, engine_);
+    }
+
+    function seedTreasury(address treasury, uint256 amount) external onlyDeployer {
+        require(!treasurySeeded, "MinimalERC20: treasury seeded");
+        require(treasury != address(0), "MinimalERC20: zero treasury");
+
+        treasurySeeded = true;
+        _mint(treasury, amount);
+    }
+
+    function mint(address to, uint256 amount) external onlyEngine {
+        _mint(to, amount);
+        emit ResourceMinted(resourceType, to, amount);
+    }
+
+    function burn(address from, uint256 amount) external onlyEngine {
+        balanceOf[from] -= amount;
+        totalSupply -= amount;
+        emit Transfer(from, address(0), amount);
+        emit ResourceBurned(resourceType, from, amount);
+    }
+
+    function _mint(address to, uint256 amount) internal {
         totalSupply += amount;
         balanceOf[to] += amount;
         emit Transfer(address(0), to, amount);

--- a/packages/contracts/src/StubPool.sol
+++ b/packages/contracts/src/StubPool.sol
@@ -97,7 +97,7 @@ contract StubPool {
     /// @notice Exact-input sell: clan sells amountIn of resource, gets goldOut.
     ///         Legacy alias for Phase 6.1 scheduled-market code.
     function sellResource(uint256 amountIn) external onlyEngine returns (uint256 goldOut) {
-        goldOut = _swapExactInForOut(amountIn, 1);
+        goldOut = _swapExactInForOut(amountIn, 0);
     }
 
     /// @notice Legacy quote alias for exact-output resource buys.

--- a/packages/contracts/src/StubPool.sol
+++ b/packages/contracts/src/StubPool.sol
@@ -1,18 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.34;
 
-/// @notice Constant-product AMM pool for one resource/gold pair.
-///         Reserves are tracked internally; ClanWorld calls the math
-///         functions to compute exchange rates, then mints/credits balances
-///         directly via the internal accounting model.
-///         No real ERC20 transfers occur here — the pool is the math oracle.
-contract StubPool {
-    address public immutable TOKEN_A;  // resource token
-    address public immutable TOKEN_B;  // gold token
-    address public immutable ENGINE;   // ClanWorld address
+interface IERC20Balance {
+    function balanceOf(address account) external view returns (uint256);
+}
 
-    uint256 public reserveA;          // resource reserve
-    uint256 public reserveB;          // gold reserve
+/// @notice Constant-product AMM pool for one resource/gold pair.
+///         TOKEN_A is the resource token and TOKEN_B is gold. ClanWorld owns
+///         the swap surface because clans use the engine's internal accounting,
+///         while the treasury seeds real ERC20 balances into the pool once.
+contract StubPool {
+    address public immutable TOKEN_A; // resource token
+    address public immutable TOKEN_B; // gold token
+    address public immutable ENGINE; // ClanWorld address
+
+    uint256 public reserveA; // resource reserve
+    uint256 public reserveB; // gold reserve
 
     bool private _seeded;
 
@@ -32,45 +35,80 @@ contract StubPool {
     function seed(uint256 amountA, uint256 amountB) external onlyEngine {
         require(!_seeded, "StubPool: already seeded");
         require(amountA > 0 && amountB > 0, "StubPool: zero seed");
+        require(IERC20Balance(TOKEN_A).balanceOf(address(this)) >= amountA, "StubPool: missing token A");
+        require(IERC20Balance(TOKEN_B).balanceOf(address(this)) >= amountB, "StubPool: missing token B");
         reserveA = amountA;
         reserveB = amountB;
         _seeded = true;
     }
 
-    /// @notice Exact-input sell: clan sells amountIn of resource, gets goldOut.
-    ///         Constant-product: goldOut = reserveB * amountIn / (reserveA + amountIn).
-    ///         Updates reserves. Called by ClanWorld; no token transfers.
-    function sellResource(uint256 amountIn) external onlyEngine returns (uint256 goldOut) {
+    function getAmountOutForExactIn(uint256 amountIn) public view returns (uint256 amountOut) {
         require(amountIn > 0, "StubPool: zero amount");
         require(reserveA > 0 && reserveB > 0, "StubPool: not seeded");
-        goldOut = (reserveB * amountIn) / (reserveA + amountIn);
-        require(goldOut > 0, "StubPool: zero output");
-        reserveA += amountIn;
-        reserveB -= goldOut;
+        amountOut = (reserveB * amountIn) / (reserveA + amountIn);
     }
 
-    /// @notice Quote a buy without updating reserves (view).
-    ///         goldIn = ceil(reserveB * amountOut / (reserveA - amountOut)).
-    function quoteBuy(uint256 amountOut) external view returns (uint256 goldIn) {
-        require(amountOut > 0, "StubPool: zero amount");
-        require(amountOut < reserveA, "StubPool: insufficient resource reserve");
-        uint256 num = reserveB * amountOut;
-        uint256 denom_ = reserveA - amountOut;
-        goldIn = num / denom_ + (num % denom_ == 0 ? 0 : 1);
-    }
-
-    /// @notice Exact-output buy: clan buys amountOut of resource, pays goldIn.
-    ///         Returns actual goldIn charged (ceiling arithmetic).
-    ///         Updates reserves. Called by ClanWorld; no token transfers.
-    function buyResource(uint256 amountOut) external onlyEngine returns (uint256 goldIn) {
+    function getAmountInForExactOut(uint256 amountOut) public view returns (uint256 amountIn) {
         require(amountOut > 0, "StubPool: zero amount");
         require(amountOut < reserveA, "StubPool: insufficient resource reserve");
         require(reserveB > 0, "StubPool: not seeded");
-        uint256 num = reserveB * amountOut;
-        uint256 denom_ = reserveA - amountOut;
-        goldIn = num / denom_ + (num % denom_ == 0 ? 0 : 1);
+
+        uint256 numerator = reserveB * amountOut;
+        uint256 denominator = reserveA - amountOut;
+        amountIn = numerator / denominator + (numerator % denominator == 0 ? 0 : 1);
+    }
+
+    /// @notice Exact-input sell: resource in, gold out.
+    function swapExactInForOut(uint256 amountIn, uint256 minOut) external onlyEngine returns (uint256 amountOut) {
+        return _swapExactInForOut(amountIn, minOut);
+    }
+
+    function _swapExactInForOut(uint256 amountIn, uint256 minOut) internal returns (uint256 amountOut) {
+        uint256 priorK = reserveA * reserveB;
+        amountOut = getAmountOutForExactIn(amountIn);
+        require(amountOut >= minOut, "StubPool: insufficient output");
+
+        reserveA += amountIn;
+        reserveB -= amountOut;
+
+        require(reserveA * reserveB >= priorK, "StubPool: k invariant");
+    }
+
+    /// @notice Exact-output buy: gold in, exact resource out.
+    function swapExactOutForInWithMaxIn(uint256 amountOut, uint256 maxIn)
+        external
+        onlyEngine
+        returns (uint256 amountIn)
+    {
+        return _swapExactOutForInWithMaxIn(amountOut, maxIn);
+    }
+
+    function _swapExactOutForInWithMaxIn(uint256 amountOut, uint256 maxIn) internal returns (uint256 amountIn) {
+        uint256 priorK = reserveA * reserveB;
+        amountIn = getAmountInForExactOut(amountOut);
+        require(amountIn <= maxIn, "StubPool: max input exceeded");
+
         reserveA -= amountOut;
-        reserveB += goldIn;
+        reserveB += amountIn;
+
+        require(reserveA * reserveB >= priorK, "StubPool: k invariant");
+    }
+
+    /// @notice Exact-input sell: clan sells amountIn of resource, gets goldOut.
+    ///         Legacy alias for Phase 6.1 scheduled-market code.
+    function sellResource(uint256 amountIn) external onlyEngine returns (uint256 goldOut) {
+        goldOut = _swapExactInForOut(amountIn, 1);
+    }
+
+    /// @notice Legacy quote alias for exact-output resource buys.
+    function quoteBuy(uint256 amountOut) external view returns (uint256 goldIn) {
+        goldIn = getAmountInForExactOut(amountOut);
+    }
+
+    /// @notice Exact-output buy: clan buys amountOut of resource, pays goldIn.
+    ///         Legacy alias for Phase 6.1 scheduled-market code.
+    function buyResource(uint256 amountOut) external onlyEngine returns (uint256 goldIn) {
+        goldIn = _swapExactOutForInWithMaxIn(amountOut, type(uint256).max);
     }
 
     function getReserves() external view returns (uint256, uint256) {

--- a/packages/contracts/test/ActionTypeEnumStability.t.sol
+++ b/packages/contracts/test/ActionTypeEnumStability.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ActionType} from "../src/IClanWorld.sol";
+
+contract ActionTypeEnumStabilityTest is Test {
+    function test_actionTypeNumericValuesAreStable() public pure {
+        assertEq(uint8(ActionType.None), 0, "None");
+        assertEq(uint8(ActionType.ChopWood), 1, "ChopWood");
+        assertEq(uint8(ActionType.MineIron), 2, "MineIron");
+        assertEq(uint8(ActionType.FishDocks), 3, "FishDocks");
+        assertEq(uint8(ActionType.FishDeepSea), 4, "FishDeepSea");
+        assertEq(uint8(ActionType.HarvestWheat), 5, "HarvestWheat");
+        assertEq(uint8(ActionType.DepositResources), 6, "DepositResources");
+        assertEq(uint8(ActionType.BuildWall), 7, "BuildWall");
+        assertEq(uint8(ActionType.UpgradeBase), 8, "UpgradeBase");
+        assertEq(uint8(ActionType.UpgradeMonument), 9, "UpgradeMonument");
+        assertEq(uint8(ActionType.DefendBase), 10, "DefendBase");
+        assertEq(uint8(ActionType.MarketBuy), 11, "MarketBuy");
+        assertEq(uint8(ActionType.MarketSell), 12, "MarketSell");
+        assertEq(uint8(ActionType.Wait), 13, "Wait");
+        assertEq(uint8(ActionType.WithdrawResources), 14, "WithdrawResources");
+    }
+}

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -25,7 +25,6 @@ import {
     Clansman,
     Mission,
     BanditTroop,
-    ScheduledMarketAction,
     DefenseContribution,
     PackedRoute,
     DerivedClanState,
@@ -792,7 +791,11 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "cooldown should force scheduled mode");
         assertTrue(m.active, "scheduled fallback should install a mission");
         assertEq(uint8(m.marketMode), uint8(MarketExecutionMode.Scheduled), "mission should be scheduled");
-        assertEq(world.getScheduledMarketActionsForTick(m.actionStartTick).length, 1, "scheduled action should enqueue");
+        assertEq(
+            world.getScheduledMarketActionsForTick(m.settlesAtTick).length,
+            0,
+            "scheduled action queues when mission settles"
+        );
         assertEq(world.getClan(clanId).goldBalance, goldBefore, "scheduled fallback should not trade immediately");
     }
 
@@ -806,7 +809,11 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "out-of-town market order should schedule");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "out-of-town should be scheduled");
         assertTrue(m.active, "scheduled fallback should install a mission");
-        assertEq(world.getScheduledMarketActionsForTick(m.actionStartTick).length, 1, "scheduled action should enqueue");
+        assertEq(
+            world.getScheduledMarketActionsForTick(m.settlesAtTick).length,
+            0,
+            "scheduled action queues when mission settles"
+        );
     }
 
     function test_immediateMarket_busyWorker_fallsBackToScheduled() public {
@@ -819,7 +826,11 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "busy market worker should schedule");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "busy worker should be scheduled");
         assertTrue(m.active, "scheduled fallback should install a mission");
-        assertEq(world.getScheduledMarketActionsForTick(m.actionStartTick).length, 1, "scheduled action should enqueue");
+        assertEq(
+            world.getScheduledMarketActionsForTick(m.settlesAtTick).length,
+            0,
+            "scheduled action queues when mission settles"
+        );
     }
 
     function test_immediateMarketBuy_executesWhenMaxGoldSatisfied() public {
@@ -896,13 +907,13 @@ contract ClanWorldTest is Test {
         // Clan starts with 20 wood in vault (starter pack)
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 
-        // Submit sell order — clansman travels to Unicorn Town then executes at actionStartTick
+        // Submit sell order — clansman travels to Unicorn Town then executes when the market mission settles
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 5e18, 0);
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "sell order should be accepted");
 
         // Find out which tick the action fires
         Mission memory m = world.getActiveMission(csId);
-        uint64 executeAtTick = m.actionStartTick;
+        uint64 executeAtTick = m.settlesAtTick;
 
         // Advance ticks until heartbeat closes executeAtTick
         uint64 curTick = world.getWorldState().currentTick;
@@ -939,7 +950,7 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "buy order should be accepted");
 
         Mission memory m = world.getActiveMission(csId);
-        uint64 executeAtTick = m.actionStartTick;
+        uint64 executeAtTick = m.settlesAtTick;
 
         uint64 curTick = world.getWorldState().currentTick;
         uint256 ticksNeeded = uint256(executeAtTick - curTick) + 1;
@@ -969,7 +980,7 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "order submission should succeed");
 
         Mission memory m = world.getActiveMission(csId);
-        uint64 executeAtTick = m.actionStartTick;
+        uint64 executeAtTick = m.settlesAtTick;
         uint64 curTick = world.getWorldState().currentTick;
 
         // Advance all ticks UP TO (but not including) the execute tick
@@ -1004,10 +1015,7 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK));
 
         Mission memory m = world.getActiveMission(csId);
-        uint64 executeAtTick = m.actionStartTick;
-
-        // Verify queue has entry before heartbeat
-        assertGt(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should have entry");
+        uint64 executeAtTick = m.settlesAtTick;
 
         uint64 curTick = world.getWorldState().currentTick;
         uint256 ticksNeeded = uint256(executeAtTick - curTick) + 1;
@@ -1029,7 +1037,7 @@ contract ClanWorldTest is Test {
         OrderResult[] memory r1 = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
         assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "first sell order should be accepted");
         Mission memory oldMission = world.getActiveMission(csId);
-        uint64 oldExecuteAtTick = oldMission.actionStartTick;
+        uint64 oldExecuteAtTick = oldMission.settlesAtTick;
 
         vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
         _advanceTick();
@@ -1037,28 +1045,26 @@ contract ClanWorldTest is Test {
         OrderResult[] memory r2 = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 2e18, 0);
         assertEq(uint8(r2[0].status), uint8(StatusCode.OK), "replacement sell order should be accepted");
         Mission memory newMission = world.getActiveMission(csId);
-        uint64 newExecuteAtTick = newMission.actionStartTick;
+        uint64 newExecuteAtTick = newMission.settlesAtTick;
         assertGt(newMission.nonce, oldMission.nonce, "replacement should bump nonce");
 
-        ScheduledMarketAction[] memory oldQueue = world.getScheduledMarketActionsForTick(oldExecuteAtTick);
-        ScheduledMarketAction[] memory newQueue = world.getScheduledMarketActionsForTick(newExecuteAtTick);
-        assertEq(oldQueue[0].missionNonce, oldMission.nonce, "old queue captures old nonce");
-        assertEq(newQueue[0].missionNonce, newMission.nonce, "new queue captures new nonce");
+        assertEq(world.getScheduledMarketActionsForTick(oldExecuteAtTick).length, 0, "old mission not queued before settle");
+        assertEq(world.getScheduledMarketActionsForTick(newExecuteAtTick).length, 0, "new mission not queued before settle");
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 
-        _advanceTick(); // close tick before the stale entry
-
-        vm.expectEmit(true, true, false, true);
-        emit IClanWorldEvents.MarketActionFailed(clanId, csId, ActionType.MarketSell, StatusCode.ERR_INVALID_ACTION);
-        _advanceTick(); // close stale entry tick
+        while (world.getWorldState().currentTick <= oldExecuteAtTick) {
+            _advanceTick();
+        }
         assertEq(world.getClan(clanId).goldBalance, goldBefore, "stale sell must not execute");
 
-        _advanceTick(); // close replacement entry tick
+        while (world.getWorldState().currentTick <= newExecuteAtTick) {
+            _advanceTick();
+        }
         assertGt(world.getClan(clanId).goldBalance, goldBefore, "replacement sell should execute");
     }
 
-    function test_scheduledMarket_defersActionsAbovePerTickCap() public {
+    function test_scheduledMarket_executesAllActionsForClosedTick() public {
         address woodAddr = _setupMarket();
         uint32[] memory distOneClans = new uint32[](12);
         uint32[] memory distTwoClans = new uint32[](12);
@@ -1087,192 +1093,87 @@ contract ClanWorldTest is Test {
             totalQueued += _submitAllClanMarketSells(distOneClans[i], woodAddr);
         }
 
-        uint64 executeAtTick = 2;
-        uint256 cap = world.MAX_MARKET_ACTIONS_PER_TICK();
-        assertGt(totalQueued, cap, "test setup must exceed cap");
-        assertEq(
-            world.getScheduledMarketActionsForTick(executeAtTick).length,
-            totalQueued,
-            "all aligned actions should share tick 2"
-        );
-
-        _advanceTick(); // close tick 1
-        _advanceTick(); // close tick 2, process cap and defer remainder
-
-        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "original tick queue cleared");
-        assertEq(
-            world.getScheduledMarketActionsForTick(executeAtTick + 1).length,
-            totalQueued - cap,
-            "overflow actions deferred to next tick"
-        );
-
-        _advanceTick(); // close tick 3, process deferred actions
-        assertEq(world.getScheduledMarketActionsForTick(executeAtTick + 1).length, 0, "deferred queue cleared");
-    }
-
-    function test_scheduledMarket_overflowExecutesBeforeNativeNextTickActions() public {
-        address woodAddr = _setupMarket();
-        uint32[] memory distOneClans = new uint32[](12);
-        uint32[] memory distTwoClans = new uint32[](12);
-        uint256 distOneCount;
-        uint256 distTwoCount;
-
-        for (uint256 i = 0; i < 12; i++) {
-            uint32 clanId = _mintClan();
-            ClanFullView memory view_ = world.getClanFullView(clanId);
-            (uint8 travelTicks,) = world.quoteTravel(view_.clan.clan.baseRegion, ClanWorldConstants.REGION_UNICORN_TOWN);
-            if (travelTicks == 1) {
-                distOneClans[distOneCount++] = clanId;
-            } else if (travelTicks == 2) {
-                distTwoClans[distTwoCount++] = clanId;
-            }
-        }
-        assertGt(distTwoCount, 0, "test setup needs a distance-two clan");
-
-        uint32 nativeClanId = distTwoClans[0];
-        ClanFullView memory nativeView = world.getClanFullView(nativeClanId);
-        uint32 nativeCsId = nativeView.clansmen[3].clansman.clansman.clansmanId;
-
-        uint256 totalQueuedForTickTwo = _submitFirstClanMarketSells(nativeClanId, woodAddr, 3);
-        for (uint256 i = 1; i < distTwoCount; i++) {
-            totalQueuedForTickTwo += _submitAllClanMarketSells(distTwoClans[i], woodAddr);
-        }
-
-        _advanceTick();
-
-        for (uint256 i = 0; i < distOneCount; i++) {
-            totalQueuedForTickTwo += _submitAllClanMarketSells(distOneClans[i], woodAddr);
-        }
-
-        OrderResult[] memory nativeResult =
-            _submitMarketOrder(nativeClanId, nativeCsId, ActionType.MarketSell, woodAddr, 1e18, 0);
-        assertEq(uint8(nativeResult[0].status), uint8(StatusCode.OK), "native next-tick action should enqueue");
-
-        uint64 overflowTick = 2;
-        uint64 nextTick = overflowTick + 1;
-        uint256 cap = world.MAX_MARKET_ACTIONS_PER_TICK();
-        assertGt(totalQueuedForTickTwo, cap, "test setup must exceed cap");
-
-        ScheduledMarketAction[] memory nativeQueueBefore = world.getScheduledMarketActionsForTick(nextTick);
-        assertEq(nativeQueueBefore.length, 1, "native next-tick queue should exist before overflow merge");
-        uint64 nativeSeq = nativeQueueBefore[0].commitSequence;
-
-        _advanceTick(); // close tick 1
-        _advanceTick(); // close tick 2, process cap and defer overflow into tick 3
-
-        uint256 overflowCount = totalQueuedForTickTwo - cap;
-        ScheduledMarketAction[] memory mergedQueue = world.getScheduledMarketActionsForTick(nextTick);
-        assertEq(mergedQueue.length, overflowCount + 1, "overflow should merge with native next-tick action");
-        assertEq(
-            mergedQueue[mergedQueue.length - 1].commitSequence,
-            nativeSeq,
-            "native action must stay after older overflow"
-        );
-        for (uint256 i = 1; i < mergedQueue.length; i++) {
-            assertGt(mergedQueue[i].commitSequence, mergedQueue[i - 1].commitSequence, "merged queue must be FIFO");
-        }
-
+        uint64 executeAtTick = 3;
         bytes32 executedSig =
             keccak256("ScheduledMarketActionExecuted(uint64,uint64,uint32,uint32,address,address,uint256,uint256)");
+
+        _advanceTick(); // close tick 1
+        _advanceTick(); // close tick 2
+
         vm.recordLogs();
-        _advanceTick(); // close tick 3 and execute the sorted merged queue
+        _advanceTick(); // close tick 3 and execute every scheduled action for the tick
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        bool sawExecution;
+        uint256 executedCount;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != address(world) || logs[i].topics.length == 0 || logs[i].topics[0] != executedSig) {
+                continue;
+            }
+            if (uint64(uint256(logs[i].topics[1])) != executeAtTick) continue;
+            executedCount++;
+        }
+
+        assertEq(executedCount, totalQueued, "all same-tick actions should execute");
+        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 15: scheduledMarket_fifo — same-tick sells execute in submission order
+    // -------------------------------------------------------------------------
+
+    function test_scheduledMarket_fifo() public {
+        address woodAddr = _setupMarket();
+        uint32 clanId = _mintClan();
+        ClanFullView memory view_ = world.getClanFullView(clanId);
+
+        ClanOrder[] memory orders = new ClanOrder[](3);
+        for (uint256 i = 0; i < orders.length; i++) {
+            orders[i] = ClanOrder({
+                clansmanId: view_.clansmen[i].clansman.clansman.clansmanId,
+                gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+                action: ActionType.MarketSell,
+                targetClanId: 0,
+                marketToken: woodAddr,
+                marketAmount: 2e18,
+                maxGoldIn: 0
+            });
+        }
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+        for (uint256 i = 0; i < results.length; i++) {
+            assertEq(uint8(results[i].status), uint8(StatusCode.OK), "sell order ok");
+        }
+
+        Mission memory m = world.getActiveMission(orders[0].clansmanId);
+        uint64 executeAtTick = m.settlesAtTick;
+        bytes32 executedSig =
+            keccak256("ScheduledMarketActionExecuted(uint64,uint64,uint32,uint32,address,address,uint256,uint256)");
+
+        while (world.getWorldState().currentTick < executeAtTick) {
+            _advanceTick();
+        }
+
+        vm.recordLogs();
+        _advanceTick();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
         uint64 previousSeq;
         uint256 executedCount;
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].emitter != address(world) || logs[i].topics.length == 0 || logs[i].topics[0] != executedSig) {
                 continue;
             }
-            uint64 executedTick = uint64(uint256(logs[i].topics[1]));
-            if (executedTick != nextTick) continue;
+            if (uint64(uint256(logs[i].topics[1])) != executeAtTick) continue;
 
             uint64 seq = uint64(uint256(logs[i].topics[2]));
-            if (sawExecution) assertGt(seq, previousSeq, "execution events must be FIFO");
-            sawExecution = true;
+            if (executedCount > 0) assertGt(seq, previousSeq, "execution should be FIFO");
+            assertEq(uint32(uint256(logs[i].topics[3])), clanId, "same clan should execute");
             previousSeq = seq;
             executedCount++;
         }
 
-        assertEq(executedCount, overflowCount + 1, "all merged actions should execute");
-        assertEq(previousSeq, nativeSeq, "native action should execute after older overflow actions");
-    }
-
-    // -------------------------------------------------------------------------
-    // Test 15: scheduledMarket_fifo — two clans queue sells; commitSequence is FIFO
-    // -------------------------------------------------------------------------
-
-    function test_scheduledMarket_fifo() public {
-        address woodAddr = _setupMarket();
-
-        // Mint two clans — they get region 1 and region 2 respectively
-        uint32 clanId1 = _mintClan();
-        vm.prank(elder2);
-        (uint32 clanId2,) = world.mintClan(elder2);
-
-        uint32 csId1 = _firstCs(clanId1);
-        uint32 csId2 = world.getClanFullView(clanId2).clansmen[0].clansman.clansman.clansmanId;
-
-        // Submit clan1's sell order first (commitSequence = 0)
-        ClanOrder[] memory orders1 = new ClanOrder[](1);
-        orders1[0] = ClanOrder({
-            clansmanId: csId1,
-            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
-            action: ActionType.MarketSell,
-            targetClanId: 0,
-            marketToken: woodAddr,
-            marketAmount: 2e18,
-            maxGoldIn: 0
-        });
-        vm.prank(elder);
-        OrderResult[] memory r1 = world.submitClanOrders(clanId1, orders1);
-        assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "clan1 sell order ok");
-
-        // Submit clan2's sell order second (commitSequence = 1)
-        ClanOrder[] memory orders2 = new ClanOrder[](1);
-        orders2[0] = ClanOrder({
-            clansmanId: csId2,
-            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
-            action: ActionType.MarketSell,
-            targetClanId: 0,
-            marketToken: woodAddr,
-            marketAmount: 2e18,
-            maxGoldIn: 0
-        });
-        vm.prank(elder2);
-        OrderResult[] memory r2 = world.submitClanOrders(clanId2, orders2);
-        assertEq(uint8(r2[0].status), uint8(StatusCode.OK), "clan2 sell order ok");
-
-        // Verify FIFO: clan1 committed before clan2 so has lower commitSequence
-        Mission memory m1 = world.getActiveMission(csId1);
-        Mission memory m2 = world.getActiveMission(csId2);
-
-        // Check commitSequence in the queues for each clan's respective tick
-        ScheduledMarketAction[] memory q1 = world.getScheduledMarketActionsForTick(m1.actionStartTick);
-        ScheduledMarketAction[] memory q2 = world.getScheduledMarketActionsForTick(m2.actionStartTick);
-
-        uint64 seq1;
-        uint64 seq2;
-        for (uint256 i = 0; i < q1.length; i++) {
-            if (q1[i].clanId == clanId1) seq1 = q1[i].commitSequence;
-        }
-        for (uint256 i = 0; i < q2.length; i++) {
-            if (q2[i].clanId == clanId2) seq2 = q2[i].commitSequence;
-        }
-        assertLt(seq1, seq2, "clan1 submitted first: lower commitSequence");
-
-        // Advance ticks to cover both actions
-        uint64 curTick = world.getWorldState().currentTick;
-        uint64 maxTick = m1.actionStartTick > m2.actionStartTick ? m1.actionStartTick : m2.actionStartTick;
-        uint256 ticksNeeded = uint256(maxTick - curTick) + 1;
-        for (uint256 i = 0; i < ticksNeeded; i++) {
-            _advanceTick();
-        }
-
-        // Both clans should have gained gold (starter 3e18 + sell proceeds)
-        assertGt(world.getClan(clanId1).goldBalance, 3e18, "clan1 should have gained gold from sell");
-        assertGt(world.getClan(clanId2).goldBalance, 3e18, "clan2 should have gained gold from sell");
+        assertEq(executedCount, 3, "three same-tick sells should execute");
+        assertGt(world.getClan(clanId).goldBalance, 3e18, "clan should gain gold from sells");
     }
 
     // -------------------------------------------------------------------------
@@ -1320,7 +1221,7 @@ contract ClanWorldTest is Test {
         Mission memory m1 = world.getActiveMission(csId1);
         Mission memory m2 = world.getActiveMission(csId2);
 
-        uint64 maxTick = m1.actionStartTick > m2.actionStartTick ? m1.actionStartTick : m2.actionStartTick;
+        uint64 maxTick = m1.settlesAtTick > m2.settlesAtTick ? m1.settlesAtTick : m2.settlesAtTick;
         uint64 curTick = world.getWorldState().currentTick;
         uint256 ticksNeeded = uint256(maxTick - curTick) + 1;
         for (uint256 i = 0; i < ticksNeeded; i++) {

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -979,34 +979,26 @@ contract ClanWorldTest is Test {
         assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
     }
 
-    function test_immediateMarketBuy_carryFullFailsAndConsumesCooldown() public {
+    function test_immediateMarketBuy_overCapacityRejectsAtSubmit() public {
         (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) =
             _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
-        harness.setCarry(csId, ClanWorldConstants.WOOD_CAP, 0, 0, 0);
+        harness.setCarry(csId, ClanWorldConstants.WOOD_CAP - 5e17, 0, 0, 0);
 
         Clan memory beforeClan = world.getClan(clanId);
+        Clansman memory beforeCs = world.getClansman(csId);
 
-        vm.expectEmit(true, false, false, true);
-        emit IClanWorldEvents.MarketActionFailed(
-            clanId,
-            csId,
-            ActionType.MarketBuy,
-            MarketExecutionMode.Immediate,
-            StatusCode.ERR_CARRY_FULL,
-            world.getWorldState().currentTick
-        );
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 10e18);
 
         Clan memory afterClan = world.getClan(clanId);
         Clansman memory cs = world.getClansman(csId);
 
-        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
-        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed buy should report immediate");
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_CARRY_FULL), "over-capacity buy should be rejected");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.None), "rejected buy has no mode");
         assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
-        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
-        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed immediate worker waits");
-        assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
+        assertEq(cs.cooldownEndsAtTs, beforeCs.cooldownEndsAtTs, "rejected buy should not consume cooldown");
+        assertEq(uint8(cs.state), uint8(beforeCs.state), "rejected buy should not change worker state");
+        assertFalse(world.getActiveMission(csId).active, "rejected buy should not install a mission");
     }
 
     // -------------------------------------------------------------------------
@@ -1172,35 +1164,28 @@ contract ClanWorldTest is Test {
         assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
     }
 
-    function test_scheduledMarketBuy_carryFullFailsAndConsumesCooldown() public {
+    function test_scheduledMarketBuy_overCapacityRejectsAtSubmit() public {
         ClanWorldTestHarness harness = new ClanWorldTestHarness();
         world = harness;
         address woodAddr = _setupMarket();
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
-        harness.setCarry(csId, ClanWorldConstants.WOOD_CAP, 0, 0, 0);
+        harness.setCarry(csId, ClanWorldConstants.WOOD_CAP - 5e17, 0, 0, 0);
 
-        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 10e18);
-        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "buy order should be accepted");
-
-        Mission memory m = world.getActiveMission(csId);
-        uint64 executeAtTick = m.settlesAtTick;
         Clan memory beforeClan = world.getClan(clanId);
-
-        _advanceUntilNextHeartbeatCloses(executeAtTick);
-        vm.expectEmit(true, false, false, true);
-        emit IClanWorldEvents.MarketActionFailed(
-            clanId, csId, ActionType.MarketBuy, MarketExecutionMode.Scheduled, StatusCode.ERR_CARRY_FULL, executeAtTick
-        );
-        _advanceTick();
+        Clansman memory beforeCs = world.getClansman(csId);
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 10e18);
 
         Clan memory afterClan = world.getClan(clanId);
         Clansman memory cs = world.getClansman(csId);
-        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
-        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
-        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed scheduled buy should consume cooldown");
-        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed scheduled worker waits");
-        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_CARRY_FULL), "over-capacity buy should be rejected");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.None), "rejected buy has no mode");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "rejected buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "rejected buy should not debit gold");
+        assertEq(cs.cooldownEndsAtTs, beforeCs.cooldownEndsAtTs, "rejected buy should not consume cooldown");
+        assertEq(uint8(cs.state), uint8(beforeCs.state), "rejected buy should not change worker state");
+        assertFalse(world.getActiveMission(csId).active, "rejected buy should not install a mission");
     }
 
     function test_scheduledMarketBuy_insufficientLiquidityFailsAndConsumesCooldown() public {

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -773,10 +773,12 @@ contract ClanWorldTest is Test {
     }
 
     function test_immediateMarketSell_executesInSubmitTx() public {
-        (, address woodAddr, uint32 clanId, uint32 csId) =
+        (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) =
             _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+        harness.setCarry(csId, 10e18, 0, 0, 0);
 
         Clan memory beforeClan = world.getClan(clanId);
+        Clansman memory beforeCs = world.getClansman(csId);
         uint256 expectedGoldOut = woodPool.getAmountOutForExactIn(5e18);
 
         vm.expectEmit(true, false, false, true);
@@ -797,7 +799,8 @@ contract ClanWorldTest is Test {
 
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "immediate sell should be accepted");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "sell should be immediate");
-        assertEq(afterClan.vaultWood, beforeClan.vaultWood - 5e18, "vault wood should be sold immediately");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "vault wood should be unchanged");
+        assertEq(cs.carryWood, beforeCs.carryWood - 5e18, "carry wood should be sold immediately");
         assertGt(afterClan.goldBalance, beforeClan.goldBalance, "gold should be credited immediately");
         assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "worker should remain waiting");
         assertEq(cs.currentRegion, ClanWorldConstants.REGION_UNICORN_TOWN, "worker should stay in town");
@@ -813,18 +816,11 @@ contract ClanWorldTest is Test {
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
-        Mission memory m = world.getActiveMission(csId);
 
-        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "market order should schedule while cooling down");
-        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "cooldown should force scheduled mode");
-        assertTrue(m.active, "scheduled fallback should install a mission");
-        assertEq(uint8(m.marketMode), uint8(MarketExecutionMode.Scheduled), "mission should be scheduled");
         assertEq(
-            world.getScheduledMarketActionsForTick(m.settlesAtTick).length,
-            0,
-            "scheduled action queues when mission settles"
+            uint8(r[0].status), uint8(StatusCode.ERR_COOLDOWN_ACTIVE), "market order on cooldown must be rejected"
         );
-        assertEq(world.getClan(clanId).goldBalance, goldBefore, "scheduled fallback should not trade immediately");
+        assertEq(world.getClan(clanId).goldBalance, goldBefore, "cooldown rejection should not trade");
     }
 
     function test_immediateMarket_notInTown_fallsBackToScheduled() public {
@@ -866,6 +862,7 @@ contract ClanWorldTest is Test {
             _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
 
         Clan memory beforeClan = world.getClan(clanId);
+        Clansman memory beforeCs = world.getClansman(csId);
         uint256 expectedGoldIn = woodPool.getAmountInForExactOut(1e18);
 
         vm.expectEmit(true, false, false, true);
@@ -882,9 +879,11 @@ contract ClanWorldTest is Test {
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 2e18);
 
         Clan memory afterClan = world.getClan(clanId);
+        Clansman memory afterCs = world.getClansman(csId);
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "immediate buy should be accepted");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "buy should be immediate");
-        assertGt(afterClan.vaultWood, beforeClan.vaultWood, "vault wood should increase immediately");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "vault wood should be unchanged");
+        assertGt(afterCs.carryWood, beforeCs.carryWood, "carry wood should increase immediately");
         assertLt(afterClan.goldBalance, beforeClan.goldBalance, "gold should be debited immediately");
         assertFalse(world.getActiveMission(csId).active, "immediate buy should not install a mission");
     }
@@ -1006,11 +1005,14 @@ contract ClanWorldTest is Test {
     // -------------------------------------------------------------------------
 
     function test_sell_creditsGold() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
+        // Give clansman carry wood so scheduled sell has something to sell
+        harness.setCarry(csId, 10e18, 0, 0, 0);
 
-        // Clan starts with 20 wood in vault (starter pack)
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 
         // Submit sell order — clansman travels to Unicorn Town then executes when the market mission settles
@@ -1063,6 +1065,7 @@ contract ClanWorldTest is Test {
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
         uint256 vaultWoodBefore = world.getClan(clanId).vaultWood;
+        uint256 carryWoodBefore = world.getClansman(csId).carryWood;
 
         // Submit buy order for 1e18 wood, maxGoldIn = generous 500e18
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 500e18);
@@ -1081,8 +1084,10 @@ contract ClanWorldTest is Test {
 
         uint256 goldAfter = world.getClan(clanId).goldBalance;
         uint256 vaultWoodAfter = world.getClan(clanId).vaultWood;
+        uint256 carryWoodAfter = world.getClansman(csId).carryWood;
         assertLt(goldAfter, goldBefore, "gold should decrease after buy");
-        assertGt(vaultWoodAfter, vaultWoodBefore, "vault wood should increase after buy");
+        assertEq(vaultWoodAfter, vaultWoodBefore, "vault wood should be unchanged after buy");
+        assertGt(carryWoodAfter, carryWoodBefore, "carry wood should increase after buy");
     }
 
     // -------------------------------------------------------------------------
@@ -1250,9 +1255,13 @@ contract ClanWorldTest is Test {
     }
 
     function test_scheduledMarket_sameTypeRetask_skipsStaleNonce() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
+        // Give carry wood so the replacement sell executes
+        harness.setCarry(csId, 10e18, 0, 0, 0);
 
         OrderResult[] memory r1 = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
         assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "first sell order should be accepted");
@@ -1289,6 +1298,8 @@ contract ClanWorldTest is Test {
     }
 
     function test_scheduledMarket_executesAllActionsForClosedTick() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
         uint32[] memory distOneClans = new uint32[](12);
         uint32[] memory distTwoClans = new uint32[](12);
@@ -1298,6 +1309,10 @@ contract ClanWorldTest is Test {
         for (uint256 i = 0; i < 12; i++) {
             uint32 clanId = _mintClan();
             ClanFullView memory view_ = world.getClanFullView(clanId);
+            // Give every clansman carry wood so their scheduled sell can execute
+            for (uint256 j = 0; j < view_.clansmen.length; j++) {
+                harness.setCarry(view_.clansmen[j].clansman.clansman.clansmanId, 10e18, 0, 0, 0);
+            }
             (uint8 travelTicks,) = world.quoteTravel(view_.clan.clan.baseRegion, ClanWorldConstants.REGION_UNICORN_TOWN);
             if (travelTicks == 1) {
                 distOneClans[distOneCount++] = clanId;
@@ -1348,9 +1363,15 @@ contract ClanWorldTest is Test {
     // -------------------------------------------------------------------------
 
     function test_scheduledMarket_fifo() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
         uint32 clanId = _mintClan();
         ClanFullView memory view_ = world.getClanFullView(clanId);
+        // Give each clansman carry wood (must be >= their respective sell amount)
+        for (uint256 i = 0; i < 3; i++) {
+            harness.setCarry(view_.clansmen[i].clansman.clansman.clansmanId, 10e18, 0, 0, 0);
+        }
 
         ClanOrder[] memory orders = new ClanOrder[](3);
         for (uint256 i = 0; i < orders.length; i++) {
@@ -1407,6 +1428,8 @@ contract ClanWorldTest is Test {
     // -------------------------------------------------------------------------
 
     function test_twoClan_sellBuyCycle() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
 
         uint32 clanId1 = _mintClan();
@@ -1415,6 +1438,8 @@ contract ClanWorldTest is Test {
 
         uint32 csId1 = _firstCs(clanId1);
         uint32 csId2 = world.getClanFullView(clanId2).clansmen[0].clansman.clansman.clansmanId;
+        // Give csId1 carry wood so scheduled sell has something to sell
+        harness.setCarry(csId1, 10e18, 0, 0, 0);
 
         // Clan 1: sell 5e18 wood
         ClanOrder[] memory sellOrders = new ClanOrder[](1);
@@ -1484,13 +1509,17 @@ contract ClanWorldTest is Test {
         assertTrue(sawClan2BuyEvent, "buy event should carry clan2 id");
         // Clan1 sold wood → gold should increase
         assertGt(world.getClan(clanId1).goldBalance, 3e18, "clan1 should have more gold after sell");
-        // Clan2 bought wood → vault wood should increase beyond starter 20e18
-        assertGt(world.getClan(clanId2).vaultWood, 20e18, "clan2 should have more vault wood after buy");
+        // Clan2 bought wood → carry wood should increase
+        assertGt(world.getClansman(csId2).carryWood, 0, "clan2 clansman should carry wood after buy");
+        // Clan2 vault is unchanged
+        assertEq(world.getClan(clanId2).vaultWood, 20e18, "clan2 vault wood should be unchanged after buy");
         // Clan2 spent gold
         assertLt(world.getClan(clanId2).goldBalance, 3e18, "clan2 should have less gold after buy");
     }
 
     function test_scheduledMarketFailure_doesNotAffectAnotherClan() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
 
         uint32 clanId1 = _mintClan();
@@ -1499,6 +1528,8 @@ contract ClanWorldTest is Test {
 
         uint32 csId1 = _firstCs(clanId1);
         uint32 csId2 = world.getClanFullView(clanId2).clansmen[0].clansman.clansman.clansmanId;
+        // Give csId2 carry wood so the sell succeeds
+        harness.setCarry(csId2, 10e18, 0, 0, 0);
 
         OrderResult[] memory buyFail = _submitMarketOrder(clanId1, csId1, ActionType.MarketBuy, woodAddr, 1e18, 0);
         assertEq(uint8(buyFail[0].status), uint8(StatusCode.OK), "failing buy should enqueue");
@@ -2460,5 +2491,122 @@ contract ClanWorldTest is Test {
         WorldState memory ws1 = world.getWorldState();
         assertEq(ws1.currentTick, 1);
         assertEq(ws1.nextHeartbeatAtTick, 2, "after tick 1, next = tick 2");
+    }
+
+    function test_marketSell_deductsFromCarry_notVault() public {
+        // Use harness to directly set carry and test immediate sell
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        _setupMarket();
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+
+        // Place worker at UT WAITING with carry wood
+        harness.setClansmanForTest(csId, ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+        harness.setCarry(csId, 10e18, 0, 0, 0);
+
+        uint256 carryBefore = world.getClansman(csId).carryWood;
+        uint256 vaultBefore = world.getClan(clanId).vaultWood;
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+
+        address woodTok = world.getTreasuryState().woodToken;
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketSell,
+            targetClanId: 0,
+            marketToken: woodTok,
+            marketAmount: 5e18,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "immediate sell must succeed");
+        assertEq(world.getClansman(csId).carryWood, carryBefore - 5e18, "sell: carry must decrease by sell amount");
+        assertEq(world.getClan(clanId).vaultWood, vaultBefore, "sell: vault must be unchanged");
+        assertGt(world.getClan(clanId).goldBalance, goldBefore, "sell: gold must increase");
+    }
+
+    function test_marketSell_fails_emptyCarry_fullVault() public {
+        // Setup: worker in UT with empty carry but vault has wood
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+        // Advance cs to UT with no carry (no gather)
+        _submitOrder(clanId, csId, ClanWorldConstants.REGION_UNICORN_TOWN, ActionType.Wait);
+        (uint8 travelToUT,) = world.quoteTravel(v.clan.clan.baseRegion, ClanWorldConstants.REGION_UNICORN_TOWN);
+        for (uint256 i = 0; i < uint256(travelToUT) + 2; i++) _advanceTick();
+        world.settleClansman(csId);
+        // Clan starts with vault wood from minting; carry is 0
+        assertEq(world.getClansman(csId).carryWood, 0, "carry must be 0");
+        assertGt(world.getClan(clanId).vaultWood, 0, "vault must have wood");
+
+        address woodTok = world.getTreasuryState().woodToken;
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketSell,
+            targetClanId: 0,
+            marketToken: woodTok,
+            marketAmount: 1e18,
+            maxGoldIn: 0
+        });
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+        // Immediate path: carry empty → ERR_MISSING_RESOURCES or market failure
+        // Either the order returns ERR_MISSING_RESOURCES at submit, or it's enqueued and fails at execution
+        // With carry-based validation, immediate sell should fail
+        assertNotEq(uint8(results[0].status), uint8(StatusCode.OK), "empty carry sell must not succeed");
+    }
+
+    function test_marketCooldown_noBypassViaScheduled() public {
+        // Use harness to set worker directly at UT with active cooldown
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        _setupMarket();
+        uint32 clanId = _mintClan();
+        ClanFullView memory v = world.getClanFullView(clanId);
+        uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
+
+        // Place worker at UT, WAITING, with cooldown active
+        uint64 cooldownEnds = uint64(block.timestamp + 120); // 2 ticks of cooldown
+        harness.setClansmanForTest(csId, ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, cooldownEnds);
+
+        // Submit a market sell — with cooldown active, must be rejected
+        address woodTok = world.getTreasuryState().woodToken;
+        ClanOrder[] memory o2 = new ClanOrder[](1);
+        o2[0] = ClanOrder({clansmanId: csId, gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketSell, targetClanId: 0, marketToken: woodTok,
+            marketAmount: 1e18, maxGoldIn: 0});
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, o2);
+        assertEq(uint8(results[0].status), uint8(StatusCode.ERR_COOLDOWN_ACTIVE),
+            "market order on cooldown must be rejected, not scheduled");
+    }
+
+    function test_marketBuy_creditsCarry_notVault() public {
+        (, address woodTok, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+
+        uint256 vaultWoodBefore = world.getClan(clanId).vaultWood;
+        uint256 carryWoodBefore = world.getClansman(csId).carryWood;
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+
+        uint256 buyAmt = 1e18;
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({clansmanId: csId, gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketBuy, targetClanId: 0, marketToken: woodTok,
+            marketAmount: buyAmt, maxGoldIn: type(uint256).max});
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "buy: immediate market buy must succeed");
+        assertGt(world.getClansman(csId).carryWood, carryWoodBefore, "buy: carry must increase");
+        assertEq(world.getClan(clanId).vaultWood, vaultWoodBefore, "buy: vault must be unchanged");
+        assertLt(world.getClan(clanId).goldBalance, goldBefore, "buy: gold must decrease");
     }
 }

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -55,6 +55,12 @@ contract ClanWorldTestHarness is ClanWorld {
         _clansmen[csId].carryWheat = wheat;
         _clansmen[csId].carryFish = fish;
     }
+
+    function setClansmanForTest(uint32 csId, ClansmanState state, uint8 region, uint64 cooldownEndsAtTs) external {
+        _clansmen[csId].state = state;
+        _clansmen[csId].currentRegion = region;
+        _clansmen[csId].cooldownEndsAtTs = cooldownEndsAtTs;
+    }
 }
 
 contract ClanWorldTest is Test {
@@ -734,6 +740,148 @@ contract ClanWorldTest is Test {
     // Helper: get the first clansman id for a clan
     function _firstCs(uint32 clanId) internal view returns (uint32) {
         return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _setupHarnessClanAt(
+        ClansmanState state,
+        uint8 region,
+        uint64 cooldownEndsAtTs
+    ) internal returns (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) {
+        harness = new ClanWorldTestHarness();
+        world = harness;
+        woodAddr = _setupMarket();
+        clanId = _mintClan();
+        csId = _firstCs(clanId);
+        harness.setClansmanForTest(csId, state, region, cooldownEndsAtTs);
+    }
+
+    function test_immediateMarketSell_executesInSubmitTx() public {
+        (, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+
+        Clan memory beforeClan = world.getClan(clanId);
+
+        vm.expectEmit(true, true, false, false);
+        emit IClanWorldEvents.ImmediateMarketActionExecuted(clanId, csId, woodAddr, address(goldToken), 5e18, 0, 0);
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 5e18, 0);
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "immediate sell should be accepted");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "sell should be immediate");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood - 5e18, "vault wood should be sold immediately");
+        assertGt(afterClan.goldBalance, beforeClan.goldBalance, "gold should be credited immediately");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "worker should remain waiting");
+        assertEq(cs.currentRegion, ClanWorldConstants.REGION_UNICORN_TOWN, "worker should stay in town");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "immediate action should consume cooldown");
+        assertFalse(world.getActiveMission(csId).active, "immediate action should not install a mission");
+        assertEq(world.getScheduledMarketActionsForTick(world.getWorldState().currentTick).length, 0, "no queue entry");
+    }
+
+    function test_immediateMarket_townOnCooldown_fallsBackToScheduled() public {
+        uint64 cooldownEndsAt = uint64(block.timestamp + 30);
+        (, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, cooldownEndsAt);
+
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
+        Mission memory m = world.getActiveMission(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "market order should schedule while cooling down");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "cooldown should force scheduled mode");
+        assertTrue(m.active, "scheduled fallback should install a mission");
+        assertEq(uint8(m.marketMode), uint8(MarketExecutionMode.Scheduled), "mission should be scheduled");
+        assertEq(world.getScheduledMarketActionsForTick(m.actionStartTick).length, 1, "scheduled action should enqueue");
+        assertEq(world.getClan(clanId).goldBalance, goldBefore, "scheduled fallback should not trade immediately");
+    }
+
+    function test_immediateMarket_notInTown_fallsBackToScheduled() public {
+        (, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_FOREST, 0);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
+        Mission memory m = world.getActiveMission(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "out-of-town market order should schedule");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "out-of-town should be scheduled");
+        assertTrue(m.active, "scheduled fallback should install a mission");
+        assertEq(world.getScheduledMarketActionsForTick(m.actionStartTick).length, 1, "scheduled action should enqueue");
+    }
+
+    function test_immediateMarket_busyWorker_fallsBackToScheduled() public {
+        (, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.ACTING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
+        Mission memory m = world.getActiveMission(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "busy market worker should schedule");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "busy worker should be scheduled");
+        assertTrue(m.active, "scheduled fallback should install a mission");
+        assertEq(world.getScheduledMarketActionsForTick(m.actionStartTick).length, 1, "scheduled action should enqueue");
+    }
+
+    function test_immediateMarketBuy_executesWhenMaxGoldSatisfied() public {
+        (, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+
+        Clan memory beforeClan = world.getClan(clanId);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 2e18);
+
+        Clan memory afterClan = world.getClan(clanId);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "immediate buy should be accepted");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "buy should be immediate");
+        assertGt(afterClan.vaultWood, beforeClan.vaultWood, "vault wood should increase immediately");
+        assertLt(afterClan.goldBalance, beforeClan.goldBalance, "gold should be debited immediately");
+        assertFalse(world.getActiveMission(csId).active, "immediate buy should not install a mission");
+    }
+
+    function test_immediateMarket_insufficientLiquidityFailsAndConsumesCooldown() public {
+        (, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+
+        Clan memory beforeClan = world.getClan(clanId);
+
+        vm.expectEmit(true, true, false, true);
+        emit IClanWorldEvents.MarketActionFailed(clanId, csId, ActionType.MarketBuy, StatusCode.ERR_INVALID_ACTION);
+        OrderResult[] memory r = _submitMarketOrder(
+            clanId, csId, ActionType.MarketBuy, woodAddr, world.INITIAL_RESOURCE_POOL_SEED() + 1, type(uint256).max
+        );
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed immediate action stays immediate");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
+        assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
+    }
+
+    function test_immediateMarketBuy_maxGoldExceededFailsAndConsumesCooldown() public {
+        (, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+
+        Clan memory beforeClan = world.getClan(clanId);
+
+        vm.expectEmit(true, true, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId, csId, ActionType.MarketBuy, StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+        );
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 0);
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed buy should report immediate");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
+        assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
     }
 
     // -------------------------------------------------------------------------

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -508,7 +508,7 @@ contract ClanWorldTest is Test {
         _advanceTickHarness(harness);
         _advanceTickHarness(harness);
         Vm.Log[] memory logs = vm.getRecordedLogs();
-        bytes32 depositedTopic = keccak256("ResourcesDeposited(uint32,uint32,uint256,uint256,uint256,uint256)");
+        bytes32 depositedTopic = keccak256("ResourcesDeposited(uint32,uint32,uint256,uint256,uint256,uint256,uint32)");
 
         for (uint256 i = 0; i < logs.length; i++) {
             assertTrue(logs[i].topics[0] != depositedTopic, "empty deposit emits no ResourcesDeposited event");
@@ -566,8 +566,8 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "deposit order should be accepted");
 
         _advanceTickHarness(harness);
-        vm.expectEmit(true, false, false, true);
-        emit IClanWorldEvents.ResourcesDeposited(clanId, csId, 5e18, 2e18, 3e18, 1e18);
+        vm.expectEmit(true, true, false, true);
+        emit IClanWorldEvents.ResourcesDeposited(clanId, csId, 5e18, 2e18, 1e18, 3e18, 1);
         _advanceTickHarness(harness);
     }
 

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -85,6 +85,10 @@ contract ClanWorldTest is Test {
 
     /// @dev Deploy tokens + pools, call initTreasury + seedPools. Returns wood token address.
     function _setupMarket() internal returns (address woodAddr) {
+        return _setupMarketWithWoodSeed(world.INITIAL_RESOURCE_POOL_SEED());
+    }
+
+    function _setupMarketWithWoodSeed(uint256 woodSeed) internal returns (address woodAddr) {
         woodToken = new MinimalERC20("Wood", "WOOD");
         ironToken = new MinimalERC20("Iron", "IRON");
         wheatToken = new MinimalERC20("Wheat", "WHEAT");
@@ -115,20 +119,20 @@ contract ClanWorldTest is Test {
         uint256 goldSeed = world.INITIAL_GOLD_POOL_SEED();
         uint256 totalGoldSeed = goldSeed * 4;
 
-        woodToken.seedTreasury(address(this), resSeed);
+        woodToken.seedTreasury(address(this), woodSeed);
         wheatToken.seedTreasury(address(this), resSeed);
         fishToken.seedTreasury(address(this), resSeed);
         ironToken.seedTreasury(address(this), resSeed);
         goldToken.seedTreasury(address(this), totalGoldSeed);
 
-        woodToken.approve(address(world), resSeed);
+        woodToken.approve(address(world), woodSeed);
         wheatToken.approve(address(world), resSeed);
         fishToken.approve(address(world), resSeed);
         ironToken.approve(address(world), resSeed);
         goldToken.approve(address(world), totalGoldSeed);
 
         PoolSeedConfig memory cfg = PoolSeedConfig({
-            woodSeed: resSeed,
+            woodSeed: woodSeed,
             wheatSeed: resSeed,
             fishSeed: resSeed,
             ironSeed: resSeed,
@@ -736,6 +740,12 @@ contract ClanWorldTest is Test {
         return count;
     }
 
+    function _advanceUntilNextHeartbeatCloses(uint64 tick) internal {
+        while (world.getWorldState().currentTick < tick) {
+            _advanceTick();
+        }
+    }
+
     // Helper: get the first clansman id for a clan
     function _firstCs(uint32 clanId) internal view returns (uint32) {
         return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
@@ -745,9 +755,18 @@ contract ClanWorldTest is Test {
         internal
         returns (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId)
     {
+        return _setupHarnessClanAtWithWoodSeed(state, region, cooldownEndsAtTs, world.INITIAL_RESOURCE_POOL_SEED());
+    }
+
+    function _setupHarnessClanAtWithWoodSeed(
+        ClansmanState state,
+        uint8 region,
+        uint64 cooldownEndsAtTs,
+        uint256 woodSeed
+    ) internal returns (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) {
         harness = new ClanWorldTestHarness();
         world = harness;
-        woodAddr = _setupMarket();
+        woodAddr = _setupMarketWithWoodSeed(woodSeed);
         clanId = _mintClan();
         csId = _firstCs(clanId);
         harness.setClansmanForTest(csId, state, region, cooldownEndsAtTs);
@@ -872,7 +891,7 @@ contract ClanWorldTest is Test {
 
     function test_immediateMarket_insufficientLiquidityFailsAndConsumesCooldown() public {
         (, address woodAddr, uint32 clanId, uint32 csId) =
-            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+            _setupHarnessClanAtWithWoodSeed(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0, 5e18);
 
         Clan memory beforeClan = world.getClan(clanId);
 
@@ -882,12 +901,11 @@ contract ClanWorldTest is Test {
             csId,
             ActionType.MarketBuy,
             MarketExecutionMode.Immediate,
-            StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+            StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
             world.getWorldState().currentTick
         );
-        OrderResult[] memory r = _submitMarketOrder(
-            clanId, csId, ActionType.MarketBuy, woodAddr, world.INITIAL_RESOURCE_POOL_SEED() + 1, type(uint256).max
-        );
+        OrderResult[] memory r =
+            _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 6e18, type(uint256).max);
 
         Clan memory afterClan = world.getClan(clanId);
         Clansman memory cs = world.getClansman(csId);
@@ -899,6 +917,7 @@ contract ClanWorldTest is Test {
         assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
         assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed immediate worker waits");
         assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
     }
 
@@ -914,7 +933,7 @@ contract ClanWorldTest is Test {
             csId,
             ActionType.MarketBuy,
             MarketExecutionMode.Immediate,
-            StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+            StatusCode.ERR_MAX_GOLD_IN_EXCEEDED,
             world.getWorldState().currentTick
         );
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 0);
@@ -927,6 +946,66 @@ contract ClanWorldTest is Test {
         assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
         assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed immediate worker waits");
+        assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
+    }
+
+    function test_immediateMarketBuy_insufficientGoldFailsAndConsumesCooldown() public {
+        (, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+
+        Clan memory beforeClan = world.getClan(clanId);
+
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Immediate,
+            StatusCode.ERR_NOT_ENOUGH_GOLD,
+            world.getWorldState().currentTick
+        );
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 7e18, 10e18);
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed buy should report immediate");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed immediate worker waits");
+        assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
+    }
+
+    function test_immediateMarketBuy_carryFullFailsAndConsumesCooldown() public {
+        (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+        harness.setCarry(csId, ClanWorldConstants.WOOD_CAP, 0, 0, 0);
+
+        Clan memory beforeClan = world.getClan(clanId);
+
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Immediate,
+            StatusCode.ERR_CARRY_FULL,
+            world.getWorldState().currentTick
+        );
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 10e18);
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed buy should report immediate");
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed immediate worker waits");
         assertFalse(world.getActiveMission(csId).active, "failed immediate action should not schedule fallback");
     }
 
@@ -1015,7 +1094,7 @@ contract ClanWorldTest is Test {
     }
 
     // -------------------------------------------------------------------------
-    // Test 13: buy_maxGoldIn — buy fails with ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+    // Test 13: buy_maxGoldIn — buy fails with ERR_MAX_GOLD_IN_EXCEEDED
     // -------------------------------------------------------------------------
 
     function test_buy_maxGoldIn() public {
@@ -1046,13 +1125,116 @@ contract ClanWorldTest is Test {
             csId,
             ActionType.MarketBuy,
             MarketExecutionMode.Scheduled,
-            StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+            StatusCode.ERR_MAX_GOLD_IN_EXCEEDED,
             executeAtTick
         );
         _advanceTick();
 
+        Clansman memory cs = world.getClansman(csId);
+
         // Verify gold balance unchanged (buy failed)
         assertEq(world.getClan(clanId).goldBalance, 3e18, "gold should be unchanged after failed buy");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed scheduled buy should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed scheduled worker waits");
+        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
+    }
+
+    function test_scheduledMarketBuy_insufficientGoldFailsAndConsumesCooldown() public {
+        address woodAddr = _setupMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 7e18, 10e18);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "buy order should be accepted");
+
+        Mission memory m = world.getActiveMission(csId);
+        uint64 executeAtTick = m.settlesAtTick;
+        Clan memory beforeClan = world.getClan(clanId);
+
+        _advanceUntilNextHeartbeatCloses(executeAtTick);
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Scheduled,
+            StatusCode.ERR_NOT_ENOUGH_GOLD,
+            executeAtTick
+        );
+        _advanceTick();
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed scheduled buy should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed scheduled worker waits");
+        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
+    }
+
+    function test_scheduledMarketBuy_carryFullFailsAndConsumesCooldown() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        address woodAddr = _setupMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+        harness.setCarry(csId, ClanWorldConstants.WOOD_CAP, 0, 0, 0);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 10e18);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "buy order should be accepted");
+
+        Mission memory m = world.getActiveMission(csId);
+        uint64 executeAtTick = m.settlesAtTick;
+        Clan memory beforeClan = world.getClan(clanId);
+
+        _advanceUntilNextHeartbeatCloses(executeAtTick);
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId, csId, ActionType.MarketBuy, MarketExecutionMode.Scheduled, StatusCode.ERR_CARRY_FULL, executeAtTick
+        );
+        _advanceTick();
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed scheduled buy should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed scheduled worker waits");
+        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
+    }
+
+    function test_scheduledMarketBuy_insufficientLiquidityFailsAndConsumesCooldown() public {
+        address woodAddr = _setupMarketWithWoodSeed(5e18);
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        OrderResult[] memory r =
+            _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 6e18, type(uint256).max);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "buy order should be accepted");
+
+        Mission memory m = world.getActiveMission(csId);
+        uint64 executeAtTick = m.settlesAtTick;
+        Clan memory beforeClan = world.getClan(clanId);
+
+        _advanceUntilNextHeartbeatCloses(executeAtTick);
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Scheduled,
+            StatusCode.ERR_LIQUIDITY_INSUFFICIENT,
+            executeAtTick
+        );
+        _advanceTick();
+
+        Clan memory afterClan = world.getClan(clanId);
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed scheduled buy should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed scheduled worker waits");
+        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
     }
 
     // -------------------------------------------------------------------------
@@ -1321,6 +1503,49 @@ contract ClanWorldTest is Test {
         assertGt(world.getClan(clanId2).vaultWood, 20e18, "clan2 should have more vault wood after buy");
         // Clan2 spent gold
         assertLt(world.getClan(clanId2).goldBalance, 3e18, "clan2 should have less gold after buy");
+    }
+
+    function test_scheduledMarketFailure_doesNotAffectAnotherClan() public {
+        address woodAddr = _setupMarket();
+
+        uint32 clanId1 = _mintClan();
+        vm.prank(elder2);
+        (uint32 clanId2,) = world.mintClan(elder2);
+
+        uint32 csId1 = _firstCs(clanId1);
+        uint32 csId2 = world.getClanFullView(clanId2).clansmen[0].clansman.clansman.clansmanId;
+
+        OrderResult[] memory buyFail = _submitMarketOrder(clanId1, csId1, ActionType.MarketBuy, woodAddr, 1e18, 0);
+        assertEq(uint8(buyFail[0].status), uint8(StatusCode.OK), "failing buy should enqueue");
+
+        ClanOrder[] memory sellOrders = new ClanOrder[](1);
+        sellOrders[0] = ClanOrder({
+            clansmanId: csId2,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketSell,
+            targetClanId: 0,
+            marketToken: woodAddr,
+            marketAmount: 5e18,
+            maxGoldIn: 0
+        });
+        vm.prank(elder2);
+        OrderResult[] memory sellOk = world.submitClanOrders(clanId2, sellOrders);
+        assertEq(uint8(sellOk[0].status), uint8(StatusCode.OK), "other clan sell should enqueue");
+
+        uint64 tick1 = world.getActiveMission(csId1).settlesAtTick;
+        uint64 tick2 = world.getActiveMission(csId2).settlesAtTick;
+        uint64 maxTick = tick1 > tick2 ? tick1 : tick2;
+        Clan memory failingBefore = world.getClan(clanId1);
+        uint256 sellerGoldBefore = world.getClan(clanId2).goldBalance;
+
+        while (world.getWorldState().currentTick <= maxTick) {
+            _advanceTick();
+        }
+
+        Clan memory failingAfter = world.getClan(clanId1);
+        assertEq(failingAfter.vaultWood, failingBefore.vaultWood, "failed buy should not credit resources");
+        assertEq(failingAfter.goldBalance, failingBefore.goldBalance, "failed buy should not debit gold");
+        assertGt(world.getClan(clanId2).goldBalance, sellerGoldBefore, "other clan sell should execute");
     }
 
     // -------------------------------------------------------------------------

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -454,7 +454,7 @@ contract ClanWorldTest is Test {
         vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
         _submitOrder(clanId, cs0, homeRegion, ActionType.DepositResources);
 
-        // Advance through travel back to homebase; deposit is instant on arrival.
+        // Advance through travel back to homebase and the deposit's 1-tick transfer.
         (uint8 travelBack,) = world.quoteTravel(targetRegion, homeRegion);
         for (uint256 i = 0; i < uint256(travelBack) + world.getActionDuration(ActionType.DepositResources) + 1; i++) {
             _advanceTick();
@@ -484,10 +484,14 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "deposit order should be accepted");
 
         Mission memory mission = harness.getActiveMission(csId);
-        assertEq(mission.settlesAtTick, mission.executesAtTick, "deposit settles instantly on arrival");
+        assertEq(
+            mission.settlesAtTick,
+            mission.executesAtTick + harness.getActionDuration(ActionType.DepositResources),
+            "deposit settles after transfer duration"
+        );
 
         _advanceTickHarness(harness);
-        harness.settleClan(clanId);
+        _advanceTickHarness(harness);
 
         assertEq(harness.getClan(clanId).vaultWood, vaultBefore + woodDelta, "vault wood receives carried wood");
         assertEq(harness.getClansman(csId).carryWood, 0, "carry wood is cleared");
@@ -500,9 +504,9 @@ contract ClanWorldTest is Test {
         OrderResult[] memory r = _submitOrderHarness(harness, clanId, csId, homeRegion, ActionType.DepositResources);
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "empty deposit order should be accepted");
 
-        _advanceTickHarness(harness);
         vm.recordLogs();
-        harness.settleClan(clanId);
+        _advanceTickHarness(harness);
+        _advanceTickHarness(harness);
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bytes32 depositedTopic = keccak256("ResourcesDeposited(uint32,uint32,uint256,uint256,uint256,uint256)");
 
@@ -527,15 +531,14 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "deposit order should be accepted");
 
         _advanceTickHarness(harness);
-        harness.settleClan(clanId);
+        _advanceTickHarness(harness);
 
         Clan memory afterClan = harness.getClan(clanId);
         Clansman memory afterCs = harness.getClansman(csId);
-        uint256 fishUpkeep = uint256(beforeClan.livingClansmen) * ClanWorldConstants.FISH_UPKEEP_PER_CLANSMAN;
 
         assertEq(afterClan.vaultWood, beforeClan.vaultWood + woodDelta, "wood transferred");
         assertEq(afterClan.vaultIron, beforeClan.vaultIron + ironDelta, "iron transferred");
-        assertEq(afterClan.vaultFish, beforeClan.vaultFish - fishUpkeep + fishDelta, "fish transferred after upkeep");
+        assertEq(afterClan.vaultFish, beforeClan.vaultFish + fishDelta, "fish transferred");
         assertEq(afterCs.carryWood, 0, "wood carry cleared");
         assertEq(afterCs.carryIron, 0, "iron carry cleared");
         assertEq(afterCs.carryFish, 0, "fish carry cleared");
@@ -565,7 +568,7 @@ contract ClanWorldTest is Test {
         _advanceTickHarness(harness);
         vm.expectEmit(true, false, false, true);
         emit IClanWorldEvents.ResourcesDeposited(clanId, csId, 5e18, 2e18, 3e18, 1e18);
-        harness.settleClan(clanId);
+        _advanceTickHarness(harness);
     }
 
     function test_quoteTravel_outOfBounds_returnsZero() public {
@@ -1404,6 +1407,7 @@ contract ClanWorldTest is Test {
         // Wait for submit-time cooldown to expire (warp only; no ticks yet)
         vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
 
+        _advanceTick();
         _advanceTick();
 
         // Settle the clan — mission completes, clansman back to WAITING with new cooldown

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -1084,7 +1084,9 @@ contract ClanWorldTest is Test {
         Clan memory afterClan = world.getClan(clanId);
         Clansman memory cs = world.getClansman(csId);
 
-        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(
+            uint8(r[0].status), uint8(StatusCode.ERR_LIQUIDITY_INSUFFICIENT), "failed immediate buy should propagate"
+        );
         assertEq(
             uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed immediate action stays immediate"
         );
@@ -1115,7 +1117,9 @@ contract ClanWorldTest is Test {
         Clan memory afterClan = world.getClan(clanId);
         Clansman memory cs = world.getClansman(csId);
 
-        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(
+            uint8(r[0].status), uint8(StatusCode.ERR_MAX_GOLD_IN_EXCEEDED), "failed immediate buy should propagate"
+        );
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed buy should report immediate");
         assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
@@ -1144,7 +1148,7 @@ contract ClanWorldTest is Test {
         Clan memory afterClan = world.getClan(clanId);
         Clansman memory cs = world.getClansman(csId);
 
-        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_NOT_ENOUGH_GOLD), "failed immediate buy should propagate");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed buy should report immediate");
         assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -48,6 +48,13 @@ contract ClanWorldTestHarness is ClanWorld {
     function killClansman(uint32 csId) external {
         _clansmen[csId].state = ClansmanState.DEAD;
     }
+
+    function setCarry(uint32 csId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        _clansmen[csId].carryWood = wood;
+        _clansmen[csId].carryIron = iron;
+        _clansmen[csId].carryWheat = wheat;
+        _clansmen[csId].carryFish = fish;
+    }
 }
 
 contract ClanWorldTest is Test {
@@ -447,7 +454,7 @@ contract ClanWorldTest is Test {
         vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
         _submitOrder(clanId, cs0, homeRegion, ActionType.DepositResources);
 
-        // Advance travel back to homebase + deposit duration.
+        // Advance through travel back to homebase; deposit is instant on arrival.
         (uint8 travelBack,) = world.quoteTravel(targetRegion, homeRegion);
         for (uint256 i = 0; i < uint256(travelBack) + world.getActionDuration(ActionType.DepositResources) + 1; i++) {
             _advanceTick();
@@ -463,6 +470,102 @@ contract ClanWorldTest is Test {
 
         // cs1 unused — suppress warning
         cs1;
+    }
+
+    function test_depositResources_woodCarryMovesToVaultAndClears() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        uint256 woodDelta = 5e18;
+
+        harness.setCarry(csId, woodDelta, 0, 0, 0);
+        uint256 vaultBefore = harness.getClan(clanId).vaultWood;
+
+        OrderResult[] memory r = _submitOrderHarness(harness, clanId, csId, homeRegion, ActionType.DepositResources);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "deposit order should be accepted");
+
+        Mission memory mission = harness.getActiveMission(csId);
+        assertEq(mission.settlesAtTick, mission.executesAtTick, "deposit settles instantly on arrival");
+
+        _advanceTickHarness(harness);
+        harness.settleClan(clanId);
+
+        assertEq(harness.getClan(clanId).vaultWood, vaultBefore + woodDelta, "vault wood receives carried wood");
+        assertEq(harness.getClansman(csId).carryWood, 0, "carry wood is cleared");
+    }
+
+    function test_depositResources_emptyCarryNoopsWithoutEvent() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+
+        OrderResult[] memory r = _submitOrderHarness(harness, clanId, csId, homeRegion, ActionType.DepositResources);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "empty deposit order should be accepted");
+
+        _advanceTickHarness(harness);
+        vm.recordLogs();
+        harness.settleClan(clanId);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 depositedTopic = keccak256("ResourcesDeposited(uint32,uint32,uint256,uint256,uint256,uint256)");
+
+        for (uint256 i = 0; i < logs.length; i++) {
+            assertTrue(logs[i].topics[0] != depositedTopic, "empty deposit emits no ResourcesDeposited event");
+        }
+
+        assertFalse(harness.getActiveMission(csId).active, "empty deposit still completes");
+    }
+
+    function test_depositResources_multipleTypesMoveTogether() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        uint256 woodDelta = 4e18;
+        uint256 ironDelta = 2e18;
+        uint256 fishDelta = 3e18;
+
+        harness.setCarry(csId, woodDelta, ironDelta, 0, fishDelta);
+        Clan memory beforeClan = harness.getClan(clanId);
+
+        OrderResult[] memory r = _submitOrderHarness(harness, clanId, csId, homeRegion, ActionType.DepositResources);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "deposit order should be accepted");
+
+        _advanceTickHarness(harness);
+        harness.settleClan(clanId);
+
+        Clan memory afterClan = harness.getClan(clanId);
+        Clansman memory afterCs = harness.getClansman(csId);
+        uint256 fishUpkeep = uint256(beforeClan.livingClansmen) * ClanWorldConstants.FISH_UPKEEP_PER_CLANSMAN;
+
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood + woodDelta, "wood transferred");
+        assertEq(afterClan.vaultIron, beforeClan.vaultIron + ironDelta, "iron transferred");
+        assertEq(afterClan.vaultFish, beforeClan.vaultFish - fishUpkeep + fishDelta, "fish transferred after upkeep");
+        assertEq(afterCs.carryWood, 0, "wood carry cleared");
+        assertEq(afterCs.carryIron, 0, "iron carry cleared");
+        assertEq(afterCs.carryFish, 0, "fish carry cleared");
+    }
+
+    function test_depositResources_requiresHomeRegion() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        uint8 nonHomeRegion = homeRegion == ClanWorldConstants.REGION_FOREST
+            ? ClanWorldConstants.REGION_MOUNTAINS
+            : ClanWorldConstants.REGION_FOREST;
+
+        OrderResult[] memory r = _submitOrderHarness(harness, clanId, csId, nonHomeRegion, ActionType.DepositResources);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_INVALID_REGION), "deposit must target home region");
+    }
+
+    function test_depositResources_eventHasCorrectDeltas() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+
+        harness.setCarry(csId, 5e18, 2e18, 1e18, 3e18);
+
+        OrderResult[] memory r = _submitOrderHarness(harness, clanId, csId, homeRegion, ActionType.DepositResources);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "deposit order should be accepted");
+
+        _advanceTickHarness(harness);
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.ResourcesDeposited(clanId, csId, 5e18, 2e18, 3e18, 1e18);
+        harness.settleClan(clanId);
     }
 
     function test_quoteTravel_outOfBounds_returnsZero() public {
@@ -1293,16 +1396,14 @@ contract ClanWorldTest is Test {
         uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
         uint8 homeRegion = v.clan.clan.baseRegion;
 
-        // Send clansman to homebase to DepositResources (empty carry → completes in 1 tick).
-        // This is the cleanest single-tick completion: _doDeposit with empty carry calls _completeMission immediately.
+        // Send clansman to homebase to DepositResources (empty carry -> completes when the arrival tick closes).
+        // _doDeposit with empty carry calls _completeMission immediately during settlement.
         OrderResult[] memory r = _submitOrder(clanId, csId, homeRegion, ActionType.DepositResources);
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "3.E5: order must succeed");
 
         // Wait for submit-time cooldown to expire (warp only; no ticks yet)
         vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
 
-        // Advance until the one-tick deposit duration has closed.
-        _advanceTick();
         _advanceTick();
 
         // Settle the clan — mission completes, clansman back to WAITING with new cooldown

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -105,9 +105,23 @@ contract ClanWorldTest is Test {
 
         world.initTreasury(tokens, pools);
 
-        // Seed: 1000 wood + 1000 gold per pool (spot price 1 gold / 1 wood)
-        uint256 resSeed = 1000e18;
-        uint256 goldSeed = 1000e18;
+        // Seed: 100,000 resource + 50,000 gold per pool (spot price 0.5 gold / resource).
+        uint256 resSeed = world.INITIAL_RESOURCE_POOL_SEED();
+        uint256 goldSeed = world.INITIAL_GOLD_POOL_SEED();
+        uint256 totalGoldSeed = goldSeed * 4;
+
+        woodToken.seedTreasury(address(this), resSeed);
+        wheatToken.seedTreasury(address(this), resSeed);
+        fishToken.seedTreasury(address(this), resSeed);
+        ironToken.seedTreasury(address(this), resSeed);
+        goldToken.seedTreasury(address(this), totalGoldSeed);
+
+        woodToken.approve(address(world), resSeed);
+        wheatToken.approve(address(world), resSeed);
+        fishToken.approve(address(world), resSeed);
+        ironToken.approve(address(world), resSeed);
+        goldToken.approve(address(world), totalGoldSeed);
+
         PoolSeedConfig memory cfg = PoolSeedConfig({
             woodSeed: resSeed,
             wheatSeed: resSeed,
@@ -1919,7 +1933,11 @@ contract ClanWorldTest is Test {
         // Call settleClansman on-demand — must be idempotent (no crash, no double-credit).
         uint256 ironBefore = world.getClansman(csId).carryIron;
         world.settleClansman(csId);
-        assertEq(world.getClansman(csId).carryIron, ironBefore, "onDemand: settleClansman is idempotent after heartbeat settle");
+        assertEq(
+            world.getClansman(csId).carryIron,
+            ironBefore,
+            "onDemand: settleClansman is idempotent after heartbeat settle"
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -2026,8 +2044,7 @@ contract ClanWorldTest is Test {
         assertEq(ws.seasonStartTick, 0);
         assertEq(ws.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS);
         assertEq(
-            ws.winterStartsAtTick,
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS
+            ws.winterStartsAtTick, ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS
         );
         assertFalse(ws.winterActive);
     }
@@ -2036,8 +2053,7 @@ contract ClanWorldTest is Test {
         // winterStartsAtTick = 100; WinterStarted fires on the heartbeat that opens tick 100
         // i.e. when closedTick=99, newTick=100 >= winterStartsAtTick=100.
         // Advance 99 heartbeats so currentTick=99, then one more heartbeat fires WinterStarted at tick 100.
-        uint64 winterStart =
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
+        uint64 winterStart = ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
         for (uint64 i = 0; i < winterStart - 1; i++) {
             vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
             world.heartbeat();

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -741,11 +741,10 @@ contract ClanWorldTest is Test {
         return world.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
     }
 
-    function _setupHarnessClanAt(
-        ClansmanState state,
-        uint8 region,
-        uint64 cooldownEndsAtTs
-    ) internal returns (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) {
+    function _setupHarnessClanAt(ClansmanState state, uint8 region, uint64 cooldownEndsAtTs)
+        internal
+        returns (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId)
+    {
         harness = new ClanWorldTestHarness();
         world = harness;
         woodAddr = _setupMarket();
@@ -759,9 +758,19 @@ contract ClanWorldTest is Test {
             _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
 
         Clan memory beforeClan = world.getClan(clanId);
+        uint256 expectedGoldOut = woodPool.getAmountOutForExactIn(5e18);
 
-        vm.expectEmit(true, true, false, false);
-        emit IClanWorldEvents.ImmediateMarketActionExecuted(clanId, csId, woodAddr, address(goldToken), 5e18, 0, 0);
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.ImmediateMarketActionExecuted(
+            clanId,
+            csId,
+            ActionType.MarketSell,
+            uint8(ResourceType.Wood),
+            5e18,
+            ClanWorldConstants.RESOURCE_GOLD,
+            expectedGoldOut,
+            world.getWorldState().currentTick
+        );
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 5e18, 0);
 
         Clan memory afterClan = world.getClan(clanId);
@@ -838,7 +847,19 @@ contract ClanWorldTest is Test {
             _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
 
         Clan memory beforeClan = world.getClan(clanId);
+        uint256 expectedGoldIn = woodPool.getAmountInForExactOut(1e18);
 
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.ImmediateMarketActionExecuted(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            ClanWorldConstants.RESOURCE_GOLD,
+            expectedGoldIn,
+            uint8(ResourceType.Wood),
+            1e18,
+            world.getWorldState().currentTick
+        );
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 2e18);
 
         Clan memory afterClan = world.getClan(clanId);
@@ -855,8 +876,15 @@ contract ClanWorldTest is Test {
 
         Clan memory beforeClan = world.getClan(clanId);
 
-        vm.expectEmit(true, true, false, true);
-        emit IClanWorldEvents.MarketActionFailed(clanId, csId, ActionType.MarketBuy, StatusCode.ERR_INVALID_ACTION);
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.MarketActionFailed(
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Immediate,
+            StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY,
+            world.getWorldState().currentTick
+        );
         OrderResult[] memory r = _submitMarketOrder(
             clanId, csId, ActionType.MarketBuy, woodAddr, world.INITIAL_RESOURCE_POOL_SEED() + 1, type(uint256).max
         );
@@ -865,7 +893,9 @@ contract ClanWorldTest is Test {
         Clansman memory cs = world.getClansman(csId);
 
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "failed immediate action is still accepted");
-        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed immediate action stays immediate");
+        assertEq(
+            uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failed immediate action stays immediate"
+        );
         assertEq(afterClan.vaultWood, beforeClan.vaultWood, "failed buy should not credit resources");
         assertEq(afterClan.goldBalance, beforeClan.goldBalance, "failed buy should not debit gold");
         assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed immediate action should consume cooldown");
@@ -878,9 +908,14 @@ contract ClanWorldTest is Test {
 
         Clan memory beforeClan = world.getClan(clanId);
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit IClanWorldEvents.MarketActionFailed(
-            clanId, csId, ActionType.MarketBuy, StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Immediate,
+            StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+            world.getWorldState().currentTick
         );
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketBuy, woodAddr, 1e18, 0);
 
@@ -914,13 +949,26 @@ contract ClanWorldTest is Test {
         // Find out which tick the action fires
         Mission memory m = world.getActiveMission(csId);
         uint64 executeAtTick = m.settlesAtTick;
+        uint256 expectedGoldOut = woodPool.getAmountOutForExactIn(5e18);
 
-        // Advance ticks until heartbeat closes executeAtTick
+        // Advance ticks until the heartbeat before executeAtTick
         uint64 curTick = world.getWorldState().currentTick;
-        uint256 ticksNeeded = uint256(executeAtTick - curTick) + 1;
-        for (uint256 i = 0; i < ticksNeeded; i++) {
+        for (uint256 i = 0; i < uint256(executeAtTick - curTick); i++) {
             _advanceTick();
         }
+
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.ScheduledMarketActionExecuted(
+            clanId,
+            csId,
+            ActionType.MarketSell,
+            uint8(ResourceType.Wood),
+            5e18,
+            ClanWorldConstants.RESOURCE_GOLD,
+            expectedGoldOut,
+            executeAtTick
+        );
+        _advanceTick();
 
         // Settle clan to apply any mission resolution
         world.settleClan(clanId);
@@ -992,9 +1040,14 @@ contract ClanWorldTest is Test {
 
         // Now the next heartbeat will close executeAtTick — that's when MarketActionFailed fires
         // Place expectEmit right before the final heartbeat
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit IClanWorldEvents.MarketActionFailed(
-            clanId, csId, ActionType.MarketBuy, StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED
+            clanId,
+            csId,
+            ActionType.MarketBuy,
+            MarketExecutionMode.Scheduled,
+            StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED,
+            executeAtTick
         );
         _advanceTick();
 
@@ -1048,8 +1101,12 @@ contract ClanWorldTest is Test {
         uint64 newExecuteAtTick = newMission.settlesAtTick;
         assertGt(newMission.nonce, oldMission.nonce, "replacement should bump nonce");
 
-        assertEq(world.getScheduledMarketActionsForTick(oldExecuteAtTick).length, 0, "old mission not queued before settle");
-        assertEq(world.getScheduledMarketActionsForTick(newExecuteAtTick).length, 0, "new mission not queued before settle");
+        assertEq(
+            world.getScheduledMarketActionsForTick(oldExecuteAtTick).length, 0, "old mission not queued before settle"
+        );
+        assertEq(
+            world.getScheduledMarketActionsForTick(newExecuteAtTick).length, 0, "new mission not queued before settle"
+        );
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 
@@ -1095,7 +1152,7 @@ contract ClanWorldTest is Test {
 
         uint64 executeAtTick = 3;
         bytes32 executedSig =
-            keccak256("ScheduledMarketActionExecuted(uint64,uint64,uint32,uint32,address,address,uint256,uint256)");
+            keccak256("ScheduledMarketActionExecuted(uint32,uint32,uint8,uint8,uint256,uint8,uint256,uint64)");
 
         _advanceTick(); // close tick 1
         _advanceTick(); // close tick 2
@@ -1109,7 +1166,9 @@ contract ClanWorldTest is Test {
             if (logs[i].emitter != address(world) || logs[i].topics.length == 0 || logs[i].topics[0] != executedSig) {
                 continue;
             }
-            if (uint64(uint256(logs[i].topics[1])) != executeAtTick) continue;
+            (,,,,,, uint64 settledAtTick) =
+                abi.decode(logs[i].data, (uint32, ActionType, uint8, uint256, uint8, uint256, uint64));
+            if (settledAtTick != executeAtTick) continue;
             executedCount++;
         }
 
@@ -1134,7 +1193,7 @@ contract ClanWorldTest is Test {
                 action: ActionType.MarketSell,
                 targetClanId: 0,
                 marketToken: woodAddr,
-                marketAmount: 2e18,
+                marketAmount: uint256(i + 1) * 1e18,
                 maxGoldIn: 0
             });
         }
@@ -1147,7 +1206,7 @@ contract ClanWorldTest is Test {
         Mission memory m = world.getActiveMission(orders[0].clansmanId);
         uint64 executeAtTick = m.settlesAtTick;
         bytes32 executedSig =
-            keccak256("ScheduledMarketActionExecuted(uint64,uint64,uint32,uint32,address,address,uint256,uint256)");
+            keccak256("ScheduledMarketActionExecuted(uint32,uint32,uint8,uint8,uint256,uint8,uint256,uint64)");
 
         while (world.getWorldState().currentTick < executeAtTick) {
             _advanceTick();
@@ -1157,18 +1216,18 @@ contract ClanWorldTest is Test {
         _advanceTick();
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        uint64 previousSeq;
         uint256 executedCount;
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].emitter != address(world) || logs[i].topics.length == 0 || logs[i].topics[0] != executedSig) {
                 continue;
             }
-            if (uint64(uint256(logs[i].topics[1])) != executeAtTick) continue;
+            (,, uint8 resourceIn, uint256 amountIn,,, uint64 settledAtTick) =
+                abi.decode(logs[i].data, (uint32, ActionType, uint8, uint256, uint8, uint256, uint64));
+            if (settledAtTick != executeAtTick) continue;
 
-            uint64 seq = uint64(uint256(logs[i].topics[2]));
-            if (executedCount > 0) assertGt(seq, previousSeq, "execution should be FIFO");
-            assertEq(uint32(uint256(logs[i].topics[3])), clanId, "same clan should execute");
-            previousSeq = seq;
+            assertEq(uint32(uint256(logs[i].topics[1])), clanId, "same clan should execute");
+            assertEq(resourceIn, uint8(ResourceType.Wood), "sell should input wood");
+            assertEq(amountIn, uint256(executedCount + 1) * 1e18, "execution should be FIFO");
             executedCount++;
         }
 
@@ -1224,13 +1283,38 @@ contract ClanWorldTest is Test {
         uint64 maxTick = m1.settlesAtTick > m2.settlesAtTick ? m1.settlesAtTick : m2.settlesAtTick;
         uint64 curTick = world.getWorldState().currentTick;
         uint256 ticksNeeded = uint256(maxTick - curTick) + 1;
+        bytes32 scheduledSig =
+            keccak256("ScheduledMarketActionExecuted(uint32,uint32,uint8,uint8,uint256,uint8,uint256,uint64)");
+        vm.recordLogs();
         for (uint256 i = 0; i < ticksNeeded; i++) {
             _advanceTick();
+        }
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bool sawClan1SellEvent;
+        bool sawClan2BuyEvent;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != address(world) || logs[i].topics.length == 0 || logs[i].topics[0] != scheduledSig) {
+                continue;
+            }
+
+            uint32 eventClanId = uint32(uint256(logs[i].topics[1]));
+            (uint32 eventCsId, ActionType eventAction,,,,,) =
+                abi.decode(logs[i].data, (uint32, ActionType, uint8, uint256, uint8, uint256, uint64));
+
+            if (eventClanId == clanId1 && eventCsId == csId1 && eventAction == ActionType.MarketSell) {
+                sawClan1SellEvent = true;
+            }
+            if (eventClanId == clanId2 && eventCsId == csId2 && eventAction == ActionType.MarketBuy) {
+                sawClan2BuyEvent = true;
+            }
         }
 
         world.settleClan(clanId1);
         world.settleClan(clanId2);
 
+        assertTrue(sawClan1SellEvent, "sell event should carry clan1 id");
+        assertTrue(sawClan2BuyEvent, "buy event should carry clan2 id");
         // Clan1 sold wood → gold should increase
         assertGt(world.getClan(clanId1).goldBalance, 3e18, "clan1 should have more gold after sell");
         // Clan2 bought wood → vault wood should increase beyond starter 20e18

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -30,6 +30,7 @@ import {
     DerivedClanState,
     DerivedClansmanState,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     PoolSeedConfig,
     LeaderboardEntry,
@@ -53,6 +54,13 @@ contract ClanWorldTestHarness is ClanWorld {
         _clansmen[csId].carryIron = iron;
         _clansmen[csId].carryWheat = wheat;
         _clansmen[csId].carryFish = fish;
+    }
+
+    function setVault(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        _clans[clanId].vaultWood = wood;
+        _clans[clanId].vaultIron = iron;
+        _clans[clanId].vaultWheat = wheat;
+        _clans[clanId].vaultFish = fish;
     }
 
     function setClansmanForTest(uint32 csId, ClansmanState state, uint8 region, uint64 cooldownEndsAtTs) external {
@@ -146,6 +154,34 @@ contract ClanWorldTest is Test {
         return address(woodToken);
     }
 
+    function _initMarketWithoutSeed() internal returns (address woodAddr) {
+        woodToken = new MinimalERC20("Wood", "WOOD");
+        ironToken = new MinimalERC20("Iron", "IRON");
+        wheatToken = new MinimalERC20("Wheat", "WHEAT");
+        fishToken = new MinimalERC20("Fish", "FISH");
+        goldToken = new MinimalERC20("Gold", "GOLD");
+        blueprintToken = new MinimalERC20("BPRT", "BPRT");
+
+        address wAddr = address(world);
+        woodPool = new StubPool(address(woodToken), address(goldToken), wAddr);
+        ironPool = new StubPool(address(ironToken), address(goldToken), wAddr);
+        wheatPool = new StubPool(address(wheatToken), address(goldToken), wAddr);
+        fishPool = new StubPool(address(fishToken), address(goldToken), wAddr);
+
+        address[6] memory tokens = [
+            address(woodToken),
+            address(ironToken),
+            address(wheatToken),
+            address(fishToken),
+            address(goldToken),
+            address(blueprintToken)
+        ];
+        address[4] memory pools = [address(woodPool), address(wheatPool), address(fishPool), address(ironPool)];
+
+        world.initTreasury(tokens, pools);
+        return address(woodToken);
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
@@ -172,10 +208,36 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);
+    }
+
+    function _submitWithdrawOrder(
+        ClanWorldTestHarness harness,
+        uint32 clanId,
+        uint32 csId,
+        uint8 gotoRegion,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish
+    ) internal returns (OrderResult[] memory) {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: gotoRegion,
+            action: ActionType.WithdrawResources,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: wood, iron: iron, wheat: wheat, fish: fish})
+        });
+        vm.prank(elder);
+        return harness.submitClanOrders(clanId, orders);
     }
 
     // -------------------------------------------------------------------------
@@ -331,7 +393,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         // Invalid order: non-existent clansmanId
         orders[1] = ClanOrder({
@@ -341,7 +404,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         vm.prank(elder);
@@ -389,7 +453,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         vm.prank(elder);
@@ -594,6 +659,108 @@ contract ClanWorldTest is Test {
         _advanceTickHarness(harness);
     }
 
+    function test_withdrawResources_vaultToCarry_happyPath() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 8e18, 3e18, 4e18, 2e18);
+
+        OrderResult[] memory r = _submitWithdrawOrder(harness, clanId, csId, homeRegion, 5e18, 2e18, 1e18, 1e18);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "withdraw order should be accepted");
+
+        _advanceTickHarness(harness);
+        vm.expectEmit(true, true, false, true);
+        emit IClanWorldEvents.ResourcesWithdrawn(clanId, csId, 5e18, 2e18, 1e18, 1e18, 1);
+        _advanceTickHarness(harness);
+
+        Clan memory clan = harness.getClan(clanId);
+        Clansman memory cs = harness.getClansman(csId);
+        assertEq(clan.vaultWood, 3e18, "wood leaves vault");
+        assertEq(clan.vaultIron, 1e18, "iron leaves vault");
+        assertEq(clan.vaultWheat, 3e18, "wheat leaves vault");
+        assertEq(clan.vaultFish, 1e18, "fish leaves vault");
+        assertEq(cs.carryWood, 5e18, "wood enters carry");
+        assertEq(cs.carryIron, 2e18, "iron enters carry");
+        assertEq(cs.carryWheat, 1e18, "wheat enters carry");
+        assertEq(cs.carryFish, 1e18, "fish enters carry");
+    }
+
+    function test_withdrawResources_failsWhenInsufficientVault() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 1e18, 0, 0, 0);
+
+        OrderResult[] memory r = _submitWithdrawOrder(harness, clanId, csId, homeRegion, 2e18, 0, 0, 0);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "vault must cover request");
+        assertFalse(harness.getActiveMission(csId).active, "rejected withdraw should not install mission");
+    }
+
+    function test_withdrawResources_failsWhenCarryAtCap() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 2e18, 0, 0, 0);
+        harness.setCarry(csId, ClanWorldConstants.WOOD_CAP, 0, 0, 0);
+
+        OrderResult[] memory r = _submitWithdrawOrder(harness, clanId, csId, homeRegion, 1e18, 0, 0, 0);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_CARRY_FULL), "withdraw must fit carry cap");
+        assertFalse(harness.getActiveMission(csId).active, "rejected withdraw should not install mission");
+    }
+
+    function test_withdrawResources_failsWhenNotAtHomebase() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        uint8 nonHomeRegion = homeRegion == ClanWorldConstants.REGION_FOREST
+            ? ClanWorldConstants.REGION_MOUNTAINS
+            : ClanWorldConstants.REGION_FOREST;
+        harness.setVault(clanId, 2e18, 0, 0, 0);
+
+        OrderResult[] memory r = _submitWithdrawOrder(harness, clanId, csId, nonHomeRegion, 1e18, 0, 0, 0);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_NOT_AT_HOMEBASE), "withdraw must target homebase");
+        assertFalse(harness.getActiveMission(csId).active, "rejected withdraw should not install mission");
+    }
+
+    function test_withdrawThenMarketSell_endToEnd() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        address woodAddr = _setupMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 6e18, 0, 0, 0);
+
+        uint256 goldBefore = harness.getClan(clanId).goldBalance;
+        OrderResult[] memory withdraw = _submitWithdrawOrder(harness, clanId, csId, homeRegion, 5e18, 0, 0, 0);
+        assertEq(uint8(withdraw[0].status), uint8(StatusCode.OK), "withdraw should start wheelbarrow flow");
+
+        _advanceTickHarness(harness);
+        _advanceTickHarness(harness);
+        assertEq(harness.getClansman(csId).carryWood, 5e18, "worker loaded from vault");
+        assertEq(harness.getClan(clanId).vaultWood, 1e18, "vault stockpile reduced");
+
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
+        OrderResult[] memory sell = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 5e18, 0);
+        assertEq(uint8(sell[0].status), uint8(StatusCode.OK), "loaded worker can sell at market");
+
+        uint64 executeAtTick = world.getActiveMission(csId).settlesAtTick;
+        while (world.getWorldState().currentTick <= executeAtTick) {
+            _advanceTick();
+        }
+
+        assertEq(harness.getClansman(csId).carryWood, 0, "sold wood leaves carry");
+        assertGt(harness.getClan(clanId).goldBalance, goldBefore, "market sale credits clan gold");
+
+        vm.warp(block.timestamp + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS + 1);
+        OrderResult[] memory backHome = _submitOrder(clanId, csId, homeRegion, ActionType.Wait);
+        assertEq(uint8(backHome[0].status), uint8(StatusCode.OK), "worker can return home after sale");
+        uint64 returnTick = world.getActiveMission(csId).settlesAtTick;
+        while (world.getWorldState().currentTick <= returnTick) {
+            _advanceTick();
+        }
+        assertEq(harness.getClansman(csId).currentRegion, homeRegion, "worker returns to homebase");
+    }
+
     function test_quoteTravel_outOfBounds_returnsZero() public {
         (uint8 ticks, bytes8 path) = world.quoteTravel(9, 1);
         assertEq(ticks, 0, "out-of-range src should return 0 ticks");
@@ -640,7 +807,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, orders);
@@ -705,7 +873,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: token,
             marketAmount: amount,
-            maxGoldIn: maxGold
+            maxGoldIn: maxGold,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);
@@ -729,7 +898,8 @@ contract ClanWorldTest is Test {
                 targetClanId: 0,
                 marketToken: token,
                 marketAmount: 1e18,
-                maxGoldIn: 0
+                maxGoldIn: 0,
+                withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
             });
         }
         vm.prank(elder);
@@ -817,15 +987,14 @@ contract ClanWorldTest is Test {
         uint256 goldBefore = world.getClan(clanId).goldBalance;
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
 
-        assertEq(
-            uint8(r[0].status), uint8(StatusCode.ERR_COOLDOWN_ACTIVE), "market order on cooldown must be rejected"
-        );
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_COOLDOWN_ACTIVE), "market order on cooldown must be rejected");
         assertEq(world.getClan(clanId).goldBalance, goldBefore, "cooldown rejection should not trade");
     }
 
     function test_immediateMarket_notInTown_fallsBackToScheduled() public {
-        (, address woodAddr, uint32 clanId, uint32 csId) =
+        (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) =
             _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_FOREST, 0);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
 
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
         Mission memory m = world.getActiveMission(csId);
@@ -833,16 +1002,13 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "out-of-town market order should schedule");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "out-of-town should be scheduled");
         assertTrue(m.active, "scheduled fallback should install a mission");
-        assertEq(
-            world.getScheduledMarketActionsForTick(m.settlesAtTick).length,
-            0,
-            "scheduled action queues when mission settles"
-        );
+        assertEq(world.getScheduledMarketActionsForTick(m.settlesAtTick).length, 1, "scheduled action queues at submit");
     }
 
     function test_immediateMarket_busyWorker_fallsBackToScheduled() public {
-        (, address woodAddr, uint32 clanId, uint32 csId) =
+        (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) =
             _setupHarnessClanAt(ClansmanState.ACTING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
 
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
         Mission memory m = world.getActiveMission(csId);
@@ -850,11 +1016,20 @@ contract ClanWorldTest is Test {
         assertEq(uint8(r[0].status), uint8(StatusCode.OK), "busy market worker should schedule");
         assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Scheduled), "busy worker should be scheduled");
         assertTrue(m.active, "scheduled fallback should install a mission");
-        assertEq(
-            world.getScheduledMarketActionsForTick(m.settlesAtTick).length,
-            0,
-            "scheduled action queues when mission settles"
-        );
+        assertEq(world.getScheduledMarketActionsForTick(m.settlesAtTick).length, 1, "scheduled action queues at submit");
+    }
+
+    function test_scheduledMarket_queueVisibleAtSubmit() public {
+        (ClanWorldTestHarness harness, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_FOREST, 0);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
+        Mission memory m = world.getActiveMission(csId);
+
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "scheduled sell should be accepted");
+        assertEq(world.getScheduledMarketActionsForTick(m.settlesAtTick).length, 1, "queue visible immediately");
+        assertEq(world.getMarketState().nextTickQueue.length, 0, "future queue stays off next tick when not next tick");
     }
 
     function test_immediateMarketBuy_executesWhenMaxGoldSatisfied() public {
@@ -998,6 +1173,45 @@ contract ClanWorldTest is Test {
         assertEq(cs.cooldownEndsAtTs, beforeCs.cooldownEndsAtTs, "rejected buy should not consume cooldown");
         assertEq(uint8(cs.state), uint8(beforeCs.state), "rejected buy should not change worker state");
         assertFalse(world.getActiveMission(csId).active, "rejected buy should not install a mission");
+    }
+
+    function test_marketSell_emptyCarry_rejectsAtSubmit_noTickConsumed() public {
+        (, address woodAddr, uint32 clanId, uint32 csId) =
+            _setupHarnessClanAt(ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+
+        Clansman memory beforeCs = world.getClansman(csId);
+        uint64 tickBefore = world.getWorldState().currentTick;
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
+
+        Clansman memory afterCs = world.getClansman(csId);
+        assertEq(uint8(r[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "empty carry sell rejects at submit");
+        assertEq(world.getWorldState().currentTick, tickBefore, "submit rejection should not advance tick");
+        assertEq(afterCs.cooldownEndsAtTs, beforeCs.cooldownEndsAtTs, "submit rejection should not consume cooldown");
+        assertEq(uint8(afterCs.state), uint8(beforeCs.state), "submit rejection should not change worker state");
+        assertEq(world.getClan(clanId).goldBalance, goldBefore, "submit rejection should not trade");
+        assertFalse(world.getActiveMission(csId).active, "submit rejection should not install mission");
+    }
+
+    function test_immediateMarketSell_failurePropagatesStatus() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        address woodAddr = _initMarketWithoutSeed();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+        harness.setClansmanForTest(csId, ClansmanState.WAITING, ClanWorldConstants.REGION_UNICORN_TOWN, 0);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
+
+        assertEq(
+            uint8(r[0].status),
+            uint8(StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN),
+            "immediate sell failure should propagate"
+        );
+        assertEq(uint8(r[0].marketMode), uint8(MarketExecutionMode.Immediate), "failure still used immediate path");
+        assertFalse(world.getActiveMission(csId).active, "failed immediate sell should not install a mission");
     }
 
     // -------------------------------------------------------------------------
@@ -1232,9 +1446,12 @@ contract ClanWorldTest is Test {
     // -------------------------------------------------------------------------
 
     function test_scheduledMarket_deletedAfterHeartbeat() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         address woodAddr = _setupMarket();
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
 
         OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
         assertEq(uint8(r[0].status), uint8(StatusCode.OK));
@@ -1277,12 +1494,12 @@ contract ClanWorldTest is Test {
         uint64 newExecuteAtTick = newMission.settlesAtTick;
         assertGt(newMission.nonce, oldMission.nonce, "replacement should bump nonce");
 
-        assertEq(
-            world.getScheduledMarketActionsForTick(oldExecuteAtTick).length, 0, "old mission not queued before settle"
-        );
-        assertEq(
-            world.getScheduledMarketActionsForTick(newExecuteAtTick).length, 0, "new mission not queued before settle"
-        );
+        if (oldExecuteAtTick == newExecuteAtTick) {
+            assertEq(world.getScheduledMarketActionsForTick(oldExecuteAtTick).length, 2, "both missions queued");
+        } else {
+            assertEq(world.getScheduledMarketActionsForTick(oldExecuteAtTick).length, 1, "old mission queued at submit");
+            assertEq(world.getScheduledMarketActionsForTick(newExecuteAtTick).length, 1, "new mission queued at submit");
+        }
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 
@@ -1382,7 +1599,8 @@ contract ClanWorldTest is Test {
                 targetClanId: 0,
                 marketToken: woodAddr,
                 marketAmount: uint256(i + 1) * 1e18,
-                maxGoldIn: 0
+                maxGoldIn: 0,
+                withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
             });
         }
         vm.prank(elder);
@@ -1450,7 +1668,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodAddr,
             marketAmount: 5e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         world.submitClanOrders(clanId1, sellOrders);
@@ -1464,7 +1683,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodAddr,
             marketAmount: 1e18,
-            maxGoldIn: 100e18
+            maxGoldIn: 100e18,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder2);
         world.submitClanOrders(clanId2, buyOrders);
@@ -1542,7 +1762,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodAddr,
             marketAmount: 5e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder2);
         OrderResult[] memory sellOk = world.submitClanOrders(clanId2, sellOrders);
@@ -1582,7 +1803,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodAddr,
             marketAmount: 1e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, orders);
@@ -1604,7 +1826,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0xBEEF),
             marketAmount: 1e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         orders[1] = ClanOrder({
             clansmanId: noopCsId,
@@ -1613,7 +1836,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         vm.prank(elder);
@@ -1646,7 +1870,8 @@ contract ClanWorldTest is Test {
             targetClanId: clanId,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r1 = world.submitClanOrders(clanId, orders);
@@ -1718,7 +1943,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r = world.submitClanOrders(clanId1, orders);
@@ -1750,7 +1976,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r = harness.submitClanOrders(clanId, orders);
@@ -1872,7 +2099,8 @@ contract ClanWorldTest is Test {
             targetClanId: clanId,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r = world.submitClanOrders(clanId, orders);
@@ -1994,7 +2222,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return harness.submitClanOrders(clanId, orders);
@@ -2181,7 +2410,8 @@ contract ClanWorldTest is Test {
             targetClanId: clanId,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r = world.submitClanOrders(clanId, orders);
@@ -2252,7 +2482,8 @@ contract ClanWorldTest is Test {
             targetClanId: clanId,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory r = harness.submitClanOrders(clanId, orders);
@@ -2356,7 +2587,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         // Order 1: invalid clansmanId 9999
@@ -2367,7 +2599,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         // Order 2: valid — cs1 Wait at homebase (NOOP)
@@ -2378,7 +2611,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         // Order 3: invalid — cs2 ChopWood to Mountains (wrong region for ChopWood)
@@ -2389,7 +2623,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         vm.prank(elder);
@@ -2519,7 +2754,8 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodTok,
             marketAmount: 5e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, orders);
@@ -2532,13 +2768,16 @@ contract ClanWorldTest is Test {
 
     function test_marketSell_fails_emptyCarry_fullVault() public {
         // Setup: worker in UT with empty carry but vault has wood
+        _setupMarket();
         uint32 clanId = _mintClan();
         ClanFullView memory v = world.getClanFullView(clanId);
         uint32 csId = v.clansmen[0].clansman.clansman.clansmanId;
         // Advance cs to UT with no carry (no gather)
         _submitOrder(clanId, csId, ClanWorldConstants.REGION_UNICORN_TOWN, ActionType.Wait);
         (uint8 travelToUT,) = world.quoteTravel(v.clan.clan.baseRegion, ClanWorldConstants.REGION_UNICORN_TOWN);
-        for (uint256 i = 0; i < uint256(travelToUT) + 2; i++) _advanceTick();
+        for (uint256 i = 0; i < uint256(travelToUT) + 2; i++) {
+            _advanceTick();
+        }
         world.settleClansman(csId);
         // Clan starts with vault wood from minting; carry is 0
         assertEq(world.getClansman(csId).carryWood, 0, "carry must be 0");
@@ -2553,14 +2792,12 @@ contract ClanWorldTest is Test {
             targetClanId: 0,
             marketToken: woodTok,
             marketAmount: 1e18,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, orders);
-        // Immediate path: carry empty → ERR_MISSING_RESOURCES or market failure
-        // Either the order returns ERR_MISSING_RESOURCES at submit, or it's enqueued and fails at execution
-        // With carry-based validation, immediate sell should fail
-        assertNotEq(uint8(results[0].status), uint8(StatusCode.OK), "empty carry sell must not succeed");
+        assertEq(uint8(results[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "empty carry sell must fail");
     }
 
     function test_marketCooldown_noBypassViaScheduled() public {
@@ -2579,13 +2816,23 @@ contract ClanWorldTest is Test {
         // Submit a market sell — with cooldown active, must be rejected
         address woodTok = world.getTreasuryState().woodToken;
         ClanOrder[] memory o2 = new ClanOrder[](1);
-        o2[0] = ClanOrder({clansmanId: csId, gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
-            action: ActionType.MarketSell, targetClanId: 0, marketToken: woodTok,
-            marketAmount: 1e18, maxGoldIn: 0});
+        o2[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketSell,
+            targetClanId: 0,
+            marketToken: woodTok,
+            marketAmount: 1e18,
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
+        });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, o2);
-        assertEq(uint8(results[0].status), uint8(StatusCode.ERR_COOLDOWN_ACTIVE),
-            "market order on cooldown must be rejected, not scheduled");
+        assertEq(
+            uint8(results[0].status),
+            uint8(StatusCode.ERR_COOLDOWN_ACTIVE),
+            "market order on cooldown must be rejected, not scheduled"
+        );
     }
 
     function test_marketBuy_creditsCarry_notVault() public {
@@ -2598,9 +2845,16 @@ contract ClanWorldTest is Test {
 
         uint256 buyAmt = 1e18;
         ClanOrder[] memory orders = new ClanOrder[](1);
-        orders[0] = ClanOrder({clansmanId: csId, gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
-            action: ActionType.MarketBuy, targetClanId: 0, marketToken: woodTok,
-            marketAmount: buyAmt, maxGoldIn: type(uint256).max});
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_UNICORN_TOWN,
+            action: ActionType.MarketBuy,
+            targetClanId: 0,
+            marketToken: woodTok,
+            marketAmount: buyAmt,
+            maxGoldIn: type(uint256).max,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
+        });
         vm.prank(elder);
         OrderResult[] memory results = world.submitClanOrders(clanId, orders);
 

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -1445,6 +1445,60 @@ contract ClanWorldTest is Test {
         assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
     }
 
+    function test_scheduledMarketSell_missingCarryEmitsFailureOnce() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        address woodAddr = _setupMarket();
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+        harness.setClansmanForTest(csId, ClansmanState.WAITING, ClanWorldConstants.REGION_FOREST, 0);
+        harness.setCarry(csId, 2e18, 0, 0, 0);
+
+        OrderResult[] memory r = _submitMarketOrder(clanId, csId, ActionType.MarketSell, woodAddr, 1e18, 0);
+        assertEq(uint8(r[0].status), uint8(StatusCode.OK), "sell order should be accepted");
+
+        Mission memory m = world.getActiveMission(csId);
+        uint64 executeAtTick = m.settlesAtTick;
+        uint256 goldBefore = world.getClan(clanId).goldBalance;
+        harness.setCarry(csId, 0, 0, 0, 0);
+
+        _advanceUntilNextHeartbeatCloses(executeAtTick);
+        bytes32 failedSig =
+            keccak256("MarketActionFailed(uint32,uint32,uint8,uint8,uint8,uint64)");
+
+        vm.recordLogs();
+        _advanceTick();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        uint256 failedCount;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != address(world) || logs[i].topics.length == 0 || logs[i].topics[0] != failedSig) {
+                continue;
+            }
+            (
+                uint32 eventCsId,
+                ActionType eventAction,
+                MarketExecutionMode eventMode,
+                StatusCode eventReason,
+                uint64 eventTick
+            ) = abi.decode(logs[i].data, (uint32, ActionType, MarketExecutionMode, StatusCode, uint64));
+            if (
+                eventCsId == csId && eventAction == ActionType.MarketSell
+                    && eventMode == MarketExecutionMode.Scheduled && eventReason == StatusCode.ERR_MISSING_RESOURCES
+                    && eventTick == executeAtTick
+            ) {
+                failedCount++;
+            }
+        }
+
+        Clansman memory cs = world.getClansman(csId);
+        assertEq(failedCount, 1, "failed scheduled sell should emit once");
+        assertEq(world.getClan(clanId).goldBalance, goldBefore, "failed sell should not credit gold");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "failed scheduled sell should consume cooldown");
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "failed scheduled worker waits");
+        assertEq(world.getScheduledMarketActionsForTick(executeAtTick).length, 0, "queue should be deleted");
+    }
+
     // -------------------------------------------------------------------------
     // Test 14: scheduledMarket_deletedAfterHeartbeat
     // -------------------------------------------------------------------------

--- a/packages/contracts/test/DefendBase.t.sol
+++ b/packages/contracts/test/DefendBase.t.sol
@@ -12,6 +12,7 @@ import {
     Clansman,
     Mission,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult
 } from "../src/IClanWorld.sol";
 
@@ -41,7 +42,8 @@ contract DefendBaseTest is Test {
             targetClanId: targetClanId,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         return orders;
     }
@@ -55,7 +57,8 @@ contract DefendBaseTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         return orders;
     }

--- a/packages/contracts/test/Gathering.t.sol
+++ b/packages/contracts/test/Gathering.t.sol
@@ -114,11 +114,11 @@ contract GatheringTest is Test {
     function test_chopWoodClampsToCarryCap() public {
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
-        world.setCarryWood(csId, ClanWorldConstants.CLANSMAN_CARRY_CAP - 1e18);
+        world.setCarryWood(csId, ClanWorldConstants.WOOD_CARRY_CAP - 1e18);
 
         Clansman memory cs = _settleChopWood(clanId, csId);
 
-        assertEq(cs.carryWood, ClanWorldConstants.CLANSMAN_CARRY_CAP, "wood carry cap");
+        assertEq(cs.carryWood, ClanWorldConstants.WOOD_CARRY_CAP, "wood carry cap");
     }
 
     function test_chopWoodAppliesCooldownPostSettle() public {

--- a/packages/contracts/test/Gathering.t.sol
+++ b/packages/contracts/test/Gathering.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {
+    ClanWorldConstants,
+    ActionType,
+    ClansmanState,
+    StatusCode,
+    Clansman,
+    Mission,
+    ClanFullView,
+    ClanOrder,
+    OrderResult
+} from "../src/IClanWorld.sol";
+
+contract GatheringHarness is ClanWorld {
+    function setCarryWood(uint32 csId, uint256 wood) external {
+        _clansmen[csId].carryWood = wood;
+    }
+}
+
+contract GatheringTest is Test {
+    GatheringHarness world;
+    address elder = address(0xA1);
+
+    function setUp() public {
+        world = new GatheringHarness();
+    }
+
+    function _advanceTick() internal {
+        vm.warp(world.getWorldState().nextHeartbeatAtTs);
+        world.heartbeat();
+    }
+
+    function _advanceUntilCurrentTick(uint64 targetTick) internal {
+        while (world.getWorldState().currentTick < targetTick) {
+            _advanceTick();
+        }
+    }
+
+    function _mintClan() internal returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
+    }
+
+    function _firstCs(uint32 clanId) internal view returns (uint32) {
+        ClanFullView memory view_ = world.getClanFullView(clanId);
+        return view_.clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _submitChopWood(uint32 clanId, uint32 csId) internal returns (OrderResult[] memory) {
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: csId,
+            gotoRegion: ClanWorldConstants.REGION_FOREST,
+            action: ActionType.ChopWood,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0
+        });
+
+        vm.prank(elder);
+        return world.submitClanOrders(clanId, orders);
+    }
+
+    function _settleChopWood(uint32 clanId, uint32 csId) internal returns (Clansman memory) {
+        OrderResult[] memory result = _submitChopWood(clanId, csId);
+        assertEq(uint8(result[0].status), uint8(StatusCode.OK), "chop wood accepted");
+
+        Mission memory mission = world.getActiveMission(csId);
+        _advanceUntilCurrentTick(mission.settlesAtTick + 1);
+        world.settleClan(clanId);
+        return world.getClansman(csId);
+    }
+
+    function test_chopWoodAtForestYieldsBaseTimesActionDuration() public {
+        vm.prevrandao(bytes32(uint256(1)));
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        Clansman memory cs = _settleChopWood(clanId, csId);
+
+        uint256 expected = ClanWorldConstants.WOOD_YIELD_PER_TICK * world.getActionDuration(ActionType.ChopWood);
+        assertEq(cs.carryWood, expected, "base wood yield");
+    }
+
+    function test_chopWoodCritDistributionAcrossSeeds() public {
+        uint256 baseYield = ClanWorldConstants.WOOD_YIELD_PER_TICK * world.getActionDuration(ActionType.ChopWood);
+        uint256 critCount = 0;
+
+        for (uint256 i = 0; i < 100; i++) {
+            world = new GatheringHarness();
+            vm.prevrandao(bytes32(uint256(i + 10_000)));
+            uint32 clanId = _mintClan();
+            uint32 csId = _firstCs(clanId);
+
+            Clansman memory cs = _settleChopWood(clanId, csId);
+            if (cs.carryWood == baseYield * 2) {
+                critCount++;
+            } else {
+                assertEq(cs.carryWood, baseYield, "non-crit yield");
+            }
+        }
+
+        assertGe(critCount, 3, "crit count too low");
+        assertLe(critCount, 20, "crit count too high");
+    }
+
+    function test_chopWoodClampsToCarryCap() public {
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+        world.setCarryWood(csId, ClanWorldConstants.CLANSMAN_CARRY_CAP - 1e18);
+
+        Clansman memory cs = _settleChopWood(clanId, csId);
+
+        assertEq(cs.carryWood, ClanWorldConstants.CLANSMAN_CARRY_CAP, "wood carry cap");
+    }
+
+    function test_chopWoodAppliesCooldownPostSettle() public {
+        uint32 clanId = _mintClan();
+        uint32 csId = _firstCs(clanId);
+
+        Clansman memory cs = _settleChopWood(clanId, csId);
+
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "mission completed");
+        assertFalse(world.getActiveMission(csId).active, "mission inactive");
+        assertGt(cs.cooldownEndsAtTs, block.timestamp, "cooldown starts on settlement");
+    }
+}

--- a/packages/contracts/test/Gathering.t.sol
+++ b/packages/contracts/test/Gathering.t.sol
@@ -77,7 +77,7 @@ contract GatheringTest is Test {
     }
 
     function test_chopWoodAtForestYieldsBaseTimesActionDuration() public {
-        vm.prevrandao(bytes32(uint256(1)));
+        vm.prevrandao(bytes32(uint256(2)));
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
 
@@ -90,9 +90,11 @@ contract GatheringTest is Test {
     function test_chopWoodCritDistributionAcrossSeeds() public {
         uint256 baseYield = ClanWorldConstants.WOOD_YIELD_PER_TICK * world.getActionDuration(ActionType.ChopWood);
         uint256 critCount = 0;
+        world = new GatheringHarness();
+        uint256 cleanState = vm.snapshotState();
 
         for (uint256 i = 0; i < 100; i++) {
-            world = new GatheringHarness();
+            assertTrue(vm.revertToState(cleanState), "reset gathering world");
             vm.prevrandao(bytes32(uint256(i + 10_000)));
             uint32 clanId = _mintClan();
             uint32 csId = _firstCs(clanId);

--- a/packages/contracts/test/Gathering.t.sol
+++ b/packages/contracts/test/Gathering.t.sol
@@ -12,6 +12,7 @@ import {
     Mission,
     ClanFullView,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult
 } from "../src/IClanWorld.sol";
 
@@ -59,7 +60,8 @@ contract GatheringTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
 
         vm.prank(elder);

--- a/packages/contracts/test/HeartbeatOrdering.t.sol
+++ b/packages/contracts/test/HeartbeatOrdering.t.sol
@@ -149,8 +149,22 @@ contract HeartbeatOrderingTest is Test {
         address[4] memory pools = [address(woodPool), address(wheatPool), address(fishPool), address(ironPool)];
         world.initTreasury(tokens, pools);
 
-        uint256 resSeed = 1000e18;
-        uint256 goldSeed = 1000e18;
+        uint256 resSeed = world.INITIAL_RESOURCE_POOL_SEED();
+        uint256 goldSeed = world.INITIAL_GOLD_POOL_SEED();
+        uint256 totalGoldSeed = goldSeed * 4;
+
+        woodToken.seedTreasury(address(this), resSeed);
+        wheatToken.seedTreasury(address(this), resSeed);
+        fishToken.seedTreasury(address(this), resSeed);
+        ironToken.seedTreasury(address(this), resSeed);
+        goldToken.seedTreasury(address(this), totalGoldSeed);
+
+        woodToken.approve(address(world), resSeed);
+        wheatToken.approve(address(world), resSeed);
+        fishToken.approve(address(world), resSeed);
+        ironToken.approve(address(world), resSeed);
+        goldToken.approve(address(world), totalGoldSeed);
+
         PoolSeedConfig memory cfg = PoolSeedConfig({
             woodSeed: resSeed,
             wheatSeed: resSeed,
@@ -191,7 +205,8 @@ contract HeartbeatOrderingTest is Test {
         world.setClansmanRegion(csId0, ClanWorldConstants.REGION_MOUNTAINS);
 
         // cs0: submit Deposit. arrivalTick = t0+1, settlesAtTick = t0+2.
-        OrderResult[] memory r0 = _submitOrder(clanId, csId0, ClanWorldConstants.REGION_FOREST, ActionType.DepositResources);
+        OrderResult[] memory r0 =
+            _submitOrder(clanId, csId0, ClanWorldConstants.REGION_FOREST, ActionType.DepositResources);
         assertEq(uint8(r0[0].status), uint8(StatusCode.OK), "deposit order must succeed");
         Mission memory depositMission = world.getActiveMission(csId0);
         assertEq(depositMission.settlesAtTick, t0 + 2, "deposit settlesAtTick must be t0+2");
@@ -318,7 +333,8 @@ contract HeartbeatOrderingTest is Test {
         // Deposit: arrivalTick = t0+1, settlesAtTick = t0+2.
         world.setClansmanRegion(csId0, ClanWorldConstants.REGION_MOUNTAINS);
         world.setCarryWood(csId0, 10e18);
-        OrderResult[] memory r0 = _submitOrder(clanId, csId0, ClanWorldConstants.REGION_FOREST, ActionType.DepositResources);
+        OrderResult[] memory r0 =
+            _submitOrder(clanId, csId0, ClanWorldConstants.REGION_FOREST, ActionType.DepositResources);
         assertEq(uint8(r0[0].status), uint8(StatusCode.OK), "deposit must succeed");
         assertEq(world.getActiveMission(csId0).settlesAtTick, t0 + 2, "deposit settlesAtTick must be t0+2");
 

--- a/packages/contracts/test/HeartbeatOrdering.t.sol
+++ b/packages/contracts/test/HeartbeatOrdering.t.sol
@@ -219,8 +219,10 @@ contract HeartbeatOrderingTest is Test {
         assertEq(sellMission.arrivalTick, t0 + 2, "sell arrivalTick must be t0+2");
         assertEq(sellMission.settlesAtTick, t0 + 3, "sell settlesAtTick must be t0+3");
 
-        // Give cs0 carry wood. Zero vault so market sell only succeeds if step1 ran first.
+        // Give cs0 carry wood (for deposit) and cs1 carry wood (for sell).
+        // Sell now draws from carry, not vault — zero vault to confirm vault is not involved.
         world.setCarryWood(csId0, 10e18);
+        world.setCarryWood(csId1, 5e18);
         world.setVaultWood(clanId, 0);
         assertEq(world.getClan(clanId).vaultWood, 0, "vault wood must be 0 before test tick");
 
@@ -228,8 +230,7 @@ contract HeartbeatOrderingTest is Test {
 
         // Advance to tick t0+4. The heartbeat closing t0+3 runs:
         //   Step 1: _settleCompletingMissions(t0+3) → deposit fires, cs0 carry 10e18 → vault
-        //   Step 2: _executeScheduledMarketActions(t0+3) → sell fires, 5e18 vault wood → gold
-        // If reversed: sell would fail (vault=0), gold unchanged.
+        //   Step 2: _executeScheduledMarketActions(t0+3) → sell fires, cs1 carry 5e18 → gold
         _advanceToTick(t0 + 4);
 
         uint256 goldAfter = world.getClan(clanId).goldBalance;
@@ -340,7 +341,8 @@ contract HeartbeatOrderingTest is Test {
         assertEq(world.getActiveMission(csId0).settlesAtTick, t0 + 3, "deposit settlesAtTick must be t0+3");
 
         // cs1: at Forest, sells wood to UT. Forest→UT = 2 ticks. settlesAtTick = t0+3.
-        // Vault has 20e18 starter wood — sell always has enough.
+        // Give cs1 carry wood — sell draws from carry (not vault).
+        world.setCarryWood(csId1, 10e18);
         OrderResult[] memory r1 = _submitMarketOrder(clanId, csId1, ActionType.MarketSell, address(woodToken), 5e18, 0);
         assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "market sell must enqueue");
         assertEq(world.getActiveMission(csId1).arrivalTick, t0 + 2, "sell arrivalTick must be t0+2");

--- a/packages/contracts/test/HeartbeatOrdering.t.sol
+++ b/packages/contracts/test/HeartbeatOrdering.t.sol
@@ -13,6 +13,7 @@ import {
     StatusCode,
     WorldState,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     Mission,
     Clan,
@@ -96,7 +97,8 @@ contract HeartbeatOrderingTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);
@@ -118,7 +120,8 @@ contract HeartbeatOrderingTest is Test {
             targetClanId: 0,
             marketToken: token,
             marketAmount: amount,
-            maxGoldIn: maxGold
+            maxGoldIn: maxGold,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);
@@ -211,6 +214,13 @@ contract HeartbeatOrderingTest is Test {
         Mission memory depositMission = world.getActiveMission(csId0);
         assertEq(depositMission.settlesAtTick, t0 + 3, "deposit settlesAtTick must be t0+3");
 
+        // Give cs0 carry wood (for deposit) and cs1 carry wood (for sell).
+        // Sell now draws from carry, not vault — zero vault to confirm vault is not involved.
+        world.setCarryWood(csId0, 10e18);
+        world.setCarryWood(csId1, 5e18);
+        world.setVaultWood(clanId, 0);
+        assertEq(world.getClan(clanId).vaultWood, 0, "vault wood must be 0 before test tick");
+
         // cs1: at Forest. Submit MarketSell to UT. Forest→UT = 2 ticks.
         // settlesAtTick = t0+3. Same tick as deposit settles.
         OrderResult[] memory r1 = _submitMarketOrder(clanId, csId1, ActionType.MarketSell, address(woodToken), 5e18, 0);
@@ -218,13 +228,6 @@ contract HeartbeatOrderingTest is Test {
         Mission memory sellMission = world.getActiveMission(csId1);
         assertEq(sellMission.arrivalTick, t0 + 2, "sell arrivalTick must be t0+2");
         assertEq(sellMission.settlesAtTick, t0 + 3, "sell settlesAtTick must be t0+3");
-
-        // Give cs0 carry wood (for deposit) and cs1 carry wood (for sell).
-        // Sell now draws from carry, not vault — zero vault to confirm vault is not involved.
-        world.setCarryWood(csId0, 10e18);
-        world.setCarryWood(csId1, 5e18);
-        world.setVaultWood(clanId, 0);
-        assertEq(world.getClan(clanId).vaultWood, 0, "vault wood must be 0 before test tick");
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 

--- a/packages/contracts/test/HeartbeatOrdering.t.sol
+++ b/packages/contracts/test/HeartbeatOrdering.t.sol
@@ -183,10 +183,10 @@ contract HeartbeatOrderingTest is Test {
     //
     // Proves Step 1 (settle) fires before Step 2 (market execute) within the SAME
     // heartbeat closing tick T:
-    //   - cs0 is placed at Mountains (region 2). Deposit to homebase Forest (region 1)
-    //     = 1 tick travel. arrivalTick = T0+1, settlesAtTick = T0+2.
+    //   - cs0 is placed at Unicorn Town (region 3). Deposit to homebase Forest
+    //     (region 1) = 2 ticks travel. arrivalTick = T0+2, settlesAtTick = T0+3.
     //   - cs1 at Forest submits MarketSell to UT (region 3) = 2 ticks travel.
-    //     executeAtTick = T0+2. (Same tick as cs0 settles.)
+    //     settlesAtTick = T0+3. (Same tick as cs0 settles.)
     //   - vault starts at 0; cs0 has carry wood.
     //   - Heartbeat at T0+2: Step 1 deposits cs0 carry wood to vault, Step 2 sells
     //     it. Gold increases only if Step 1 ran first (vault was 0 before Step 1).
@@ -200,23 +200,24 @@ contract HeartbeatOrderingTest is Test {
 
         uint64 t0 = world.getWorldState().currentTick;
 
-        // Place cs0 at Mountains (region 2). Homebase = Forest (region 1).
-        // Deposit from Mountains to Forest: travel = 1 tick.
-        world.setClansmanRegion(csId0, ClanWorldConstants.REGION_MOUNTAINS);
+        // Place cs0 at Unicorn Town (region 3). Homebase = Forest (region 1).
+        // Deposit from Unicorn Town to Forest: travel = 2 ticks.
+        world.setClansmanRegion(csId0, ClanWorldConstants.REGION_UNICORN_TOWN);
 
-        // cs0: submit Deposit. arrivalTick = t0+1, settlesAtTick = t0+2.
+        // cs0: submit Deposit. arrivalTick = t0+2, settlesAtTick = t0+3.
         OrderResult[] memory r0 =
             _submitOrder(clanId, csId0, ClanWorldConstants.REGION_FOREST, ActionType.DepositResources);
         assertEq(uint8(r0[0].status), uint8(StatusCode.OK), "deposit order must succeed");
         Mission memory depositMission = world.getActiveMission(csId0);
-        assertEq(depositMission.settlesAtTick, t0 + 2, "deposit settlesAtTick must be t0+2");
+        assertEq(depositMission.settlesAtTick, t0 + 3, "deposit settlesAtTick must be t0+3");
 
         // cs1: at Forest. Submit MarketSell to UT. Forest→UT = 2 ticks.
-        // executeAtTick = t0+2. Same tick as deposit settles.
+        // settlesAtTick = t0+3. Same tick as deposit settles.
         OrderResult[] memory r1 = _submitMarketOrder(clanId, csId1, ActionType.MarketSell, address(woodToken), 5e18, 0);
         assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "market sell order must enqueue");
         Mission memory sellMission = world.getActiveMission(csId1);
         assertEq(sellMission.arrivalTick, t0 + 2, "sell arrivalTick must be t0+2");
+        assertEq(sellMission.settlesAtTick, t0 + 3, "sell settlesAtTick must be t0+3");
 
         // Give cs0 carry wood. Zero vault so market sell only succeeds if step1 ran first.
         world.setCarryWood(csId0, 10e18);
@@ -225,11 +226,11 @@ contract HeartbeatOrderingTest is Test {
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 
-        // Advance to tick t0+2. The heartbeat closing t0+2 runs:
-        //   Step 1: _settleCompletingMissions(t0+2) → deposit fires, cs0 carry 10e18 → vault
-        //   Step 2: _executeScheduledMarketActions(t0+2) → sell fires, 5e18 vault wood → gold
+        // Advance to tick t0+4. The heartbeat closing t0+3 runs:
+        //   Step 1: _settleCompletingMissions(t0+3) → deposit fires, cs0 carry 10e18 → vault
+        //   Step 2: _executeScheduledMarketActions(t0+3) → sell fires, 5e18 vault wood → gold
         // If reversed: sell would fail (vault=0), gold unchanged.
-        _advanceToTick(t0 + 3);
+        _advanceToTick(t0 + 4);
 
         uint256 goldAfter = world.getClan(clanId).goldBalance;
         assertGt(goldAfter, goldBefore, "gold must increase: settlement ran before market sell");
@@ -317,9 +318,9 @@ contract HeartbeatOrderingTest is Test {
     //
     // Proves that when a mission settles at tick T AND a market action is queued at
     // tick T, both fire in the same heartbeat without conflict.
-    //   - cs0 placed at Mountains, deposits to Forest homebase: settlesAtTick = T0+2
-    //   - cs1 sells wood to UT from Forest: executeAtTick = T0+2
-    //   Both succeed in the same heartbeat call at T0+2.
+    //   - cs0 placed at Unicorn Town, deposits to Forest homebase: settlesAtTick = T0+3
+    //   - cs1 sells wood to UT from Forest: settlesAtTick = T0+3
+    //   Both succeed in the same heartbeat call at T0+3.
     // -------------------------------------------------------------------------
     function test_heartbeat_multipleStepsInOneTick() public {
         _setupMarket();
@@ -329,27 +330,28 @@ contract HeartbeatOrderingTest is Test {
 
         uint64 t0 = world.getWorldState().currentTick;
 
-        // cs0: placed at Mountains (1 tick from Forest homebase).
-        // Deposit: arrivalTick = t0+1, settlesAtTick = t0+2.
-        world.setClansmanRegion(csId0, ClanWorldConstants.REGION_MOUNTAINS);
+        // cs0: placed at Unicorn Town (2 ticks from Forest homebase).
+        // Deposit: arrivalTick = t0+2, settlesAtTick = t0+3.
+        world.setClansmanRegion(csId0, ClanWorldConstants.REGION_UNICORN_TOWN);
         world.setCarryWood(csId0, 10e18);
         OrderResult[] memory r0 =
             _submitOrder(clanId, csId0, ClanWorldConstants.REGION_FOREST, ActionType.DepositResources);
         assertEq(uint8(r0[0].status), uint8(StatusCode.OK), "deposit must succeed");
-        assertEq(world.getActiveMission(csId0).settlesAtTick, t0 + 2, "deposit settlesAtTick must be t0+2");
+        assertEq(world.getActiveMission(csId0).settlesAtTick, t0 + 3, "deposit settlesAtTick must be t0+3");
 
-        // cs1: at Forest, sells wood to UT. Forest→UT = 2 ticks. executeAtTick = t0+2.
+        // cs1: at Forest, sells wood to UT. Forest→UT = 2 ticks. settlesAtTick = t0+3.
         // Vault has 20e18 starter wood — sell always has enough.
         OrderResult[] memory r1 = _submitMarketOrder(clanId, csId1, ActionType.MarketSell, address(woodToken), 5e18, 0);
         assertEq(uint8(r1[0].status), uint8(StatusCode.OK), "market sell must enqueue");
-        assertEq(world.getActiveMission(csId1).arrivalTick, t0 + 2, "sell executeAtTick must be t0+2");
+        assertEq(world.getActiveMission(csId1).arrivalTick, t0 + 2, "sell arrivalTick must be t0+2");
+        assertEq(world.getActiveMission(csId1).settlesAtTick, t0 + 3, "sell settlesAtTick must be t0+3");
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 
-        // Advance to tick t0+3 (the heartbeat closing t0+2 runs step1+step2 together).
-        _advanceToTick(t0 + 3);
+        // Advance to tick t0+4 (the heartbeat closing t0+3 runs step1+step2 together).
+        _advanceToTick(t0 + 4);
 
-        // Both cs0 deposit (settled at T0+2) and cs1 sell (at T0+2) must have fired.
+        // Both cs0 deposit (settled at T0+3) and cs1 sell (at T0+3) must have fired.
         assertEq(world.getClansman(csId0).carryWood, 0, "deposit settled: carry cleared");
         assertGt(world.getClan(clanId).goldBalance, goldBefore, "sell executed: gold increased");
         assertFalse(world.getActiveMission(csId0).active, "deposit mission must be complete");

--- a/packages/contracts/test/MissionTiming.t.sol
+++ b/packages/contracts/test/MissionTiming.t.sol
@@ -125,7 +125,7 @@ contract MissionTimingTest is Test {
         assertEq(world.getActionDuration(ActionType.FishDocks), 4, "fish docks");
         assertEq(world.getActionDuration(ActionType.FishDeepSea), 4, "fish deep sea");
         assertEq(world.getActionDuration(ActionType.HarvestWheat), 4, "harvest wheat");
-        assertEq(world.getActionDuration(ActionType.DepositResources), 1, "deposit");
+        assertEq(world.getActionDuration(ActionType.DepositResources), 0, "deposit");
         assertEq(world.getActionDuration(ActionType.BuildWall), 1, "build wall");
         assertEq(world.getActionDuration(ActionType.UpgradeBase), 1, "upgrade base");
         assertEq(world.getActionDuration(ActionType.UpgradeMonument), 1, "upgrade monument");

--- a/packages/contracts/test/MissionTiming.t.sol
+++ b/packages/contracts/test/MissionTiming.t.sol
@@ -11,6 +11,7 @@ import {
     ClanFullView,
     Clansman,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     Mission
 } from "../src/IClanWorld.sol";
@@ -56,7 +57,8 @@ contract MissionTimingTest is Test {
             targetClanId: 0,
             marketToken: address(0),
             marketAmount: 0,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);

--- a/packages/contracts/test/MissionTiming.t.sol
+++ b/packages/contracts/test/MissionTiming.t.sol
@@ -125,7 +125,7 @@ contract MissionTimingTest is Test {
         assertEq(world.getActionDuration(ActionType.FishDocks), 4, "fish docks");
         assertEq(world.getActionDuration(ActionType.FishDeepSea), 4, "fish deep sea");
         assertEq(world.getActionDuration(ActionType.HarvestWheat), 4, "harvest wheat");
-        assertEq(world.getActionDuration(ActionType.DepositResources), 0, "deposit");
+        assertEq(world.getActionDuration(ActionType.DepositResources), 1, "deposit");
         assertEq(world.getActionDuration(ActionType.BuildWall), 1, "build wall");
         assertEq(world.getActionDuration(ActionType.UpgradeBase), 1, "upgrade base");
         assertEq(world.getActionDuration(ActionType.UpgradeMonument), 1, "upgrade monument");

--- a/packages/contracts/test/Reentrancy.t.sol
+++ b/packages/contracts/test/Reentrancy.t.sol
@@ -11,6 +11,7 @@ import {
     ActionType,
     StatusCode,
     ClanOrder,
+    WithdrawResourcesData,
     OrderResult,
     Mission,
     PoolSeedConfig
@@ -223,7 +224,8 @@ contract ReentrancyTest is Test {
             targetClanId: 0,
             marketToken: token,
             marketAmount: amount,
-            maxGoldIn: 0
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
         });
         vm.prank(elder);
         return world.submitClanOrders(clanId, orders);

--- a/packages/contracts/test/Reentrancy.t.sol
+++ b/packages/contracts/test/Reentrancy.t.sol
@@ -125,7 +125,7 @@ contract ReentrancyTest is Test {
 
         Mission memory mission = world.getActiveMission(csId);
         uint64 currentTick = world.getWorldState().currentTick;
-        uint256 ticksNeeded = uint256(mission.actionStartTick - currentTick) + 1;
+        uint256 ticksNeeded = uint256(mission.settlesAtTick - currentTick) + 1;
         for (uint256 i = 0; i < ticksNeeded; i++) {
             _advanceTick();
         }

--- a/packages/contracts/test/Reentrancy.t.sol
+++ b/packages/contracts/test/Reentrancy.t.sol
@@ -160,8 +160,22 @@ contract ReentrancyTest is Test {
         address[4] memory pools = [address(woodPool), address(wheatPool), address(fishPool), address(ironPool)];
         world.initTreasury(tokens, pools);
 
-        uint256 resSeed = 1000e18;
-        uint256 goldSeed = 1000e18;
+        uint256 resSeed = world.INITIAL_RESOURCE_POOL_SEED();
+        uint256 goldSeed = world.INITIAL_GOLD_POOL_SEED();
+        uint256 totalGoldSeed = goldSeed * 4;
+
+        woodToken.seedTreasury(address(this), resSeed);
+        wheatToken.seedTreasury(address(this), resSeed);
+        fishToken.seedTreasury(address(this), resSeed);
+        ironToken.seedTreasury(address(this), resSeed);
+        goldToken.seedTreasury(address(this), totalGoldSeed);
+
+        woodToken.approve(address(world), resSeed);
+        wheatToken.approve(address(world), resSeed);
+        fishToken.approve(address(world), resSeed);
+        ironToken.approve(address(world), resSeed);
+        goldToken.approve(address(world), totalGoldSeed);
+
         PoolSeedConfig memory cfg = PoolSeedConfig({
             woodSeed: resSeed,
             wheatSeed: resSeed,

--- a/packages/contracts/test/Reentrancy.t.sol
+++ b/packages/contracts/test/Reentrancy.t.sol
@@ -94,8 +94,14 @@ contract MockReentrantPool {
     }
 }
 
+contract ClanWorldReentrantHarness is ClanWorld {
+    function setCarryWood(uint32 csId, uint256 amount) external {
+        _clansmen[csId].carryWood = amount;
+    }
+}
+
 contract ReentrancyTest is Test {
-    ClanWorld world;
+    ClanWorldReentrantHarness world;
     address elder = address(0xA1);
 
     MinimalERC20 woodToken;
@@ -110,13 +116,15 @@ contract ReentrancyTest is Test {
     StubPool fishPool;
 
     function setUp() public {
-        world = new ClanWorld();
+        world = new ClanWorldReentrantHarness();
     }
 
     function test_marketPoolHeartbeatCallback_revertsWithReentrancyGuard() public {
         _setupReentrantMarket();
         uint32 clanId = _mintClan();
         uint32 csId = _firstCs(clanId);
+        // Give clansman carry wood so the scheduled sell has something to sell
+        world.setCarryWood(csId, 10e18);
 
         uint256 goldBefore = world.getClan(clanId).goldBalance;
 

--- a/packages/contracts/test/ResourceBoundaryTokens.t.sol
+++ b/packages/contracts/test/ResourceBoundaryTokens.t.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {MinimalERC20} from "../src/MinimalERC20.sol";
+import {StubPool} from "../src/StubPool.sol";
+import {ResourceType} from "../src/IClanWorld.sol";
+
+contract ResourceBoundaryTokensTest is Test {
+    event ResourceMinted(uint8 indexed resourceType, address indexed to, uint256 amount);
+    event ResourceBurned(uint8 indexed resourceType, address indexed from, uint256 amount);
+
+    ClanWorld world;
+    MinimalERC20 woodToken;
+    MinimalERC20 ironToken;
+    MinimalERC20 wheatToken;
+    MinimalERC20 fishToken;
+    MinimalERC20 goldToken;
+    MinimalERC20 blueprintToken;
+
+    function setUp() public {
+        world = new ClanWorld();
+        woodToken = new MinimalERC20("Wood", "WOOD");
+        ironToken = new MinimalERC20("Iron", "IRON");
+        wheatToken = new MinimalERC20("Wheat", "WHEAT");
+        fishToken = new MinimalERC20("Fish", "FISH");
+        goldToken = new MinimalERC20("Gold", "GOLD");
+        blueprintToken = new MinimalERC20("BPRT", "BPRT");
+
+        woodToken.configureBoundary(uint8(ResourceType.Wood), address(world));
+        ironToken.configureBoundary(uint8(ResourceType.Iron), address(world));
+        wheatToken.configureBoundary(uint8(ResourceType.Wheat), address(world));
+        fishToken.configureBoundary(uint8(ResourceType.Fish), address(world));
+    }
+
+    function test_getResourceTokenReturnsConfiguredBoundaryTokens() public {
+        StubPool woodPool = new StubPool(address(woodToken), address(goldToken), address(world));
+        StubPool wheatPool = new StubPool(address(wheatToken), address(goldToken), address(world));
+        StubPool fishPool = new StubPool(address(fishToken), address(goldToken), address(world));
+        StubPool ironPool = new StubPool(address(ironToken), address(goldToken), address(world));
+
+        address[6] memory tokens = [
+            address(woodToken),
+            address(ironToken),
+            address(wheatToken),
+            address(fishToken),
+            address(goldToken),
+            address(blueprintToken)
+        ];
+        address[4] memory pools = [address(woodPool), address(wheatPool), address(fishPool), address(ironPool)];
+
+        world.initTreasury(tokens, pools);
+
+        assertEq(world.getResourceToken(uint8(ResourceType.Wood)), address(woodToken), "wood");
+        assertEq(world.getResourceToken(uint8(ResourceType.Iron)), address(ironToken), "iron");
+        assertEq(world.getResourceToken(uint8(ResourceType.Wheat)), address(wheatToken), "wheat");
+        assertEq(world.getResourceToken(uint8(ResourceType.Fish)), address(fishToken), "fish");
+    }
+
+    function test_onlyEngineCanMintAndBurnBoundaryTokens() public {
+        address holder = address(0xCAFE);
+
+        vm.expectRevert(bytes("MinimalERC20: not engine"));
+        woodToken.mint(holder, 10e18);
+
+        vm.expectEmit(true, true, false, true, address(woodToken));
+        emit ResourceMinted(uint8(ResourceType.Wood), holder, 10e18);
+        vm.prank(address(world));
+        woodToken.mint(holder, 10e18);
+
+        assertEq(woodToken.balanceOf(holder), 10e18, "minted balance");
+
+        vm.expectEmit(true, true, false, true, address(woodToken));
+        emit ResourceBurned(uint8(ResourceType.Wood), holder, 4e18);
+        vm.prank(address(world));
+        woodToken.burn(holder, 4e18);
+
+        assertEq(woodToken.balanceOf(holder), 6e18, "burned balance");
+    }
+
+    function test_seedTreasuryMintsStartingSupply() public {
+        address treasury = address(0xBEEF);
+
+        woodToken.seedTreasury(treasury, 1000e18);
+
+        assertEq(woodToken.balanceOf(treasury), 1000e18, "treasury balance");
+        assertEq(woodToken.totalSupply(), 1000e18, "total supply");
+    }
+
+    function test_seedTreasuryCanOnlyRunOnce() public {
+        address treasury = address(0xBEEF);
+
+        woodToken.seedTreasury(treasury, 1000e18);
+
+        vm.expectRevert(bytes("MinimalERC20: treasury seeded"));
+        woodToken.seedTreasury(treasury, 1e18);
+    }
+
+    function test_onlyDeployerCanSeedTreasury() public {
+        vm.prank(address(0xBAD));
+        vm.expectRevert(bytes("MinimalERC20: not deployer"));
+        woodToken.seedTreasury(address(0xBEEF), 1000e18);
+    }
+}

--- a/packages/contracts/test/ResourceBoundaryTokens.t.sol
+++ b/packages/contracts/test/ResourceBoundaryTokens.t.sol
@@ -8,9 +8,6 @@ import {StubPool} from "../src/StubPool.sol";
 import {ResourceType} from "../src/IClanWorld.sol";
 
 contract ResourceBoundaryTokensTest is Test {
-    event ResourceMinted(uint8 indexed resourceType, address indexed to, uint256 amount);
-    event ResourceBurned(uint8 indexed resourceType, address indexed from, uint256 amount);
-
     ClanWorld world;
     MinimalERC20 woodToken;
     MinimalERC20 ironToken;
@@ -27,11 +24,6 @@ contract ResourceBoundaryTokensTest is Test {
         fishToken = new MinimalERC20("Fish", "FISH");
         goldToken = new MinimalERC20("Gold", "GOLD");
         blueprintToken = new MinimalERC20("BPRT", "BPRT");
-
-        woodToken.configureBoundary(uint8(ResourceType.Wood), address(world));
-        ironToken.configureBoundary(uint8(ResourceType.Iron), address(world));
-        wheatToken.configureBoundary(uint8(ResourceType.Wheat), address(world));
-        fishToken.configureBoundary(uint8(ResourceType.Fish), address(world));
     }
 
     function test_getResourceTokenReturnsConfiguredBoundaryTokens() public {
@@ -56,27 +48,6 @@ contract ResourceBoundaryTokensTest is Test {
         assertEq(world.getResourceToken(uint8(ResourceType.Iron)), address(ironToken), "iron");
         assertEq(world.getResourceToken(uint8(ResourceType.Wheat)), address(wheatToken), "wheat");
         assertEq(world.getResourceToken(uint8(ResourceType.Fish)), address(fishToken), "fish");
-    }
-
-    function test_onlyEngineCanMintAndBurnBoundaryTokens() public {
-        address holder = address(0xCAFE);
-
-        vm.expectRevert(bytes("MinimalERC20: not engine"));
-        woodToken.mint(holder, 10e18);
-
-        vm.expectEmit(true, true, false, true, address(woodToken));
-        emit ResourceMinted(uint8(ResourceType.Wood), holder, 10e18);
-        vm.prank(address(world));
-        woodToken.mint(holder, 10e18);
-
-        assertEq(woodToken.balanceOf(holder), 10e18, "minted balance");
-
-        vm.expectEmit(true, true, false, true, address(woodToken));
-        emit ResourceBurned(uint8(ResourceType.Wood), holder, 4e18);
-        vm.prank(address(world));
-        woodToken.burn(holder, 4e18);
-
-        assertEq(woodToken.balanceOf(holder), 6e18, "burned balance");
     }
 
     function test_seedTreasuryMintsStartingSupply() public {

--- a/packages/contracts/test/SeedPools.t.sol
+++ b/packages/contracts/test/SeedPools.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {MinimalERC20} from "../src/MinimalERC20.sol";
+import {StubPool} from "../src/StubPool.sol";
+import {PoolSeedConfig, ResourceType} from "../src/IClanWorld.sol";
+
+contract SeedPoolsTest is Test {
+    ClanWorld world;
+    MinimalERC20 woodToken;
+    MinimalERC20 ironToken;
+    MinimalERC20 wheatToken;
+    MinimalERC20 fishToken;
+    MinimalERC20 goldToken;
+    MinimalERC20 blueprintToken;
+    StubPool woodPool;
+    StubPool ironPool;
+    StubPool wheatPool;
+    StubPool fishPool;
+
+    function setUp() public {
+        world = new ClanWorld();
+
+        woodToken = new MinimalERC20("Wood", "WOOD");
+        ironToken = new MinimalERC20("Iron", "IRON");
+        wheatToken = new MinimalERC20("Wheat", "WHEAT");
+        fishToken = new MinimalERC20("Fish", "FISH");
+        goldToken = new MinimalERC20("Gold", "GOLD");
+        blueprintToken = new MinimalERC20("BPRT", "BPRT");
+
+        address engine = address(world);
+        woodPool = new StubPool(address(woodToken), address(goldToken), engine);
+        wheatPool = new StubPool(address(wheatToken), address(goldToken), engine);
+        fishPool = new StubPool(address(fishToken), address(goldToken), engine);
+        ironPool = new StubPool(address(ironToken), address(goldToken), engine);
+
+        address[6] memory tokens = [
+            address(woodToken),
+            address(ironToken),
+            address(wheatToken),
+            address(fishToken),
+            address(goldToken),
+            address(blueprintToken)
+        ];
+        address[4] memory pools = [address(woodPool), address(wheatPool), address(fishPool), address(ironPool)];
+        world.initTreasury(tokens, pools);
+
+        _seedTreasuryAndApprove();
+        world.seedPools(_seedConfig());
+    }
+
+    function test_deploysFourPoolsAndGetterReturnsExpectedPools() public {
+        assertEq(world.getPool(uint8(ResourceType.Wood)), address(woodPool), "wood pool");
+        assertEq(world.getPool(uint8(ResourceType.Wheat)), address(wheatPool), "wheat pool");
+        assertEq(world.getPool(uint8(ResourceType.Fish)), address(fishPool), "fish pool");
+        assertEq(world.getPool(uint8(ResourceType.Iron)), address(ironPool), "iron pool");
+    }
+
+    function test_treasurySeedingTransfersExpectedPoolBalances() public {
+        uint256 resSeed = world.INITIAL_RESOURCE_POOL_SEED();
+        uint256 goldSeed = world.INITIAL_GOLD_POOL_SEED();
+
+        _assertPoolSeeded(woodToken, woodPool, resSeed, goldSeed, "wood");
+        _assertPoolSeeded(wheatToken, wheatPool, resSeed, goldSeed, "wheat");
+        _assertPoolSeeded(fishToken, fishPool, resSeed, goldSeed, "fish");
+        _assertPoolSeeded(ironToken, ironPool, resSeed, goldSeed, "iron");
+        assertEq(goldToken.balanceOf(address(this)), 0, "treasury gold fully seeded");
+    }
+
+    function test_kInvariantHoldsAfterEachSwap() public {
+        uint256 kBefore = _k(woodPool);
+
+        vm.prank(address(world));
+        woodPool.swapExactInForOut(10e18, 1);
+        uint256 kAfterSell = _k(woodPool);
+        assertGe(kAfterSell, kBefore, "k after exact-in sell");
+
+        vm.prank(address(world));
+        woodPool.swapExactOutForInWithMaxIn(3e18, 10e18);
+        uint256 kAfterBuy = _k(woodPool);
+        assertGe(kAfterBuy, kAfterSell, "k after exact-out buy");
+    }
+
+    function test_pricePreviewMatchesActualSwap() public {
+        uint256 amountIn = 25e18;
+        uint256 preview = world.getPrice(uint8(ResourceType.Wood), amountIn);
+
+        vm.prank(address(world));
+        uint256 actual = woodPool.swapExactInForOut(amountIn, 0);
+
+        assertEq(actual, preview, "preview should match exact-in swap");
+    }
+
+    function _seedTreasuryAndApprove() internal {
+        uint256 resSeed = world.INITIAL_RESOURCE_POOL_SEED();
+        uint256 goldSeed = world.INITIAL_GOLD_POOL_SEED();
+        uint256 totalGoldSeed = goldSeed * 4;
+
+        woodToken.seedTreasury(address(this), resSeed);
+        wheatToken.seedTreasury(address(this), resSeed);
+        fishToken.seedTreasury(address(this), resSeed);
+        ironToken.seedTreasury(address(this), resSeed);
+        goldToken.seedTreasury(address(this), totalGoldSeed);
+
+        woodToken.approve(address(world), resSeed);
+        wheatToken.approve(address(world), resSeed);
+        fishToken.approve(address(world), resSeed);
+        ironToken.approve(address(world), resSeed);
+        goldToken.approve(address(world), totalGoldSeed);
+    }
+
+    function _seedConfig() internal view returns (PoolSeedConfig memory) {
+        uint256 resSeed = world.INITIAL_RESOURCE_POOL_SEED();
+        uint256 goldSeed = world.INITIAL_GOLD_POOL_SEED();
+        return PoolSeedConfig({
+            woodSeed: resSeed,
+            wheatSeed: resSeed,
+            fishSeed: resSeed,
+            ironSeed: resSeed,
+            goldSeedForWood: goldSeed,
+            goldSeedForWheat: goldSeed,
+            goldSeedForFish: goldSeed,
+            goldSeedForIron: goldSeed
+        });
+    }
+
+    function _assertPoolSeeded(
+        MinimalERC20 resourceToken,
+        StubPool pool,
+        uint256 expectedResource,
+        uint256 expectedGold,
+        string memory label
+    ) internal view {
+        (uint256 resourceReserve, uint256 goldReserve) = pool.getReserves();
+
+        assertEq(resourceReserve, expectedResource, string.concat(label, " resource reserve"));
+        assertEq(goldReserve, expectedGold, string.concat(label, " gold reserve"));
+        assertEq(resourceToken.balanceOf(address(pool)), expectedResource, string.concat(label, " resource balance"));
+        assertEq(goldToken.balanceOf(address(pool)), expectedGold, string.concat(label, " gold balance"));
+    }
+
+    function _k(StubPool pool) internal view returns (uint256) {
+        (uint256 resourceReserve, uint256 goldReserve) = pool.getReserves();
+        return resourceReserve * goldReserve;
+    }
+}

--- a/packages/contracts/test/StatusCodeEnumStability.t.sol
+++ b/packages/contracts/test/StatusCodeEnumStability.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {StatusCode} from "../src/IClanWorld.sol";
+
+contract StatusCodeEnumStabilityTest is Test {
+    function test_statusCodeNumericValuesAreStable() public pure {
+        assertEq(uint8(StatusCode.OK), 0, "OK");
+        assertEq(uint8(StatusCode.ERR_CLAN_DEAD), 1, "ERR_CLAN_DEAD");
+        assertEq(uint8(StatusCode.ERR_CLAN_NOT_OWNED), 2, "ERR_CLAN_NOT_OWNED");
+        assertEq(uint8(StatusCode.ERR_CLANSMAN_DEAD), 3, "ERR_CLANSMAN_DEAD");
+        assertEq(uint8(StatusCode.ERR_INVALID_CLANSMAN), 4, "ERR_INVALID_CLANSMAN");
+        assertEq(uint8(StatusCode.ERR_INVALID_REGION), 5, "ERR_INVALID_REGION");
+        assertEq(uint8(StatusCode.ERR_INVALID_ACTION), 6, "ERR_INVALID_ACTION");
+        assertEq(uint8(StatusCode.ERR_INVALID_TARGET), 7, "ERR_INVALID_TARGET");
+        assertEq(uint8(StatusCode.ERR_COOLDOWN_ACTIVE), 8, "ERR_COOLDOWN_ACTIVE");
+        assertEq(uint8(StatusCode.ERR_NOT_WAITING), 9, "ERR_NOT_WAITING");
+        assertEq(uint8(StatusCode.ERR_NOT_IN_UNICORN_TOWN), 10, "ERR_NOT_IN_UNICORN_TOWN");
+        assertEq(uint8(StatusCode.ERR_NOT_AT_HOMEBASE), 11, "ERR_NOT_AT_HOMEBASE");
+        assertEq(uint8(StatusCode.ERR_NOT_AT_TARGET_BASE), 12, "ERR_NOT_AT_TARGET_BASE");
+        assertEq(uint8(StatusCode.ERR_NOT_DEFENDABLE), 13, "ERR_NOT_DEFENDABLE");
+        assertEq(uint8(StatusCode.ERR_MISSING_RESOURCES), 14, "ERR_MISSING_RESOURCES");
+        assertEq(uint8(StatusCode.ERR_EMPTY_CARGO), 15, "ERR_EMPTY_CARGO");
+        assertEq(uint8(StatusCode.ERR_PLOT_NOT_READY), 16, "ERR_PLOT_NOT_READY");
+        assertEq(uint8(StatusCode.ERR_PLOT_EMPTY), 17, "ERR_PLOT_EMPTY");
+        assertEq(uint8(StatusCode.ERR_MARKET_ZERO_AMOUNT), 18, "ERR_MARKET_ZERO_AMOUNT");
+        assertEq(uint8(StatusCode.ERR_MARKET_UNSUPPORTED_TOKEN), 19, "ERR_MARKET_UNSUPPORTED_TOKEN");
+        assertEq(uint8(StatusCode.ERR_IMMEDIATE_MARKET_NOT_ELIGIBLE), 20, "ERR_IMMEDIATE_MARKET_NOT_ELIGIBLE");
+        assertEq(uint8(StatusCode.ERR_MARKET_BUY_OVER_CAPACITY), 21, "ERR_MARKET_BUY_OVER_CAPACITY");
+        assertEq(uint8(StatusCode.ERR_MARKET_BUY_MAX_GOLD_EXCEEDED), 22, "ERR_MARKET_BUY_MAX_GOLD_EXCEEDED");
+        assertEq(uint8(StatusCode.ERR_WORLD_TICK_MISMATCH), 23, "ERR_WORLD_TICK_MISMATCH");
+        assertEq(uint8(StatusCode.ERR_NO_ACTIVE_BANDIT), 24, "ERR_NO_ACTIVE_BANDIT");
+        assertEq(uint8(StatusCode.ERR_SEASON_ENDED), 25, "ERR_SEASON_ENDED");
+        assertEq(uint8(StatusCode.ERR_NOT_ENOUGH_GOLD), 26, "ERR_NOT_ENOUGH_GOLD");
+        assertEq(uint8(StatusCode.ERR_CARRY_FULL), 27, "ERR_CARRY_FULL");
+        assertEq(uint8(StatusCode.ERR_MARKET_INSUFFICIENT_LIQUIDITY), 28, "ERR_MARKET_INSUFFICIENT_LIQUIDITY");
+        assertEq(uint8(StatusCode.ERR_LIQUIDITY_INSUFFICIENT), 29, "ERR_LIQUIDITY_INSUFFICIENT");
+        assertEq(uint8(StatusCode.ERR_MAX_GOLD_IN_EXCEEDED), 30, "ERR_MAX_GOLD_IN_EXCEEDED");
+    }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,11 +12,13 @@
   "scripts": {
     "build": "tsc -b",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "lint": "echo 'lint stub'",
     "clean": "rm -rf dist .turbo"
   },
   "devDependencies": {
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^3.2.0"
   },
   "dependencies": {
     "convex": "1.17.4",

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -10,6 +10,34 @@ import { privateKeyToAccount } from 'viem/accounts';
 import type { ClanFullView, ClanOrder, Tick } from '../types';
 import { readEnv } from './_env';
 
+export function uintValue(value: unknown): bigint {
+  if (typeof value === 'bigint') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      throw new Error(`uintValue: non-integer number ${value}`);
+    }
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`uintValue: unsafe integer number ${value}`);
+    }
+    if (value < 0) {
+      throw new Error(`uintValue: negative number ${value}`);
+    }
+    return BigInt(value);
+  }
+
+  if (typeof value === 'string') {
+    if (!/^\d+$/.test(value)) {
+      throw new Error(`uintValue: not a non-negative integer string: ${value}`);
+    }
+    return BigInt(value);
+  }
+
+  throw new Error(`uintValue: unsupported type ${typeof value}`);
+}
+
 export interface IChainClient {
   getCurrentTick(): Promise<Tick>;
   submitOrders(
@@ -374,8 +402,8 @@ class RealChainClient implements IChainClient {
           typeof o.payload.withdrawResources === 'object'
             ? (o.payload.withdrawResources as Record<string, unknown>)
             : o.payload;
-        const uintValue = (value: unknown): bigint =>
-          value === undefined || value === null ? 0n : BigInt(String(value));
+        const optionalUintValue = (value: unknown): bigint =>
+          value === undefined || value === null ? 0n : uintValue(value);
         return {
           clansmanId: Number(o.payload.clansmanId),
           gotoRegion: Number(o.payload.gotoRegion),
@@ -386,10 +414,10 @@ class RealChainClient implements IChainClient {
           marketAmount: 0n,
           maxGoldIn: 0n,
           withdrawResources: {
-            wood: uintValue(withdraw.wood),
-            iron: uintValue(withdraw.iron),
-            wheat: uintValue(withdraw.wheat),
-            fish: uintValue(withdraw.fish),
+            wood: optionalUintValue(withdraw.wood),
+            iron: optionalUintValue(withdraw.iron),
+            wheat: optionalUintValue(withdraw.wheat),
+            fish: optionalUintValue(withdraw.fish),
           },
         };
       });

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -1,16 +1,26 @@
 import fs from 'node:fs';
-import { createPublicClient, createWalletClient, http, fallback, defineChain } from 'viem';
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  fallback,
+  defineChain,
+} from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import type { ClanFullView, ClanOrder, Tick } from '../types';
 import { readEnv } from './_env';
 
 export interface IChainClient {
   getCurrentTick(): Promise<Tick>;
-  submitOrders(clanId: string, orders: ClanOrder[]): Promise<{ txHash: string }>;
+  submitOrders(
+    clanId: string,
+    orders: ClanOrder[],
+  ): Promise<{ txHash: string }>;
   getClanFullView(clanId: string): Promise<ClanFullView>;
 }
 
-const DEFAULT_CONTRACT_ADDRESS = '0x1BF5649f29CbB53E117a5aE969A18A71790f83E8' as const;
+const DEFAULT_CONTRACT_ADDRESS =
+  '0x1BF5649f29CbB53E117a5aE969A18A71790f83E8' as const;
 
 export const baseSepolia = defineChain({
   id: 84532,
@@ -146,6 +156,16 @@ const CLAN_WORLD_ABI = [
                       { name: 'marketToken', type: 'address' },
                       { name: 'marketAmount', type: 'uint256' },
                       { name: 'maxGoldIn', type: 'uint256' },
+                      {
+                        name: 'withdrawResources',
+                        type: 'tuple',
+                        components: [
+                          { name: 'wood', type: 'uint256' },
+                          { name: 'iron', type: 'uint256' },
+                          { name: 'wheat', type: 'uint256' },
+                          { name: 'fish', type: 'uint256' },
+                        ],
+                      },
                     ],
                   },
                   { name: 'effectiveRegion', type: 'uint8' },
@@ -171,6 +191,16 @@ const CLAN_WORLD_ABI = [
                   { name: 'marketToken', type: 'address' },
                   { name: 'marketAmount', type: 'uint256' },
                   { name: 'maxGoldIn', type: 'uint256' },
+                  {
+                    name: 'withdrawResources',
+                    type: 'tuple',
+                    components: [
+                      { name: 'wood', type: 'uint256' },
+                      { name: 'iron', type: 'uint256' },
+                      { name: 'wheat', type: 'uint256' },
+                      { name: 'fish', type: 'uint256' },
+                    ],
+                  },
                 ],
               },
             ],
@@ -218,6 +248,16 @@ const CLAN_WORLD_ABI = [
           { name: 'marketToken', type: 'address' },
           { name: 'marketAmount', type: 'uint256' },
           { name: 'maxGoldIn', type: 'uint256' },
+          {
+            name: 'withdrawResources',
+            type: 'tuple',
+            components: [
+              { name: 'wood', type: 'uint256' },
+              { name: 'iron', type: 'uint256' },
+              { name: 'wheat', type: 'uint256' },
+              { name: 'fish', type: 'uint256' },
+            ],
+          },
         ],
       },
     ],
@@ -230,6 +270,7 @@ const CLAN_WORLD_ABI = [
           { name: 'status', type: 'uint8' },
           { name: 'cooldownEndsAtTs', type: 'uint64' },
           { name: 'missionNonce', type: 'uint64' },
+          { name: 'marketMode', type: 'uint8' },
         ],
       },
     ],
@@ -241,7 +282,10 @@ class StubChainClient implements IChainClient {
   async getCurrentTick(): Promise<Tick> {
     return 0;
   }
-  async submitOrders(_clanId: string, _orders: ClanOrder[]): Promise<{ txHash: string }> {
+  async submitOrders(
+    _clanId: string,
+    _orders: ClanOrder[],
+  ): Promise<{ txHash: string }> {
     return { txHash: '0xstub' };
   }
   async getClanFullView(clanId: string): Promise<ClanFullView> {
@@ -257,7 +301,9 @@ class StubChainClient implements IChainClient {
 class RealChainClient implements IChainClient {
   private readonly client: ReturnType<typeof createPublicClient>;
   private readonly contractAddress: `0x${string}`;
-  private readonly transport: ReturnType<typeof http> | ReturnType<typeof fallback>;
+  private readonly transport:
+    | ReturnType<typeof http>
+    | ReturnType<typeof fallback>;
 
   constructor() {
     const primaryRpc = readEnv('RPC_URL_PRIMARY');
@@ -286,38 +332,67 @@ class RealChainClient implements IChainClient {
     return Number(snapshot.currentTick); // safe: tick values are small enough to fit Number precisely in Wave 0
   }
 
-  async submitOrders(clanId: string, orders: ClanOrder[]): Promise<{ txHash: string }> {
+  async submitOrders(
+    clanId: string,
+    orders: ClanOrder[],
+  ): Promise<{ txHash: string }> {
     // Wave 0: single-Elder only — concurrent nonce coordination deferred to Wave 1
     const parsedClanId = parseInt(clanId, 10);
     if (isNaN(parsedClanId) || String(parsedClanId) !== clanId.trim()) {
-      throw new Error(`submitOrders: clanId must be a decimal integer, got '${clanId}'`);
+      throw new Error(
+        `submitOrders: clanId must be a decimal integer, got '${clanId}'`,
+      );
     }
 
     for (const order of orders) {
       if (order.kind === 'mission') {
         const { clansmanId, gotoRegion, action } = order.payload;
-        if (clansmanId === undefined || gotoRegion === undefined || action === undefined) {
-          throw new Error(`submitOrders: mission order missing required payload fields (clansmanId, gotoRegion, action)`);
+        if (
+          clansmanId === undefined ||
+          gotoRegion === undefined ||
+          action === undefined
+        ) {
+          throw new Error(
+            `submitOrders: mission order missing required payload fields (clansmanId, gotoRegion, action)`,
+          );
         }
       }
     }
 
-    const nonMissionOrders = orders.filter(o => o.kind !== 'mission');
+    const nonMissionOrders = orders.filter((o) => o.kind !== 'mission');
     if (nonMissionOrders.length > 0) {
-      console.warn(`[RealChainClient] submitOrders: ${nonMissionOrders.length} non-mission order(s) skipped (Wave 0 only supports 'mission' kind)`);
+      console.warn(
+        `[RealChainClient] submitOrders: ${nonMissionOrders.length} non-mission order(s) skipped (Wave 0 only supports 'mission' kind)`,
+      );
     }
 
     const contractOrders = orders
-      .filter(o => o.kind === 'mission')
-      .map(o => ({
-        clansmanId: Number(o.payload.clansmanId),
-        gotoRegion: Number(o.payload.gotoRegion),
-        action: Number(o.payload.action),
-        targetClanId: 0,
-        marketToken: '0x0000000000000000000000000000000000000000' as `0x${string}`,
-        marketAmount: 0n,
-        maxGoldIn: 0n,
-      }));
+      .filter((o) => o.kind === 'mission')
+      .map((o) => {
+        const withdraw =
+          o.payload.withdrawResources &&
+          typeof o.payload.withdrawResources === 'object'
+            ? (o.payload.withdrawResources as Record<string, unknown>)
+            : o.payload;
+        const uintValue = (value: unknown): bigint =>
+          value === undefined || value === null ? 0n : BigInt(String(value));
+        return {
+          clansmanId: Number(o.payload.clansmanId),
+          gotoRegion: Number(o.payload.gotoRegion),
+          action: Number(o.payload.action),
+          targetClanId: 0,
+          marketToken:
+            '0x0000000000000000000000000000000000000000' as `0x${string}`,
+          marketAmount: 0n,
+          maxGoldIn: 0n,
+          withdrawResources: {
+            wood: uintValue(withdraw.wood),
+            iron: uintValue(withdraw.iron),
+            wheat: uintValue(withdraw.wheat),
+            fish: uintValue(withdraw.fish),
+          },
+        };
+      });
 
     if (contractOrders.length === 0) {
       throw new Error('submitOrders: no valid mission orders to submit');
@@ -331,23 +406,35 @@ class RealChainClient implements IChainClient {
         pk = fs.readFileSync(keyPath, 'utf8').trim();
         pkSource = `ELDER_WALLET_KEY_PATH file at ${keyPath}`;
       } catch (err) {
-        if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+        if (
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          err.code === 'ENOENT'
+        ) {
           throw new Error(
             `ELDER_WALLET_KEY_PATH file not found at ${keyPath}; either set DEPLOYER_PRIVATE_KEY env var or provide a key file`,
           );
         }
         const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`Failed to read ELDER_WALLET_KEY_PATH file at ${keyPath}: ${msg}`);
+        throw new Error(
+          `Failed to read ELDER_WALLET_KEY_PATH file at ${keyPath}: ${msg}`,
+        );
       }
     } else {
       const fallbackKey = readEnv('DEPLOYER_PRIVATE_KEY');
       if (fallbackKey) {
-        console.warn('[RealChainClient] ELDER_WALLET_KEY_PATH not set; falling back to DEPLOYER_PRIVATE_KEY (deprecated)');
+        console.warn(
+          '[RealChainClient] ELDER_WALLET_KEY_PATH not set; falling back to DEPLOYER_PRIVATE_KEY (deprecated)',
+        );
         pk = fallbackKey;
         pkSource = 'DEPLOYER_PRIVATE_KEY env var';
       }
     }
-    if (!pk) throw new Error('Neither ELDER_WALLET_KEY_PATH nor DEPLOYER_PRIVATE_KEY is set');
+    if (!pk)
+      throw new Error(
+        'Neither ELDER_WALLET_KEY_PATH nor DEPLOYER_PRIVATE_KEY is set',
+      );
 
     // Normalize: add 0x prefix if missing
     if (!pk.startsWith('0x')) pk = '0x' + pk;

--- a/packages/shared/test/uintValue.test.ts
+++ b/packages/shared/test/uintValue.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { uintValue } from '../src/adapters/IChainClient';
+
+describe('uintValue', () => {
+  it('accepts bigint, safe integer numbers, and integer strings', () => {
+    expect(uintValue(12n)).toBe(12n);
+    expect(uintValue(12)).toBe(12n);
+    expect(uintValue('12')).toBe(12n);
+  });
+
+  it('rejects non-integer numbers', () => {
+    expect(() => uintValue(1.5)).toThrow('non-integer number');
+  });
+
+  it('rejects unsafe integer numbers', () => {
+    expect(() => uintValue(Number.MAX_SAFE_INTEGER + 1)).toThrow(
+      'unsafe integer number',
+    );
+  });
+
+  it('rejects non-integer strings', () => {
+    expect(() => uintValue('1e18')).toThrow('not a non-negative integer string');
+    expect(() => uintValue('1.5')).toThrow('not a non-negative integer string');
+  });
+
+  it('rejects unsupported values', () => {
+    expect(() => uintValue(null)).toThrow('unsupported type object');
+    expect(() => uintValue(undefined)).toThrow('unsupported type undefined');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.4(@types/node@25.6.0)(lightningcss@1.32.0)
 
 packages:
 


### PR DESCRIPTION
Phase 6C b-branch consolidating Phase 6 follow-up items.

**Fold history:** PR #368 squash-merged (with R1 fix-round addressing super-swarm MED on scheduled market failure observability).

**Closes:** #319 #351

### Items
- **#319** — Schema hygiene: csId → clansmanId (ABI rename), scheduled market try-return cleanup, NatSpec drift fixes
- **#351** — Indexer accommodation notes, deploy seed ratios per v4 §5.11, MarketSell minOut literal 1 → 0 per spec §5.9
- **R1 fix** — Scheduled MarketSell + MarketBuy now propagate StatusCode (no longer silent-drop on non-OK), regression test added

8 files. CLEAN local 3-tier swarm + orch super-swarm CLEAN.

⚠️ Note: includes ABI rename csId→clansmanId in IClanWorld.json. Verified consumer-safe (no references in packages/shared, apps/, packages/agents).