### PR TITLE
fix(contracts): Phase 10 dev-merge follow-ups — dead constant + sim/winter parity

### DIFF
--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -151,8 +151,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     uint256 private constant WHEAT_HARVEST_RATE = 20e18;
     uint256 private constant RESOURCE_UNIT = 1e18;
     uint256 internal constant BLUEPRINT_UNIT = 1e18;
-    /// @dev Caps market queue work per heartbeat; overflow is deferred to the next tick.
-    uint256 public constant MAX_MARKET_ACTIONS_PER_TICK = 32;
     /// @dev Caps winter crop boundary work; current clan cap keeps transitions within this budget.
     uint256 public constant MAX_CROP_TRANSITION_PER_TICK = 48;
     uint256 internal constant DOMAIN_BANDIT_SPAWN = uint256(keccak256("clanworld.bandit.spawn.v1"));
@@ -1296,14 +1294,27 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             }
         }
 
+        if (toTick > fromTick && !_isWinterActiveAt(toTick) && _isWinterActiveAt(toTick - 1)) {
+            sim.clan.coldDamage = 0;
+        }
+
         sim.clan.lastSettledTick = toTick;
     }
 
     function _simulateApplyUpkeep(SettlementSimulation memory sim, uint64 tick) internal view {
+        bool winter = _isWinterActiveAt(tick);
+        if (!winter && tick > 0 && _isWinterActiveAt(tick - 1)) {
+            sim.clan.coldDamage = 0;
+        }
+
         if (sim.clan.livingClansmen == 0) return;
 
         uint256 wheatNeeded = uint256(sim.clan.livingClansmen) * ClanWorldConstants.WHEAT_UPKEEP_PER_CLANSMAN;
         uint256 fishNeeded = uint256(sim.clan.livingClansmen) * ClanWorldConstants.FISH_UPKEEP_PER_CLANSMAN;
+        if (winter) {
+            wheatNeeded = wheatNeeded * ClanWorldConstants.WINTER_UPKEEP_MULTIPLIER_BPS / 10000;
+            fishNeeded = fishNeeded * ClanWorldConstants.WINTER_UPKEEP_MULTIPLIER_BPS / 10000;
+        }
 
         uint256 spendableWheat = sim.clan.vaultWheat > sim.reservedWheat ? sim.clan.vaultWheat - sim.reservedWheat : 0;
         bool hadEnoughWheat = spendableWheat >= wheatNeeded;
@@ -1323,8 +1334,94 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             sim.clan.starvationStartsAtTick = 0;
         }
 
