### PR TITLE
Phase 10C — orchestrator REGION_FOREST + starvation NatSpec + submitOrders sim semantics

### DIFF
--- a/apps/orchestrator/src/main.ts
+++ b/apps/orchestrator/src/main.ts
@@ -20,18 +20,25 @@ async function main(): Promise<void> {
   ];
 
   console.error(`[orchestrator] submitting orders for clan-${CLAN_ID}...`);
-  const { txHash } = await chain.submitOrders(CLAN_ID, orders);
-  console.error(`[orchestrator] tx submitted: ${txHash}`);
+  const { txHash, results } = await chain.submitOrders(CLAN_ID, orders);
+  const failedResults = results.filter(result => result.status !== 0);
+  console.error(`[orchestrator] tx submitted: ${txHash}; results=${JSON.stringify(results)}`);
+  if (failedResults.length > 0) {
+    console.error(`[orchestrator] ${failedResults.length} order(s) returned non-OK status`);
+  }
 
   try {
-    await convex.postLog('info', `Elder Aldric (clan-${CLAN_ID}): ChopWood submitted — txHash=${txHash} tick=${tick}`);
+    await convex.postLog(
+      failedResults.length > 0 ? 'warn' : 'info',
+      `Elder Aldric (clan-${CLAN_ID}): ChopWood submitted — txHash=${txHash} tick=${tick} results=${JSON.stringify(results)}`,
+    );
   } catch (err) {
     console.error('[orchestrator] convex log failed (non-fatal):', err);
   }
 
   // Print final JSON summary to stdout
   process.stdout.write(
-    JSON.stringify({ tick, txHash, clan: CLAN_ID, mission: 'ChopWood-Forest' }, null, 2) + '\n',
+    JSON.stringify({ tick, txHash, results, clan: CLAN_ID, mission: 'ChopWood-Forest' }, null, 2) + '\n',
   );
 }
 

--- a/apps/orchestrator/src/main.ts
+++ b/apps/orchestrator/src/main.ts
@@ -1,4 +1,4 @@
-import type { ClanOrder } from '@clan-world/shared';
+import { REGION_FOREST, type ClanOrder } from '@clan-world/shared';
 import { createChainClient, createConvexClient } from '@clan-world/shared/adapters';
 
 const CLAN_ID = process.env.CLAN_ID || '1';
