### PR TITLE
feat(contracts): Phase 7 OTC strip-out — direct transfers + clan ownership (#386)

### DIFF
--- a/docs/reviews/pr389-spec-compliance-uat.md
+++ b/docs/reviews/pr389-spec-compliance-uat.md
@@ -1,0 +1,37 @@
+# PR 389 Phase 7 Spec Compliance + UAT
+
+## Scope
+
+Phase 7 implements the v4 direct OTC transfer surface and clan ownership handoff:
+
+- `transferGold`
+- `transferVaultResource`
+- `transferBlueprint`
+- `transferBundle`
+- `transferClanOwnership`
+
+Deprecated proposal/accept escrow mechanics are intentionally not present. OTC negotiation remains social/off-chain or agent-mediated; settlement is a direct owner-authorized transfer.
+
+## Spec Alignment
+
+| Area | Expected behavior | Implementation status |
+| --- | --- | --- |
+| Direct OTC transfers | Sender clan owner can transfer gold, vault resources, blueprints, or bundles directly to another clan. | Matches. |
+| Dead clan restriction | Dead sender cannot transfer; dead recipient can receive. | Matches v4.3 outbound-only restriction. |
+| Settlement freshness | Transfers cannot execute against partially settled clans after the lazy-settlement cap. | Matches via `ClanWorld: must settle first`. |
+| Invalid resource enum | Invalid resource values must not fall through to fish. | Matches via explicit invalid-resource revert. |
+| Atomic bundle | Bundle component debits/credits are atomic after settlement. | Matches. |
+| Clan ownership transfer | Current owner can transfer ownership and increments `ownerNonce`. | Matches. |
+| Self ownership transfer | Same-owner transfer is rejected; no nonce-only rotation feature. | Accepted implementation choice. |
+
+## UAT Checklist
+
+- Run direct-transfer Forge tests and verify all pass.
+- Verify generated ABI contains the direct transfer functions and `ClanOwnershipTransferred`.
+- Verify generated ABI does not contain OTC proposal/accept functions or events.
+- Verify chainclient ABI generation/check passes.
+- In local smoke testing, mint two clans and confirm an owner can transfer gold/resources from one clan to the other.
+
+## Notes
+
+`ownerNonce` exists for ownership handoff tracking only in this phase. If a later phase introduces off-chain signatures that require nonce-only invalidation, add an explicit ADR before changing same-owner transfer behavior.

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -594,6 +594,11 @@
               "internalType": "uint16"
             },
             {
+              "name": "ownerNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
               "name": "goldBalance",
               "type": "uint256",
               "internalType": "uint256"
@@ -713,6 +718,11 @@
                       "name": "coldDamage",
                       "type": "uint16",
                       "internalType": "uint16"
+                    },
+                    {
+                      "name": "ownerNonce",
+                      "type": "uint64",
+                      "internalType": "uint64"
                     },
                     {
                       "name": "goldBalance",
@@ -1360,6 +1370,11 @@
                   "name": "coldDamage",
                   "type": "uint16",
                   "internalType": "uint16"
+                },
+                {
+                  "name": "ownerNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
                 },
                 {
                   "name": "goldBalance",
@@ -2918,6 +2933,24 @@
     },
     {
       "type": "function",
+      "name": "transferClanOwnership",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "newOwner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
       "name": "transferGold",
       "inputs": [
         {
@@ -3390,6 +3423,37 @@
           "name": "tick",
           "type": "uint64",
           "indexed": true,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ClanOwnershipTransferred",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "oldOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newOwnerNonce",
+          "type": "uint64",
+          "indexed": false,
           "internalType": "uint64"
         }
       ],

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -4484,27 +4484,174 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     // =========================================================================
+    // CLAN OWNERSHIP TRANSFER
+    // =========================================================================
+
+    /// @notice Transfer clan ownership to a new address. Increments ownerNonce.
+    function transferClanOwnership(uint32 clanId, address newOwner) external override nonReentrant {
+        Clan storage clan = _clans[clanId];
+        require(clan.clanId != 0, "ClanWorld: clan not found");
+        require(clan.owner == msg.sender, "ClanWorld: not clan owner");
+        require(newOwner != address(0), "ClanWorld: zero address");
+        require(newOwner != clan.owner, "ClanWorld: same owner");
+        address oldOwner = clan.owner;
+        clan.owner = newOwner;
+        clan.ownerNonce++;
+        emit ClanOwnershipTransferred(clanId, oldOwner, newOwner, clan.ownerNonce);
+    }
+
+    // =========================================================================
     // OTC TRANSFERS
     // =========================================================================
 
-    function transferGold(uint32, uint32, uint256) external pure override {
-        revert("OTC transfers not implemented");
+    /// @notice Transfer gold from one clan to another. Caller must be owner of fromClan.
+    function transferGold(uint32 fromClanId, uint32 toClanId, uint256 amount) external override nonReentrant {
+        require(amount > 0, "ClanWorld: zero amount");
+        require(fromClanId != toClanId, "ClanWorld: same clan");
+
+        Clan storage fromClan = _clans[fromClanId];
+        Clan storage toClan = _clans[toClanId];
+
+        require(fromClan.clanId != 0, "ClanWorld: from clan not found");
+        require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
+        require(toClan.clanId != 0, "ClanWorld: to clan not found");
+
+        _settleClan(fromClanId);
+        _settleClan(toClanId);
+
+        require(fromClan.clanState != ClanState.DEAD, "ClanWorld: clan dead");
+        require(fromClan.goldBalance >= amount, "ClanWorld: insufficient gold");
+
+        fromClan.goldBalance -= amount;
+        toClan.goldBalance += amount;
+
+        emit GoldTransferred(fromClanId, toClanId, amount, _world.currentTick);
     }
 
-    function transferVaultResource(uint32, uint32, ResourceType, uint256) external pure override {
-        revert("OTC transfers not implemented");
-    }
-
-    function transferBlueprint(uint32, uint32, uint256) external pure override {
-        revert("OTC transfers not implemented");
-    }
-
-    function transferBundle(uint32, uint32, uint256, uint256, uint256, uint256, uint256, uint256)
+    /// @notice Transfer a vault resource from one clan to another. Caller must be owner of fromClan.
+    function transferVaultResource(uint32 fromClanId, uint32 toClanId, ResourceType resource, uint256 amount)
         external
-        pure
         override
+        nonReentrant
     {
-        revert("OTC transfers not implemented");
+        require(amount > 0, "ClanWorld: zero amount");
+        require(fromClanId != toClanId, "ClanWorld: same clan");
+
+        Clan storage fromClan = _clans[fromClanId];
+        Clan storage toClan = _clans[toClanId];
+
+        require(fromClan.clanId != 0, "ClanWorld: from clan not found");
+        require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
+        require(toClan.clanId != 0, "ClanWorld: to clan not found");
+
+        _settleClan(fromClanId);
+        _settleClan(toClanId);
+
+        require(fromClan.clanState != ClanState.DEAD, "ClanWorld: clan dead");
+        if (resource == ResourceType.Wood) {
+            require(fromClan.vaultWood >= amount, "ClanWorld: insufficient wood");
+            fromClan.vaultWood -= amount;
+            toClan.vaultWood += amount;
+        } else if (resource == ResourceType.Iron) {
+            require(fromClan.vaultIron >= amount, "ClanWorld: insufficient iron");
+            fromClan.vaultIron -= amount;
+            toClan.vaultIron += amount;
+        } else if (resource == ResourceType.Wheat) {
+            require(fromClan.vaultWheat >= amount, "ClanWorld: insufficient wheat");
+            fromClan.vaultWheat -= amount;
+            toClan.vaultWheat += amount;
+        } else {
+            require(fromClan.vaultFish >= amount, "ClanWorld: insufficient fish");
+            fromClan.vaultFish -= amount;
+            toClan.vaultFish += amount;
+        }
+
+        emit VaultResourceTransferred(fromClanId, toClanId, resource, amount, _world.currentTick);
+    }
+
+    /// @notice Transfer blueprints from one clan to another. Caller must be owner of fromClan.
+    function transferBlueprint(uint32 fromClanId, uint32 toClanId, uint256 amount) external override nonReentrant {
+        require(amount > 0, "ClanWorld: zero amount");
+        require(fromClanId != toClanId, "ClanWorld: same clan");
+
+        Clan storage fromClan = _clans[fromClanId];
+        Clan storage toClan = _clans[toClanId];
+
+        require(fromClan.clanId != 0, "ClanWorld: from clan not found");
+        require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
+        require(toClan.clanId != 0, "ClanWorld: to clan not found");
+
+        _settleClan(fromClanId);
+        _settleClan(toClanId);
+
+        require(fromClan.clanState != ClanState.DEAD, "ClanWorld: clan dead");
+        require(fromClan.blueprintBalance >= amount, "ClanWorld: insufficient blueprints");
+
+        fromClan.blueprintBalance -= amount;
+        toClan.blueprintBalance += amount;
+
+        emit BlueprintTransferred(fromClanId, toClanId, amount, _world.currentTick);
+    }
+
+    /// @notice Transfer a bundle of resources atomically. Caller must be owner of fromClan.
+    ///         At least one component must be non-zero. All checks run before any state mutation.
+    function transferBundle(
+        uint32 fromClanId,
+        uint32 toClanId,
+        uint256 gold,
+        uint256 blueprint,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish
+    ) external override nonReentrant {
+        require(gold > 0 || blueprint > 0 || wood > 0 || iron > 0 || wheat > 0 || fish > 0, "ClanWorld: empty bundle");
+        require(fromClanId != toClanId, "ClanWorld: same clan");
+
+        Clan storage fromClan = _clans[fromClanId];
+        Clan storage toClan = _clans[toClanId];
+
+        require(fromClan.clanId != 0, "ClanWorld: from clan not found");
+        require(fromClan.owner == msg.sender, "ClanWorld: not clan owner");
+        require(toClan.clanId != 0, "ClanWorld: to clan not found");
+
+        _settleClan(fromClanId);
+        _settleClan(toClanId);
+
+        require(fromClan.clanState != ClanState.DEAD, "ClanWorld: clan dead");
+        // All balance checks before any mutation (atomic)
+        if (gold > 0) require(fromClan.goldBalance >= gold, "ClanWorld: insufficient gold");
+        if (blueprint > 0) require(fromClan.blueprintBalance >= blueprint, "ClanWorld: insufficient blueprints");
+        if (wood > 0) require(fromClan.vaultWood >= wood, "ClanWorld: insufficient wood");
+        if (iron > 0) require(fromClan.vaultIron >= iron, "ClanWorld: insufficient iron");
+        if (wheat > 0) require(fromClan.vaultWheat >= wheat, "ClanWorld: insufficient wheat");
+        if (fish > 0) require(fromClan.vaultFish >= fish, "ClanWorld: insufficient fish");
+
+        // Apply debits
+        if (gold > 0) fromClan.goldBalance -= gold;
+        if (blueprint > 0) fromClan.blueprintBalance -= blueprint;
+        if (wood > 0) fromClan.vaultWood -= wood;
+        if (iron > 0) fromClan.vaultIron -= iron;
+        if (wheat > 0) fromClan.vaultWheat -= wheat;
+        if (fish > 0) fromClan.vaultFish -= fish;
+
+        // Apply credits
+        if (gold > 0) toClan.goldBalance += gold;
+        if (blueprint > 0) toClan.blueprintBalance += blueprint;
+        if (wood > 0) toClan.vaultWood += wood;
+        if (iron > 0) toClan.vaultIron += iron;
+        if (wheat > 0) toClan.vaultWheat += wheat;
+        if (fish > 0) toClan.vaultFish += fish;
+
+        // Emit per-component events
+        if (gold > 0) emit GoldTransferred(fromClanId, toClanId, gold, _world.currentTick);
+        if (blueprint > 0) emit BlueprintTransferred(fromClanId, toClanId, blueprint, _world.currentTick);
+        if (wood > 0) emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Wood, wood, _world.currentTick);
+        if (iron > 0) emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Iron, iron, _world.currentTick);
+        if (wheat > 0) {
+            emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Wheat, wheat, _world.currentTick);
+        }
+        if (fish > 0) emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Fish, fish, _world.currentTick);
     }
 
     // =========================================================================

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -4504,6 +4504,13 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     // OTC TRANSFERS
     // =========================================================================
 