-        if (starving && _isWinterActiveAt(tick) && sim.clan.starvationStartsAtTick <= tick) {
-            _simulateKillNextClansmanFromStarvation(sim);
+        uint8 livingBeforeStarvation = sim.clan.livingClansmen;
+        if (winter && starving) {
+            (, uint64 winterStartsAtTick,) = _winterWindowForTick(tick);
+            uint64 effectiveStarvationStartsAtTick =
+                sim.clan.starvationStartsAtTick > winterStartsAtTick ? sim.clan.starvationStartsAtTick : winterStartsAtTick;
+            if (effectiveStarvationStartsAtTick < tick) {
+                _simulateKillNextClansmanFromStarvation(sim);
+            }
+        }
+        if (sim.clan.clanState == ClanState.DEAD) return;
+
+        if (winter) {
+            uint256 woodNeeded = ClanWorldConstants.WINTER_WOOD_BURN_PER_BASE + uint256(livingBeforeStarvation)
+                * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
+            if (sim.clan.vaultWood >= woodNeeded) {
+                sim.clan.vaultWood -= woodNeeded;
+            } else {
+                sim.clan.vaultWood = 0;
+                uint16 oldColdDamage = sim.clan.coldDamage;
+                if (sim.clan.coldDamage < type(uint16).max) {
+                    sim.clan.coldDamage += 1;
+                }
+                _simulateApplyColdDamageConsequence(sim, tick, oldColdDamage);
+            }
+        }
+    }
+
+    function _simulateApplyColdDamageConsequence(
+        SettlementSimulation memory sim,
+        uint64 tick,
+        uint16 oldColdDamage
+    ) internal view {
+        uint16 newColdDamage = sim.clan.coldDamage;
+        if (newColdDamage == oldColdDamage) return;
+
+        if (sim.clan.wallLevel > 0) {
+            if (
+                newColdDamage / ClanWorldConstants.COLD_DAMAGE_PER_WALL_DEGRADATION
+                    <= oldColdDamage / ClanWorldConstants.COLD_DAMAGE_PER_WALL_DEGRADATION
+            ) return;
+
+            sim.clan.wallLevel--;
+            return;
+        }
+
+        if (
+            newColdDamage / ClanWorldConstants.COLD_DAMAGE_PER_CLANSMAN_DEATH
+                <= oldColdDamage / ClanWorldConstants.COLD_DAMAGE_PER_CLANSMAN_DEATH
+        ) return;
+
+        _simulateKillRandomClansmanFromCold(sim, tick, newColdDamage);
+    }
+
+    function _simulateKillRandomClansmanFromCold(
+        SettlementSimulation memory sim,
+        uint64 tick,
+        uint16 coldDamage
+    ) internal view {
+        if (sim.clan.livingClansmen == 0) return;
+
+        uint256 livingCount = 0;
+        for (uint256 i = 0; i < sim.clansmen.length; i++) {
+            if (sim.clansmen[i].state != ClansmanState.DEAD) {
+                livingCount++;
+            }
+        }
+        if (livingCount == 0) return;
+
+        uint256 pick = RNG.rngBounded(
+            _tickSeeds[tick],
+            RNG.DOMAIN_COLD_DAMAGE,
+            uint256(keccak256(abi.encodePacked(sim.clan.clanId, tick, coldDamage))),
+            livingCount
+        );
+
+        uint256 seen = 0;
+        for (uint256 i = 0; i < sim.clansmen.length; i++) {
+            if (sim.clansmen[i].state == ClansmanState.DEAD) continue;
+            if (seen != pick) {
+                seen++;
+                continue;
+            }
+
+            _simulateMarkClansmanDead(sim, i);
+            if (sim.clan.livingClansmen == 0) {
+                _simulateMarkClanDead(sim);
+            }
+            return;
         }
     }
 

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -3077,6 +3077,50 @@ contract ClanWorldTest is Test {
         assertEq(deadCount, 1, "exactly one stored clansman should be dead");
     }
 
