### PR TITLE
release: v1.1.2 — World ID error/loading states (#405) + post-tag audit synthesis

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -72,16 +72,34 @@ function MainApp() {
   // When the guard is required, start verified=false and prompt for verification;
   // otherwise render directly in browser/dev.
   const [verified, setVerified] = useState(!REQUIRE_WORLD_APP_GUARD);
+  const [verifyState, setVerifyState] = useState<
+    'idle' | 'loading' | 'error' | 'success'
+  >('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const isInWorldApp = MiniKit.isInstalled() || !REQUIRE_WORLD_APP_GUARD;
 
   const { open: openIDKit, result, isSuccess } = useIDKitRequest(IDKIT_CONFIG);
+
+  const handleOpenIDKit = () => {
+    setVerifyState('idle');
+    setErrorMessage(null);
+    openIDKit();
+  };
 
   useEffect(() => {
     if (!isSuccess || result === null) return;
     if (!CONVEX_SITE_URL) {
       console.error('CONVEX_SITE_URL not set — VITE_CONVEX_URL missing');
+      setVerifyState('error');
+      setErrorMessage(
+        import.meta.env.DEV
+          ? '[Dev] VITE_CONVEX_URL not configured. World ID verification disabled.'
+          : 'World ID verification is not available right now. Please try again later.',
+      );
       return;
     }
+    setVerifyState('loading');
+    setErrorMessage(null);
     fetch(`${CONVEX_SITE_URL}/api/verify`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -90,11 +108,23 @@ function MainApp() {
       .then((res) => {
         if (res.ok) {
           setVerified(true);
+          setVerifyState('success');
+          setErrorMessage(null);
         } else {
           console.error('Verify failed:', res.status);
+          setVerifyState('error');
+          setErrorMessage(
+            'World ID verification failed. Please try again in a moment.',
+          );
         }
       })
-      .catch((err) => console.error('Verify error:', err));
+      .catch((err) => {
+        console.error('Verify error:', err);
+        setVerifyState('error');
+        setErrorMessage(
+          'Could not reach the verification service. Check your connection and try again.',
+        );
+      });
   }, [isSuccess, result]);
 
   if (!isInWorldApp) {
@@ -164,17 +194,60 @@ function MainApp() {
     >
       {/* Page title removed — host chrome (Telegram / World App) shows the app name. */}
       {!verified && (
-        <button
-          onClick={openIDKit}
+        <div
           style={{
             margin: '8px',
-            padding: '12px 24px',
-            fontFamily: 'monospace',
-            cursor: 'pointer',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '8px',
           }}
         >
-          Claim Your Clan Identity
-        </button>
+          <button
+            onClick={handleOpenIDKit}
+            disabled={verifyState === 'loading'}
+            aria-busy={verifyState === 'loading'}
+            style={{
+              padding: '12px 24px',
+              fontFamily: 'monospace',
+              cursor: verifyState === 'loading' ? 'wait' : 'pointer',
+              opacity: verifyState === 'loading' ? 0.68 : 1,
+            }}
+          >
+            {verifyState === 'loading'
+              ? 'Verifying...'
+              : 'Claim Your Clan Identity'}
+          </button>
+          {!CONVEX_SITE_URL && import.meta.env.DEV && (
+            <div
+              role="status"
+              style={{
+                color: '#f2c572',
+                fontFamily: 'monospace',
+                fontSize: '0.78rem',
+                lineHeight: 1.4,
+              }}
+            >
+              [Dev] VITE_CONVEX_URL not configured. World ID verification disabled.
+            </div>
+          )}
+          {verifyState === 'error' && errorMessage && (
+            <div
+              role="alert"
+              aria-live="polite"
+              style={{
+                background: 'rgba(122, 34, 34, 0.24)',
+                border: '1px solid rgba(242, 103, 103, 0.56)',
+                color: '#ffd0d0',
+                fontFamily: 'monospace',
+                fontSize: '0.85rem',
+                lineHeight: 1.45,
+                padding: '10px 12px',
+              }}
+            >
+              {errorMessage}
+            </div>
+          )}
+        </div>
       )}
       {verified && (
         <WorldMapBoundary>

--- a/docs/architecture/diamond-pattern.md
+++ b/docs/architecture/diamond-pattern.md
@@ -1,0 +1,162 @@
+# ClanWorld Diamond Pattern Plan
+
+## Summary
+
+ClanWorld must move from one oversized engine contract to an EIP-2535 Diamond.
+The current monolith is far above the 24,576 byte EIP-170 runtime limit, and
+read-only lenses alone are unlikely to create enough headroom. The diamond keeps
+one logical game address and shared state while distributing logic across many
+small facets.
+
+Design goals:
+
+- Keep `IClanWorld` ABI stable for callers unless an ABI break is explicitly
+  approved.
+- Use one shared `AppStorage` through `LibStorage`.
+- Prefer many small, domain-focused facets over a few near-limit facets.
+- Target each facet under `16 KB`; split before merge if any facet approaches
+  `20 KB`.
+- Keep cross-facet calls rare and intentional.
+
+## Storage Model
+
+Use a single `AppStorage` struct at a deterministic slot:
+
+```solidity
+library LibStorage {
+    bytes32 internal constant STORAGE_SLOT =
+        keccak256("clan.world.app.storage.v1");
+
+    struct AppStorage {
+        // shared reentrancy flag
+        // world, treasury, clans, clansmen, missions, wheat plots
+        // market queues, reservations, defenders, bandits, seeds
+    }
+
+    function appStorage() internal pure returns (AppStorage storage s) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            s.slot := slot
+        }
+    }
+}
+```
+
+Rules:
+
+- No facet-level state variables.
+- Existing storage fields are append-only after deployment.
+- Nested structs used inside `AppStorage` are also append-only.
+- Storage layout snapshots must be updated and reviewed whenever storage changes.
+- The shared reentrancy guard lives in `AppStorage`, not in individual facets.
+
+## Facet Boundaries
+
+Recommended initial facet set:
+
+| Facet | Responsibility |
+|---|---|
+| `WorldClockFacet` | `heartbeat`, tick advancement, orchestration of settlement, market, bandits, and seasons. |
+| `SeasonFacet` | `finalizeSeason`, season freeze checks, ranking snapshot behavior. |
+| `ClanLifecycleFacet` | `mintClan`, ownership transfer, clan death/elimination cleanup entrypoints. |
+| `OrdersFacet` | `submitClanOrders`, order validation, mission install/interruption. |
+| `SettlementFacet` | Lazy settlement loop and mission progress mechanics. |
+| `UpkeepFacet` | Starvation, winter upkeep/cold damage, crop lock/regrow transitions. |
+| `GatheringFacet` | Wood, iron, fish, wheat action resolution. |
+| `DepositWithdrawFacet` | Deposit and withdraw mission resolution. |
+| `UpgradesFacet` | Wall/base/monument reservations, refunds, settlement, cost tables. |
+| `MarketFacet` | Immediate/scheduled market execution, pool calls, market failure handling. |
+| `TreasuryFacet` | Treasury init, pool seeding, token/pool routing. |
+| `DirectTransfersFacet` | Gold/resource/blueprint/bundle transfers. |
+| `BanditStateFacet` | Spawn probability, active registry, movement, transitions, escape/delete. |
+| `BanditTargetingFacet` | Spawn weights, target selection, defender discovery. |
+| `BanditCombatFacet` | Attack resolution, wall/base damage, casualties, loot and rewards. |
+| `RawViewsFacet` | Raw storage getters and simple state views. |
+| `DerivedViewsFacet` | Settlement simulation, rankings, scores, full clan views. |
+| `MarketViewsFacet` | Pool reserves, market state, quotes. |
+| `BanditViewsFacet` | Active bandit view, target preview, bandit/region read models. |
+
+Expected size-risk facets:
+
+- `SettlementFacet`
+- `UpgradesFacet`
+- `BanditCombatFacet`
+- `DerivedViewsFacet`
+- `OrdersFacet`
+
+Split these further before merging if any one crosses the warning line.
+
+## Libraries
+
+Use libraries for small shared rules that should not become public selectors:
+
+- `LibTravel`: route matrix, path packing, travel ticks.
+- `LibResourceAccounting`: vault/carry add, deduct, spendable, reserved math.
+- `LibRules`: small pure action durations, clamps, rule tables.
+- `LibStorage`: storage pointer, shared modifiers, and common diamond helpers.
+
+Avoid large internal libraries that get inlined into many facets unless bytecode
+measurements prove the duplication is acceptable.
+
+## Cross-Facet Calls
+
+Cross-facet calls are allowed but should be rare.
+
+- Prefer libraries for small pure/shared helpers.
+- Prefer same-facet internal calls for tightly coupled mutation.
+- Use external self-calls through the diamond only for intentional orchestration
+  boundaries, such as heartbeat invoking market execution with `try/catch`.
+- Guard internal-only external selectors with `onlyDiamond`.
+- Document any orchestrator function that cannot use `nonReentrant` because it
+  must call another facet through the diamond.
+
+## Migration Plan
+
+1. **Rules and design**
+   - Update `packages/contracts/AGENTS.md`.
+   - Keep this architecture doc current.
+   - Re-run `forge build --sizes` after pending main/dev merges settle.
+
+2. **Diamond skeleton**
+   - Add `Diamond`, `DiamondCutFacet`, `DiamondLoupeFacet`, `IDiamondCut`,
+     `LibDiamond`, `LibStorage`, deploy helper, and empty facets.
+   - Add selector collision and loupe coverage tests.
+
+3. **Storage and raw reads**
+   - Move storage layout into `LibStorage.AppStorage`.
+   - Add `RawViewsFacet` and prove raw getter parity with the monolith.
+
+4. **World and lifecycle**
+   - Move world clock, season finalization, clan minting, ownership transfer, and
+     death cleanup entrypoints.
+
+5. **Settlement and orders**
+   - Move settlement, upkeep, gathering, deposit/withdraw, upgrades, orders, and
+     shared resource accounting.
+
+6. **Economy**
+   - Move market execution, treasury setup, pool seeding, and direct transfers.
+
+7. **Bandits**
+   - Move bandit state, targeting, and combat into separate facets.
+
+8. **Derived views**
+   - Move settlement simulation, rankings, scores, full clan views, market views,
+     and bandit views.
+
+9. **Final parity and deploy**
+   - Run full test suite, ABI parity, selector coverage, storage snapshot, and
+     size report.
+   - Deploy to local Anvil, then Base Sepolia.
+   - Archive or remove the monolith only after parity is proven.
+
+## Acceptance Criteria
+
+- Every facet runtime is below `20 KB`; target is below `16 KB`.
+- `IClanWorld` ABI selectors route through the diamond.
+- Full `forge test` passes.
+- `forge build --sizes` report is saved in the PR.
+- Existing heartbeat, settlement, market, bandit, transfer, and view behavior is
+  preserved.
+- Cross-facet reentrancy and internal-only selector guards are tested.
+- Storage layout snapshot is committed and enforced.

--- a/docs/reviews/main-v110-synthesis.md
+++ b/docs/reviews/main-v110-synthesis.md
@@ -1,0 +1,180 @@
+# v1.1.0 Post-Tag Audit Synthesis — main `1487cd7`
+
+**Date:** 2026-05-02 02:00 ET
+**Reviewers:** codex 5-4 ✅ NEEDS_HOTFIX, codex 5-5 ✅ NEEDS_HOTFIX, Claude feature-dev:code-reviewer ✅ NEEDS_V12_WORK, gemini 3.1 Pro ❌ (Ripgrep error), opus 4.6 ❌ (silent fail), opus 4.7 ❌ (silent fail)
+
+**Verdict:** **NEEDS v1.1.1 HOTFIX** — 2/3 reviewers converged on the cockpit auth HIGH (codex 5-4 + 5-5; Claude didn't surface it). Claude added 4 distinct MEDIUMs codex missed including a real `stepStatus` ternary bug. ClanWorld engine itself is CLEAN — all 3 reviewers agree (boundary-freeze coverage complete, starvation/freeze semantics aligned, webhook auth directionally correct).
+
+---
+
+## MUST FIX — v1.1.1 hotfix
+
+### MUST-1.1.1.1 — Bridge cockpit API exposes secret-backed commands without independent auth
+
+**Confirmed by:** codex 5-4 + codex 5-5 (convergent)
+
+**Files:**
+- `gold-bridge-monorepo/scripts/20-cockpit-api.mjs:31-107, 189-197, 228-230, 1435-1455, 1504`
+- `gold-bridge-monorepo/.env.template:87-90`
+
+**Bug:** The cockpit is a localhost control plane for privileged operations, but:
+
+1. **Default CORS allowlist includes `https://bridge-dev.clan-world.com`** (a remote origin), not just localhost.
+2. **No independent auth beyond CORS.** Any XSS, compromised deployment, or malicious JS served from the allowed remote origin can drive the operator's localhost API.
+3. **Privileged endpoints exposed:** `recover-base-execute`, `timelock-schedule`, `timelock-execute`, `ntt:*` series, `liquidity:recover-base`. These run with the operator's local `.env` and private keys.
+4. **`/api/actions` and `/api/actions/:id/preview` reveal confirmation strings** needed by `/run` — a remote attacker reading those + crafting a `/run` request gets full privileged execution.
+5. **Env var name typo:** template documents `COCKPIT_CORS_ORIGIN`, server reads `COCKPIT_CORS_ORIGINS`. Operators following the template believe they've changed the allowlist; in fact their override is silently ignored, leaving the remote default in place.
+
+**Effect:** A funded bridge-operator running cockpit with default config has a remotely-driveable privileged surface. The remote origin doesn't even need to be malicious — a compromised `bridge-dev.clan-world.com` deployment, a stored XSS, or a local-network attack on DNS for that domain all yield the same outcome.
+
+**Suggested fix (synthesizing both reviewers):**
+1. **Default-allow only localhost origins.** Remove `bridge-dev.clan-world.com` from code defaults.
+2. **Honor the documented env var name** (or rename the template — pick one, document explicitly, print active allowlist on startup).
+3. **Require an operator secret/nonce** on every mutating + reconcile endpoint. Use `COCKPIT_API_TOKEN` (high-entropy) or signed nonce. CORS alone is not auth.
+4. **Stop exposing runnable confirmation values from public read endpoints.**
+
+---
+
+## SHOULD FIX — bundle into v1.1.1 if cheap, else v1.2
+
+### SHOULD-1 — `stepStatus` ternary bug — both branches return `'ready'`
+
+**Confirmed by:** Claude
+
+**File:** `gold-bridge-monorepo/scripts/20-cockpit-api.mjs:1088-1091`
+
+**Bug:**
+```javascript
+function stepStatus(done, blockers = []) {
+  if (done) return 'done';
+  return blockers.length ? 'ready' : 'ready';  // both branches return 'ready'
+}
+```
+
+Both ternary branches return `'ready'`. Passing blockers has no effect. Steps that should show `'blocked'` show `'ready'` in the cockpit guide sidebar, misleading operators about execution prerequisites. Downstream pass partially rescues via `dependsOn` chains, but direct `stepStatus(false, ['dep'])` callers fail.
+
+**Fix:** `return blockers.length ? 'blocked' : 'ready';`
+
+This is a small standalone fix. **Bundle into v1.1.1.**
+
+### SHOULD-2 — Wallet intent reconciliation trusts browser-supplied data
+
+**Confirmed by:** codex 5-4
+
+**File:** `gold-bridge-monorepo/scripts/20-cockpit-api.mjs:368-399`
+
+**Bug:** For `deploy-base-gold-proxy`, the server does not verify that `contractAddress` actually came from `txHash`, that the tx succeeded, that it's on the expected chain, or that helper bytecode matches `UpgradeableGoldDeployer`. It just reads three getters from whatever the browser passed and persists token/timelock/admin addresses into `.env`.
+
+**Effect:** Benign failure → poisoned local deployment state aiming later upgrade/minter/recovery actions at wrong contracts. Same threat model as MUST-1.1.1.1 → state poisoning trivial.
+
+**Fix:** Server-side fetch the receipt; verify chain + success + contract creation address; verify helper bytecode or expected immutable layout before writing env updates.
+
+### SHOULD-3 — `payload.engineAddress` validation only fires for strings
+
+**Confirmed by:** codex 5-5
+
+**File:** `apps/server/convex/heartbeat.ts:77`
+
+**Bug:** Validation only runs when `payload.engineAddress` is a string. Missing, null, numeric, or object values silently accepted. Receipt `to` + log-address filters still prevent wrong-engine ingestion (so not direct spoofing), but weakens the auth/diagnostic invariant.
+
+**Fix:** Require valid 20-byte hex address equal to `CLAN_WORLD_CONTRACT_ADDRESS`; reject other shapes.
+
+### SHOULD-4 — `recoverFromAllowedSource` lacks EOA-only enforcement
+
+**Confirmed by:** Claude
+
+**File:** `gold-bridge-monorepo/packages/contracts/src/GoldBridgeToken.sol:110-126`
+
+**Bug:** `recoverFromAllowedSource` calls `_transfer(source, recipient, amount)` which works on any address. The README warns "User wallets should not be allowlisted" but there is no on-chain enforcement. If timelock governance mistakenly allowlists a user's Smart Account or Safe wallet, the owner can forcibly move their GOLD with no recourse. Protected by 24h `TIMELOCK_DELAY_SECONDS` (sufficient for testnet) but needs explicit governance policy doc + ideally on-chain check before mainnet.
+
+**Fix for v1.2:** Add `require(source.code.length > 0, "GoldBridgeToken: recovery source must be contract");` to `setRecoveryAllowed`. Document governance policy. Consider whether recovery hook needed post-NTT-integration (`disableRecoveryForever` is the preferred endgame).
+
+### SHOULD-5 — `BridgePanel` hidden when cockpit API offline
+
+**Confirmed by:** Claude
+
+**File:** `gold-bridge-monorepo/apps/web/src/components/CockpitDashboard.tsx:95-107`
+
+**Bug:** `BridgePanel` reads from pre-generated `goldDeployment.ts` and doesn't need cockpit API, but all tabs gated behind `{state && ...}` where `state` is the cockpit API response. Frontend running independently → tabs blank, Wormhole Connect inaccessible.
+
+**Fix:** Move `{tab === 'bridge' && <BridgePanel />}` outside the `{state && ...}` guard.
+
+---
+
+## DEFER — v1.2 work
+
+### V1.2-1 — Decimal reconciliation between bridge GOLD (9) and game GOLD (18)
+
+**Confirmed by:** codex 5-5
+
+**Files:** `gold-bridge-monorepo/packages/contracts/src/GoldBridgeToken.sol:27`, `packages/contracts/src/ClanWorld.sol`
+
+Bridge GOLD = 9 decimals; game GOLD = 18 decimals. Not a v1.1.0 bug because bridge is not yet integrated into game flows. v1.2 needs explicit conversion boundary, dust rejection, round-trip tests. Codex 5-5 verified Wormhole NTT EVM docs match the bridge's `burn(uint256)` + `mint(address,uint256)` interface.
+
+### V1.2-2 — `numberFromPayload` NaN handling
+
+**File:** `apps/server/convex/heartbeat.ts:31`
+
+`numberFromPayload` can convert non-empty nonnumeric string into NaN. Authenticated path, low impact. Drop non-finite or 400.
+
+### V1.2-3 — No-op heartbeat keeper churn
+
+**File:** `packages/contracts/src/ClanWorld.sol:2989`
+
+During season-finalization limbo, `heartbeat()` returns before updating `nextHeartbeatAtTs`. Correct for avoiding replay, but keepers can keep submitting successful no-op txs once old timestamp is reached. Optional: emit no-op event or throttle if gas churn gets noisy.
+
+---
+
+## SKIP
+
+None convergent. The 3 LOWs above are all explicitly flagged as deferred/not-blocking by the reviewers.
+
+---
+
+## Cross-cutting — what's CLEAN (both reviewers agree)
+
+✅ **`_requireNoPendingSeasonFinalization` coverage complete** for all IClanWorld external mutators: settle, mint, submit orders, ownership transfer, OTC transfers all guard before settlement or balance mutation. `initTreasury` and `seedPools` are owner-only setup actions and don't mutate clan ranking inputs — coverage decision is consistent.
+
+✅ **Heartbeat boundary freeze placed correctly** — before settlement, market execution, bandit progression, winter transitions, and tick increment. Round-2's "freeze too late" replay class did NOT reintroduce.
+
+✅ **Starvation `tick+1` onset + strict `< tick` winter-kill semantics** consistent across both storage settlement (`_settleClanThroughTick`) and simulation paths (`_isStarvingAtTick`).
+
+✅ **Convex real-indexer receipt checks** directionally correct: waits for receipt, rejects reverted tx, compares `receipt.to`, filters logs by engine address before parsing, uses receipt block for snapshot refresh. Remaining gap is payload-shape strictness, not log spoofing.
+
+✅ **Wormhole NTT EVM token interface alignment** — bridge's `burn(uint256)` + `mint(address,uint256)` matches Wormhole spec.
+
+---
+
+## V1.1.1 hotfix dispatch shape
+
+**Branch:** `fix/v111-bridge-cockpit-auth` based on `main` HEAD `1487cd7`.
+
+**Scope:** Single codex Pattern B-bulk dispatch addressing MUST-1.1.1.1 (cockpit API auth + env var typo + remove remote default origin + stop exposing confirmation strings publicly). Optional: bundle SHOULD-1 (wallet intent verification) into the same PR if Liam wants belt-and-suspenders.
+
+**Validation:**
+- Cockpit cannot be driven from a remote origin without `COCKPIT_API_TOKEN` set to a non-empty value
+- Mutating endpoints reject requests without valid token/nonce
+- `/api/actions/preview` doesn't reveal confirmation strings used by `/run`
+- Env var name documented + read by server matches; startup logs active allowlist
+- Manual smoke test: localhost-only operation works; remote origin without token denied
+
+**Time:** ~30-45 min for the cockpit hardening. Add ~15 min if bundling SHOULD-1.
+
+---
+
+## Round-1 reviewer attribution
+
+| Reviewer | File | Verdict | HIGH count | Notes |
+|---|---|---|---|---|
+| codex 5-4 | `/tmp/main-v110-review-codex-5-4.log` | NEEDS_HOTFIX | 1 | Cockpit auth + env var typo (with fix details) + SHOULD-1 |
+| codex 5-5 | `/tmp/main-v110-review-codex-5-5.log` | NEEDS_HOTFIX | 1 | Same cockpit finding + SHOULD-3 + V1.2-1/2/3 |
+| Claude feature-dev:code-reviewer | (read-only sandbox; review verbatim in agent reply) | NEEDS_V12_WORK | 0 | **Missed cockpit auth HIGH** but added 4 distinct MEDIUMs (stepStatus ternary, recoverFromAllowedSource, BridgePanel gating, timelock delay test gap) + confirmed clean cross-cutting + explicit decimal conversion warning for v1.2 |
+| gemini 3.1 Pro | `docs/reviews/main-v110-codereview-gemini-3-1-pro.md` | (failed early — Ripgrep not available) | — | — |
+| opus 4.6 | `docs/reviews/main-v110-codereview-opus-4-6.md` | (silent fail, 0 bytes) | — | Headless `claude -p` known issue |
+| opus 4.7 | `docs/reviews/main-v110-codereview-opus-4-7.md` | (silent fail, 0 bytes) | — | Same |
+
+**Convergence:** 2/3 reviewers (both codex) identified the same MUST finding with identical file paths, line numbers, and threat model. Claude missed the cockpit auth issue but found 4 distinct MEDIUMs the codex reviewers missed (most notably the `stepStatus` ternary bug — both branches return `'ready'`, real fix needed). The cross-model gap on the cockpit auth is interesting: codex models read the cockpit API code in security-review mode; Claude focused more on contract surface analysis.
+
+Strong signal — v1.1.1 hotfix is justified. Recommended hotfix scope: MUST-1.1.1.1 (cockpit API auth + env var typo) + SHOULD-1 (stepStatus ternary, trivial fix). SHOULDs 2-5 deferred to v1.2.
+
+🤖 Synthesized by Claude Opus 4.7 from codex review logs in /tmp/main-v110-review-codex-*.log

--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -1,42 +1,88 @@
 # packages/contracts — AGENTS.md
 
-Solidity contracts for ClanWorld. Foundry-managed. The canonical seam interface is `src/IClanWorld.sol` — every other workspace talks to chain through it (via the `IChainClient` adapter).
+Solidity contracts for ClanWorld. Foundry-managed. The canonical chain seam is
+`src/IClanWorld.sol`; every other workspace talks to chain through the
+`IChainClient` adapter and ABIs from this package.
 
-## What this package does
+## Current Shape
 
-- Defines the `IClanWorld` interface (24KB, ABI-stable).
-- (Wave 1+) Implements the engine: tick advancement, mission resolution, heartbeat throttle, treasury accounting.
-- (Wave 2+) Includes deploy script for World Chain Sepolia (S1) and Base Sepolia (S2).
-- (S2 only) Adds `ClanIdentity` (ERC-7857 iNFT wrapper) and `ClanMemory` (0G Storage KV wrapper) libraries.
+- `src/IClanWorld.sol` is the public ABI seam.
+- `src/ClanWorld.sol` is the current monolithic engine and is over EIP-170.
+- `foundry.toml` pins Solidity `0.8.34`, optimizer on, `via_ir = true`.
+- Deploy target is Base Sepolia for the current wave.
 
-## Wave 0 status
-
-Only `src/IClanWorld.sol` exists. No engine impl, no deploy scripts, no tests. Wave 1 ships the engine + deploy.
-
-## Key files
-
-- `src/IClanWorld.sol` — canonical seam (DO NOT MODIFY without ADR; see `../../docs/adr/ADR001-IClanWorld-as-web2-web3-integration-seam.md`).
-- `foundry.toml` — Foundry config; reads `RPC_URL_PRIMARY` from env.
-- `package.json` — minimal; this is a Foundry project, not a TS package. The npm scripts shell out to `forge`.
-
-## Local conventions
-
-- **No TypeScript in this package.** Type generation for consumers happens via `wagmi typegen` or hand-written ABI types in `@clan-world/shared`.
-- **`IClanWorld.sol` is sacred.** Changes require: ADR amendment, full team sign-off, all 6 spec docs reviewed for ripple effects.
-- **Solc version pinned** in `foundry.toml` (`0.8.24`). Don't bump without a CI test run.
-- **Two deploy targets:** `worldchain-sepolia` (S1) and `base-sepolia` (S2). Both use the same contract bytecode.
-- **Test on a local anvil first.** Don't burn testnet faucet funds debugging silly bugs.
-
-## How it interacts with adapters
-
-This package IS one side of `IChainClient` — `RealChainClient` (in `@clan-world/shared/adapters`) calls into the deployed contract via viem/ethers using ABIs derived from this package.
-
-## Running
+## Local Commands
 
 ```bash
-forge build          # build contracts
-forge test           # run tests (Wave 1+)
+forge build
+forge build --sizes
+forge test
 forge script script/Deploy.s.sol --rpc-url $RPC_URL_PRIMARY --broadcast
 ```
 
-See `../../docs/guides/stream-contracts.md` for the full deploy workflow including wallet management.
+## Contract Rules
+
+- Use `rg`/`rg --files` first when searching.
+- Do not change `IClanWorld.sol` or generated ABI files casually. ABI changes
+  require explicit user approval and downstream adapter/test updates.
+- Run `forge build --sizes` for any change that can affect deployed bytecode.
+- Keep tests focused on happy paths and critical failures per repo hackathon
+  rules; do not add exhaustive regression suites unless needed for safety.
+- Never commit real secrets or funded keys. `.env*` files stay local unless they
+  are templates.
+
+## Diamond / Facet Rules
+
+ClanWorld is moving toward an EIP-2535 Diamond because the monolith is far above
+the 24,576 byte EIP-170 runtime limit. Follow these rules for any diamond work:
+
+- Use one shared `AppStorage` accessed through `LibStorage.appStorage()`.
+- Facets MUST NOT declare contract-level state variables. All persistent game
+  state goes through `AppStorage`; facet-level state silently corrupts diamond
+  storage under `delegatecall`.
+- `AppStorage` and nested storage structs are append-only after deployment. Do
+  not reorder fields or insert fields in the middle.
+- Prefer more small, domain-focused facets over near-limit mega-facets.
+- Target each facet under `16 KB` runtime. Treat `20 KB` as a split-before-merge
+  warning line.
+- Avoid chatty cross-facet orchestration. Most calls should enter one facet,
+  mutate shared storage, and return.
+- Any external selector that exists only for internal diamond orchestration must
+  be guarded with `onlyDiamond` or a stricter equivalent.
+- State-writing user entrypoints use the shared `nonReentrant` guard, unless an
+  orchestrator exception is explicitly documented and tested.
+- Selector coverage tests must prove every intended `IClanWorld` selector routes
+  through the diamond.
+- Storage layout snapshot checks are mandatory for `LibStorage` changes.
+
+## Facet vs Library
+
+- Use a **facet** for external ABI functions, large stateful domains, future
+  growth areas, or logic that needs diamond routing.
+- Use an **internal library** for small pure/shared helpers that are cheap to
+  inline and should not be exposed as selectors.
+- Use an **external library** only when a shared helper is too large to inline
+  and does not naturally belong as a facet.
+
+Recommended initial slices:
+
+- Facets: `WorldClockFacet`, `SeasonFacet`, `ClanLifecycleFacet`,
+  `OrdersFacet`, `SettlementFacet`, `UpkeepFacet`, `GatheringFacet`,
+  `DepositWithdrawFacet`, `UpgradesFacet`, `MarketFacet`, `TreasuryFacet`,
+  `DirectTransfersFacet`, `BanditStateFacet`, `BanditTargetingFacet`,
+  `BanditCombatFacet`, `RawViewsFacet`, `DerivedViewsFacet`,
+  `MarketViewsFacet`, `BanditViewsFacet`.
+- Libraries: `LibStorage`, `LibTravel`, `LibResourceAccounting`, `LibRules`.
+
+High-risk facets for size creep: `SettlementFacet`, `UpgradesFacet`,
+`BanditCombatFacet`, `DerivedViewsFacet`, and `OrdersFacet`.
+
+## Integration Boundary
+
+This package is one side of `IChainClient`. If ABI, event, or deploy address
+behavior changes, update `packages/shared` adapters/generated ABI and any server,
+runner, or frontend consumers in the same PR.
+
+See `../../docs/guides/stream-contracts.md` and
+`../../docs/architecture/diamond-pattern.md` for deeper workflow and design
+context.

--- a/packages/contracts/src/diamond/IDiamondCut.sol
+++ b/packages/contracts/src/diamond/IDiamondCut.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+interface IDiamondCut {
+    enum FacetCutAction {
+        Add,
+        Replace,
+        Remove
+    }
+
+    struct FacetCut {
+        address facetAddress;
+        FacetCutAction action;
+        bytes4[] functionSelectors;
+    }
+
+    event DiamondCut(FacetCut[] diamondCut, address init, bytes calldata data);
+
+    function diamondCut(FacetCut[] calldata diamondCut_, address init, bytes calldata data) external;
+}

--- a/packages/contracts/src/diamond/IDiamondLoupe.sol
+++ b/packages/contracts/src/diamond/IDiamondLoupe.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+interface IDiamondLoupe {
+    struct Facet {
+        address facetAddress;
+        bytes4[] functionSelectors;
+    }
+
+    function facets() external view returns (Facet[] memory facets_);
+    function facetFunctionSelectors(address facet) external view returns (bytes4[] memory selectors);
+    function facetAddresses() external view returns (address[] memory facetAddresses_);
+    function facetAddress(bytes4 selector) external view returns (address facet);
+}


### PR DESCRIPTION
## Summary

Quick demo-prep PR. Brings dev's polish onto main:

- **#405 World ID verification error/loading states** (PR #417 merged into dev) — user-visible error messages with `aria-live`, loading state on CTA, dev-only config hint. Closes silent-failure UX gap on the primary mini-app journey.
- **Post-tag audit synthesis** (`docs/reviews/main-v110-synthesis.md`) — full v1.1.0 audit synthesis with reviewer attributions and 4 deferred MEDIUMs queued for v1.2.

Both already merged through normal review. v1.1.1 hotfix that landed earlier today is already on main; this PR brings the additional dev polish.

## Validation

- chainclient-abi green at HEAD
- forge tests 352/352 (unchanged from v1.1.0 — no contract code changes in this PR)
- pnpm typecheck + build green at dev HEAD

## Test plan post-merge

- [ ] World ID flow: error message visible on backend failure
- [ ] World ID flow: loading state during verify POST
- [ ] Tag v1.1.2 on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)