### PR TITLE
fix(contracts): WithdrawResources reservation-aware (CONFIRMED CRITICAL bug)

### DIFF
--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -1077,7 +1077,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         WithdrawResourcesData memory req = m.withdrawResources;
-        if (!_hasWithdrawRequest(req) || !_hasVaultResources(clan, req) || !_hasCarryCapacityForWithdraw(cs, req)) {
+        HeldUpgradeResources memory released;
+        if (
+            !_hasWithdrawRequest(req) || !_hasSpendableForWithdraw(clanId, clan, req, released)
+                || !_hasCarryCapacityForWithdraw(cs, req)
+        ) {
             _completeMission(cs, m);
             return;
         }
@@ -3691,9 +3695,23 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return req.wood > 0 || req.iron > 0 || req.wheat > 0 || req.fish > 0;
     }
 
-    function _hasVaultResources(Clan storage clan, WithdrawResourcesData memory req) internal view returns (bool) {
-        return clan.vaultWood >= req.wood && clan.vaultIron >= req.iron && clan.vaultWheat >= req.wheat
-            && clan.vaultFish >= req.fish;
+    function _hasSpendableForWithdraw(
+        uint32 clanId,
+        Clan storage clan,
+        WithdrawResourcesData memory req,
+        HeldUpgradeResources memory released
+    ) internal view returns (bool) {
+        if (_spendableAfterReleasing(clan.vaultWood, _reservedWoodByClan[clanId], released.wood) < req.wood) {
+            return false;
+        }
+        if (_spendableAfterReleasing(clan.vaultIron, _reservedIronByClan[clanId], released.iron) < req.iron) {
+            return false;
+        }
+        if (_spendableAfterReleasing(clan.vaultWheat, _reservedWheatByClan[clanId], released.wheat) < req.wheat) {
+            return false;
+        }
+        if (clan.vaultFish < req.fish) return false;
+        return true;
     }
 
     function _hasCarryCapacityForWithdraw(Clansman storage cs, WithdrawResourcesData memory req)
@@ -4055,7 +4073,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             if (gotoRegion != clan.baseRegion) return StatusCode.ERR_NOT_AT_HOMEBASE;
             WithdrawResourcesData memory req = order.withdrawResources;
             if (!_hasWithdrawRequest(req)) return StatusCode.ERR_EMPTY_CARGO;
-            if (!_hasVaultResources(clan, req)) return StatusCode.ERR_MISSING_RESOURCES;
+            HeldUpgradeResources memory released = _releasedUpgradeResources(clan.clanId, cs.clansmanId);
+            if (!_hasSpendableForWithdraw(clan.clanId, clan, req, released)) {
+                return StatusCode.ERR_MISSING_RESOURCES;
+            }
             if (!_hasCarryCapacityForWithdraw(cs, req)) return StatusCode.ERR_CARRY_FULL;
         }
 

--- a/packages/contracts/test/ClanWorld.t.sol
+++ b/packages/contracts/test/ClanWorld.t.sol
@@ -798,6 +798,95 @@ contract ClanWorldTest is Test {
         assertEq(cs.carryFish, 1e18, "fish enters carry");
     }
 