+    function test_simulatedWinterUpkeepMatchesManualSettleForViewAndRankings() public {
+        ClanWorldTestHarness harness = new ClanWorldTestHarness();
+        world = harness;
+        uint32 clanId = _mintClan();
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        _advanceToTick(winterStart + 1);
+
+        harness.setClanWallLevel(clanId, 2);
+        harness.setClanUpkeepState(clanId, winterStart, 0, 100e18, 100e18, 1);
+
+        Clan memory storedBefore = world.getClan(clanId);
+        assertEq(storedBefore.wallLevel, 2, "stored wall starts above simulated winter degradation");
+        assertEq(storedBefore.coldDamage, 1, "stored cold damage starts below degradation threshold");
+
+        ClanFullView memory preview = world.getClanFullView(clanId);
+        (uint32[] memory rankedPreview, uint256[] memory scoresPreview) = world.getRankings();
+        uint256 lootPreview = world.quoteLootValueSettled(clanId);
+
+        assertEq(preview.clan.clan.wallLevel, 1, "preview applies winter wall degradation");
+        assertEq(preview.clan.clan.coldDamage, 2, "preview applies winter cold damage");
+        assertEq(preview.clan.clan.vaultWheat, 92e18, "preview applies winter wheat multiplier");
+        assertEq(preview.clan.clan.vaultFish, 100e18 - 8e17, "preview applies winter fish multiplier");
+        assertEq(preview.clan.clan.vaultWood, 0, "preview consumes short winter wood");
+        assertEq(preview.clan.clan.livingClansmen, 4, "wall absorbs cold before clansmen die");
+        assertEq(rankedPreview.length, 1, "preview rankings include active clan");
+        assertEq(rankedPreview[0], clanId, "preview ranking clan id");
+
+        world.settleClan(clanId);
+
+        Clan memory settled = world.getClan(clanId);
+        (uint32[] memory rankedSettled, uint256[] memory scoresSettled) = world.getRankings();
+        uint256 lootSettled = world.quoteLootValueSettled(clanId);
+
+        assertEq(preview.clan.clan.wallLevel, settled.wallLevel, "preview wall matches settled wall");
+        assertEq(preview.clan.clan.coldDamage, settled.coldDamage, "preview cold damage matches settled cold damage");
+        assertEq(preview.clan.clan.vaultWheat, settled.vaultWheat, "preview wheat matches settled wheat");
+        assertEq(preview.clan.clan.vaultFish, settled.vaultFish, "preview fish matches settled fish");
+        assertEq(preview.clan.clan.vaultWood, settled.vaultWood, "preview wood matches settled wood");
+        assertEq(lootPreview, lootSettled, "settled loot quote matches preview");
+        assertEq(rankedPreview.length, rankedSettled.length, "ranking length matches after settle");
+        assertEq(rankedPreview[0], rankedSettled[0], "ranking clan matches after settle");
+        assertEq(scoresPreview[0], scoresSettled[0], "ranking score matches after settle");
+    }
+
     function test_coldDamage_victimIsStableAcrossDelayedSettlement() public {
         ClanWorldTestHarness immediate = new ClanWorldTestHarness();
         ClanWorldTestHarness delayed = new ClanWorldTestHarness();


### PR DESCRIPTION
## Summary

Two follow-ups from the 3-reviewer Phase 10 audit, combined into one PR per Liam directive 2026-05-01 (msg 10085).

## Fix 1 — Dead constant cleanup (Claude audit, MINOR)

`MAX_MARKET_ACTIONS_PER_TICK = 32` constant + stale comment deleted from `packages/contracts/src/ClanWorld.sol`. Phase 6B (#270) intentionally removed both the cap and the deferral logic in favor of "reject over-capacity at submit." Phase 8 merge resolution `dacf3aa` re-introduced the constant but not the deferral. Constant was unused. Verified zero source refs after deletion.

## Fix 2 — Sim/real winter parity (Codex 5.5 audit)

`_simulateApplyUpkeep` now mirrors real winter upkeep + cold damage. Real `_applyUpkeep` handles winter food multiplier (2x consumption) + wood burn (heat) + cold damage thresholds + wall degradation + cold-death cleanup + cold-reset on warming. Sim was missing all of it. Result: `getClanFullView` / `getRankings` / `quoteLootValueSettled` could disagree with real `settleClan` DURING WINTER.

Same divergence pattern as the prior PR #391 sim-upkeep-reserved-wheat fix. Same fix shape (inline mirror, no helper extraction).

## Test added

Parity assertion that `getClanFullView` + `getRankings` agree with `settleClan` after manual settle, including winter-active scenarios. Catches sim/real divergence empirically.

## Verification

- `forge build` passes
- `forge test`: **254 passed, 0 failed, 0 skipped** (was 253 pre-fix; +1 new parity test)

## Out of scope (deferred / separate PRs)

- WithdrawResources reservation-aware fix (separate PR in flight, dispatched per Liam directive 10078 after both validators returned CONFIRMED CRITICAL)
- StatusCode ordinal stability — Liam decided NO backcompat (msg 10084), separate spec-doc cleanup if needed
- Phase 6 follow-ups (separate)

## Test plan

- [ ] CI runs full forge test suite
- [ ] Liam UAT: confirm winter-period view paths agree with real settlement

🤖 Generated with [Claude Code](https://claude.com/claude-code)