@@ -15,22 +15,22 @@ async function main(): Promise<void> {
   const orders: ClanOrder[] = [
     {
       kind: 'mission',
-      payload: { clansmanId: 1, gotoRegion: 0, action: 1 }, // action=1 is ChopWood
+      payload: { clansmanId: 1, gotoRegion: REGION_FOREST, action: 1 }, // action=1 is ChopWood
     },
   ];
 
   console.error(`[orchestrator] submitting orders for clan-${CLAN_ID}...`);
-  const { txHash, results } = await chain.submitOrders(CLAN_ID, orders);
-  const failedResults = results.filter(result => result.status !== 0);
-  console.error(`[orchestrator] tx submitted: ${txHash}; results=${JSON.stringify(results)}`);
-  if (failedResults.length > 0) {
-    console.error(`[orchestrator] ${failedResults.length} order(s) returned non-OK status`);
+  const { txHash, results: simulationResults } = await chain.submitOrders(CLAN_ID, orders);
+  const failedSimulationResults = simulationResults.filter(result => result.status !== 0);
+  console.error(`[orchestrator] tx submitted: ${txHash}; [sim] results=${JSON.stringify(simulationResults)}`);
+  if (failedSimulationResults.length > 0) {
+    console.error(`[orchestrator] [sim] ${failedSimulationResults.length} order(s) returned non-OK status`);
   }
 
   try {
     await convex.postLog(
-      failedResults.length > 0 ? 'warn' : 'info',
-      `Elder Aldric (clan-${CLAN_ID}): ChopWood submitted — txHash=${txHash} tick=${tick} results=${JSON.stringify(results)}`,
+      failedSimulationResults.length > 0 ? 'warn' : 'info',
+      `Elder Aldric (clan-${CLAN_ID}): ChopWood submitted — txHash=${txHash} tick=${tick} [sim] results=${JSON.stringify(simulationResults)}`,
     );
   } catch (err) {
     console.error('[orchestrator] convex log failed (non-fatal):', err);
@@ -38,7 +38,11 @@ async function main(): Promise<void> {
 
   // Print final JSON summary to stdout
   process.stdout.write(
-    JSON.stringify({ tick, txHash, results, clan: CLAN_ID, mission: 'ChopWood-Forest' }, null, 2) + '\n',
+    JSON.stringify(
+      { tick, txHash, simulationResults, resultSemantics: 'simulation-only', clan: CLAN_ID, mission: 'ChopWood-Forest' },
+      null,
+      2,
+    ) + '\n',
   );
 }
 

--- a/docs/planning/clanworld_v4_spec.md
+++ b/docs/planning/clanworld_v4_spec.md
@@ -832,7 +832,7 @@ Winter lasts `10` ticks.
 During winter, each clan consumes:
 - wheat consumption = `2×` normal
 - fish consumption = `2×` normal
-- wood burn = `1e18` wood per base per tick
+- wood burn = `1e18` wood per base per tick, plus `0.5e18` wood per living clansman per tick
 
 ## 7.4 Winter farming rule
 During winter:
@@ -1211,4 +1211,3 @@ The following values are intentionally tunable without changing the core mechani
 - bandit spawn probability ramp
 - bandit reward magnitudes
 - season reward pot percentages in later versions
-

--- a/docs/planning/clanworld_v4_spec.md
+++ b/docs/planning/clanworld_v4_spec.md
@@ -823,7 +823,7 @@ This is a required bookkeeping part of the combat model.
 # 7. Winter Rules
 
 ## 7.1 Winter cadence
-Winter occurs every `110` ticks.
+Winter occurs every `110` ticks. The first winter opens at tick `110`, so ticks `[100, 110)` remain pre-winter preparation time.
 
 ## 7.2 Winter duration
 Winter lasts `10` ticks.

--- a/packages/agents/src/__tests__/cli.test.ts
+++ b/packages/agents/src/__tests__/cli.test.ts
@@ -30,7 +30,7 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
 function makeChain(overrides: Partial<IChainClient> = {}): IChainClient {
   return {
     getCurrentTick: vi.fn(async () => 0),
-    submitOrders: vi.fn(async () => ({ txHash: '0xdeadbeef' })),
+    submitOrders: vi.fn(async () => ({ txHash: '0xdeadbeef', results: [] })),
     getClanFullView: vi.fn(async (clanId: string) => ({
       clan: { id: clanId, name: `Chain Clan ${clanId}`, treasury: '0' },
       controlledRegions: [],
@@ -95,8 +95,9 @@ describe('clan submit-orders', () => {
       convex: makeConvex(),
       chain,
     });
-    const result = JSON.parse(out) as { txHash: string };
+    const result = JSON.parse(out) as { txHash: string; results: unknown[] };
     expect(result.txHash).toBe('0xdeadbeef');
+    expect(result.results).toEqual([]);
     expect(chain.submitOrders).toHaveBeenCalledWith('1', expect.arrayContaining([expect.objectContaining({ kind: 'mission' })]));
   });
 

--- a/packages/agents/test/cli.test.ts
+++ b/packages/agents/test/cli.test.ts
@@ -40,7 +40,7 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
 
 function makeChain(overrides: Partial<IChainClient> = {}): IChainClient {
   return {
-    async submitOrders() { return { txHash: '0xdeadbeef' }; },
+    async submitOrders() { return { txHash: '0xdeadbeef', results: [] }; },
     async getCurrentTick(): Promise<Tick> { return 0; },
     async getClanFullView(clanId: string): Promise<ClanFullView> {
       return {

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -3001,56 +3001,6 @@
     },
     {
       "type": "event",
-      "name": "ClansmanDiedFromCold",
-      "inputs": [
-        {
-          "name": "clanId",
-          "type": "uint32",
-          "indexed": true,
-          "internalType": "uint32"
-        },
-        {
-          "name": "atTick",
-          "type": "uint64",
-          "indexed": false,
-          "internalType": "uint64"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
-      "name": "ColdDamageApplied",
-      "inputs": [
-        {
-          "name": "clanId",
-          "type": "uint32",
-          "indexed": true,
-          "internalType": "uint32"
-        },
-        {
-          "name": "oldDamage",
-          "type": "uint16",
-          "indexed": false,
-          "internalType": "uint16"
-        },
-        {
-          "name": "newDamage",
-          "type": "uint16",
-          "indexed": false,
-          "internalType": "uint16"
-        },
-        {
-          "name": "atTick",
-          "type": "uint64",
-          "indexed": false,
-          "internalType": "uint64"
-        }
-      ],
-      "anonymous": false
-    },
-    {
-      "type": "event",
       "name": "GoldTransferred",
       "inputs": [
         {

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2951,6 +2951,31 @@
     },
     {
       "type": "event",
+      "name": "ClansmanColdDeath",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "csId",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tick",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
       "name": "ClansmanDiedFromCold",
       "inputs": [
         {
@@ -3635,6 +3660,31 @@
           "type": "uint64",
           "indexed": false,
           "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WallDegradedByCold",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "newWallLevel",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "tick",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
         }
       ],
       "anonymous": false

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2826,6 +2826,31 @@
     },
     {
       "type": "event",
+      "name": "ClanColdShortage",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tick",
+          "type": "uint32",
+          "indexed": false,
+          "internalType": "uint32"
+        },
+        {
+          "name": "woodShort",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
       "name": "ClanEliminated",
       "inputs": [
         {

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2836,9 +2836,9 @@
         },
         {
           "name": "tick",
-          "type": "uint32",
+          "type": "uint64",
           "indexed": false,
-          "internalType": "uint32"
+          "internalType": "uint64"
         },
         {
           "name": "woodShort",
@@ -2992,9 +2992,9 @@
         },
         {
           "name": "tick",
-          "type": "uint32",
+          "type": "uint64",
           "indexed": false,
-          "internalType": "uint32"
+          "internalType": "uint64"
         }
       ],
       "anonymous": false
@@ -3707,9 +3707,9 @@
         },
         {
           "name": "tick",
-          "type": "uint32",
+          "type": "uint64",
           "indexed": false,
-          "internalType": "uint32"
+          "internalType": "uint64"
         }
       ],
       "anonymous": false

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -9,6 +9,25 @@
     },
     {
       "type": "function",
+      "name": "getActionDuration",
+      "inputs": [
+        {
+          "name": "action",
+          "type": "uint8",
+          "internalType": "enum ActionType"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
       "name": "getActiveBanditView",
       "inputs": [],
       "outputs": [
@@ -231,83 +250,6 @@
         }
       ],
       "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "getMissionTiming",
-      "inputs": [
-        {
-          "name": "clanId",
-          "type": "uint32",
-          "internalType": "uint32"
-        },
-        {
-          "name": "clansmanId",
-          "type": "uint32",
-          "internalType": "uint32"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "submitted",
-          "type": "uint64",
-          "internalType": "uint64"
-        },
-        {
-          "name": "executes",
-          "type": "uint64",
-          "internalType": "uint64"
-        },
-        {
-          "name": "settles",
-          "type": "uint64",
-          "internalType": "uint64"
-        }
-      ],
-      "stateMutability": "view"
-    },
-    {
-      "type": "function",
-      "name": "getActionDuration",
-      "inputs": [
-        {
-          "name": "action",
-          "type": "uint8",
-          "internalType": "enum ActionType"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint64",
-          "internalType": "uint64"
-        }
-      ],
-      "stateMutability": "pure"
-    },
-    {
-      "type": "function",
-      "name": "getTravelTicks",
-      "inputs": [
-        {
-          "name": "fromRegion",
-          "type": "uint8",
-          "internalType": "uint8"
-        },
-        {
-          "name": "toRegion",
-          "type": "uint8",
-          "internalType": "uint8"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint64",
-          "internalType": "uint64"
-        }
-      ],
-      "stateMutability": "pure"
     },
     {
       "type": "function",
@@ -1641,6 +1583,40 @@
     },
     {
       "type": "function",
+      "name": "getMissionTiming",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "submitted",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "executes",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "settles",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "getRegionPopulation",
       "inputs": [
         {
@@ -1750,6 +1726,30 @@
         }
       ],
       "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getTravelTicks",
+      "inputs": [
+        {
+          "name": "fromRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "toRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "pure"
     },
     {
       "type": "function",
@@ -1930,6 +1930,16 @@
               "internalType": "bool"
             },
             {
+              "name": "currentSeasonNumber",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextHeartbeatAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
               "name": "winterActive",
               "type": "bool",
               "internalType": "bool"
@@ -2037,6 +2047,16 @@
               "internalType": "bool"
             },
             {
+              "name": "currentSeasonNumber",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextHeartbeatAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
               "name": "nextHeartbeatAtTs",
               "type": "uint64",
               "internalType": "uint64"
@@ -2110,6 +2130,19 @@
       ],
       "outputs": [],
       "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "isWinter",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
     },
     {
       "type": "function",
@@ -2263,6 +2296,19 @@
       "inputs": [
         {
           "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "settleClansman",
+      "inputs": [
+        {
+          "name": "csId",
           "type": "uint32",
           "internalType": "uint32"
         }
@@ -3605,9 +3651,9 @@
       "inputs": [
         {
           "name": "tick",
-          "type": "uint64",
+          "type": "uint32",
           "indexed": true,
-          "internalType": "uint64"
+          "internalType": "uint32"
         }
       ],
       "anonymous": false
@@ -3618,9 +3664,9 @@
       "inputs": [
         {
           "name": "tick",
-          "type": "uint64",
+          "type": "uint32",
           "indexed": true,
-          "internalType": "uint64"
+          "internalType": "uint32"
         }
       ],
       "anonymous": false

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2851,6 +2851,31 @@
     },
     {
       "type": "event",
+      "name": "ClanDied",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "indexed": false,
+          "internalType": "string"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
       "name": "ClanEliminated",
       "inputs": [
         {

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -3751,9 +3751,9 @@
       "inputs": [
         {
           "name": "tick",
-          "type": "uint32",
+          "type": "uint64",
           "indexed": true,
-          "internalType": "uint32"
+          "internalType": "uint64"
         }
       ],
       "anonymous": false
@@ -3764,9 +3764,9 @@
       "inputs": [
         {
           "name": "tick",
-          "type": "uint32",
+          "type": "uint64",
           "indexed": true,
-          "internalType": "uint32"
+          "internalType": "uint64"
         }
       ],
       "anonymous": false

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -89,11 +89,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _world.seasonEndTick = ClanWorldConstants.SEASON_DURATION_TICKS;
         _world.currentSeasonNumber = 1;
         _world.nextHeartbeatAtTick = 1; // first heartbeat will open tick 1
-        // First winter: last WINTER_DURATION_TICKS of first TICKS_PER_WINTER_CYCLE cycle
-        // i.e. ticks [100, 110)
-        _world.winterStartsAtTick =
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
-        _world.winterEndsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE; // = 110
+        _world.winterStartsAtTick = ClanWorldConstants.WINTER_START_TICK;
+        _world.winterEndsAtTick = ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS;
         _world.winterActive = false;
         _treasury.treasuryOwner = msg.sender;
         _nextClanId = 1;
@@ -942,37 +939,55 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             _world.currentSeasonNumber += 1;
             _world.seasonStartTick = _world.seasonEndTick;
             _world.seasonEndTick = _world.seasonStartTick + ClanWorldConstants.SEASON_DURATION_TICKS;
-            // reset winter timers for new season
-            _world.winterActive = false;
-            _world.winterStartsAtTick = _world.seasonStartTick + ClanWorldConstants.TICKS_PER_WINTER_CYCLE
-                - ClanWorldConstants.WINTER_DURATION_TICKS;
-            _world.winterEndsAtTick = _world.seasonStartTick + ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
         }
 
         // --- winter transitions (timer only; mechanics = Phase 10) ---
-        if (
-            !_world.winterActive && newTick >= _world.winterStartsAtTick
-                && _world.winterStartsAtTick < _world.seasonEndTick
-        ) {
-            _world.winterActive = true;
-            emit WinterStarted(newTick);
+        bool wasWinter = _isWinterActiveAt(closedTick);
+        bool nowWinter = _isWinterActiveAt(newTick);
+        if (!wasWinter && nowWinter) {
+            emit WinterStarted(_winterEventTick(newTick));
         }
-        if (_world.winterActive && newTick >= _world.winterEndsAtTick) {
-            _world.winterActive = false;
-            emit WinterEnded(newTick);
-            // schedule next winter cycle within this season
-            uint64 nextWinterStart = _world.winterEndsAtTick + ClanWorldConstants.TICKS_PER_WINTER_CYCLE
-                - ClanWorldConstants.WINTER_DURATION_TICKS;
-            uint64 nextWinterEnd = _world.winterEndsAtTick + ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
-            if (nextWinterStart < _world.seasonEndTick) {
-                _world.winterStartsAtTick = nextWinterStart;
-                _world.winterEndsAtTick = nextWinterEnd;
-            } else {
-                // no more winters this season; sentinel = seasonEndTick so guard never fires
-                _world.winterStartsAtTick = _world.seasonEndTick;
-                _world.winterEndsAtTick = _world.seasonEndTick;
-            }
+        if (wasWinter && !nowWinter) {
+            emit WinterEnded(_winterEventTick(newTick));
         }
+    }
+
+    function _winterEventTick(uint64 tick) internal pure returns (uint32) {
+        require(tick <= type(uint32).max, "ClanWorld: winter tick overflow");
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint32(tick);
+    }
+
+    function _isWinterActiveAt(uint64 tick) internal pure returns (bool) {
+        if (tick < ClanWorldConstants.WINTER_START_TICK) {
+            return false;
+        }
+        uint64 elapsed = tick - ClanWorldConstants.WINTER_START_TICK;
+        return elapsed % ClanWorldConstants.WINTER_PERIOD_TICKS < ClanWorldConstants.WINTER_DURATION_TICKS;
+    }
+
+    function _winterWindowForTick(uint64 tick)
+        internal
+        pure
+        returns (bool active, uint64 startsAtTick, uint64 endsAtTick)
+    {
+        if (tick < ClanWorldConstants.WINTER_START_TICK) {
+            startsAtTick = ClanWorldConstants.WINTER_START_TICK;
+            endsAtTick = ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS;
+            return (false, startsAtTick, endsAtTick);
+        }
+
+        uint64 elapsed = tick - ClanWorldConstants.WINTER_START_TICK;
+        uint64 cycleIndex = elapsed / ClanWorldConstants.WINTER_PERIOD_TICKS;
+        uint64 cycleStart = ClanWorldConstants.WINTER_START_TICK + cycleIndex * ClanWorldConstants.WINTER_PERIOD_TICKS;
+        active = elapsed % ClanWorldConstants.WINTER_PERIOD_TICKS < ClanWorldConstants.WINTER_DURATION_TICKS;
+        startsAtTick = active ? cycleStart : cycleStart + ClanWorldConstants.WINTER_PERIOD_TICKS;
+        endsAtTick = startsAtTick + ClanWorldConstants.WINTER_DURATION_TICKS;
+    }
+
+    function _worldStateView() internal view returns (WorldState memory ws) {
+        ws = _world;
+        (ws.winterActive, ws.winterStartsAtTick, ws.winterEndsAtTick) = _winterWindowForTick(_world.currentTick);
     }
 
     /// @notice Public settlement trigger — lazily settle a clan.
@@ -1761,7 +1776,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     // =========================================================================
 
     function getWorldState() external view override returns (WorldState memory) {
-        return _world;
+        return _worldStateView();
     }
 
     function getTreasuryState() external view override returns (TreasuryState memory) {
@@ -1791,6 +1806,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             return (0, 0, 0);
         }
         return (m.submittedAtTick, m.executesAtTick, m.settlesAtTick);
+    }
+
+    function isWinter() external view override returns (bool) {
+        return _isWinterActiveAt(_world.currentTick);
     }
 
     function getActionDuration(ActionType action) public pure override returns (uint64) {
@@ -1976,18 +1995,19 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             });
         }
 
+        WorldState memory ws = _worldStateView();
         return WorldSnapshot({
-            currentTick: _world.currentTick,
-            seasonStartTick: _world.seasonStartTick,
-            seasonEndTick: _world.seasonEndTick,
-            seasonFinalized: _world.seasonFinalized,
-            currentSeasonNumber: _world.currentSeasonNumber,
-            nextHeartbeatAtTick: _world.nextHeartbeatAtTick,
-            winterActive: _world.winterActive,
-            winterStartsAtTick: _world.winterStartsAtTick,
-            winterEndsAtTick: _world.winterEndsAtTick,
-            activeBanditId: _world.activeBanditId,
-            currentTickSeed: _world.currentTickSeed,
+            currentTick: ws.currentTick,
+            seasonStartTick: ws.seasonStartTick,
+            seasonEndTick: ws.seasonEndTick,
+            seasonFinalized: ws.seasonFinalized,
+            currentSeasonNumber: ws.currentSeasonNumber,
+            nextHeartbeatAtTick: ws.nextHeartbeatAtTick,
+            winterActive: ws.winterActive,
+            winterStartsAtTick: ws.winterStartsAtTick,
+            winterEndsAtTick: ws.winterEndsAtTick,
+            activeBanditId: ws.activeBanditId,
+            currentTickSeed: ws.currentTickSeed,
             leaderboard: lb
         });
     }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -437,14 +437,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             emit ClanStarvationChanged(clan.clanId, false, tick);
         }
 
-        (, uint64 winterStartsAtTick,) = _winterWindowForTick(tick);
-        if (winter && starving && clan.starvationStartsAtTick >= winterStartsAtTick) {
+        if (winter && starving && clan.starvationStartsAtTick < tick) {
             _killNextClansmanFromStarvation(clan, tick);
         }
         if (clan.clanState == ClanState.DEAD) return;
 
         if (winter) {
-            uint256 woodNeeded = uint256(clan.livingClansmen) * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
+            uint256 woodNeeded = ClanWorldConstants.WINTER_WOOD_BURN_PER_BASE
+                + uint256(clan.livingClansmen) * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
             if (clan.vaultWood >= woodNeeded) {
                 clan.vaultWood -= woodNeeded;
             } else {
@@ -1135,7 +1135,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             uint32 clanId = _allClanIds[i];
             for (uint256 pi = 0; pi < 2; pi++) {
                 require(transitions < MAX_CROP_TRANSITION_PER_TICK, "ClanWorld: crop transition cap");
-                _wheatPlots[clanId][pi].state = WheatPlotState.WinterLocked;
+                WheatPlot storage plot = _wheatPlots[clanId][pi];
+                plot.state = WheatPlotState.WinterLocked;
+                plot.remainingWheat = 0;
+                plot.regrowUntilTick = 0;
                 transitions++;
             }
         }
@@ -1164,8 +1167,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
     }
 
-    function _winterEventTick(uint64 tick) internal pure returns (uint32) {
-        return _eventTick(tick);
+    function _winterEventTick(uint64 tick) internal pure returns (uint64) {
+        return tick;
     }
 
     function _eventTick(uint64 tick) internal pure returns (uint32) {

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1324,7 +1324,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         // Guard: if clan is more than 200 ticks behind, caller must call settleClan() first
         // (_settleClan caps at 200 ticks per call; submitting into a partially-settled clan corrupts invariants)
-        // ERR_MUST_SETTLE_FIRST not in StatusCode enum — using ERR_INVALID_ACTION as the closest proxy
         {
             uint64 lastSettled = _clans[clanId].lastSettledTick;
             if (_world.currentTick > lastSettled + 200) {
@@ -1332,7 +1331,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 for (uint256 i = 0; i < orders.length; i++) {
                     results[i] = OrderResult({
                         clansmanId: orders[i].clansmanId,
-                        status: StatusCode.ERR_INVALID_ACTION,
+                        status: StatusCode.ERR_MUST_SETTLE_FIRST,
                         cooldownEndsAtTs: 0,
                         missionNonce: 0
                     });

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -38,6 +38,7 @@ import {
     RegionOccupant
 } from "./IClanWorld.sol";
 import {StubPool} from "./StubPool.sol";
+import {RNG} from "./lib/RNG.sol";
 import {ReentrancyGuard} from "./util/ReentrancyGuard.sol";
 
 /// @title ClanWorld
@@ -440,12 +441,87 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             } else {
                 uint256 woodShort = woodNeeded - clan.vaultWood;
                 clan.vaultWood = 0;
+                uint16 oldColdDamage = clan.coldDamage;
                 if (clan.coldDamage < type(uint16).max) {
                     clan.coldDamage += 1;
                 }
                 emit ClanColdShortage(clan.clanId, _eventTick(tick), woodShort);
+                _applyColdDamageConsequence(clan, tick, oldColdDamage);
             }
         }
+    }
+
+    function _applyColdDamageConsequence(Clan storage clan, uint64 tick, uint16 oldColdDamage) internal {
+        uint16 newColdDamage = clan.coldDamage;
+        if (newColdDamage == oldColdDamage) return;
+
+        if (clan.wallLevel > 0) {
+            if (
+                newColdDamage / ClanWorldConstants.COLD_DAMAGE_PER_WALL_DEGRADATION
+                    <= oldColdDamage / ClanWorldConstants.COLD_DAMAGE_PER_WALL_DEGRADATION
+            ) return;
+
+            clan.wallLevel--;
+            emit WallDegradedByCold(clan.clanId, clan.wallLevel, _eventTick(tick));
+            return;
+        }
+
+        if (
+            newColdDamage / ClanWorldConstants.COLD_DAMAGE_PER_CLANSMAN_DEATH
+                <= oldColdDamage / ClanWorldConstants.COLD_DAMAGE_PER_CLANSMAN_DEATH
+        ) return;
+
+        _killRandomClansmanFromCold(clan, tick, newColdDamage);
+    }
+
+    function _killRandomClansmanFromCold(Clan storage clan, uint64 tick, uint16 coldDamage) internal {
+        if (clan.livingClansmen == 0) return;
+
+        uint32[] storage csIds = _clanClansmanIds[clan.clanId];
+        uint256 livingCount = 0;
+        for (uint256 i = 0; i < csIds.length; i++) {
+            if (_clansmen[csIds[i]].state != ClansmanState.DEAD) {
+                livingCount++;
+            }
+        }
+        if (livingCount == 0) return;
+
+        uint256 pick = RNG.rngBounded(
+            _world.currentTickSeed,
+            RNG.DOMAIN_COLD_DAMAGE,
+            uint256(keccak256(abi.encodePacked(clan.clanId, tick, coldDamage))),
+            livingCount
+        );
+
+        uint256 seen = 0;
+        for (uint256 i = 0; i < csIds.length; i++) {
+            Clansman storage cs = _clansmen[csIds[i]];
+            if (cs.state == ClansmanState.DEAD) continue;
+            if (seen != pick) {
+                seen++;
+                continue;
+            }
+
+            _markClansmanDeadFromCold(clan, cs, tick);
+            return;
+        }
+    }
+
+    function _markClansmanDeadFromCold(Clan storage clan, Clansman storage cs, uint64 tick) internal {
+        cs.state = ClansmanState.DEAD;
+        if (clan.livingClansmen > 0) {
+            clan.livingClansmen--;
+        }
+
+        Mission storage m = _missions[cs.clansmanId];
+        if (m.active) {
+            if (m.action == ActionType.DefendBase) {
+                _clearDefender(cs.clansmanId);
+            }
+            m.active = false;
+        }
+
+        emit ClansmanColdDeath(clan.clanId, cs.clansmanId, _eventTick(tick));
     }
 
     /// @dev Check if a clan is currently starving (lazy read).

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -371,6 +371,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         for (uint64 tick = fromTick; tick < curTick; tick++) {
             // 1. Apply upkeep for this tick
             _applyUpkeep(clan, tick);
+            if (clan.clanState == ClanState.DEAD) break;
 
             // 2. Wheat plot regrow check (lazy, per tick)
             for (uint256 pi = 0; pi < 2; pi++) {
@@ -435,6 +436,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             clan.starvationStartsAtTick = 0;
             emit ClanStarvationChanged(clan.clanId, false, tick);
         }
+
+        (, uint64 winterStartsAtTick,) = _winterWindowForTick(tick);
+        if (winter && starving && clan.starvationStartsAtTick >= winterStartsAtTick) {
+            _killNextClansmanFromStarvation(clan, tick);
+        }
+        if (clan.clanState == ClanState.DEAD) return;
 
         if (winter) {
             uint256 woodNeeded = uint256(clan.livingClansmen) * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
@@ -509,7 +516,34 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
     }
 
+    function _killNextClansmanFromStarvation(Clan storage clan, uint64 tick) internal {
+        if (clan.livingClansmen == 0) return;
+
+        uint32[] storage csIds = _clanClansmanIds[clan.clanId];
+        for (uint256 i = 0; i < csIds.length; i++) {
+            Clansman storage cs = _clansmen[csIds[i]];
+            if (cs.state == ClansmanState.DEAD) continue;
+
+            _markClansmanDead(clan, cs);
+            if (clan.livingClansmen == 0) {
+                _markClanDead(clan.clanId, "starvation", tick);
+            }
+            return;
+        }
+    }
+
     function _markClansmanDeadFromCold(Clan storage clan, Clansman storage cs, uint64 tick) internal {
+        _markClansmanDead(clan, cs);
+
+        emit ClansmanColdDeath(clan.clanId, cs.clansmanId, _eventTick(tick));
+        if (clan.livingClansmen == 0) {
+            _markClanDead(clan.clanId, "cold", tick);
+        }
+    }
+
+    function _markClansmanDead(Clan storage clan, Clansman storage cs) internal {
+        if (cs.state == ClansmanState.DEAD) return;
+
         cs.state = ClansmanState.DEAD;
         if (clan.livingClansmen > 0) {
             clan.livingClansmen--;
@@ -522,8 +556,38 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             }
             m.active = false;
         }
+    }
 
-        emit ClansmanColdDeath(clan.clanId, cs.clansmanId, _eventTick(tick));
+    function _markClanDead(uint32 clanId) internal {
+        _markClanDead(clanId, "unknown", _world.currentTick);
+    }
+
+    function _markClanDead(uint32 clanId, string memory reason, uint64 tick) internal {
+        Clan storage clan = _clans[clanId];
+        if (clan.clanId == 0 || clan.clanState == ClanState.DEAD) return;
+
+        clan.clanState = ClanState.DEAD;
+        clan.vaultWood = 0;
+        clan.vaultWheat = 0;
+        clan.vaultFish = 0;
+        clan.vaultIron = 0;
+        clan.starvationStartsAtTick = 0;
+        clan.livingClansmen = 0;
+
+        uint32[] storage csIds = _clanClansmanIds[clanId];
+        for (uint256 i = 0; i < csIds.length; i++) {
+            _clansmen[csIds[i]].state = ClansmanState.DEAD;
+            Mission storage m = _missions[csIds[i]];
+            if (m.active) {
+                if (m.action == ActionType.DefendBase) {
+                    _clearDefender(csIds[i]);
+                }
+                m.active = false;
+            }
+        }
+
+        emit ClanEliminated(clanId, tick);
+        emit ClanDied(clanId, tick, reason);
     }
 
     /// @dev Check if a clan is currently starving (lazy read).
@@ -1281,6 +1345,17 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _settleClan(clanId);
 
         results = new OrderResult[](orders.length);
+        if (clan.clanState == ClanState.DEAD) {
+            for (uint256 i = 0; i < orders.length; i++) {
+                results[i] = OrderResult({
+                    clansmanId: orders[i].clansmanId,
+                    status: StatusCode.ERR_CLAN_DEAD,
+                    cooldownEndsAtTs: 0,
+                    missionNonce: 0
+                });
+            }
+            return results;
+        }
 
         for (uint256 i = 0; i < orders.length; i++) {
             results[i] = _processOrder(clanId, clan, orders[i]);

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -386,16 +386,29 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             }
         }
 
+        if (curTick > fromTick && !_isWinterActiveAt(curTick) && _isWinterActiveAt(curTick - 1)) {
+            clan.coldDamage = 0;
+        }
+
         clan.lastSettledTick = curTick;
         emit ClanSettled(clanId, curTick);
     }
 
-    /// @dev Apply one tick of upkeep. Marks starvation if insufficient food.
+    /// @dev Apply one tick of upkeep. Marks starvation if insufficient food and cold damage if winter wood is short.
     function _applyUpkeep(Clan storage clan, uint64 tick) internal {
+        bool winter = _isWinterActiveAt(tick);
+        if (!winter && tick > 0 && _isWinterActiveAt(tick - 1)) {
+            clan.coldDamage = 0;
+        }
+
         if (clan.livingClansmen == 0) return;
 
         uint256 wheatNeeded = uint256(clan.livingClansmen) * ClanWorldConstants.WHEAT_UPKEEP_PER_CLANSMAN;
         uint256 fishNeeded = uint256(clan.livingClansmen) * ClanWorldConstants.FISH_UPKEEP_PER_CLANSMAN;
+        if (winter) {
+            wheatNeeded = wheatNeeded * ClanWorldConstants.WINTER_UPKEEP_MULTIPLIER_BPS / 10000;
+            fishNeeded = fishNeeded * ClanWorldConstants.WINTER_UPKEEP_MULTIPLIER_BPS / 10000;
+        }
 
         bool hadEnoughWheat = clan.vaultWheat >= wheatNeeded;
         bool hadEnoughFish = clan.vaultFish >= fishNeeded;
@@ -418,6 +431,20 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         } else if (!starving && clan.starvationStartsAtTick != 0) {
             clan.starvationStartsAtTick = 0;
             emit ClanStarvationChanged(clan.clanId, false, tick);
+        }
+
+        if (winter) {
+            uint256 woodNeeded = uint256(clan.livingClansmen) * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
+            if (clan.vaultWood >= woodNeeded) {
+                clan.vaultWood -= woodNeeded;
+            } else {
+                uint256 woodShort = woodNeeded - clan.vaultWood;
+                clan.vaultWood = 0;
+                if (clan.coldDamage < type(uint16).max) {
+                    clan.coldDamage += 1;
+                }
+                emit ClanColdShortage(clan.clanId, _eventTick(tick), woodShort);
+            }
         }
     }
 
@@ -948,11 +975,22 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             emit WinterStarted(_winterEventTick(newTick));
         }
         if (wasWinter && !nowWinter) {
+            _resetColdDamageForAllClans();
             emit WinterEnded(_winterEventTick(newTick));
         }
     }
 
+    function _resetColdDamageForAllClans() internal {
+        for (uint256 i = 0; i < _allClanIds.length; i++) {
+            _clans[_allClanIds[i]].coldDamage = 0;
+        }
+    }
+
     function _winterEventTick(uint64 tick) internal pure returns (uint32) {
+        return _eventTick(tick);
+    }
+
+    function _eventTick(uint64 tick) internal pure returns (uint32) {
         require(tick <= type(uint32).max, "ClanWorld: winter tick overflow");
         // forge-lint: disable-next-line(unsafe-typecast)
         return uint32(tick);

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -78,8 +78,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
-    /// @dev Caps winter crop boundary work: 24 clans x 2 wheat plots = 48 plot writes.
+    /// @dev Caps winter crop boundary work; mintClan keeps the clan cap within this budget.
     uint256 public constant MAX_CROP_TRANSITION_PER_TICK = 48;
+    uint256 private constant MAX_CLANS_FOR_CROP_TRANSITIONS = MAX_CROP_TRANSITION_PER_TICK / 2;
 
     // =========================================================================
     // CONSTRUCTOR
@@ -437,14 +438,20 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             emit ClanStarvationChanged(clan.clanId, false, tick);
         }
 
-        if (winter && starving && clan.starvationStartsAtTick < tick) {
-            _killNextClansmanFromStarvation(clan, tick);
+        uint8 livingBeforeStarvation = clan.livingClansmen;
+        if (winter && starving) {
+            (, uint64 winterStartsAtTick,) = _winterWindowForTick(tick);
+            uint64 effectiveStarvationStartsAtTick =
+                clan.starvationStartsAtTick > winterStartsAtTick ? clan.starvationStartsAtTick : winterStartsAtTick;
+            if (effectiveStarvationStartsAtTick < tick) {
+                _killNextClansmanFromStarvation(clan, tick);
+            }
         }
         if (clan.clanState == ClanState.DEAD) return;
 
         if (winter) {
-            uint256 woodNeeded = ClanWorldConstants.WINTER_WOOD_BURN_PER_BASE
-                + uint256(clan.livingClansmen) * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
+            uint256 woodNeeded = ClanWorldConstants.WINTER_WOOD_BURN_PER_BASE + uint256(livingBeforeStarvation)
+                * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
             if (clan.vaultWood >= woodNeeded) {
                 clan.vaultWood -= woodNeeded;
             } else {
@@ -454,7 +461,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 if (clan.coldDamage < type(uint16).max) {
                     clan.coldDamage += 1;
                 }
-                emit ClanColdShortage(clan.clanId, _eventTick(tick), woodShort);
+                emit ClanColdShortage(clan.clanId, tick, woodShort);
                 _applyColdDamageConsequence(clan, tick, oldColdDamage);
             }
         }
@@ -471,7 +478,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             ) return;
 
             clan.wallLevel--;
-            emit WallDegradedByCold(clan.clanId, clan.wallLevel, _eventTick(tick));
+            emit WallDegradedByCold(clan.clanId, clan.wallLevel, tick);
             return;
         }
 
@@ -535,7 +542,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     function _markClansmanDeadFromCold(Clan storage clan, Clansman storage cs, uint64 tick) internal {
         _markClansmanDead(clan, cs);
 
-        emit ClansmanColdDeath(clan.clanId, cs.clansmanId, _eventTick(tick));
+        emit ClansmanColdDeath(clan.clanId, cs.clansmanId, tick);
         if (clan.livingClansmen == 0) {
             _markClanDead(clan.clanId, "cold", tick);
         }
@@ -1123,7 +1130,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             emit WinterStarted(_winterEventTick(newTick));
         }
         if (wasWinter && !nowWinter) {
-            _resetColdDamageForAllClans();
             _restartWheatPlotsAfterWinter(newTick);
             emit WinterEnded(_winterEventTick(newTick));
         }
@@ -1161,20 +1167,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
     }
 
-    function _resetColdDamageForAllClans() internal {
-        for (uint256 i = 0; i < _allClanIds.length; i++) {
-            _clans[_allClanIds[i]].coldDamage = 0;
-        }
-    }
-
     function _winterEventTick(uint64 tick) internal pure returns (uint64) {
         return tick;
-    }
-
-    function _eventTick(uint64 tick) internal pure returns (uint32) {
-        require(tick <= type(uint32).max, "ClanWorld: winter tick overflow");
-        // forge-lint: disable-next-line(unsafe-typecast)
-        return uint32(tick);
     }
 
     function _isWinterActiveAt(uint64 tick) internal pure returns (bool) {
@@ -1237,6 +1231,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     function mintClan(address to) external override nonReentrant returns (uint32 clanId, uint256 iftTokenId) {
         require(to != address(0), "ClanWorld: zero address");
         require(_allClanIds.length < 12, "ClanWorld: max clans");
+        require(_allClanIds.length < MAX_CLANS_FOR_CROP_TRANSITIONS, "ClanWorld: clan cap");
         clanId = _nextClanId++;
         iftTokenId = uint256(clanId); // Phase 1 placeholder; real iNFT is Phase 7
 
@@ -1275,18 +1270,20 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         WheatPlotState startingPlotState =
             _isWinterActiveAt(_world.currentTick) ? WheatPlotState.WinterLocked : WheatPlotState.Harvestable;
+        uint256 startingWheat =
+            startingPlotState == WheatPlotState.WinterLocked ? 0 : ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT;
 
         // Wheat plots
         _wheatPlots[clanId][0] = WheatPlot({
             state: startingPlotState,
             region: ClanWorldConstants.REGION_WEST_FARMS,
-            remainingWheat: ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT,
+            remainingWheat: startingWheat,
             regrowUntilTick: 0
         });
         _wheatPlots[clanId][1] = WheatPlot({
             state: startingPlotState,
             region: ClanWorldConstants.REGION_EAST_FARMS,
-            remainingWheat: ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT,
+            remainingWheat: startingWheat,
             regrowUntilTick: 0
         });
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -41,6 +41,22 @@ import {StubPool} from "./StubPool.sol";
 import {RNG} from "./lib/RNG.sol";
 import {ReentrancyGuard} from "./util/ReentrancyGuard.sol";
 
+/// @dev Production storage excludes derived winter fields; _worldStateView() synthesizes the public ABI shape.
+struct StoredWorldState {
+    uint64 currentTick;
+    uint64 seasonStartTick;
+    uint64 seasonEndTick;
+    bool seasonFinalized;
+    uint64 currentSeasonNumber;
+    uint64 nextHeartbeatAtTick;
+    uint64 nextHeartbeatAtTs;
+    uint64 nextBanditSpawnEligibleTick;
+    uint16 currentBanditSpawnChanceBps;
+    bytes32 currentTickSeed;
+    uint32 activeBanditId;
+    uint64 nextCommitSequence;
+}
+
 /// @title ClanWorld
 /// @notice Phase 1+2 real engine implementation of IClanWorld v4.
 ///         Implements: world clock, clan lifecycle, lazy settlement, resource gathering,
@@ -51,7 +67,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     // STORAGE
     // =========================================================================
 
-    WorldState private _world;
+    StoredWorldState private _world;
     TreasuryState private _treasury;
 
     mapping(uint32 => Clan) internal _clans;
@@ -93,9 +109,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _world.seasonEndTick = ClanWorldConstants.SEASON_DURATION_TICKS;
         _world.currentSeasonNumber = 1;
         _world.nextHeartbeatAtTick = 1; // first heartbeat will open tick 1
-        _world.winterStartsAtTick = ClanWorldConstants.WINTER_START_TICK;
-        _world.winterEndsAtTick = ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS;
-        _world.winterActive = false;
         _treasury.treasuryOwner = msg.sender;
         _nextClanId = 1;
         _nextClansmanId = 1;
@@ -503,7 +516,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (livingCount == 0) return;
 
         uint256 pick = RNG.rngBounded(
-            _world.currentTickSeed,
+            _tickSeeds[tick],
             RNG.DOMAIN_COLD_DAMAGE,
             uint256(keccak256(abi.encodePacked(clan.clanId, tick, coldDamage))),
             livingCount
@@ -1199,7 +1212,18 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     function _worldStateView() internal view returns (WorldState memory ws) {
-        ws = _world;
+        ws.currentTick = _world.currentTick;
+        ws.seasonStartTick = _world.seasonStartTick;
+        ws.seasonEndTick = _world.seasonEndTick;
+        ws.seasonFinalized = _world.seasonFinalized;
+        ws.currentSeasonNumber = _world.currentSeasonNumber;
+        ws.nextHeartbeatAtTick = _world.nextHeartbeatAtTick;
+        ws.nextHeartbeatAtTs = _world.nextHeartbeatAtTs;
+        ws.nextBanditSpawnEligibleTick = _world.nextBanditSpawnEligibleTick;
+        ws.currentBanditSpawnChanceBps = _world.currentBanditSpawnChanceBps;
+        ws.currentTickSeed = _world.currentTickSeed;
+        ws.activeBanditId = _world.activeBanditId;
+        ws.nextCommitSequence = _world.nextCommitSequence;
         (ws.winterActive, ws.winterStartsAtTick, ws.winterEndsAtTick) = _winterWindowForTick(_world.currentTick);
     }
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -78,6 +78,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
     uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
+    /// @dev Caps winter crop boundary work: 24 clans x 2 wheat plots = 48 plot writes.
+    uint256 public constant MAX_CROP_TRANSITION_PER_TICK = 48;
 
     // =========================================================================
     // CONSTRUCTOR
@@ -738,6 +740,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         WheatPlot storage plot = _wheatPlots[clanId][plotIdx];
+        if (plot.state == WheatPlotState.WinterLocked) {
+            // Winter-locked plots cannot be harvested; queued missions end with no yield.
+            _completeMission(cs, m);
+            return;
+        }
         if (plot.state != WheatPlotState.Harvestable || plot.remainingWheat == 0) {
             // Plot not ready — worker waits
             _completeMission(cs, m);
@@ -1048,11 +1055,42 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         bool wasWinter = _isWinterActiveAt(closedTick);
         bool nowWinter = _isWinterActiveAt(newTick);
         if (!wasWinter && nowWinter) {
+            _lockWheatPlotsForWinter();
             emit WinterStarted(_winterEventTick(newTick));
         }
         if (wasWinter && !nowWinter) {
             _resetColdDamageForAllClans();
+            _restartWheatPlotsAfterWinter(newTick);
             emit WinterEnded(_winterEventTick(newTick));
+        }
+    }
+
+    function _lockWheatPlotsForWinter() internal {
+        uint256 transitions;
+        for (uint256 i = 0; i < _allClanIds.length; i++) {
+            uint32 clanId = _allClanIds[i];
+            for (uint256 pi = 0; pi < 2; pi++) {
+                require(transitions < MAX_CROP_TRANSITION_PER_TICK, "ClanWorld: crop transition cap");
+                _wheatPlots[clanId][pi].state = WheatPlotState.WinterLocked;
+                transitions++;
+            }
+        }
+    }
+
+    function _restartWheatPlotsAfterWinter(uint64 currentTick) internal {
+        uint256 transitions;
+        for (uint256 i = 0; i < _allClanIds.length; i++) {
+            uint32 clanId = _allClanIds[i];
+            for (uint256 pi = 0; pi < 2; pi++) {
+                require(transitions < MAX_CROP_TRANSITION_PER_TICK, "ClanWorld: crop transition cap");
+                WheatPlot storage plot = _wheatPlots[clanId][pi];
+                if (plot.state == WheatPlotState.WinterLocked) {
+                    plot.state = WheatPlotState.Regrowing;
+                    plot.remainingWheat = 0;
+                    plot.regrowUntilTick = currentTick + ClanWorldConstants.WHEAT_PLOT_REGROW_TICKS;
+                }
+                transitions++;
+            }
         }
     }
 
@@ -1168,15 +1206,18 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         clan.vaultWheat = 20e18;
         clan.vaultFish = 2e18;
 
+        WheatPlotState startingPlotState =
+            _isWinterActiveAt(_world.currentTick) ? WheatPlotState.WinterLocked : WheatPlotState.Harvestable;
+
         // Wheat plots
         _wheatPlots[clanId][0] = WheatPlot({
-            state: WheatPlotState.Harvestable,
+            state: startingPlotState,
             region: ClanWorldConstants.REGION_WEST_FARMS,
             remainingWheat: ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT,
             regrowUntilTick: 0
         });
         _wheatPlots[clanId][1] = WheatPlot({
-            state: WheatPlotState.Harvestable,
+            state: startingPlotState,
             region: ClanWorldConstants.REGION_EAST_FARMS,
             remainingWheat: ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT,
             regrowUntilTick: 0
@@ -1774,6 +1815,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 gotoRegion != ClanWorldConstants.REGION_WEST_FARMS && gotoRegion != ClanWorldConstants.REGION_EAST_FARMS
             ) {
                 return StatusCode.ERR_INVALID_REGION;
+            }
+            if (_isWinterActiveAt(_world.currentTick)) {
+                return StatusCode.ERR_WINTER_LOCKED;
             }
         }
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -444,6 +444,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         bool starving = !hadEnoughWheat || !hadEnoughFish;
         if (starving && clan.starvationStartsAtTick == 0) {
+            /// @dev Same-tick onset is canonical; see docs/planning/clanworld_v4_6_phase5_economy_alignment.md §5.2.
+            ///      This also makes bandit-defense starvation effects apply on the upkeep-failure tick.
             clan.starvationStartsAtTick = tick;
             emit ClanStarvationChanged(clan.clanId, true, tick);
         } else if (!starving && clan.starvationStartsAtTick != 0) {

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -51,9 +51,8 @@ contract ClanWorldStub is IClanWorld {
         _world.seasonEndTick = ClanWorldConstants.SEASON_DURATION_TICKS;
         _world.currentSeasonNumber = 1;
         _world.nextHeartbeatAtTick = _world.currentTick + 1;
-        _world.winterStartsAtTick =
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS;
-        _world.winterEndsAtTick = ClanWorldConstants.TICKS_PER_WINTER_CYCLE;
+        _world.winterStartsAtTick = ClanWorldConstants.WINTER_START_TICK;
+        _world.winterEndsAtTick = ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS;
         _world.winterActive = false;
 
         _treasury.woodToken = tokens[0];
@@ -80,6 +79,14 @@ contract ClanWorldStub is IClanWorld {
         _world.currentTick += 1;
         _world.nextHeartbeatAtTick = _world.currentTick + 1;
         _world.nextHeartbeatAtTs = uint64(block.timestamp);
+        bool wasWinter = _isWinterActiveAt(closed);
+        bool nowWinter = _isWinterActiveAt(_world.currentTick);
+        if (!wasWinter && nowWinter) {
+            emit WinterStarted(_winterEventTick(_world.currentTick));
+        }
+        if (wasWinter && !nowWinter) {
+            emit WinterEnded(_winterEventTick(_world.currentTick));
+        }
         emit TickAdvanced(closed, _world.currentTick, bytes32(0));
     }
 
@@ -130,7 +137,7 @@ contract ClanWorldStub is IClanWorld {
     // -------------------------------------------------------------------------
 
     function getWorldState() external view override returns (WorldState memory) {
-        return _world;
+        return _worldStateView();
     }
 
     function getTreasuryState() external view override returns (TreasuryState memory) {
@@ -205,6 +212,10 @@ contract ClanWorldStub is IClanWorld {
         returns (uint64 submitted, uint64 executes, uint64 settles)
     {
         return (0, 0, 0);
+    }
+
+    function isWinter() external view override returns (bool) {
+        return _isWinterActiveAt(_world.currentTick);
     }
 
     function getActionDuration(ActionType) external pure override returns (uint64) {
@@ -288,16 +299,17 @@ contract ClanWorldStub is IClanWorld {
     // -------------------------------------------------------------------------
 
     function getWorldSnapshot() external view override returns (WorldSnapshot memory) {
+        WorldState memory ws = _worldStateView();
         return WorldSnapshot({
-            currentTick: _world.currentTick,
-            seasonStartTick: _world.seasonStartTick,
-            seasonEndTick: _world.seasonEndTick,
+            currentTick: ws.currentTick,
+            seasonStartTick: ws.seasonStartTick,
+            seasonEndTick: ws.seasonEndTick,
             seasonFinalized: false,
-            currentSeasonNumber: _world.currentSeasonNumber,
-            nextHeartbeatAtTick: _world.nextHeartbeatAtTick,
-            winterActive: _world.winterActive,
-            winterStartsAtTick: _world.winterStartsAtTick,
-            winterEndsAtTick: _world.winterEndsAtTick,
+            currentSeasonNumber: ws.currentSeasonNumber,
+            nextHeartbeatAtTick: ws.nextHeartbeatAtTick,
+            winterActive: ws.winterActive,
+            winterStartsAtTick: ws.winterStartsAtTick,
+            winterEndsAtTick: ws.winterEndsAtTick,
             activeBanditId: 0,
             currentTickSeed: bytes32(0),
             leaderboard: new LeaderboardEntry[](0)
@@ -360,5 +372,43 @@ contract ClanWorldStub is IClanWorld {
 
     function getRegionPopulation(uint8) external pure override returns (RegionOccupant[] memory) {
         return new RegionOccupant[](0);
+    }
+
+    function _isWinterActiveAt(uint64 tick) internal pure returns (bool) {
+        if (tick < ClanWorldConstants.WINTER_START_TICK) {
+            return false;
+        }
+        uint64 elapsed = tick - ClanWorldConstants.WINTER_START_TICK;
+        return elapsed % ClanWorldConstants.WINTER_PERIOD_TICKS < ClanWorldConstants.WINTER_DURATION_TICKS;
+    }
+
+    function _winterEventTick(uint64 tick) internal pure returns (uint32) {
+        require(tick <= type(uint32).max, "ClanWorldStub: winter tick overflow");
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint32(tick);
+    }
+
+    function _winterWindowForTick(uint64 tick)
+        internal
+        pure
+        returns (bool active, uint64 startsAtTick, uint64 endsAtTick)
+    {
+        if (tick < ClanWorldConstants.WINTER_START_TICK) {
+            startsAtTick = ClanWorldConstants.WINTER_START_TICK;
+            endsAtTick = ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS;
+            return (false, startsAtTick, endsAtTick);
+        }
+
+        uint64 elapsed = tick - ClanWorldConstants.WINTER_START_TICK;
+        uint64 cycleIndex = elapsed / ClanWorldConstants.WINTER_PERIOD_TICKS;
+        uint64 cycleStart = ClanWorldConstants.WINTER_START_TICK + cycleIndex * ClanWorldConstants.WINTER_PERIOD_TICKS;
+        active = elapsed % ClanWorldConstants.WINTER_PERIOD_TICKS < ClanWorldConstants.WINTER_DURATION_TICKS;
+        startsAtTick = active ? cycleStart : cycleStart + ClanWorldConstants.WINTER_PERIOD_TICKS;
+        endsAtTick = startsAtTick + ClanWorldConstants.WINTER_DURATION_TICKS;
+    }
+
+    function _worldStateView() internal view returns (WorldState memory ws) {
+        ws = _world;
+        (ws.winterActive, ws.winterStartsAtTick, ws.winterEndsAtTick) = _winterWindowForTick(_world.currentTick);
     }
 }

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -382,10 +382,8 @@ contract ClanWorldStub is IClanWorld {
         return elapsed % ClanWorldConstants.WINTER_PERIOD_TICKS < ClanWorldConstants.WINTER_DURATION_TICKS;
     }
 
-    function _winterEventTick(uint64 tick) internal pure returns (uint32) {
-        require(tick <= type(uint32).max, "ClanWorldStub: winter tick overflow");
-        // forge-lint: disable-next-line(unsafe-typecast)
-        return uint32(tick);
+    function _winterEventTick(uint64 tick) internal pure returns (uint64) {
+        return tick;
     }
 
     function _winterWindowForTick(uint64 tick)

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -26,8 +26,9 @@ pragma solidity ^0.8.34;
 library ClanWorldConstants {
     // World cadence
     uint64 internal constant HEARTBEAT_INTERVAL_SECONDS = 60;
-    uint64 internal constant TICKS_PER_WINTER_CYCLE = 110;
+    uint64 internal constant WINTER_START_TICK = 110;
     uint64 internal constant WINTER_DURATION_TICKS = 10;
+    uint64 internal constant WINTER_PERIOD_TICKS = 110;
     uint64 internal constant SEASON_DURATION_TICKS = 360;
 
     // Bandit cadence
@@ -489,8 +490,8 @@ struct RegionOccupant {
 interface IClanWorldEvents {
     // ----- world clock -----
     event TickAdvanced(uint64 closedTick, uint64 openedTick, bytes32 tickSeed);
-    event WinterStarted(uint64 indexed tick);
-    event WinterEnded(uint64 indexed tick);
+    event WinterStarted(uint32 indexed tick);
+    event WinterEnded(uint32 indexed tick);
     event SeasonFinalized(uint64 indexed tick, uint32[] rankedClanIds);
 
     // ----- clan lifecycle -----
@@ -709,6 +710,9 @@ interface IClanWorld is IClanWorldEvents {
         external
         view
         returns (uint64 submitted, uint64 executes, uint64 settles);
+
+    /// @notice True iff currentTick is inside the recurring winter window.
+    function isWinter() external view returns (bool);
 
     function getActionDuration(ActionType action) external pure returns (uint64);
 

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -26,6 +26,7 @@ pragma solidity ^0.8.34;
 library ClanWorldConstants {
     // World cadence
     uint64 internal constant HEARTBEAT_INTERVAL_SECONDS = 60;
+    // First winter opens at tick 110; ticks [100,110) remain pre-winter runway.
     uint64 internal constant WINTER_START_TICK = 110;
     uint64 internal constant WINTER_DURATION_TICKS = 10;
     uint64 internal constant WINTER_PERIOD_TICKS = 110;
@@ -507,9 +508,9 @@ interface IClanWorldEvents {
     event ClanEliminated(uint32 indexed clanId, uint64 indexed tick);
     event ClanDied(uint32 indexed clanId, uint64 tick, string reason);
     event ClanStarvationChanged(uint32 indexed clanId, bool isStarving, uint64 atTick);
-    event ClanColdShortage(uint32 indexed clanId, uint32 tick, uint256 woodShort);
-    event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint32 tick);
-    event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint32 tick);
+    event ClanColdShortage(uint32 indexed clanId, uint64 tick, uint256 woodShort);
+    event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint64 tick);
+    event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint64 tick);
 
     // ----- missions -----
     event MissionAssigned(

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -180,7 +180,8 @@ enum StatusCode {
     ERR_SEASON_ENDED,
     ERR_NOT_ENOUGH_GOLD,
     ERR_CARRY_FULL,
-    ERR_WINTER_LOCKED
+    ERR_WINTER_LOCKED,
+    ERR_MUST_SETTLE_FIRST
 }
 
 // =============================================================================

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -187,7 +187,7 @@ enum StatusCode {
 }
 
 // =============================================================================
-// CORE STATE STRUCTS (raw storage shape)
+// CORE STATE STRUCTS (canonical ABI shape; implementations may derive view-only fields)
 // =============================================================================
 
 struct WorldState {
@@ -204,6 +204,7 @@ struct WorldState {
     bytes32 currentTickSeed;
 
     uint32 activeBanditId; // 0 if none
+    // Derived view fields. ClanWorld.sol intentionally does not store these as source-of-truth.
     bool winterActive;
     uint64 winterStartsAtTick;
     uint64 winterEndsAtTick; // 0 if not active
@@ -619,10 +620,6 @@ interface IClanWorldEvents {
         uint256 wheat,
         uint256 fish
     );
-
-    // ----- winter cold damage -----
-    event ColdDamageApplied(uint32 indexed clanId, uint16 oldDamage, uint16 newDamage, uint64 atTick);
-    event ClansmanDiedFromCold(uint32 indexed clanId, uint64 atTick);
 
     // ----- OTC transfers -----
     event GoldTransferred(uint32 indexed fromClanId, uint32 indexed toClanId, uint256 amount, uint64 atTick);

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -503,6 +503,7 @@ interface IClanWorldEvents {
     );
     event ClanSettled(uint32 indexed clanId, uint64 settledToTick);
     event ClanEliminated(uint32 indexed clanId, uint64 indexed tick);
+    event ClanDied(uint32 indexed clanId, uint64 tick, string reason);
     event ClanStarvationChanged(uint32 indexed clanId, bool isStarving, uint64 atTick);
     event ClanColdShortage(uint32 indexed clanId, uint32 tick, uint256 woodShort);
     event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint32 tick);

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -61,7 +61,7 @@ library ClanWorldConstants {
     // Upkeep
     uint256 internal constant WHEAT_UPKEEP_PER_CLANSMAN = 1e18;
     uint256 internal constant FISH_UPKEEP_PER_CLANSMAN = 1e17; // 0.1
-    uint256 internal constant WINTER_WOOD_BURN_PER_BASE = 1e18;
+    uint256 internal constant WINTER_WOOD_BURN_PER_CLANSMAN = 5e17; // 0.5
     uint16 internal constant WINTER_UPKEEP_MULTIPLIER_BPS = 20000; // 2x
 
     // Wheat plots
@@ -189,8 +189,8 @@ struct WorldState {
     uint64 seasonStartTick;
     uint64 seasonEndTick;
     bool seasonFinalized;
-    uint64 currentSeasonNumber;   // 1-indexed; incremented each time seasonEndTick is crossed
-    uint64 nextHeartbeatAtTick;   // estimated tick that will be opened by the next heartbeat (for off-chain UI)
+    uint64 currentSeasonNumber; // 1-indexed; incremented each time seasonEndTick is crossed
+    uint64 nextHeartbeatAtTick; // estimated tick that will be opened by the next heartbeat (for off-chain UI)
 
     uint64 nextHeartbeatAtTs;
     uint64 nextBanditSpawnEligibleTick;
@@ -501,6 +501,7 @@ interface IClanWorldEvents {
     event ClanSettled(uint32 indexed clanId, uint64 settledToTick);
     event ClanEliminated(uint32 indexed clanId, uint64 indexed tick);
     event ClanStarvationChanged(uint32 indexed clanId, bool isStarving, uint64 atTick);
+    event ClanColdShortage(uint32 indexed clanId, uint32 tick, uint256 woodShort);
 
     // ----- missions -----
     event MissionAssigned(

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -62,6 +62,7 @@ library ClanWorldConstants {
     uint256 internal constant WHEAT_UPKEEP_PER_CLANSMAN = 1e18;
     uint256 internal constant FISH_UPKEEP_PER_CLANSMAN = 1e17; // 0.1
     uint256 internal constant WINTER_WOOD_BURN_PER_CLANSMAN = 5e17; // 0.5
+    uint256 internal constant WINTER_WOOD_BURN_PER_BASE = 1e18;
     uint16 internal constant WINTER_UPKEEP_MULTIPLIER_BPS = 20000; // 2x
     uint16 internal constant COLD_DAMAGE_PER_WALL_DEGRADATION = 2;
     uint16 internal constant COLD_DAMAGE_PER_CLANSMAN_DEATH = 2;
@@ -494,8 +495,8 @@ struct RegionOccupant {
 interface IClanWorldEvents {
     // ----- world clock -----
     event TickAdvanced(uint64 closedTick, uint64 openedTick, bytes32 tickSeed);
-    event WinterStarted(uint32 indexed tick);
-    event WinterEnded(uint32 indexed tick);
+    event WinterStarted(uint64 indexed tick);
+    event WinterEnded(uint64 indexed tick);
     event SeasonFinalized(uint64 indexed tick, uint32[] rankedClanIds);
 
     // ----- clan lifecycle -----

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -63,6 +63,8 @@ library ClanWorldConstants {
     uint256 internal constant FISH_UPKEEP_PER_CLANSMAN = 1e17; // 0.1
     uint256 internal constant WINTER_WOOD_BURN_PER_CLANSMAN = 5e17; // 0.5
     uint16 internal constant WINTER_UPKEEP_MULTIPLIER_BPS = 20000; // 2x
+    uint16 internal constant COLD_DAMAGE_PER_WALL_DEGRADATION = 2;
+    uint16 internal constant COLD_DAMAGE_PER_CLANSMAN_DEATH = 2;
 
     // Wheat plots
     uint64 internal constant WHEAT_PLOT_REGROW_TICKS = 4;
@@ -502,6 +504,8 @@ interface IClanWorldEvents {
     event ClanEliminated(uint32 indexed clanId, uint64 indexed tick);
     event ClanStarvationChanged(uint32 indexed clanId, bool isStarving, uint64 atTick);
     event ClanColdShortage(uint32 indexed clanId, uint32 tick, uint256 woodShort);
+    event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint32 tick);
+    event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint32 tick);
 
     // ----- missions -----
     event MissionAssigned(

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -179,7 +179,8 @@ enum StatusCode {
     ERR_NO_ACTIVE_BANDIT,
     ERR_SEASON_ENDED,
     ERR_NOT_ENOUGH_GOLD,
-    ERR_CARRY_FULL
+    ERR_CARRY_FULL,
+    ERR_WINTER_LOCKED
 }
 
 // =============================================================================

--- a/packages/contracts/src/lib/RNG.sol
+++ b/packages/contracts/src/lib/RNG.sol
@@ -9,7 +9,7 @@ library RNG {
     uint256 internal constant DOMAIN_MARKET_NOISE = uint256(keccak256("clanworld.market.noise.v1"));
     uint256 internal constant DOMAIN_WEATHER = uint256(keccak256("clanworld.weather.v1"));
     uint256 internal constant DOMAIN_FAIR_ITERATION = uint256(keccak256("clanworld.fair.iteration.v1"));
-    uint256 internal constant DOMAIN_COLD_DAMAGE = uint256(keccak256("cold_damage"));
+    uint256 internal constant DOMAIN_COLD_DAMAGE = uint256(keccak256("clanworld.cold.damage.v1"));
 
     uint256 internal constant MAX_SHUFFLE_N = 64;
 

--- a/packages/contracts/src/lib/RNG.sol
+++ b/packages/contracts/src/lib/RNG.sol
@@ -9,6 +9,7 @@ library RNG {
     uint256 internal constant DOMAIN_MARKET_NOISE = uint256(keccak256("clanworld.market.noise.v1"));
     uint256 internal constant DOMAIN_WEATHER = uint256(keccak256("clanworld.weather.v1"));
     uint256 internal constant DOMAIN_FAIR_ITERATION = uint256(keccak256("clanworld.fair.iteration.v1"));
+    uint256 internal constant DOMAIN_COLD_DAMAGE = uint256(keccak256("cold_damage"));
 
     uint256 internal constant MAX_SHUFFLE_N = 64;
 

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -69,6 +69,10 @@ contract ClanWorldTestHarness is ClanWorld {
         _clans[clanId].wallLevel = wallLevel;
     }
 
+    function setClanStarvationStartsAtTick(uint32 clanId, uint64 starvationStartsAtTick) external {
+        _clans[clanId].starvationStartsAtTick = starvationStartsAtTick;
+    }
+
     function setClanIronAndGold(uint32 clanId, uint256 vaultIron, uint256 goldBalance) external {
         _clans[clanId].vaultIron = vaultIron;
         _clans[clanId].goldBalance = goldBalance;
@@ -2008,7 +2012,7 @@ contract ClanWorldTest is Test {
         _advanceTick();
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        assertEq(_countLogs(logs, keccak256("WinterStarted(uint32)")), 1, "WinterStarted emits once");
+        assertEq(_countLogs(logs, keccak256("WinterStarted(uint64)")), 1, "WinterStarted emits once");
         assertEq(world.getWorldState().currentTick, winterStart, "currentTick should be winter start");
 
         _advanceTick();
@@ -2033,7 +2037,7 @@ contract ClanWorldTest is Test {
         WorldState memory ws = world.getWorldState();
         assertFalse(ws.winterActive, "winter should be over");
         assertFalse(world.isWinter(), "isWinter should be false after winter end");
-        assertEq(_countLogs(logs, keccak256("WinterEnded(uint32)")), 1, "WinterEnded emits once");
+        assertEq(_countLogs(logs, keccak256("WinterEnded(uint64)")), 1, "WinterEnded emits once");
         assertEq(ws.winterStartsAtTick, ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_PERIOD_TICKS);
     }
 
@@ -2047,14 +2051,18 @@ contract ClanWorldTest is Test {
         _advanceTick();
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        assertEq(_countLogs(logs, keccak256("WinterStarted(uint32)")), 1, "next WinterStarted emits once");
+        assertEq(_countLogs(logs, keccak256("WinterStarted(uint64)")), 1, "next WinterStarted emits once");
         assertTrue(world.isWinter(), "winter should be active in next period");
         assertEq(world.getWorldState().currentTick, nextWinterStart + 1);
     }
 
     function test_winter_cropTransitions_lockThenRestartRegrow() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
         uint32 clanId1 = _mintClan();
         uint32 clanId2 = _mintClan();
+        harness.setClanUpkeepState(clanId1, 0, 1000e18, 1000e18, 1000e18, 0);
+        harness.setClanUpkeepState(clanId2, 0, 1000e18, 1000e18, 1000e18, 0);
 
         (WheatPlot memory westBefore, WheatPlot memory eastBefore) = world.getWheatPlots(clanId1);
         assertEq(uint8(westBefore.state), uint8(WheatPlotState.Harvestable), "west starts harvestable");
@@ -2070,8 +2078,10 @@ contract ClanWorldTest is Test {
         assertEq(uint8(east1.state), uint8(WheatPlotState.WinterLocked), "clan1 east locks at winter start");
         assertEq(uint8(west2.state), uint8(WheatPlotState.WinterLocked), "clan2 west locks at winter start");
         assertEq(uint8(east2.state), uint8(WheatPlotState.WinterLocked), "clan2 east locks at winter start");
-        assertEq(west1.remainingWheat, westBefore.remainingWheat, "winter lock preserves remaining wheat");
-        assertEq(west1.regrowUntilTick, westBefore.regrowUntilTick, "winter lock preserves regrow tick");
+        assertEq(west1.remainingWheat, 0, "winter lock clears remaining wheat");
+        assertEq(east1.remainingWheat, 0, "winter lock clears all plots");
+        assertEq(west1.regrowUntilTick, 0, "winter lock clears regrow tick");
+        assertEq(east2.regrowUntilTick, 0, "winter lock clears all regrow ticks");
 
         OrderResult[] memory results =
             _submitOrder(clanId1, 1, ClanWorldConstants.REGION_WEST_FARMS, ActionType.HarvestWheat);
@@ -2125,7 +2135,7 @@ contract ClanWorldTest is Test {
         assertFalse(mission.active, "locked harvest mission should complete");
         assertEq(cs.carryWheat, 0, "locked harvest should yield no wheat");
         assertEq(uint8(west.state), uint8(WheatPlotState.WinterLocked), "plot remains winter locked");
-        assertEq(west.remainingWheat, ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT, "locked harvest does not drain plot");
+        assertEq(west.remainingWheat, 0, "winter start clears locked plot");
     }
 
     function test_winter_upkeep_doublesFoodAndBurnsWood() public {
@@ -2143,7 +2153,7 @@ contract ClanWorldTest is Test {
         Clan memory clan = world.getClan(clanId);
         assertEq(clan.vaultWheat, 92e18, "winter wheat upkeep should be 2x");
         assertEq(clan.vaultFish, 100e18 - 8e17, "winter fish upkeep should be 2x");
-        assertEq(clan.vaultWood, 98e18, "winter wood burn should be per clansman");
+        assertEq(clan.vaultWood, 97e18, "winter wood burn should include base and per clansman");
         assertEq(clan.coldDamage, 0, "sufficient wood should avoid cold damage");
         assertEq(clan.wallLevel, 2, "sufficient wood should not degrade wall");
         assertEq(clan.livingClansmen, 4, "sufficient wood should not kill clansmen");
@@ -2159,7 +2169,7 @@ contract ClanWorldTest is Test {
         harness.setClanUpkeepState(clanId, winterStart, 1e18, 100e18, 100e18, 0);
 
         vm.expectEmit(true, false, false, true);
-        emit IClanWorldEvents.ClanColdShortage(clanId, uint32(winterStart), 1e18);
+        emit IClanWorldEvents.ClanColdShortage(clanId, uint32(winterStart), 2e18);
         world.settleClan(clanId);
 
         Clan memory clan = world.getClan(clanId);
@@ -2216,6 +2226,49 @@ contract ClanWorldTest is Test {
         assertEq(deadCount, 1, "exactly one stored clansman should be dead");
     }
 
+    function test_pre_winter_starver_dies_in_winter_at_same_cadence() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 preWinterStarver = _mintClan();
+        uint32 winterStarver = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart + 6);
+
+        harness.setClanUpkeepState(preWinterStarver, winterStart + 3, 100e18, 0, 0, 0);
+        harness.setClanStarvationStartsAtTick(preWinterStarver, winterStart - 5);
+        harness.setClanUpkeepState(winterStarver, winterStart + 3, 100e18, 0, 0, 0);
+        harness.setClanStarvationStartsAtTick(winterStarver, winterStart + 2);
+
+        world.settleClan(preWinterStarver);
+        world.settleClan(winterStarver);
+
+        Clan memory preWinterClan = world.getClan(preWinterStarver);
+        Clan memory winterClan = world.getClan(winterStarver);
+        assertEq(preWinterClan.livingClansmen, 1, "pre-winter starver should lose one clansman per winter tick");
+        assertEq(winterClan.livingClansmen, 1, "fresh winter starver should lose clansmen at the same cadence");
+    }
+
+    function test_starvation_kill_deferred_to_next_tick() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart + 1);
+
+        harness.setClanUpkeepState(clanId, winterStart, 100e18, 0, 0, 0);
+        world.settleClan(clanId);
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(clan.starvationStartsAtTick, winterStart, "starvation starts on first short-food tick");
+        assertEq(clan.livingClansmen, 4, "first starvation tick should not kill");
+
+        _advanceTick();
+        world.settleClan(clanId);
+
+        clan = world.getClan(clanId);
+        assertEq(clan.livingClansmen, 3, "first death lands on the next tick");
+    }
+
     function test_clanDeath_starvationMarksDeadBurnsVaultAndPreservesGold() public {
         ClanWorldTestHarness harness = new ClanWorldTestHarness();
         world = harness;
@@ -2223,7 +2276,7 @@ contract ClanWorldTest is Test {
         uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
         uint256 goldBalance = 11e18;
 
-        _advanceToTick(winterStart + 4);
+        _advanceToTick(winterStart + 5);
         harness.setClanUpkeepState(clanId, winterStart, 100e18, 0, 0, 0);
         harness.setClanIronAndGold(clanId, 5e18, goldBalance);
 
@@ -2239,7 +2292,7 @@ contract ClanWorldTest is Test {
         assertEq(clan.vaultFish, 0, "fish should burn on death");
         assertEq(clan.vaultIron, 0, "iron should burn on death");
         assertEq(clan.goldBalance, goldBalance, "gold should survive clan death");
-        _assertClanDiedLog(logs, clanId, winterStart + 3, "starvation");
+        _assertClanDiedLog(logs, clanId, winterStart + 4, "starvation");
     }
 
     function test_clanDeath_coldDamageMarksDeadAndBurnsVault() public {
@@ -2274,7 +2327,7 @@ contract ClanWorldTest is Test {
         uint32 clanId = _mintClan();
 
         uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
-        _advanceToTick(winterStart + 4);
+        _advanceToTick(winterStart + 5);
         harness.setClanUpkeepState(clanId, winterStart, 100e18, 0, 0, 0);
         world.settleClan(clanId);
 
@@ -2290,7 +2343,7 @@ contract ClanWorldTest is Test {
         uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
         Clan memory clanABefore = world.getClan(clanIdA);
 
-        _advanceToTick(winterStart + 4);
+        _advanceToTick(winterStart + 5);
         harness.setClanUpkeepState(clanIdB, winterStart, 100e18, 0, 0, 0);
         world.settleClan(clanIdB);
 

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -6,6 +6,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {ClanWorld} from "../src/ClanWorld.sol";
 import {MinimalERC20} from "../src/MinimalERC20.sol";
 import {StubPool} from "../src/StubPool.sol";
+import {RNG} from "../src/lib/RNG.sol";
 import {
     IClanWorld,
     IClanWorldEvents,
@@ -160,6 +161,13 @@ contract ClanWorldTest is Test {
         }
     }
 
+    function _advanceWorldToTick(ClanWorld target, uint64 targetTick) internal {
+        while (target.getWorldState().currentTick < targetTick) {
+            vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+            target.heartbeat();
+        }
+    }
+
     function _countLogs(Vm.Log[] memory logs, bytes32 eventSig) internal pure returns (uint256 count) {
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].topics.length > 0 && logs[i].topics[0] == eventSig) {
@@ -193,6 +201,32 @@ contract ClanWorldTest is Test {
     function _mintClan() internal returns (uint32 clanId) {
         vm.prank(elder);
         (clanId,) = world.mintClan(elder);
+    }
+
+    function _mintClanOn(ClanWorld target) internal returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = target.mintClan(elder);
+    }
+
+    function _firstColdDeathAtTick(Vm.Log[] memory logs, uint32 expectedClanId, uint64 expectedTick)
+        internal
+        returns (uint32)
+    {
+        bytes32 eventSig = keccak256("ClansmanColdDeath(uint32,uint32,uint64)");
+        bytes32 expectedClanTopic = bytes32(uint256(expectedClanId));
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics.length < 2 || logs[i].topics[0] != eventSig || logs[i].topics[1] != expectedClanTopic) {
+                continue;
+            }
+
+            (uint32 csId, uint64 tick) = abi.decode(logs[i].data, (uint32, uint64));
+            if (tick == expectedTick) {
+                return csId;
+            }
+        }
+
+        fail("expected cold death log at tick");
+        return 0;
     }
 
     function _submitOrder(uint32 clanId, uint32 csId, uint8 gotoRegion, ActionType action)
@@ -2224,6 +2258,54 @@ contract ClanWorldTest is Test {
             }
         }
         assertEq(deadCount, 1, "exactly one stored clansman should be dead");
+    }
+
+    function test_coldDamage_victimIsStableAcrossDelayedSettlement() public {
+        ClanWorldTestHarness immediate = new ClanWorldTestHarness();
+        ClanWorldTestHarness delayed = new ClanWorldTestHarness();
+        uint32 immediateClanId = _mintClanOn(immediate);
+        uint32 delayedClanId = _mintClanOn(delayed);
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+
+        _advanceWorldToTick(immediate, winterStart + 1);
+        _advanceWorldToTick(delayed, winterStart + 1);
+
+        uint256 nonce = uint256(keccak256(abi.encodePacked(delayedClanId, winterStart, uint16(2))));
+        uint256 historicalPick = RNG.rngBounded(
+            delayed.getWorldState().currentTickSeed,
+            RNG.DOMAIN_COLD_DAMAGE,
+            nonce,
+            4
+        );
+        for (uint256 attempts = 0; attempts < 64; attempts++) {
+            if (
+                RNG.rngBounded(delayed.getWorldState().currentTickSeed, RNG.DOMAIN_COLD_DAMAGE, nonce, 4)
+                    != historicalPick
+            ) {
+                break;
+            }
+            _advanceWorldToTick(delayed, delayed.getWorldState().currentTick + 1);
+        }
+        assertNotEq(
+            RNG.rngBounded(delayed.getWorldState().currentTickSeed, RNG.DOMAIN_COLD_DAMAGE, nonce, 4),
+            historicalPick,
+            "test setup needs a delayed tick that would alter settlement-time RNG"
+        );
+
+        immediate.setClanUpkeepState(immediateClanId, winterStart, 0, 100e18, 100e18, 1);
+        delayed.setClanUpkeepState(delayedClanId, winterStart, 0, 100e18, 100e18, 1);
+
+        vm.recordLogs();
+        immediate.settleClan(immediateClanId);
+        Vm.Log[] memory immediateLogs = vm.getRecordedLogs();
+        uint32 immediateVictim = _firstColdDeathAtTick(immediateLogs, immediateClanId, winterStart);
+
+        vm.recordLogs();
+        delayed.settleClan(delayedClanId);
+        Vm.Log[] memory delayedLogs = vm.getRecordedLogs();
+        uint32 delayedVictim = _firstColdDeathAtTick(delayedLogs, delayedClanId, winterStart);
+
+        assertEq(delayedVictim, immediateVictim, "cold death victim must use historical tick RNG");
     }
 
     function test_pre_winter_starver_dies_in_winter_at_same_cadence() public {

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -2169,7 +2169,7 @@ contract ClanWorldTest is Test {
         harness.setClanUpkeepState(clanId, winterStart, 1e18, 100e18, 100e18, 0);
 
         vm.expectEmit(true, false, false, true);
-        emit IClanWorldEvents.ClanColdShortage(clanId, uint32(winterStart), 2e18);
+        emit IClanWorldEvents.ClanColdShortage(clanId, winterStart, 2e18);
         world.settleClan(clanId);
 
         Clan memory clan = world.getClan(clanId);
@@ -2188,7 +2188,7 @@ contract ClanWorldTest is Test {
         harness.setClanUpkeepState(clanId, winterStart, 0, 100e18, 100e18, 1);
 
         vm.expectEmit(true, false, false, true);
-        emit IClanWorldEvents.WallDegradedByCold(clanId, 1, uint32(winterStart));
+        emit IClanWorldEvents.WallDegradedByCold(clanId, 1, winterStart);
         world.settleClan(clanId);
 
         Clan memory clan = world.getClan(clanId);
@@ -2214,7 +2214,7 @@ contract ClanWorldTest is Test {
         assertEq(clan.coldDamage, 2, "cold damage should hit death threshold");
         assertEq(clan.wallLevel, 0, "wall should remain clamped at zero");
         assertEq(clan.livingClansmen, 3, "one clansman should die from cold");
-        assertEq(_countLogs(logs, keccak256("ClansmanColdDeath(uint32,uint32,uint32)")), 1, "cold death should emit");
+        assertEq(_countLogs(logs, keccak256("ClansmanColdDeath(uint32,uint32,uint64)")), 1, "cold death should emit");
 
         ClanFullView memory view_ = world.getClanFullView(clanId);
         uint256 deadCount = 0;
@@ -2232,20 +2232,93 @@ contract ClanWorldTest is Test {
         uint32 preWinterStarver = _mintClan();
         uint32 winterStarver = _mintClan();
         uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
-        _advanceToTick(winterStart + 6);
+        _advanceToTick(winterStart + 2);
 
-        harness.setClanUpkeepState(preWinterStarver, winterStart + 3, 100e18, 0, 0, 0);
+        harness.setClanUpkeepState(preWinterStarver, winterStart, 100e18, 0, 0, 0);
         harness.setClanStarvationStartsAtTick(preWinterStarver, winterStart - 5);
-        harness.setClanUpkeepState(winterStarver, winterStart + 3, 100e18, 0, 0, 0);
-        harness.setClanStarvationStartsAtTick(winterStarver, winterStart + 2);
+        harness.setClanUpkeepState(winterStarver, winterStart, 100e18, 0, 0, 0);
 
         world.settleClan(preWinterStarver);
         world.settleClan(winterStarver);
 
         Clan memory preWinterClan = world.getClan(preWinterStarver);
         Clan memory winterClan = world.getClan(winterStarver);
-        assertEq(preWinterClan.livingClansmen, 1, "pre-winter starver should lose one clansman per winter tick");
-        assertEq(winterClan.livingClansmen, 1, "fresh winter starver should lose clansmen at the same cadence");
+        assertEq(preWinterClan.livingClansmen, 3, "pre-winter starver should skip first winter tick death");
+        assertEq(winterClan.livingClansmen, 3, "fresh winter starver should match pre-winter cadence");
+    }
+
+    function test_winter_starvationWoodBurnUsesPreDeathLivingCount() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart + 2);
+
+        harness.setClanUpkeepState(clanId, winterStart + 1, 25e17, 0, 0, 0);
+        harness.setClanStarvationStartsAtTick(clanId, winterStart);
+
+        world.settleClan(clanId);
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(clan.livingClansmen, 3, "starvation should kill one clansman");
+        assertEq(clan.vaultWood, 0, "wood should be consumed after shortage");
+        assertEq(clan.coldDamage, 1, "wood burn should use the pre-starvation living count");
+    }
+
+    function test_winterColdDamageResetIsLazyPerClanAfterPartialSettlement() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 partiallySettledClan = _mintClan();
+        uint32 neverSettledClan = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        uint64 winterEnd = winterStart + ClanWorldConstants.WINTER_DURATION_TICKS;
+        _advanceToTick(winterStart + 3);
+
+        harness.setClanWallLevel(partiallySettledClan, 10);
+        harness.setClanWallLevel(neverSettledClan, 10);
+        harness.setClanUpkeepState(partiallySettledClan, winterStart, 0, 100e18, 100e18, 0);
+        harness.setClanUpkeepState(neverSettledClan, winterStart, 0, 100e18, 100e18, 0);
+
+        world.settleClan(partiallySettledClan);
+        Clan memory partialMidWinter = world.getClan(partiallySettledClan);
+        assertEq(partialMidWinter.wallLevel, 9, "three shortages should have degraded one wall level");
+        assertEq(partialMidWinter.coldDamage, 3, "mid-winter settlement should preserve accrued cold");
+
+        _advanceToTick(winterEnd);
+        world.settleClan(partiallySettledClan);
+        world.settleClan(neverSettledClan);
+
+        Clan memory partialAfterWinter = world.getClan(partiallySettledClan);
+        Clan memory neverAfterWinter = world.getClan(neverSettledClan);
+        assertEq(
+            partialAfterWinter.wallLevel, neverAfterWinter.wallLevel, "partial and lazy settlement should converge"
+        );
+        assertEq(partialAfterWinter.wallLevel, 5, "ten shortages should degrade five wall levels");
+        assertEq(partialAfterWinter.coldDamage, 0, "partial clan cold damage resets after crossing winter end");
+        assertEq(neverAfterWinter.coldDamage, 0, "lazy clan cold damage resets after crossing winter end");
+    }
+
+    function test_winterMintedClanStartsWithLockedEmptyWheatPlots() public {
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart);
+
+        uint32 clanId = _mintClan();
+        ClanFullView memory view_ = world.getClanFullView(clanId);
+        assertEq(uint8(view_.westPlot.state), uint8(WheatPlotState.WinterLocked), "west plot should start locked");
+        assertEq(uint8(view_.eastPlot.state), uint8(WheatPlotState.WinterLocked), "east plot should start locked");
+        assertEq(view_.westPlot.remainingWheat, 0, "west locked plot should start empty");
+        assertEq(view_.eastPlot.remainingWheat, 0, "east locked plot should start empty");
+    }
+
+    function test_winterCropTransitionCapCoversCurrentClanCap() public {
+        for (uint256 i = 0; i < 12; i++) {
+            _mintClan();
+        }
+        assertGe(world.MAX_CROP_TRANSITION_PER_TICK(), 24, "transition cap must cover 12 clans x 2 plots");
+
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart);
+        assertEq(world.getWorldState().currentTick, winterStart, "full clan cap should not brick winter heartbeat");
     }
 
     function test_starvation_kill_deferred_to_next_tick() public {

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -125,6 +125,20 @@ contract ClanWorldTest is Test {
         world.heartbeat();
     }
 
+    function _advanceToTick(uint64 targetTick) internal {
+        while (world.getWorldState().currentTick < targetTick) {
+            _advanceTick();
+        }
+    }
+
+    function _countLogs(Vm.Log[] memory logs, bytes32 eventSig) internal pure returns (uint256 count) {
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics.length > 0 && logs[i].topics[0] == eventSig) {
+                count++;
+            }
+        }
+    }
+
     function _mintClan() internal returns (uint32 clanId) {
         vm.prank(elder);
         (clanId,) = world.mintClan(elder);
@@ -1920,56 +1934,63 @@ contract ClanWorldTest is Test {
         assertEq(ws.currentSeasonNumber, 1, "season starts at 1");
         assertEq(ws.seasonStartTick, 0);
         assertEq(ws.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS);
-        assertEq(
-            ws.winterStartsAtTick,
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS
-        );
+        assertEq(ws.winterStartsAtTick, ClanWorldConstants.WINTER_START_TICK);
+        assertEq(ws.winterEndsAtTick, ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS);
         assertFalse(ws.winterActive);
+        assertFalse(world.isWinter());
     }
 
     function test_winter_onset() public {
-        // winterStartsAtTick = 100; WinterStarted fires on the heartbeat that opens tick 100
-        // i.e. when closedTick=99, newTick=100 >= winterStartsAtTick=100.
-        // Advance 99 heartbeats so currentTick=99, then one more heartbeat fires WinterStarted at tick 100.
-        uint64 winterStart =
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS; // = 100
-        for (uint64 i = 0; i < winterStart - 1; i++) {
-            vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
-            world.heartbeat();
-        }
-        // currentTick == 99; next heartbeat opens tick 100 and should emit WinterStarted(100)
+        _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart - 1);
+
         vm.recordLogs();
-        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
-        world.heartbeat();
+        _advanceTick();
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        bytes32 winterSig = keccak256("WinterStarted(uint64)");
-        bool foundWinterStarted = false;
-        for (uint256 i = 0; i < logs.length; i++) {
-            if (logs[i].topics.length > 0 && logs[i].topics[0] == winterSig) {
-                foundWinterStarted = true;
-                break;
-            }
-        }
-        assertTrue(foundWinterStarted, "WinterStarted event should have been emitted at tick 100");
-        assertTrue(world.getWorldState().winterActive, "winter should be active");
-        assertEq(world.getWorldState().currentTick, winterStart, "currentTick should be 100");
+        assertEq(_countLogs(logs, keccak256("WinterStarted(uint32)")), 1, "WinterStarted emits once");
+        assertEq(world.getWorldState().currentTick, winterStart, "currentTick should be winter start");
+
+        _advanceTick();
+        WorldState memory ws = world.getWorldState();
+        assertTrue(world.isWinter(), "winter should be active past start tick");
+        assertTrue(ws.winterActive, "world state should report winter active");
+        assertEq(ws.winterStartsAtTick, winterStart);
+        assertEq(ws.winterEndsAtTick, winterStart + ClanWorldConstants.WINTER_DURATION_TICKS);
     }
 
     function test_winter_end_and_next_cycle() public {
-        // Advance past first winter end tick (= 110)
-        uint64 winterEnd = ClanWorldConstants.TICKS_PER_WINTER_CYCLE; // = 110
-        for (uint64 i = 0; i <= winterEnd; i++) {
-            vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
-            world.heartbeat();
-        }
+        _mintClan();
+        uint64 winterEnd = ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS;
+        _advanceToTick(winterEnd - 1);
+
+        vm.recordLogs();
+        _advanceTick();
+        _advanceTick();
+        _advanceTick();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
         WorldState memory ws = world.getWorldState();
         assertFalse(ws.winterActive, "winter should be over");
-        // next winter at [210, 220)
-        assertEq(
-            ws.winterStartsAtTick,
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE * 2 - ClanWorldConstants.WINTER_DURATION_TICKS
-        );
+        assertFalse(world.isWinter(), "isWinter should be false after winter end");
+        assertEq(_countLogs(logs, keccak256("WinterEnded(uint32)")), 1, "WinterEnded emits once");
+        assertEq(ws.winterStartsAtTick, ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_PERIOD_TICKS);
+    }
+
+    function test_winter_restarts_after_full_period() public {
+        _mintClan();
+        uint64 nextWinterStart = ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_PERIOD_TICKS;
+        _advanceToTick(nextWinterStart - 1);
+
+        vm.recordLogs();
+        _advanceTick();
+        _advanceTick();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(_countLogs(logs, keccak256("WinterStarted(uint32)")), 1, "next WinterStarted emits once");
+        assertTrue(world.isWinter(), "winter should be active in next period");
+        assertEq(world.getWorldState().currentTick, nextWinterStart + 1);
     }
 
     function test_season_transition() public {
@@ -1982,9 +2003,8 @@ contract ClanWorldTest is Test {
         assertEq(ws.currentSeasonNumber, 2, "season number should increment");
         assertEq(ws.seasonStartTick, ClanWorldConstants.SEASON_DURATION_TICKS);
         assertEq(ws.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS * 2);
-        // winter reset for new season
-        uint64 expectedWinterStart = ClanWorldConstants.SEASON_DURATION_TICKS
-            + ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS;
+        // winter is derived from the global recurring schedule
+        uint64 expectedWinterStart = ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_PERIOD_TICKS * 3;
         assertEq(ws.winterStartsAtTick, expectedWinterStart);
     }
 

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -2017,6 +2017,82 @@ contract ClanWorldTest is Test {
         assertEq(world.getWorldState().currentTick, nextWinterStart + 1);
     }
 
+    function test_winter_cropTransitions_lockThenRestartRegrow() public {
+        uint32 clanId1 = _mintClan();
+        uint32 clanId2 = _mintClan();
+
+        (WheatPlot memory westBefore, WheatPlot memory eastBefore) = world.getWheatPlots(clanId1);
+        assertEq(uint8(westBefore.state), uint8(WheatPlotState.Harvestable), "west starts harvestable");
+        assertEq(uint8(eastBefore.state), uint8(WheatPlotState.Harvestable), "east starts harvestable");
+
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart - 1);
+        _advanceTick();
+
+        (WheatPlot memory west1, WheatPlot memory east1) = world.getWheatPlots(clanId1);
+        (WheatPlot memory west2, WheatPlot memory east2) = world.getWheatPlots(clanId2);
+        assertEq(uint8(west1.state), uint8(WheatPlotState.WinterLocked), "clan1 west locks at winter start");
+        assertEq(uint8(east1.state), uint8(WheatPlotState.WinterLocked), "clan1 east locks at winter start");
+        assertEq(uint8(west2.state), uint8(WheatPlotState.WinterLocked), "clan2 west locks at winter start");
+        assertEq(uint8(east2.state), uint8(WheatPlotState.WinterLocked), "clan2 east locks at winter start");
+        assertEq(west1.remainingWheat, westBefore.remainingWheat, "winter lock preserves remaining wheat");
+        assertEq(west1.regrowUntilTick, westBefore.regrowUntilTick, "winter lock preserves regrow tick");
+
+        OrderResult[] memory results =
+            _submitOrder(clanId1, 1, ClanWorldConstants.REGION_WEST_FARMS, ActionType.HarvestWheat);
+        assertEq(uint8(results[0].status), uint8(StatusCode.ERR_WINTER_LOCKED), "harvest locked during winter");
+
+        uint64 winterEnd = ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS;
+        _advanceToTick(winterEnd - 1);
+        _advanceTick();
+
+        uint64 expectedRegrowUntil = winterEnd + ClanWorldConstants.WHEAT_PLOT_REGROW_TICKS;
+        (west1, east1) = world.getWheatPlots(clanId1);
+        (west2, east2) = world.getWheatPlots(clanId2);
+        assertEq(uint8(west1.state), uint8(WheatPlotState.Regrowing), "clan1 west restarts regrow");
+        assertEq(uint8(east1.state), uint8(WheatPlotState.Regrowing), "clan1 east restarts regrow");
+        assertEq(uint8(west2.state), uint8(WheatPlotState.Regrowing), "clan2 west restarts regrow");
+        assertEq(uint8(east2.state), uint8(WheatPlotState.Regrowing), "clan2 east restarts regrow");
+        assertEq(west1.remainingWheat, 0, "winter end clears remaining wheat");
+        assertEq(east2.remainingWheat, 0, "winter end clears all plots");
+        assertEq(west1.regrowUntilTick, expectedRegrowUntil, "west regrow restarts from winter end");
+        assertEq(east2.regrowUntilTick, expectedRegrowUntil, "east regrow restarts from winter end");
+
+        _advanceToTick(expectedRegrowUntil + 1);
+        world.settleClan(clanId1);
+        world.settleClan(clanId2);
+
+        (west1, east1) = world.getWheatPlots(clanId1);
+        (west2, east2) = world.getWheatPlots(clanId2);
+        assertEq(uint8(west1.state), uint8(WheatPlotState.Harvestable), "clan1 west harvestable after regrow");
+        assertEq(uint8(east1.state), uint8(WheatPlotState.Harvestable), "clan1 east harvestable after regrow");
+        assertEq(uint8(west2.state), uint8(WheatPlotState.Harvestable), "clan2 west harvestable after regrow");
+        assertEq(uint8(east2.state), uint8(WheatPlotState.Harvestable), "clan2 east harvestable after regrow");
+        assertEq(west1.remainingWheat, ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT, "west wheat refills");
+        assertEq(east2.remainingWheat, ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT, "east wheat refills");
+    }
+
+    function test_winterLockedPlotSettlesInFlightHarvestWithNoYield() public {
+        uint32 clanId = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart - 2);
+
+        OrderResult[] memory results =
+            _submitOrder(clanId, 1, ClanWorldConstants.REGION_WEST_FARMS, ActionType.HarvestWheat);
+        assertEq(uint8(results[0].status), uint8(StatusCode.OK), "pre-winter harvest order should queue");
+        Mission memory queuedMission = world.getActiveMission(1);
+
+        _advanceToTick(queuedMission.settlesAtTick + 1);
+
+        Clansman memory cs = world.getClansman(1);
+        Mission memory mission = world.getActiveMission(1);
+        (WheatPlot memory west,) = world.getWheatPlots(clanId);
+        assertFalse(mission.active, "locked harvest mission should complete");
+        assertEq(cs.carryWheat, 0, "locked harvest should yield no wheat");
+        assertEq(uint8(west.state), uint8(WheatPlotState.WinterLocked), "plot remains winter locked");
+        assertEq(west.remainingWheat, ClanWorldConstants.WHEAT_PLOT_STARTING_WHEAT, "locked harvest does not drain plot");
+    }
+
     function test_winter_upkeep_doublesFoodAndBurnsWood() public {
         ClanWorldTestHarness harness = new ClanWorldTestHarness();
         world = harness;

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -68,6 +68,11 @@ contract ClanWorldTestHarness is ClanWorld {
     function setClanWallLevel(uint32 clanId, uint8 wallLevel) external {
         _clans[clanId].wallLevel = wallLevel;
     }
+
+    function setClanIronAndGold(uint32 clanId, uint256 vaultIron, uint256 goldBalance) external {
+        _clans[clanId].vaultIron = vaultIron;
+        _clans[clanId].goldBalance = goldBalance;
+    }
 }
 
 contract ClanWorldTest is Test {
@@ -157,6 +162,28 @@ contract ClanWorldTest is Test {
                 count++;
             }
         }
+    }
+
+    function _assertClanDiedLog(
+        Vm.Log[] memory logs,
+        uint32 expectedClanId,
+        uint64 expectedTick,
+        string memory expectedReason
+    ) internal {
+        bytes32 eventSig = keccak256("ClanDied(uint32,uint64,string)");
+        bytes32 expectedClanTopic = bytes32(uint256(expectedClanId));
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics.length < 2 || logs[i].topics[0] != eventSig || logs[i].topics[1] != expectedClanTopic) {
+                continue;
+            }
+
+            (uint64 tick, string memory reason) = abi.decode(logs[i].data, (uint64, string));
+            if (tick == expectedTick && keccak256(bytes(reason)) == keccak256(bytes(expectedReason))) {
+                return;
+            }
+        }
+
+        fail("expected ClanDied log");
     }
 
     function _mintClan() internal returns (uint32 clanId) {
@@ -2179,6 +2206,95 @@ contract ClanWorldTest is Test {
             }
         }
         assertEq(deadCount, 1, "exactly one stored clansman should be dead");
+    }
+
+    function test_clanDeath_starvationMarksDeadBurnsVaultAndPreservesGold() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        uint256 goldBalance = 11e18;
+
+        _advanceToTick(winterStart + 4);
+        harness.setClanUpkeepState(clanId, winterStart, 100e18, 0, 0, 0);
+        harness.setClanIronAndGold(clanId, 5e18, goldBalance);
+
+        vm.recordLogs();
+        world.settleClan(clanId);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(uint8(clan.clanState), uint8(ClanState.DEAD), "starvation should mark clan dead");
+        assertEq(clan.livingClansmen, 0, "all clansmen should be dead");
+        assertEq(clan.vaultWood, 0, "wood should burn on death");
+        assertEq(clan.vaultWheat, 0, "wheat should burn on death");
+        assertEq(clan.vaultFish, 0, "fish should burn on death");
+        assertEq(clan.vaultIron, 0, "iron should burn on death");
+        assertEq(clan.goldBalance, goldBalance, "gold should survive clan death");
+        _assertClanDiedLog(logs, clanId, winterStart + 3, "starvation");
+    }
+
+    function test_clanDeath_coldDamageMarksDeadAndBurnsVault() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        uint256 goldBalance = 13e18;
+        _advanceToTick(winterStart + 7);
+
+        harness.setClanUpkeepState(clanId, winterStart, 0, 100e18, 100e18, 1);
+        harness.setClanIronAndGold(clanId, 9e18, goldBalance);
+
+        vm.recordLogs();
+        world.settleClan(clanId);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(uint8(clan.clanState), uint8(ClanState.DEAD), "cold should mark clan dead");
+        assertEq(clan.livingClansmen, 0, "all clansmen should be dead");
+        assertEq(clan.vaultWood, 0, "wood should burn on death");
+        assertEq(clan.vaultWheat, 0, "wheat should burn on death");
+        assertEq(clan.vaultFish, 0, "fish should burn on death");
+        assertEq(clan.vaultIron, 0, "iron should burn on death");
+        assertEq(clan.goldBalance, goldBalance, "gold should survive clan death");
+        _assertClanDiedLog(logs, clanId, winterStart + 6, "cold");
+    }
+
+    function test_deadClanCannotSubmitClanOrders() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart + 4);
+        harness.setClanUpkeepState(clanId, winterStart, 100e18, 0, 0, 0);
+        world.settleClan(clanId);
+
+        vm.expectRevert("ClanWorld: clan dead");
+        _submitOrder(clanId, 1, ClanWorldConstants.REGION_FOREST, ActionType.Wait);
+    }
+
+    function test_clanDeath_doesNotAffectOtherClan() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanIdA = _mintClan();
+        uint32 clanIdB = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        Clan memory clanABefore = world.getClan(clanIdA);
+
+        _advanceToTick(winterStart + 4);
+        harness.setClanUpkeepState(clanIdB, winterStart, 100e18, 0, 0, 0);
+        world.settleClan(clanIdB);
+
+        Clan memory clanAAfter = world.getClan(clanIdA);
+        Clan memory clanB = world.getClan(clanIdB);
+        assertEq(uint8(clanB.clanState), uint8(ClanState.DEAD), "clan B should be dead");
+        assertEq(uint8(clanAAfter.clanState), uint8(ClanState.ACTIVE), "clan A should stay active");
+        assertEq(clanAAfter.livingClansmen, clanABefore.livingClansmen, "clan A living count should not change");
+        assertEq(clanAAfter.vaultWood, clanABefore.vaultWood, "clan A wood should not burn");
+        assertEq(clanAAfter.vaultWheat, clanABefore.vaultWheat, "clan A wheat should not burn");
+        assertEq(clanAAfter.vaultFish, clanABefore.vaultFish, "clan A fish should not burn");
+        assertEq(clanAAfter.goldBalance, clanABefore.goldBalance, "clan A gold should not change");
     }
 
     function test_winter_upkeep_returnsToNormalAfterWinter() public {

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -48,6 +48,22 @@ contract ClanWorldTestHarness is ClanWorld {
     function killClansman(uint32 csId) external {
         _clansmen[csId].state = ClansmanState.DEAD;
     }
+
+    function setClanUpkeepState(
+        uint32 clanId,
+        uint64 lastSettledTick,
+        uint256 vaultWood,
+        uint256 vaultWheat,
+        uint256 vaultFish,
+        uint16 coldDamage
+    ) external {
+        Clan storage clan = _clans[clanId];
+        clan.lastSettledTick = lastSettledTick;
+        clan.vaultWood = vaultWood;
+        clan.vaultWheat = vaultWheat;
+        clan.vaultFish = vaultFish;
+        clan.coldDamage = coldDamage;
+    }
 }
 
 contract ClanWorldTest is Test {
@@ -1828,7 +1844,11 @@ contract ClanWorldTest is Test {
         // Call settleClansman on-demand — must be idempotent (no crash, no double-credit).
         uint256 ironBefore = world.getClansman(csId).carryIron;
         world.settleClansman(csId);
-        assertEq(world.getClansman(csId).carryIron, ironBefore, "onDemand: settleClansman is idempotent after heartbeat settle");
+        assertEq(
+            world.getClansman(csId).carryIron,
+            ironBefore,
+            "onDemand: settleClansman is idempotent after heartbeat settle"
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -1991,6 +2011,60 @@ contract ClanWorldTest is Test {
         assertEq(_countLogs(logs, keccak256("WinterStarted(uint32)")), 1, "next WinterStarted emits once");
         assertTrue(world.isWinter(), "winter should be active in next period");
         assertEq(world.getWorldState().currentTick, nextWinterStart + 1);
+    }
+
+    function test_winter_upkeep_doublesFoodAndBurnsWood() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart + 1);
+
+        harness.setClanUpkeepState(clanId, winterStart, 100e18, 100e18, 100e18, 0);
+
+        world.settleClan(clanId);
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(clan.vaultWheat, 92e18, "winter wheat upkeep should be 2x");
+        assertEq(clan.vaultFish, 100e18 - 8e17, "winter fish upkeep should be 2x");
+        assertEq(clan.vaultWood, 98e18, "winter wood burn should be per clansman");
+        assertEq(clan.coldDamage, 0, "sufficient wood should avoid cold damage");
+    }
+
+    function test_winter_upkeep_insufficientWood_emitsColdShortage() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart + 1);
+
+        harness.setClanUpkeepState(clanId, winterStart, 1e18, 100e18, 100e18, 0);
+
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.ClanColdShortage(clanId, uint32(winterStart), 1e18);
+        world.settleClan(clanId);
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(clan.vaultWood, 0, "short winter burn should consume remaining wood");
+        assertEq(clan.coldDamage, 1, "short winter burn should mark cold damage");
+    }
+
+    function test_winter_upkeep_returnsToNormalAfterWinter() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+        uint64 winterEnd = ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS;
+        _advanceToTick(winterEnd + 1);
+
+        harness.setClanUpkeepState(clanId, winterEnd, 100e18, 100e18, 100e18, 2);
+
+        world.settleClan(clanId);
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(clan.vaultWheat, 96e18, "post-winter wheat upkeep should be normal");
+        assertEq(clan.vaultFish, 100e18 - 4e17, "post-winter fish upkeep should be normal");
+        assertEq(clan.vaultWood, 100e18, "post-winter should not burn wood");
+        assertEq(clan.coldDamage, 0, "cold damage should reset after winter");
     }
 
     function test_season_transition() public {

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -549,10 +549,10 @@ contract ClanWorldTest is Test {
     }
 
     // -------------------------------------------------------------------------
-    // Test B: submitClanOrders returns ERR_INVALID_ACTION when clan is >200 ticks behind
+    // Test B: submitClanOrders returns ERR_MUST_SETTLE_FIRST when clan is >200 ticks behind
     // -------------------------------------------------------------------------
 
-    function test_submitClanOrders_reverts_when_clan_too_far_behind() public {
+    function test_submitClanOrders_returnsMustSettleFirst_when_clan_too_far_behind() public {
         uint32 clanId = _mintClan();
         ClanFullView memory view_ = world.getClanFullView(clanId);
         uint32 csId = view_.clansmen[0].clansman.clansman.clansmanId;
@@ -562,7 +562,7 @@ contract ClanWorldTest is Test {
             _advanceTick();
         }
 
-        // submitClanOrders should return ERR_INVALID_ACTION (ERR_MUST_SETTLE_FIRST proxy)
+        // submitClanOrders should return ERR_MUST_SETTLE_FIRST
         // without reverting, for every order in the batch
         ClanOrder[] memory orders = new ClanOrder[](1);
         orders[0] = ClanOrder({
@@ -580,9 +580,11 @@ contract ClanWorldTest is Test {
         assertEq(results.length, 1, "should return one result");
         assertEq(
             uint8(results[0].status),
-            uint8(StatusCode.ERR_INVALID_ACTION),
-            "clan >200 ticks behind must return ERR_INVALID_ACTION (settle-first guard)"
+            uint8(StatusCode.ERR_MUST_SETTLE_FIRST),
+            "clan >200 ticks behind must return ERR_MUST_SETTLE_FIRST"
         );
+        assertEq(uint8(StatusCode.ERR_WINTER_LOCKED), 28, "existing status indices must remain stable");
+        assertEq(uint8(StatusCode.ERR_MUST_SETTLE_FIRST), 29, "new status code must be appended");
     }
 
     // -------------------------------------------------------------------------
@@ -1989,6 +1991,12 @@ contract ClanWorldTest is Test {
         assertEq(ws.winterEndsAtTick, ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS);
         assertFalse(ws.winterActive);
         assertFalse(world.isWinter());
+    }
+
+    function test_worldSnapshot_initialWinterStartsAtTick() public view {
+        WorldSnapshot memory snapshot = world.getWorldSnapshot();
+        assertEq(snapshot.winterStartsAtTick, ClanWorldConstants.WINTER_START_TICK);
+        assertEq(snapshot.winterStartsAtTick, 110);
     }
 
     function test_winter_onset() public {

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -64,6 +64,10 @@ contract ClanWorldTestHarness is ClanWorld {
         clan.vaultFish = vaultFish;
         clan.coldDamage = coldDamage;
     }
+
+    function setClanWallLevel(uint32 clanId, uint8 wallLevel) external {
+        _clans[clanId].wallLevel = wallLevel;
+    }
 }
 
 contract ClanWorldTest is Test {
@@ -2020,6 +2024,7 @@ contract ClanWorldTest is Test {
         uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
         _advanceToTick(winterStart + 1);
 
+        harness.setClanWallLevel(clanId, 2);
         harness.setClanUpkeepState(clanId, winterStart, 100e18, 100e18, 100e18, 0);
 
         world.settleClan(clanId);
@@ -2029,6 +2034,8 @@ contract ClanWorldTest is Test {
         assertEq(clan.vaultFish, 100e18 - 8e17, "winter fish upkeep should be 2x");
         assertEq(clan.vaultWood, 98e18, "winter wood burn should be per clansman");
         assertEq(clan.coldDamage, 0, "sufficient wood should avoid cold damage");
+        assertEq(clan.wallLevel, 2, "sufficient wood should not degrade wall");
+        assertEq(clan.livingClansmen, 4, "sufficient wood should not kill clansmen");
     }
 
     function test_winter_upkeep_insufficientWood_emitsColdShortage() public {
@@ -2047,6 +2054,55 @@ contract ClanWorldTest is Test {
         Clan memory clan = world.getClan(clanId);
         assertEq(clan.vaultWood, 0, "short winter burn should consume remaining wood");
         assertEq(clan.coldDamage, 1, "short winter burn should mark cold damage");
+    }
+
+    function test_coldDamage_degradesWallEveryTwoShortages() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart + 1);
+
+        harness.setClanWallLevel(clanId, 2);
+        harness.setClanUpkeepState(clanId, winterStart, 0, 100e18, 100e18, 1);
+
+        vm.expectEmit(true, false, false, true);
+        emit IClanWorldEvents.WallDegradedByCold(clanId, 1, uint32(winterStart));
+        world.settleClan(clanId);
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(clan.coldDamage, 2, "cold damage should increment");
+        assertEq(clan.wallLevel, 1, "second cold damage should degrade wall by one");
+        assertEq(clan.livingClansmen, 4, "wall should absorb cold before clansmen die");
+    }
+
+    function test_coldDamage_zeroWallKillsOneClansmanEveryTwoShortages() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart + 1);
+
+        harness.setClanUpkeepState(clanId, winterStart, 0, 100e18, 100e18, 1);
+
+        vm.recordLogs();
+        world.settleClan(clanId);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(clan.coldDamage, 2, "cold damage should hit death threshold");
+        assertEq(clan.wallLevel, 0, "wall should remain clamped at zero");
+        assertEq(clan.livingClansmen, 3, "one clansman should die from cold");
+        assertEq(_countLogs(logs, keccak256("ClansmanColdDeath(uint32,uint32,uint32)")), 1, "cold death should emit");
+
+        ClanFullView memory view_ = world.getClanFullView(clanId);
+        uint256 deadCount = 0;
+        for (uint256 i = 0; i < view_.clansmen.length; i++) {
+            if (view_.clansmen[i].clansman.clansman.state == ClansmanState.DEAD) {
+                deadCount++;
+            }
+        }
+        assertEq(deadCount, 1, "exactly one stored clansman should be dead");
     }
 
     function test_winter_upkeep_returnsToNormalAfterWinter() public {

--- a/packages/contracts/test/ClanWorldStub.t.sol
+++ b/packages/contracts/test/ClanWorldStub.t.sol
@@ -42,11 +42,9 @@ contract ClanWorldStubTest is Test {
         assertEq(ws.seasonStartTick, 0);
         assertEq(ws.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS);
         assertEq(ws.nextHeartbeatAtTick, ws.currentTick + 1, "next heartbeat opens currentTick + 1");
-        assertEq(
-            ws.winterStartsAtTick,
-            ClanWorldConstants.TICKS_PER_WINTER_CYCLE - ClanWorldConstants.WINTER_DURATION_TICKS
-        );
-        assertEq(ws.winterEndsAtTick, ClanWorldConstants.TICKS_PER_WINTER_CYCLE);
+        assertEq(ws.winterStartsAtTick, ClanWorldConstants.WINTER_START_TICK);
+        assertEq(ws.winterEndsAtTick, ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS);
         assertFalse(ws.winterActive);
+        assertFalse(stub.isWinter());
     }
 }

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -40,6 +40,8 @@ const HEARTBEAT_ABI = [
           { name: 'seasonStartTick', type: 'uint64' },
           { name: 'seasonEndTick', type: 'uint64' },
           { name: 'seasonFinalized', type: 'bool' },
+          { name: 'currentSeasonNumber', type: 'uint64' },
+          { name: 'nextHeartbeatAtTick', type: 'uint64' },
           { name: 'nextHeartbeatAtTs', type: 'uint64' },
           { name: 'nextBanditSpawnEligibleTick', type: 'uint64' },
           { name: 'currentBanditSpawnChanceBps', type: 'uint16' },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsc -b",
+    "test": "node scripts/check-chain-abi-parity.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "echo 'lint stub'",
     "clean": "rm -rf dist .turbo"

--- a/packages/shared/scripts/check-chain-abi-parity.mjs
+++ b/packages/shared/scripts/check-chain-abi-parity.mjs
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '../../..');
+const canonicalAbiPath = resolve(repoRoot, 'packages/contracts/abi/IClanWorld.json');
+const chainClientPath = resolve(repoRoot, 'packages/shared/src/adapters/IChainClient.ts');
+
+const abiJson = JSON.parse(readFileSync(canonicalAbiPath, 'utf8'));
+const abi = abiJson.abi ?? abiJson;
+const chainClientSource = readFileSync(chainClientPath, 'utf8');
+
+function findFunction(name) {
+  const fn = abi.find(item => item.type === 'function' && item.name === name);
+  if (!fn) throw new Error(`canonical ABI missing function ${name}`);
+  return fn;
+}
+
+function namedComponents(tuple) {
+  if (!Array.isArray(tuple.components)) throw new Error(`ABI tuple ${tuple.name} has no components`);
+  return tuple.components.map(component => ({ name: component.name, type: component.type }));
+}
+
+function extractArrayBody(source, openBracketIndex) {
+  let depth = 0;
+  for (let i = openBracketIndex; i < source.length; i++) {
+    const char = source[i];
+    if (char === '[') depth++;
+    if (char === ']') {
+      depth--;
+      if (depth === 0) return source.slice(openBracketIndex + 1, i);
+    }
+  }
+  throw new Error('unterminated components array in IChainClient.ts');
+}
+
+function extractHardcodedMissionShapes() {
+  const viewStart = chainClientSource.indexOf("name: 'getClanFullView'");
+  const nextFunction = chainClientSource.indexOf("name: 'submitClanOrders'", viewStart);
+  if (viewStart === -1 || nextFunction === -1) {
+    throw new Error('could not isolate getClanFullView ABI fragment in IChainClient.ts');
+  }
+
+  const viewSource = chainClientSource.slice(viewStart, nextFunction);
+  const shapes = [];
+  let searchFrom = 0;
+  while (true) {
+    const missionIndex = viewSource.indexOf("name: 'activeMission'", searchFrom);
+    if (missionIndex === -1) break;
+
+    const componentsIndex = viewSource.indexOf('components: [', missionIndex);
+    if (componentsIndex === -1) throw new Error('activeMission tuple missing components array');
+    const openBracketIndex = viewSource.indexOf('[', componentsIndex);
+    const body = extractArrayBody(viewSource, openBracketIndex);
+    shapes.push([...body.matchAll(/\{\s*name: '([^']+)',\s*type: '([^']+)'\s*\}/g)].map(match => ({
+      name: match[1],
+      type: match[2],
+    })));
+    searchFrom = componentsIndex + body.length;
+  }
+
+  return shapes;
+}
+
+const canonicalMission = namedComponents(findFunction('getActiveMission').outputs[0]);
+const hardcodedMissions = extractHardcodedMissionShapes();
+
+if (hardcodedMissions.length !== 2) {
+  throw new Error(`expected 2 getClanFullView activeMission tuples, found ${hardcodedMissions.length}`);
+}
+
+for (const [index, hardcodedMission] of hardcodedMissions.entries()) {
+  if (JSON.stringify(hardcodedMission) !== JSON.stringify(canonicalMission)) {
+    throw new Error(
+      `getClanFullView activeMission tuple ${index} diverges from canonical Mission ABI\n`
+      + `canonical=${JSON.stringify(canonicalMission)}\n`
+      + `hardcoded=${JSON.stringify(hardcodedMission)}`,
+    );
+  }
+}
+
+console.log('getClanFullView Mission ABI parity OK');

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -4,9 +4,21 @@ import { privateKeyToAccount } from 'viem/accounts';
 import type { ClanFullView, ClanOrder, Tick } from '../types';
 import { readEnv } from './_env';
 
+export interface OrderResult {
+  clansmanId: number;
+  status: number;
+  cooldownEndsAtTs: number;
+  missionNonce: number;
+}
+
+export interface SubmitOrdersResult {
+  txHash: string;
+  results: OrderResult[];
+}
+
 export interface IChainClient {
   getCurrentTick(): Promise<Tick>;
-  submitOrders(clanId: string, orders: ClanOrder[]): Promise<{ txHash: string }>;
+  submitOrders(clanId: string, orders: ClanOrder[]): Promise<SubmitOrdersResult>;
   getClanFullView(clanId: string): Promise<ClanFullView>;
 }
 
@@ -135,6 +147,9 @@ const CLAN_WORLD_ABI = [
                     components: [
                       { name: 'active', type: 'bool' },
                       { name: 'nonce', type: 'uint64' },
+                      { name: 'submittedAtTick', type: 'uint64' },
+                      { name: 'executesAtTick', type: 'uint64' },
+                      { name: 'settlesAtTick', type: 'uint64' },
                       { name: 'clansmanId', type: 'uint32' },
                       { name: 'startRegion', type: 'uint8' },
                       { name: 'targetRegion', type: 'uint8' },
@@ -160,6 +175,9 @@ const CLAN_WORLD_ABI = [
                 components: [
                   { name: 'active', type: 'bool' },
                   { name: 'nonce', type: 'uint64' },
+                  { name: 'submittedAtTick', type: 'uint64' },
+                  { name: 'executesAtTick', type: 'uint64' },
+                  { name: 'settlesAtTick', type: 'uint64' },
                   { name: 'clansmanId', type: 'uint32' },
                   { name: 'startRegion', type: 'uint8' },
                   { name: 'targetRegion', type: 'uint8' },
@@ -243,8 +261,8 @@ class StubChainClient implements IChainClient {
   async getCurrentTick(): Promise<Tick> {
     return 0;
   }
-  async submitOrders(_clanId: string, _orders: ClanOrder[]): Promise<{ txHash: string }> {
-    return { txHash: '0xstub' };
+  async submitOrders(_clanId: string, _orders: ClanOrder[]): Promise<SubmitOrdersResult> {
+    return { txHash: '0xstub', results: [] };
   }
   async getClanFullView(clanId: string): Promise<ClanFullView> {
     return {
@@ -288,7 +306,7 @@ class RealChainClient implements IChainClient {
     return Number(snapshot.currentTick); // safe: tick values are small enough to fit Number precisely in Wave 0
   }
 
-  async submitOrders(clanId: string, orders: ClanOrder[]): Promise<{ txHash: string }> {
+  async submitOrders(clanId: string, orders: ClanOrder[]): Promise<SubmitOrdersResult> {
     // Wave 0: single-Elder only — concurrent nonce coordination deferred to Wave 1
     const parsedClanId = parseInt(clanId, 10);
     if (isNaN(parsedClanId) || String(parsedClanId) !== clanId.trim()) {
@@ -366,14 +384,25 @@ class RealChainClient implements IChainClient {
       transport: this.transport,
     });
 
-    const hash = await walletClient.writeContract({
+    const { request, result } = await this.client.simulateContract({
       address: this.contractAddress,
       abi: CLAN_WORLD_ABI,
       functionName: 'submitClanOrders',
       args: [parsedClanId, contractOrders],
+      account,
     });
 
-    return { txHash: hash };
+    const hash = await walletClient.writeContract(request);
+
+    return {
+      txHash: hash,
+      results: result.map(orderResult => ({
+        clansmanId: Number(orderResult.clansmanId),
+        status: Number(orderResult.status),
+        cooldownEndsAtTs: Number(orderResult.cooldownEndsAtTs),
+        missionNonce: Number(orderResult.missionNonce),
+      })),
+    };
   }
 
   async getClanFullView(clanId: string): Promise<ClanFullView> {

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -36,6 +36,8 @@ const CLAN_WORLD_ABI = [
           { name: 'seasonStartTick', type: 'uint64' },
           { name: 'seasonEndTick', type: 'uint64' },
           { name: 'seasonFinalized', type: 'bool' },
+          { name: 'currentSeasonNumber', type: 'uint64' },
+          { name: 'nextHeartbeatAtTick', type: 'uint64' },
           { name: 'winterActive', type: 'bool' },
           { name: 'winterStartsAtTick', type: 'uint64' },
           { name: 'winterEndsAtTick', type: 'uint64' },

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -13,6 +13,11 @@ export interface OrderResult {
 
 export interface SubmitOrdersResult {
   txHash: string;
+  /**
+   * Per-order statuses returned by pre-send contract simulation.
+   * These are useful for client-side expectations, but are not chain-authoritative
+   * finalized outcomes for the submitted transaction.
+   */
   results: OrderResult[];
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -4,6 +4,9 @@
 
 export type Tick = number;
 
+/** Mirrors ClanWorldConstants.REGION_FOREST in packages/contracts/src/IClanWorld.sol. */
+export const REGION_FOREST = 1;
+
 export interface TickEpoch {
   /** Unix seconds when this tick window started. */
   startedAt: number;


### PR DESCRIPTION
Phase 10C b-branch consolidating Phase 10 follow-up items.

**Fold history:** PR #363 squash-merged.

**Closes:** #331 #332 #334

### Items
- **#331** — orchestrator now uses explicit `REGION_FOREST` for ChopWood (was `gotoRegion: 0` REGION_NOOP, fragile)
- **#332** — `ClanWorld.sol:445` NatSpec referencing v4.6 phase 5 §5.2 for same-tick starvation rationale
- **#334** — `submitOrders.results` JSDoc'd as simulation-only; orchestrator logs labeled `[sim]`

4 files +24/-10. Codex local 3-tier CLEAN.