+    function test_withdrawResources_rejectsReservedWheat() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 upgradeCsId) = _setupHarness();
+        uint32 withdrawCsId = _harnessCsAt(harness, clanId, 1);
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 100e18, 100e18, 50e18, 0);
+
+        OrderResult[] memory upgrade =
+            _submitOrderHarness(harness, clanId, upgradeCsId, homeRegion, ActionType.UpgradeBase);
+        assertEq(uint8(upgrade[0].status), uint8(StatusCode.OK), "base upgrade reserves wheat");
+
+        OrderResult[] memory withdraw = _submitWithdrawOrder(harness, clanId, withdrawCsId, homeRegion, 0, 0, 35e18, 0);
+
+        assertEq(uint8(withdraw[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "reserved wheat is unavailable");
+        assertFalse(harness.getActiveMission(withdrawCsId).active, "rejected withdraw should not install mission");
+    }
+
+    function test_withdrawResources_rejectsReservedWood() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 upgradeCsId) = _setupHarness();
+        uint32 withdrawCsId = _harnessCsAt(harness, clanId, 1);
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 30e18, 100e18, 100e18, 0);
+
+        OrderResult[] memory upgrade =
+            _submitOrderHarness(harness, clanId, upgradeCsId, homeRegion, ActionType.UpgradeWall);
+        assertEq(uint8(upgrade[0].status), uint8(StatusCode.OK), "wall upgrade reserves wood");
+
+        OrderResult[] memory withdraw = _submitWithdrawOrder(harness, clanId, withdrawCsId, homeRegion, 11e18, 0, 0, 0);
+
+        assertEq(uint8(withdraw[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "reserved wood is unavailable");
+        assertFalse(harness.getActiveMission(withdrawCsId).active, "rejected withdraw should not install mission");
+    }
+
+    function test_withdrawResources_rejectsReservedIron() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 upgradeCsId) = _setupHarness();
+        uint32 withdrawCsId = _harnessCsAt(harness, clanId, 1);
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setClanWallLevel(clanId, 2);
+        harness.setVault(clanId, 40e18, 7e18, 100e18, 0);
+
+        OrderResult[] memory upgrade =
+            _submitOrderHarness(harness, clanId, upgradeCsId, homeRegion, ActionType.UpgradeWall);
+        assertEq(uint8(upgrade[0].status), uint8(StatusCode.OK), "wall upgrade reserves iron");
+
+        OrderResult[] memory withdraw = _submitWithdrawOrder(harness, clanId, withdrawCsId, homeRegion, 0, 3e18, 0, 0);
+
+        assertEq(uint8(withdraw[0].status), uint8(StatusCode.ERR_MISSING_RESOURCES), "reserved iron is unavailable");
+        assertFalse(harness.getActiveMission(withdrawCsId).active, "rejected withdraw should not install mission");
+    }
+
+    function test_withdrawResources_allowsFishWithActiveReservation() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 upgradeCsId) = _setupHarness();
+        uint32 withdrawCsId = _harnessCsAt(harness, clanId, 1);
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 100e18, 100e18, 100e18, 8e18);
+
+        OrderResult[] memory upgrade =
+            _submitOrderHarness(harness, clanId, upgradeCsId, homeRegion, ActionType.UpgradeBase);
+        assertEq(uint8(upgrade[0].status), uint8(StatusCode.OK), "base upgrade reserves non-fish resources");
+
+        OrderResult[] memory withdraw = _submitWithdrawOrder(harness, clanId, withdrawCsId, homeRegion, 0, 0, 0, 8e18);
+        assertEq(uint8(withdraw[0].status), uint8(StatusCode.OK), "fish has no reservation surface");
+
+        _advanceTickHarness(harness);
+        _advanceTickHarness(harness);
+
+        assertEq(harness.getClan(clanId).vaultFish, 0, "fish leaves vault");
+        assertEq(harness.getClansman(withdrawCsId).carryFish, 8e18, "fish enters carry");
+    }
+
+    function test_withdrawResources_allowsWheatSurplusAboveReservation() public {
+        (ClanWorldTestHarness harness, uint32 clanId, uint32 upgradeCsId) = _setupHarness();
+        uint32 withdrawCsId = _harnessCsAt(harness, clanId, 1);
+        uint8 homeRegion = harness.getClan(clanId).baseRegion;
+        harness.setVault(clanId, 100e18, 100e18, 50e18, 0);
+
+        OrderResult[] memory upgrade =
+            _submitOrderHarness(harness, clanId, upgradeCsId, homeRegion, ActionType.UpgradeBase);
+        assertEq(uint8(upgrade[0].status), uint8(StatusCode.OK), "base upgrade reserves wheat");
+
+        OrderResult[] memory withdraw = _submitWithdrawOrder(harness, clanId, withdrawCsId, homeRegion, 0, 0, 25e18, 0);
+        assertEq(uint8(withdraw[0].status), uint8(StatusCode.OK), "spendable wheat surplus can be withdrawn");
+
+        _advanceTickHarness(harness);
+        _advanceTickHarness(harness);
+
+        assertEq(harness.getClan(clanId).vaultWheat, 5e18, "wheat withdraw and reserved upgrade both settle");
+        assertEq(harness.getClansman(withdrawCsId).carryWheat, 25e18, "wheat enters carry");
+    }
+
     function test_withdrawResources_failsWhenInsufficientVault() public {
         (ClanWorldTestHarness harness, uint32 clanId, uint32 csId) = _setupHarness();
         uint8 homeRegion = harness.getClan(clanId).baseRegion;
@@ -2392,6 +2481,10 @@ contract ClanWorldTest is Test {
         vm.prank(elder);
         (clanId,) = harness.mintClan(elder);
         csId = harness.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+    }
+
+    function _harnessCsAt(ClanWorldTestHarness harness, uint32 clanId, uint256 index) internal view returns (uint32) {
+        return harness.getClanFullView(clanId).clansmen[index].clansman.clansman.clansmanId;
     }
 
     // Helper: submit an order on a harness-based world


### PR DESCRIPTION
## Summary

**CONFIRMED CRITICAL** bug fix per Liam directive 2026-05-01 (msg 10078). Both audit validators (Claude subagent + Codex 5.5) reproduced the exploit empirically on dev-merge HEAD `53e9b13`.

## The bug

`WithdrawResources` action bypasses Phase 8 upgrade reservations. A clansman can withdraw wheat/wood/iron that an active base/wall/monument upgrade has already reserved — breaks the reservation invariant that `getRankings` / `getClanScore` / `quoteLootValueSettled` depend on.

### Empirical proof (Claude validator forge test)

```
vault wheat = 50
queue Base L1→L2 (reserves 20 wheat, spendable = 30)
submit withdraw of 35 wheat
expected: ERR_MISSING_RESOURCES (14)
actual:   OK (0)  ← bug
```

### Root cause

- `_hasVaultResources` did raw `clan.vaultX >= req.X` checks with zero reservation awareness.
- Two buggy call sites:
  - `_validateOrderForClansman` (submit-time)
  - `_doWithdrawResources` (settlement-time)

The canonical `_deductFromVault` already showed the right pattern: `_spendableAfterReleasing(...)` for resources with reservation surfaces; raw check for fish (no fish reservation).

## The fix

- New helper `_hasSpendableForWithdraw(clanId, clan, req)` mirrors `_deductFromVault`'s pattern
- Both buggy call sites now use the helper
- Walls reserve wood + iron only; bases + monuments reserve wheat too — so all 3 resources need reservation-awareness

## Tests added

5 new tests in `ClanWorld.t.sol`:

1. **Exploit test** — reproduces the validator's scenario (asserts `ERR_MISSING_RESOURCES`)
2. **Wood reservation** — same shape for wood + wall upgrade
3. **Iron reservation** — same shape for iron + wall upgrade
4. **Fish (stays raw)** — confirms fish withdraw is unrestricted (no fish reservation surface)
5. **Surplus-OK** — reserve 20 of 50, withdraw 25 succeeds (spendable margin honored)

## Verification

- `forge build` passes
- `forge test`: **258 passed, 0 failed** (was 253; +5 new tests)

## Validators

- Claude subagent: `~/claudes-world/tmp/20260501-withdraw-reservation-bypass-validation-claude.md`
- Codex 5.5: `~/code/omnipass-world/clan-world/.withdraw-reservation-validation-codex.md`

Both rated **CONFIRMED CRITICAL**. Claude wrote + ran a forge test that proved the bug exists on dev-merge HEAD.

## Test plan

- [ ] CI runs full forge test suite
- [ ] Liam UAT: confirm withdraw rejects when reservations would be bled

🤖 Generated with [Claude Code](https://claude.com/claude-code)