+    function _requireTransferSettlementComplete(Clan storage fromClan, Clan storage toClan) private view {
+        require(
+            fromClan.lastSettledTick == _world.currentTick && toClan.lastSettledTick == _world.currentTick,
+            "ClanWorld: must settle first"
+        );
+    }
+
     /// @notice Transfer gold from one clan to another. Caller must be owner of fromClan.
     function transferGold(uint32 fromClanId, uint32 toClanId, uint256 amount) external override nonReentrant {
         require(amount > 0, "ClanWorld: zero amount");
@@ -4519,6 +4526,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _settleClan(fromClanId);
         _settleClan(toClanId);
 
+        _requireTransferSettlementComplete(fromClan, toClan);
         require(fromClan.clanState != ClanState.DEAD, "ClanWorld: clan dead");
         require(fromClan.goldBalance >= amount, "ClanWorld: insufficient gold");
 
@@ -4547,6 +4555,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _settleClan(fromClanId);
         _settleClan(toClanId);
 
+        _requireTransferSettlementComplete(fromClan, toClan);
         require(fromClan.clanState != ClanState.DEAD, "ClanWorld: clan dead");
         if (resource == ResourceType.Wood) {
             require(fromClan.vaultWood >= amount, "ClanWorld: insufficient wood");
@@ -4560,10 +4569,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             require(fromClan.vaultWheat >= amount, "ClanWorld: insufficient wheat");
             fromClan.vaultWheat -= amount;
             toClan.vaultWheat += amount;
-        } else {
+        } else if (resource == ResourceType.Fish) {
             require(fromClan.vaultFish >= amount, "ClanWorld: insufficient fish");
             fromClan.vaultFish -= amount;
             toClan.vaultFish += amount;
+        } else {
+            revert("ClanWorld: invalid resource");
         }
 
         emit VaultResourceTransferred(fromClanId, toClanId, resource, amount, _world.currentTick);
@@ -4584,6 +4595,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _settleClan(fromClanId);
         _settleClan(toClanId);
 
+        _requireTransferSettlementComplete(fromClan, toClan);
         require(fromClan.clanState != ClanState.DEAD, "ClanWorld: clan dead");
         require(fromClan.blueprintBalance >= amount, "ClanWorld: insufficient blueprints");
 
@@ -4594,7 +4606,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     /// @notice Transfer a bundle of resources atomically. Caller must be owner of fromClan.
-    ///         At least one component must be non-zero. All checks run before any state mutation.
+    ///         At least one component must be non-zero. Component debits and credits are atomic after settlement.
     function transferBundle(
         uint32 fromClanId,
         uint32 toClanId,
@@ -4618,6 +4630,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _settleClan(fromClanId);
         _settleClan(toClanId);
 
+        _requireTransferSettlementComplete(fromClan, toClan);
         require(fromClan.clanState != ClanState.DEAD, "ClanWorld: clan dead");
         // All balance checks before any mutation (atomic)
         if (gold > 0) require(fromClan.goldBalance >= gold, "ClanWorld: insufficient gold");

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -44,6 +44,8 @@ import {
 contract ClanWorldStub is IClanWorld {
     WorldState private _world;
     TreasuryState private _treasury;
+    uint32 private _nextClanId = 1;
+    mapping(uint32 => Clan) private _clans;
 
     constructor(address[6] memory tokens, address[4] memory pools) {
         _world.currentTick = 0;
@@ -103,8 +105,25 @@ contract ClanWorldStub is IClanWorld {
     // Clan lifecycle
     // -------------------------------------------------------------------------
 
-    function mintClan(address) external override returns (uint32, uint256) {
-        return (1, 1);
+    function mintClan(address to) external override returns (uint32 clanId, uint256 iftTokenId) {
+        require(to != address(0), "ClanWorldStub: zero address");
+
+        clanId = _nextClanId++;
+        iftTokenId = uint256(clanId);
+
+        Clan storage clan = _clans[clanId];
+        clan.clanId = clanId;
+        clan.iftTokenId = iftTokenId;
+        clan.owner = to;
+        clan.clanState = ClanState.ACTIVE;
+        clan.lastSettledTick = _world.currentTick;
+        clan.livingClansmen = 4;
+        clan.goldBalance = 3e18;
+        clan.vaultWood = 20e18;
+        clan.vaultWheat = 20e18;
+        clan.vaultFish = 2e18;
+
+        emit ClanSpawned(clanId, to, iftTokenId, 0, _world.currentTick);
     }
 
     function submitClanOrders(uint32, ClanOrder[] calldata orders)
@@ -128,7 +147,16 @@ contract ClanWorldStub is IClanWorld {
     // -------------------------------------------------------------------------
 
     function transferClanOwnership(uint32 clanId, address newOwner) external override {
-        emit ClanOwnershipTransferred(clanId, msg.sender, newOwner, 1);
+        Clan storage clan = _clans[clanId];
+        require(clan.clanId != 0, "ClanWorldStub: clan not found");
+        require(clan.owner == msg.sender, "ClanWorldStub: not clan owner");
+        require(newOwner != address(0), "ClanWorldStub: zero address");
+        require(newOwner != clan.owner, "ClanWorldStub: same owner");
+
+        address oldOwner = clan.owner;
+        clan.owner = newOwner;
+        clan.ownerNonce++;
+        emit ClanOwnershipTransferred(clanId, oldOwner, newOwner, clan.ownerNonce);
     }
 
     // -------------------------------------------------------------------------
@@ -136,6 +164,14 @@ contract ClanWorldStub is IClanWorld {
     // -------------------------------------------------------------------------
 
     function transferGold(uint32 fromClanId, uint32 toClanId, uint256 amount) external override {
+        Clan storage fromClan = _clans[fromClanId];
+        Clan storage toClan = _clans[toClanId];
+        require(fromClan.owner == msg.sender, "ClanWorldStub: not clan owner");
+        require(toClan.clanId != 0, "ClanWorldStub: to clan not found");
+        require(fromClan.goldBalance >= amount, "ClanWorldStub: insufficient gold");
+
+        fromClan.goldBalance -= amount;
+        toClan.goldBalance += amount;
         emit GoldTransferred(fromClanId, toClanId, amount, _world.currentTick);
     }
 
@@ -143,10 +179,43 @@ contract ClanWorldStub is IClanWorld {
         external
         override
     {
+        Clan storage fromClan = _clans[fromClanId];
+        Clan storage toClan = _clans[toClanId];
+        require(fromClan.owner == msg.sender, "ClanWorldStub: not clan owner");
+        require(toClan.clanId != 0, "ClanWorldStub: to clan not found");
+
+        if (resource == ResourceType.Wood) {
+            require(fromClan.vaultWood >= amount, "ClanWorldStub: insufficient wood");
+            fromClan.vaultWood -= amount;
+            toClan.vaultWood += amount;
+        } else if (resource == ResourceType.Iron) {
+            require(fromClan.vaultIron >= amount, "ClanWorldStub: insufficient iron");
+            fromClan.vaultIron -= amount;
+            toClan.vaultIron += amount;
+        } else if (resource == ResourceType.Wheat) {
+            require(fromClan.vaultWheat >= amount, "ClanWorldStub: insufficient wheat");
+            fromClan.vaultWheat -= amount;
+            toClan.vaultWheat += amount;
+        } else if (resource == ResourceType.Fish) {
+            require(fromClan.vaultFish >= amount, "ClanWorldStub: insufficient fish");
+            fromClan.vaultFish -= amount;
+            toClan.vaultFish += amount;
+        } else {
+            revert("ClanWorldStub: invalid resource");
+        }
+
         emit VaultResourceTransferred(fromClanId, toClanId, resource, amount, _world.currentTick);
     }
 
     function transferBlueprint(uint32 fromClanId, uint32 toClanId, uint256 amount) external override {
+        Clan storage fromClan = _clans[fromClanId];
+        Clan storage toClan = _clans[toClanId];
+        require(fromClan.owner == msg.sender, "ClanWorldStub: not clan owner");
+        require(toClan.clanId != 0, "ClanWorldStub: to clan not found");
+        require(fromClan.blueprintBalance >= amount, "ClanWorldStub: insufficient blueprints");
+
+        fromClan.blueprintBalance -= amount;
+        toClan.blueprintBalance += amount;
         emit BlueprintTransferred(fromClanId, toClanId, amount, _world.currentTick);
     }
 
@@ -160,6 +229,30 @@ contract ClanWorldStub is IClanWorld {
         uint256 wheat,
         uint256 fish
     ) external override {
+        Clan storage fromClan = _clans[fromClanId];
+        Clan storage toClan = _clans[toClanId];
+        require(fromClan.owner == msg.sender, "ClanWorldStub: not clan owner");
+        require(toClan.clanId != 0, "ClanWorldStub: to clan not found");
+        require(fromClan.goldBalance >= gold, "ClanWorldStub: insufficient gold");
+        require(fromClan.blueprintBalance >= blueprint, "ClanWorldStub: insufficient blueprints");
+        require(fromClan.vaultWood >= wood, "ClanWorldStub: insufficient wood");
+        require(fromClan.vaultIron >= iron, "ClanWorldStub: insufficient iron");
+        require(fromClan.vaultWheat >= wheat, "ClanWorldStub: insufficient wheat");
+        require(fromClan.vaultFish >= fish, "ClanWorldStub: insufficient fish");
+
+        fromClan.goldBalance -= gold;
+        fromClan.blueprintBalance -= blueprint;
+        fromClan.vaultWood -= wood;
+        fromClan.vaultIron -= iron;
+        fromClan.vaultWheat -= wheat;
+        fromClan.vaultFish -= fish;
+        toClan.goldBalance += gold;
+        toClan.blueprintBalance += blueprint;
+        toClan.vaultWood += wood;
+        toClan.vaultIron += iron;
+        toClan.vaultWheat += wheat;
+        toClan.vaultFish += fish;
+
         if (gold > 0) emit GoldTransferred(fromClanId, toClanId, gold, _world.currentTick);
         if (blueprint > 0) emit BlueprintTransferred(fromClanId, toClanId, blueprint, _world.currentTick);
         if (wood > 0) {
@@ -208,28 +301,8 @@ contract ClanWorldStub is IClanWorld {
         return 0;
     }
 
-    function getClan(uint32) external pure override returns (Clan memory) {
-        return Clan({
-            clanId: 0,
-            iftTokenId: 0,
-            owner: address(0),
-            clanState: ClanState.ACTIVE,
-            baseRegion: 0,
-            baseLevel: 0,
-            wallLevel: 0,
-            monumentLevel: 0,
-            livingClansmen: 0,
-            lastSettledTick: 0,
-            starvationStartsAtTick: 0,
-            coldDamage: 0,
-            ownerNonce: 0,
-            goldBalance: 0,
-            blueprintBalance: 0,
-            vaultWood: 0,
-            vaultIron: 0,
-            vaultWheat: 0,
-            vaultFish: 0
-        });
+    function getClan(uint32 clanId) external view override returns (Clan memory) {
+        return _clans[clanId];
     }
 
     function getClansman(uint32) external pure override returns (Clansman memory) {

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -124,16 +124,57 @@ contract ClanWorldStub is IClanWorld {
     function seedPools(PoolSeedConfig calldata) external override {}
 
     // -------------------------------------------------------------------------
+    // Clan ownership transfer
+    // -------------------------------------------------------------------------
+
+    function transferClanOwnership(uint32 clanId, address newOwner) external override {
+        emit ClanOwnershipTransferred(clanId, msg.sender, newOwner, 1);
+    }
+
+    // -------------------------------------------------------------------------
     // OTC transfers
     // -------------------------------------------------------------------------
 
-    function transferGold(uint32, uint32, uint256) external override {}
+    function transferGold(uint32 fromClanId, uint32 toClanId, uint256 amount) external override {
+        emit GoldTransferred(fromClanId, toClanId, amount, _world.currentTick);
+    }
 
-    function transferVaultResource(uint32, uint32, ResourceType, uint256) external override {}
+    function transferVaultResource(uint32 fromClanId, uint32 toClanId, ResourceType resource, uint256 amount)
+        external
+        override
+    {
+        emit VaultResourceTransferred(fromClanId, toClanId, resource, amount, _world.currentTick);
+    }
 
-    function transferBlueprint(uint32, uint32, uint256) external override {}
+    function transferBlueprint(uint32 fromClanId, uint32 toClanId, uint256 amount) external override {
+        emit BlueprintTransferred(fromClanId, toClanId, amount, _world.currentTick);
+    }
 
-    function transferBundle(uint32, uint32, uint256, uint256, uint256, uint256, uint256, uint256) external override {}
+    function transferBundle(
+        uint32 fromClanId,
+        uint32 toClanId,
+        uint256 gold,
+        uint256 blueprint,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish
+    ) external override {
+        if (gold > 0) emit GoldTransferred(fromClanId, toClanId, gold, _world.currentTick);
+        if (blueprint > 0) emit BlueprintTransferred(fromClanId, toClanId, blueprint, _world.currentTick);
+        if (wood > 0) {
+            emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Wood, wood, _world.currentTick);
+        }
+        if (iron > 0) {
+            emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Iron, iron, _world.currentTick);
+        }
+        if (wheat > 0) {
+            emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Wheat, wheat, _world.currentTick);
+        }
+        if (fish > 0) {
+            emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Fish, fish, _world.currentTick);
+        }
+    }
 
     // -------------------------------------------------------------------------
     // Raw read getters
@@ -181,6 +222,7 @@ contract ClanWorldStub is IClanWorld {
             lastSettledTick: 0,
             starvationStartsAtTick: 0,
             coldDamage: 0,
+            ownerNonce: 0,
             goldBalance: 0,
             blueprintBalance: 0,
             vaultWood: 0,

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -257,6 +257,8 @@ struct Clan {
 
     uint16 coldDamage; // resets to 0 at winter end
 
+    uint64 ownerNonce; // incremented on every ownership transfer
+
     uint256 goldBalance;
     uint256 blueprintBalance;
 
@@ -691,6 +693,11 @@ interface IClanWorldEvents {
         uint256 fish
     );
 
+    // ----- clan ownership -----
+    event ClanOwnershipTransferred(
+        uint32 indexed clanId, address indexed oldOwner, address indexed newOwner, uint64 newOwnerNonce
+    );
+
     // ----- OTC transfers -----
     event GoldTransferred(uint32 indexed fromClanId, uint32 indexed toClanId, uint256 amount, uint64 atTick);
     event VaultResourceTransferred(
@@ -768,6 +775,14 @@ interface IClanWorld is IClanWorldEvents {
         uint256 wheat,
         uint256 fish
     ) external;
+
+    // -------------------------------------------------------------------------
+    // Clan ownership transfer
+    // -------------------------------------------------------------------------
+
+    /// @notice Transfer clan ownership to a new address. Increments ownerNonce.
+    ///         Caller must be current owner.
+    function transferClanOwnership(uint32 clanId, address newOwner) external;
 
     // -------------------------------------------------------------------------
     // Raw read getters (committed storage, no settlement simulation)

--- a/packages/contracts/test/DirectTransfers.t.sol
+++ b/packages/contracts/test/DirectTransfers.t.sol
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {
+    ClanWorldConstants,
+    ClanState,
+    ClansmanState,
+    ResourceType,
+    Clan,
+    ClanOrder,
+    OrderResult
+} from "../src/IClanWorld.sol";
+
+/// @dev Harness that exposes storage manipulation for tests.
+contract DirectTransferHarness is ClanWorld {
+    function setGoldBalance(uint32 clanId, uint256 amount) external {
+        _clans[clanId].goldBalance = amount;
+    }
+
+    function setBlueprintBalance(uint32 clanId, uint256 amount) external {
+        _clans[clanId].blueprintBalance = amount;
+    }
+
+    function setVaultBalances(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        _clans[clanId].vaultWood = wood;
+        _clans[clanId].vaultIron = iron;
+        _clans[clanId].vaultWheat = wheat;
+        _clans[clanId].vaultFish = fish;
+    }
+
+    function killClan(uint32 clanId) external {
+        _clans[clanId].clanState = ClanState.DEAD;
+    }
+
+    /// @dev Set when starvation started (for settlement death scenario).
+    function setClanStarvationStartsAtTick(uint32 clanId, uint64 starvedAtTick) external {
+        _clans[clanId].starvationStartsAtTick = starvedAtTick;
+    }
+
+    /// @dev Set when clan was last settled (so _settleClan re-processes unsettled ticks).
+    function setClanLastSettledTick(uint32 clanId, uint64 tick) external {
+        _clans[clanId].lastSettledTick = tick;
+    }
+
+    /// @dev Kill a clansman by ID (for reducing living count to 1).
+    function killClansman(uint32 clansmanId) external {
+        if (_clansmen[clansmanId].state != ClansmanState.DEAD) {
+            _clansmen[clansmanId].state = ClansmanState.DEAD;
+            uint32 clanId = _clansmen[clansmanId].clanId;
+            if (_clans[clanId].livingClansmen > 0) {
+                _clans[clanId].livingClansmen--;
+            }
+        }
+    }
+
+}
+
+contract DirectTransfersTest is Test {
+    DirectTransferHarness world;
+
+    address owner1 = address(0xA1);
+    address owner2 = address(0xA2);
+    address stranger = address(0xBB);
+
+    uint32 clan1;
+    uint32 clan2;
+
+    function setUp() public {
+        world = new DirectTransferHarness();
+
+        vm.prank(owner1);
+        (clan1,) = world.mintClan(owner1);
+
+        vm.prank(owner2);
+        (clan2,) = world.mintClan(owner2);
+    }
+
+    // =========================================================================
+    // transferGold
+    // =========================================================================
+
+    function test_transferGold_happy_path() public {
+        uint256 amount = 1e18;
+        uint256 from0 = world.getClan(clan1).goldBalance;
+        uint256 to0 = world.getClan(clan2).goldBalance;
+
+        vm.expectEmit(true, true, false, true);
+        emit GoldTransferred(clan1, clan2, amount, world.getWorldState().currentTick);
+
+        vm.prank(owner1);
+        world.transferGold(clan1, clan2, amount);
+
+        assertEq(world.getClan(clan1).goldBalance, from0 - amount, "from deducted");
+        assertEq(world.getClan(clan2).goldBalance, to0 + amount, "to credited");
+    }
+
+    function test_transferGold_wrong_caller_reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert("ClanWorld: not clan owner");
+        world.transferGold(clan1, clan2, 1e18);
+    }
+
+    function test_transferGold_same_clan_reverts() public {
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: same clan");
+        world.transferGold(clan1, clan1, 1e18);
+    }
+
+    function test_transferGold_zero_amount_reverts() public {
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: zero amount");
+        world.transferGold(clan1, clan2, 0);
+    }
+
+    function test_transferGold_insufficient_balance_reverts() public {
+        world.setGoldBalance(clan1, 1e17);
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: insufficient gold");
+        world.transferGold(clan1, clan2, 1e18);
+    }
+
+    function test_transferGold_dead_sender_reverts() public {
+        world.killClan(clan1);
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: clan dead");
+        world.transferGold(clan1, clan2, 1e18);
+    }
+
+    function test_transferGold_dead_recipient_allowed() public {
+        uint256 amount = 1e18;
+        uint256 to0 = world.getClan(clan2).goldBalance;
+        world.killClan(clan2);
+        vm.prank(owner1);
+        world.transferGold(clan1, clan2, amount);
+        assertEq(world.getClan(clan2).goldBalance, to0 + amount, "dead recipient receives gold");
+    }
+
+    function test_transferGold_after_ownership_transfer_old_owner_blocked() public {
+        vm.prank(owner1);
+        world.transferClanOwnership(clan1, owner2);
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: not clan owner");
+        world.transferGold(clan1, clan2, 1e18);
+    }
+
+    // =========================================================================
+    // transferVaultResource
+    // =========================================================================
+
+    function test_transferVaultResource_wood_happy_path() public {
+        uint256 amount = 5e18;
+        uint256 from0 = world.getClan(clan1).vaultWood;
+        uint256 to0 = world.getClan(clan2).vaultWood;
+        vm.prank(owner1);
+        world.transferVaultResource(clan1, clan2, ResourceType.Wood, amount);
+        assertEq(world.getClan(clan1).vaultWood, from0 - amount);
+        assertEq(world.getClan(clan2).vaultWood, to0 + amount);
+    }
+
+    function test_transferVaultResource_iron_happy_path() public {
+        world.setVaultBalances(clan1, 0, 50e18, 0, 0);
+        uint256 amount = 25e18;
+        vm.prank(owner1);
+        world.transferVaultResource(clan1, clan2, ResourceType.Iron, amount);
+        // iron starts at 0 for clan2, so absolute check is fine
+        assertEq(world.getClan(clan1).vaultIron, 25e18);
+        assertEq(world.getClan(clan2).vaultIron, 25e18);
+    }
+
+    function test_transferVaultResource_wheat_happy_path() public {
+        uint256 amount = 5e18;
+        uint256 from0 = world.getClan(clan1).vaultWheat;
+        uint256 to0 = world.getClan(clan2).vaultWheat;
+        vm.prank(owner1);
+        world.transferVaultResource(clan1, clan2, ResourceType.Wheat, amount);
+        assertEq(world.getClan(clan1).vaultWheat, from0 - amount);
+        assertEq(world.getClan(clan2).vaultWheat, to0 + amount);
+    }
+
+    function test_transferVaultResource_fish_happy_path() public {
+        uint256 amount = 1e18;
+        uint256 from0 = world.getClan(clan1).vaultFish;
+        uint256 to0 = world.getClan(clan2).vaultFish;
+        vm.prank(owner1);
+        world.transferVaultResource(clan1, clan2, ResourceType.Fish, amount);
+        assertEq(world.getClan(clan1).vaultFish, from0 - amount);
+        assertEq(world.getClan(clan2).vaultFish, to0 + amount);
+    }
+
+    function test_transferVaultResource_wrong_caller_reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert("ClanWorld: not clan owner");
+        world.transferVaultResource(clan1, clan2, ResourceType.Wood, 1e18);
+    }
+
+    function test_transferVaultResource_insufficient_reverts() public {
+        world.setVaultBalances(clan1, 1e17, 0, 0, 0);
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: insufficient wood");
+        world.transferVaultResource(clan1, clan2, ResourceType.Wood, 1e18);
+    }
+
+    function test_transferVaultResource_dead_sender_reverts() public {
+        world.killClan(clan1);
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: clan dead");
+        world.transferVaultResource(clan1, clan2, ResourceType.Wood, 1e18);
+    }
+
+    function test_transferVaultResource_dead_recipient_allowed() public {
+        uint256 amount = 5e18;
+        uint256 to0 = world.getClan(clan2).vaultWood;
+        world.killClan(clan2);
+        vm.prank(owner1);
+        world.transferVaultResource(clan1, clan2, ResourceType.Wood, amount);
+        assertEq(world.getClan(clan2).vaultWood, to0 + amount);
+    }
+
+    // =========================================================================
+    // transferBlueprint
+    // =========================================================================
+
+    function test_transferBlueprint_happy_path() public {
+        world.setBlueprintBalance(clan1, 10e18);
+        vm.expectEmit(true, true, false, true);
+        emit BlueprintTransferred(clan1, clan2, 5e18, world.getWorldState().currentTick);
+        vm.prank(owner1);
+        world.transferBlueprint(clan1, clan2, 5e18);
+        assertEq(world.getClan(clan1).blueprintBalance, 5e18);
+        assertEq(world.getClan(clan2).blueprintBalance, 5e18);
+    }
+
+    function test_transferBlueprint_zero_amount_reverts() public {
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: zero amount");
+        world.transferBlueprint(clan1, clan2, 0);
+    }
+
+    function test_transferBlueprint_wrong_caller_reverts() public {
+        world.setBlueprintBalance(clan1, 10e18);
+        vm.prank(stranger);
+        vm.expectRevert("ClanWorld: not clan owner");
+        world.transferBlueprint(clan1, clan2, 5e18);
+    }
+
+    function test_transferBlueprint_insufficient_reverts() public {
+        world.setBlueprintBalance(clan1, 2e18);
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: insufficient blueprints");
+        world.transferBlueprint(clan1, clan2, 5e18);
+    }
+
+    function test_transferBlueprint_dead_sender_reverts() public {
+        world.setBlueprintBalance(clan1, 10e18);
+        world.killClan(clan1);
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: clan dead");
+        world.transferBlueprint(clan1, clan2, 5e18);
+    }
+
+    // =========================================================================
+    // transferBundle
+    // =========================================================================
+
+    function test_transferBundle_happy_path_multi_component() public {
+        world.setBlueprintBalance(clan1, 10e18);
+        // Use known starting values (from mintClan: gold=3e18, wood=20e18, wheat=20e18, fish=2e18, iron=0, bp=0)
+        // After setBlueprintBalance clan1 has bp=10e18
+        // Transfer: gold=1e18, bp=2e18, wood=5e18, iron=0, wheat=5e18, fish=1e18
+        uint256 g0_1 = world.getClan(clan1).goldBalance;
+        uint256 w0_1 = world.getClan(clan1).vaultWood;
+        uint256 wh0_1 = world.getClan(clan1).vaultWheat;
+        uint256 f0_1 = world.getClan(clan1).vaultFish;
+        uint256 g0_2 = world.getClan(clan2).goldBalance;
+        uint256 w0_2 = world.getClan(clan2).vaultWood;
+
+        vm.prank(owner1);
+        world.transferBundle(clan1, clan2, 1e18, 2e18, 5e18, 0, 5e18, 1e18);
+
+        assertEq(world.getClan(clan1).goldBalance, g0_1 - 1e18);
+        assertEq(world.getClan(clan1).blueprintBalance, 8e18);
+        assertEq(world.getClan(clan1).vaultWood, w0_1 - 5e18);
+        assertEq(world.getClan(clan1).vaultWheat, wh0_1 - 5e18);
+        assertEq(world.getClan(clan1).vaultFish, f0_1 - 1e18);
+
+        assertEq(world.getClan(clan2).goldBalance, g0_2 + 1e18);
+        assertEq(world.getClan(clan2).blueprintBalance, 2e18);
+        assertEq(world.getClan(clan2).vaultWood, w0_2 + 5e18);
+    }
+
+    function test_transferBundle_empty_reverts() public {
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: empty bundle");
+        world.transferBundle(clan1, clan2, 0, 0, 0, 0, 0, 0);
+    }
+
+    function test_transferBundle_insufficient_one_component_entire_call_reverts() public {
+        // Set clan1 iron = 0 explicitly (iron starts at 0 from mintClan)
+        // Bundle asks for iron=50e18 which clan1 doesn't have, plus gold=1e18 which it does
+        uint256 gold0 = world.getClan(clan1).goldBalance;
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: insufficient iron");
+        world.transferBundle(clan1, clan2, 1e18, 0, 0, 50e18, 0, 0);
+        // gold unchanged (atomic)
+        assertEq(world.getClan(clan1).goldBalance, gold0);
+        assertEq(world.getClan(clan2).goldBalance, world.getClan(clan2).goldBalance);
+    }
+
+    function test_transferBundle_dead_sender_reverts() public {
+        world.killClan(clan1);
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: clan dead");
+        world.transferBundle(clan1, clan2, 1e18, 0, 0, 0, 0, 0);
+    }
+
+    function test_transferBundle_dead_recipient_allowed() public {
+        uint256 amount = 1e18;
+        uint256 to0 = world.getClan(clan2).goldBalance;
+        world.killClan(clan2);
+        vm.prank(owner1);
+        world.transferBundle(clan1, clan2, amount, 0, 0, 0, 0, 0);
+        assertEq(world.getClan(clan2).goldBalance, to0 + amount);
+    }
+
+    // =========================================================================
+    // DeadClanTransfer — dies-during-settle scenario (spec §M)
+    // =========================================================================
+
+    /// @dev Advance the world clock to `targetTick` by calling heartbeat() repeatedly.
+    function _advanceToTick(uint64 targetTick) internal {
+        // Ensure we start past the genesis timestamp to avoid underflow edge cases
+        if (block.timestamp == 0) vm.warp(1);
+        while (world.getWorldState().currentTick < targetTick) {
+            vm.warp(world.getWorldState().nextHeartbeatAtTs + 1);
+            world.heartbeat();
+        }
+    }
+
+    /// @dev Put clan into a state where _settleClan will mark it DEAD on the next call.
+    ///
+    ///      Setup:
+    ///      1. Advance world to tick 112 (inside winter window 110-119).
+    ///      2. Kill 3 of clan1's 4 clansmen so only 1 lives (IDs 0-3 for clan1 which
+    ///         was minted first; setUp mints clan1 then clan2 so clan1 csm IDs = 0,1,2,3).
+    ///      3. Set last-settled tick back to 111 so _settleClan must process tick 111.
+    ///      4. Set starvationStartsAtTick=110 and zero food.
+    ///
+    ///      During tick-111 settlement: winter=true, starving=true,
+    ///      effectiveStarvationStartsAtTick=110 < 111 → kills last clansman → _markClanDead.
+    ///
+    ///      The clan is ALIVE before the transfer call (not yet settled to 112),
+    ///      but DEAD after _settleClan runs inside the transfer function.
+    function _setupDiesDuringSettle() internal {
+        // Advance world to tick 112 (deep winter) without settling clan1
+        // (clan1.lastSettledTick will be reset below to 111 after advance)
+        _advanceToTick(112);
+
+        // clan1 clansmen IDs: 1,2,3,4 (_nextClansmanId starts at 1 per constructor)
+        world.killClansman(1);
+        world.killClansman(2);
+        world.killClansman(3);
+        // 1 clansman (ID=3) still alive
+
+        // Rewind lastSettledTick to 111 so _settleClan processes tick 111
+        world.setClanLastSettledTick(clan1, 111);
+        // Starvation started at winter onset (tick 110)
+        world.setClanStarvationStartsAtTick(clan1, 110);
+        // Zero food so upkeep is failing
+        world.setVaultBalances(clan1, 100e18, 0, 0, 0);
+        // Also ensure goldBalance is non-zero for the transfer tests
+        world.setGoldBalance(clan1, 10e18);
+        world.setBlueprintBalance(clan1, 10e18);
+    }
+
+    function test_transferGold_dies_during_settle_reverts() public {
+        _setupDiesDuringSettle();
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: clan dead");
+        world.transferGold(clan1, clan2, 1e18);
+    }
+
+    function test_transferVaultResource_dies_during_settle_reverts() public {
+        _setupDiesDuringSettle();
+        // Also set some iron so the wood=100e18 doesn't confuse things; the clan dies on settle
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: clan dead");
+        world.transferVaultResource(clan1, clan2, ResourceType.Wood, 1e18);
+    }
+
+    function test_transferBlueprint_dies_during_settle_reverts() public {
+        _setupDiesDuringSettle();
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: clan dead");
+        world.transferBlueprint(clan1, clan2, 5e18);
+    }
+
+    function test_transferBundle_dies_during_settle_reverts() public {
+        _setupDiesDuringSettle();
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: clan dead");
+        world.transferBundle(clan1, clan2, 1e18, 0, 0, 0, 0, 0);
+    }
+
+    // =========================================================================
+    // transferClanOwnership
+    // =========================================================================
+
+    function test_transferClanOwnership_happy_path() public {
+        assertEq(world.getClan(clan1).ownerNonce, 0);
+        vm.expectEmit(true, true, true, true);
+        emit ClanOwnershipTransferred(clan1, owner1, stranger, 1);
+        vm.prank(owner1);
+        world.transferClanOwnership(clan1, stranger);
+        assertEq(world.getClan(clan1).owner, stranger);
+        assertEq(world.getClan(clan1).ownerNonce, 1);
+    }
+
+    function test_transferClanOwnership_nonce_increments_each_transfer() public {
+        vm.prank(owner1);
+        world.transferClanOwnership(clan1, owner2);
+        assertEq(world.getClan(clan1).ownerNonce, 1);
+        vm.prank(owner2);
+        world.transferClanOwnership(clan1, stranger);
+        assertEq(world.getClan(clan1).ownerNonce, 2);
+    }
+
+    function test_transferClanOwnership_non_owner_reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert("ClanWorld: not clan owner");
+        world.transferClanOwnership(clan1, stranger);
+    }
+
+    function test_transferClanOwnership_zero_address_reverts() public {
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: zero address");
+        world.transferClanOwnership(clan1, address(0));
+    }
+
+    function test_transferClanOwnership_same_owner_reverts() public {
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: same owner");
+        world.transferClanOwnership(clan1, owner1);
+    }
+
+    function test_old_owner_cannot_transferGold_after_ownership_transfer() public {
+        vm.prank(owner1);
+        world.transferClanOwnership(clan1, owner2);
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: not clan owner");
+        world.transferGold(clan1, clan2, 1e18);
+        // New owner can
+        uint256 g0_1 = world.getClan(clan1).goldBalance;
+        uint256 g0_2 = world.getClan(clan2).goldBalance;
+        vm.prank(owner2);
+        world.transferGold(clan1, clan2, 1e18);
+        assertEq(world.getClan(clan1).goldBalance, g0_1 - 1e18);
+        assertEq(world.getClan(clan2).goldBalance, g0_2 + 1e18);
+    }
+
+    // =========================================================================
+    // Events (used in expectEmit)
+    // =========================================================================
+    event GoldTransferred(uint32 indexed fromClanId, uint32 indexed toClanId, uint256 amount, uint64 atTick);
+    event BlueprintTransferred(uint32 indexed fromClanId, uint32 indexed toClanId, uint256 amount, uint64 atTick);
+    event VaultResourceTransferred(
+        uint32 indexed fromClanId, uint32 indexed toClanId, ResourceType resource, uint256 amount, uint64 atTick
+    );
+    event ClanOwnershipTransferred(
+        uint32 indexed clanId, address indexed oldOwner, address indexed newOwner, uint64 newOwnerNonce
+    );
+}

--- a/packages/contracts/test/DirectTransfers.t.sol
+++ b/packages/contracts/test/DirectTransfers.t.sol
@@ -3,15 +3,7 @@ pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
 import {ClanWorld} from "../src/ClanWorld.sol";
-import {
-    ClanWorldConstants,
-    ClanState,
-    ClansmanState,
-    ResourceType,
-    Clan,
-    ClanOrder,
-    OrderResult
-} from "../src/IClanWorld.sol";
+import {ClanWorldConstants, ClanState, ClansmanState, ResourceType} from "../src/IClanWorld.sol";
 
 /// @dev Harness that exposes storage manipulation for tests.
 contract DirectTransferHarness is ClanWorld {
@@ -54,7 +46,6 @@ contract DirectTransferHarness is ClanWorld {
             }
         }
     }
-
 }
 
 contract DirectTransfersTest is Test {
@@ -218,6 +209,13 @@ contract DirectTransfersTest is Test {
         assertEq(world.getClan(clan2).vaultWood, to0 + amount);
     }
 
+    function test_transferVaultResource_invalid_resource_reverts() public {
+        vm.prank(owner1);
+        (bool ok,) = address(world)
+            .call(abi.encodeWithSelector(world.transferVaultResource.selector, clan1, clan2, uint8(99), uint256(1e18)));
+        assertFalse(ok, "invalid enum value must revert");
+    }
+
     // =========================================================================
     // transferBlueprint
     // =========================================================================
@@ -299,13 +297,14 @@ contract DirectTransfersTest is Test {
     function test_transferBundle_insufficient_one_component_entire_call_reverts() public {
         // Set clan1 iron = 0 explicitly (iron starts at 0 from mintClan)
         // Bundle asks for iron=50e18 which clan1 doesn't have, plus gold=1e18 which it does
-        uint256 gold0 = world.getClan(clan1).goldBalance;
+        uint256 fromGold0 = world.getClan(clan1).goldBalance;
+        uint256 toGold0 = world.getClan(clan2).goldBalance;
         vm.prank(owner1);
         vm.expectRevert("ClanWorld: insufficient iron");
         world.transferBundle(clan1, clan2, 1e18, 0, 0, 50e18, 0, 0);
         // gold unchanged (atomic)
-        assertEq(world.getClan(clan1).goldBalance, gold0);
-        assertEq(world.getClan(clan2).goldBalance, world.getClan(clan2).goldBalance);
+        assertEq(world.getClan(clan1).goldBalance, fromGold0);
+        assertEq(world.getClan(clan2).goldBalance, toGold0);
     }
 
     function test_transferBundle_dead_sender_reverts() public {
@@ -322,6 +321,18 @@ contract DirectTransfersTest is Test {
         vm.prank(owner1);
         world.transferBundle(clan1, clan2, amount, 0, 0, 0, 0, 0);
         assertEq(world.getClan(clan2).goldBalance, to0 + amount);
+    }
+
+    function test_transferGold_sender_must_be_fully_settled() public {
+        _advanceToTick(201);
+        world.setVaultBalances(clan1, 1000e18, 0, 1000e18, 1000e18);
+        world.setVaultBalances(clan2, 1000e18, 0, 1000e18, 1000e18);
+        world.setClanLastSettledTick(clan1, 0);
+        world.setClanLastSettledTick(clan2, world.getWorldState().currentTick);
+
+        vm.prank(owner1);
+        vm.expectRevert("ClanWorld: must settle first");
+        world.transferGold(clan1, clan2, 1e18);
     }
 
     // =========================================================================
@@ -341,32 +352,21 @@ contract DirectTransfersTest is Test {
     /// @dev Put clan into a state where _settleClan will mark it DEAD on the next call.
     ///
     ///      Setup:
-    ///      1. Advance world to tick 112 (inside winter window 110-119).
-    ///      2. Kill 3 of clan1's 4 clansmen so only 1 lives (IDs 0-3 for clan1 which
-    ///         was minted first; setUp mints clan1 then clan2 so clan1 csm IDs = 0,1,2,3).
-    ///      3. Set last-settled tick back to 111 so _settleClan must process tick 111.
-    ///      4. Set starvationStartsAtTick=110 and zero food.
+    ///      1. Advance world to tick 115 (inside winter window 110-119).
+    ///      2. Set last-settled tick back to 110 so _settleClan must process ticks 110-114.
+    ///      3. Zero food so starvation starts at tick 110 and kills one clansman per later winter tick.
     ///
-    ///      During tick-111 settlement: winter=true, starving=true,
-    ///      effectiveStarvationStartsAtTick=110 < 111 → kills last clansman → _markClanDead.
+    ///      During ticks 111-114 settlement: winter=true, starving=true,
+    ///      effectiveStarvationStartsAtTick=110 < tick → kills all 4 clansmen → _markClanDead.
     ///
-    ///      The clan is ALIVE before the transfer call (not yet settled to 112),
+    ///      The clan is ALIVE before the transfer call (not yet settled to 115),
     ///      but DEAD after _settleClan runs inside the transfer function.
     function _setupDiesDuringSettle() internal {
-        // Advance world to tick 112 (deep winter) without settling clan1
-        // (clan1.lastSettledTick will be reset below to 111 after advance)
-        _advanceToTick(112);
+        _advanceToTick(ClanWorldConstants.WINTER_START_TICK + 5);
 
-        // clan1 clansmen IDs: 1,2,3,4 (_nextClansmanId starts at 1 per constructor)
-        world.killClansman(1);
-        world.killClansman(2);
-        world.killClansman(3);
-        // 1 clansman (ID=3) still alive
-
-        // Rewind lastSettledTick to 111 so _settleClan processes tick 111
-        world.setClanLastSettledTick(clan1, 111);
-        // Starvation started at winter onset (tick 110)
-        world.setClanStarvationStartsAtTick(clan1, 110);
+        // Rewind lastSettledTick so _settleClan processes the first 5 winter ticks.
+        world.setClanLastSettledTick(clan1, ClanWorldConstants.WINTER_START_TICK);
+        world.setClanStarvationStartsAtTick(clan1, 0);
         // Zero food so upkeep is failing
         world.setVaultBalances(clan1, 100e18, 0, 0, 0);
         // Also ensure goldBalance is non-zero for the transfer tests

--- a/packages/contracts/test/GasProfiling.t.sol
+++ b/packages/contracts/test/GasProfiling.t.sol
@@ -142,9 +142,7 @@ contract GasProfilingTest is Test {
         emit log_named_uint(
             "heartbeat gas (12 clans, 200-tick cap / 4320-tick lag) OPTIMIZATION NEEDED if > 5M", gasUsed
         );
-        emit log_named_uint(
-            "heartbeat gas over 5M budget by", gasUsed > 5_000_000 ? gasUsed - 5_000_000 : 0
-        );
+        emit log_named_uint("heartbeat gas over 5M budget by", gasUsed > 5_000_000 ? gasUsed - 5_000_000 : 0);
         // No assertLt — this scenario intentionally exceeds budget and is tracked in #322.
         // The log output provides the baseline for optimization work.
         assertTrue(true, "log-only test always passes");

--- a/packages/contracts/test/RNG.t.sol
+++ b/packages/contracts/test/RNG.t.sol
@@ -52,7 +52,10 @@ contract RNGTest is Test {
             if (RNG.rngBool(SEED, DOMAIN_A, nonce) != RNG.rngBool(SEED, DOMAIN_B, nonce)) {
                 boolDiffs++;
             }
-            if (RNG.rngWeightedPick(SEED, DOMAIN_A, nonce, weights) != RNG.rngWeightedPick(SEED, DOMAIN_B, nonce, weights)) {
+            if (
+                RNG.rngWeightedPick(SEED, DOMAIN_A, nonce, weights)
+                    != RNG.rngWeightedPick(SEED, DOMAIN_B, nonce, weights)
+            ) {
                 weightedDiffs++;
             }
             if (!_sameUint8Array(RNG.rngShuffle(SEED, DOMAIN_A, nonce, 8), RNG.rngShuffle(SEED, DOMAIN_B, nonce, 8))) {

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -244,6 +244,11 @@ export const CLAN_WORLD_ABI = [
             "internalType": "uint16"
           },
           {
+            "name": "ownerNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
             "name": "goldBalance",
             "type": "uint256",
             "internalType": "uint256"
@@ -721,6 +726,11 @@ export const CLAN_WORLD_ABI = [
                 "internalType": "uint16"
               },
               {
+                "name": "ownerNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
                 "name": "goldBalance",
                 "type": "uint256",
                 "internalType": "uint256"
@@ -1186,6 +1196,11 @@ export const CLAN_WORLD_ABI = [
                     "name": "coldDamage",
                     "type": "uint16",
                     "internalType": "uint16"
+                  },
+                  {
+                    "name": "ownerNonce",
+                    "type": "uint64",
+                    "internalType": "uint64"
                   },
                   {
                     "name": "goldBalance",


### PR DESCRIPTION
## Summary

Replaces the never-merged on-chain OTC propose/accept infrastructure with the canonical v4 §10.3 direct-transfer surface. The OTC proposal code existed only on `dev-phase-7-otc` (PR #200) and `dev-phase-7b-otc-spec` (PR #358) — neither was merged to `dev`. This PR fills in the 4 dead-revert stubs already on `dev` with real implementations and salvages the clan ownership primitives from #358.

### Changes
- **4 direct transfer functions implemented** (`transferGold`, `transferVaultResource`, `transferBlueprint`, `transferBundle`) — owner-initiated, atomic, dead-sender-rejected per v4.3 §M
- **Dead-state check post-settle** — clan that dies during `_settleClan` correctly blocked from outbound transfer (matches `submitClanOrders` pattern); includes 4 dies-during-settle test cases
- **Clan ownership primitives salvaged** from PR #358: `Clan.ownerNonce`, `transferClanOwnership()`, `ClanOwnershipTransferred` event (proposer-nonce-binding logic NOT included)
- **ClanWorldStub** updated with real stub bodies for all 5 functions
- **ABI regenerated** — no proposal entries
- **Tests**: `DirectTransfers.t.sol` (473 lines) — covers all 4 transfer functions + ownership transfer + dead-clan scenarios

### Spec alignment
- v4 §3.13 + §11.1–11.3: OTC is non-atomic by design; no protocol-level escrow
- v4.2 §10.3: canonical 4-function direct-transfer surface
- v4.3 §M: dead-sender rejection on all 4 transfers (post-settle check)

### Swarm review
Local 3-tier swarm (Codex + Gemini) — CLEAN. One HIGH caught pre-push (dead-state check pre-settle) and fixed.

### Out of scope
- Mercenary-negotiations skill (issue #386 — gated on this merge)
- Off-chain plumbing (IChainClient, CLI, Convex, frontend) — zero proposal dependencies confirmed on `dev`

## Test plan
- [ ] `forge test` full suite passes
- [ ] DirectTransfers: happy path (all 4 functions), wrong caller, zero amount, self-transfer, insufficient balance, dead sender (pre-existing), dead sender (dies during settle), dead recipient (allowed), post-ownership-transfer
- [ ] ClanOwnershipTransfer: owner updates, nonce increments, old owner locked out
- [ ] DeadClanTransfer: dead sender rejected, dead recipient allowed, dies-during-settle rejected

Closes #386
Closes #223 #224 #225 #226 #227 #285 #286 #346
Supersedes #200 #358 (close after this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)