### PR TITLE
[codex] add diamond lens foundation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,6 +18,7 @@ RPC_URL_PRIMARY=https://base-sepolia.g.alchemy.com/v2/<YOUR_ALCHEMY_KEY>
 # Fallback: public Base Sepolia endpoint
 RPC_URL_FALLBACK=https://sepolia.base.org
 CLAN_WORLD_CONTRACT_ADDRESS=
+CLAN_WORLD_LENS_ADDRESS=
 DEPLOYER_PRIVATE_KEY=
 
 # --- Convex backend ---

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -635,6 +635,25 @@
     },
     {
       "type": "function",
+      "name": "getClanClansmanIds",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "clansmanIds",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "getClanFullView",
       "inputs": [
         {
@@ -1173,6 +1192,19 @@
     },
     {
       "type": "function",
+      "name": "getClanIds",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "clanIds",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "getClanScore",
       "inputs": [
         {
@@ -1267,6 +1299,25 @@
               "internalType": "uint256"
             }
           ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getClansmanDefendingRegion",
+      "inputs": [
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "region",
+          "type": "uint8",
+          "internalType": "uint8"
         }
       ],
       "stateMutability": "view"
@@ -4093,25 +4144,25 @@
           "internalType": "uint32"
         },
         {
-          "name": "wood",
+          "name": "woodDelta",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
         },
         {
-          "name": "iron",
+          "name": "ironDelta",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
         },
         {
-          "name": "wheat",
+          "name": "wheatDelta",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"
         },
         {
-          "name": "fish",
+          "name": "fishDelta",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"

--- a/packages/contracts/abi/IClanWorldLens.json
+++ b/packages/contracts/abi/IClanWorldLens.json
@@ -1,0 +1,1480 @@
+{
+  "abi": [
+    {
+      "type": "function",
+      "name": "getActiveBanditView",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct ActiveBanditView",
+          "components": [
+            {
+              "name": "exists",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "banditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum BanditState"
+            },
+            {
+              "name": "currentRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackAttemptsMade",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "maxAttemptsRemaining",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "stateEnteredTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextActionTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "tier",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "attackPower",
+              "type": "uint16",
+              "internalType": "uint16"
+            },
+            {
+              "name": "carryWood",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryIron",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryWheat",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "carryFish",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "projectedTargetClanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "projectedTargetLootValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getBanditTargetPreview",
+      "inputs": [
+        {
+          "name": "banditId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "previewClanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getClanFullView",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct ClanFullView",
+          "components": [
+            {
+              "name": "clan",
+              "type": "tuple",
+              "internalType": "struct DerivedClanState",
+              "components": [
+                {
+                  "name": "clan",
+                  "type": "tuple",
+                  "internalType": "struct Clan",
+                  "components": [
+                    {
+                      "name": "clanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "iftTokenId",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "owner",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "clanState",
+                      "type": "uint8",
+                      "internalType": "enum ClanState"
+                    },
+                    {
+                      "name": "baseRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "baseLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "wallLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "monumentLevel",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "livingClansmen",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "lastSettledTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "starvationStartsAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "coldDamage",
+                      "type": "uint16",
+                      "internalType": "uint16"
+                    },
+                    {
+                      "name": "ownerNonce",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "goldBalance",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "blueprintBalance",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultWood",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultIron",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultWheat",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "vaultFish",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "name": "isStarving",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "lootValue",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "derivedAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "clansmen",
+              "type": "tuple[]",
+              "internalType": "struct ClansmanFullView[]",
+              "components": [
+                {
+                  "name": "clansman",
+                  "type": "tuple",
+                  "internalType": "struct DerivedClansmanState",
+                  "components": [
+                    {
+                      "name": "clansman",
+                      "type": "tuple",
+                      "internalType": "struct Clansman",
+                      "components": [
+                        {
+                          "name": "clansmanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "clanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "state",
+                          "type": "uint8",
+                          "internalType": "enum ClansmanState"
+                        },
+                        {
+                          "name": "currentRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "cooldownEndsAtTs",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "lastMissionNonce",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "carryWood",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryIron",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryWheat",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "carryFish",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "activeMission",
+                      "type": "tuple",
+                      "internalType": "struct Mission",
+                      "components": [
+                        {
+                          "name": "active",
+                          "type": "bool",
+                          "internalType": "bool"
+                        },
+                        {
+                          "name": "nonce",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "submittedAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "executesAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "settlesAtTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "clansmanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "startRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "targetRegion",
+                          "type": "uint8",
+                          "internalType": "uint8"
+                        },
+                        {
+                          "name": "action",
+                          "type": "uint8",
+                          "internalType": "enum ActionType"
+                        },
+                        {
+                          "name": "startTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "arrivalTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "actionStartTick",
+                          "type": "uint64",
+                          "internalType": "uint64"
+                        },
+                        {
+                          "name": "missionSeed",
+                          "type": "bytes32",
+                          "internalType": "bytes32"
+                        },
+                        {
+                          "name": "marketMode",
+                          "type": "uint8",
+                          "internalType": "enum MarketExecutionMode"
+                        },
+                        {
+                          "name": "targetClanId",
+                          "type": "uint32",
+                          "internalType": "uint32"
+                        },
+                        {
+                          "name": "marketToken",
+                          "type": "address",
+                          "internalType": "address"
+                        },
+                        {
+                          "name": "marketAmount",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "maxGoldIn",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "withdrawResources",
+                          "type": "tuple",
+                          "internalType": "struct WithdrawResourcesData",
+                          "components": [
+                            {
+                              "name": "wood",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            },
+                            {
+                              "name": "iron",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            },
+                            {
+                              "name": "wheat",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            },
+                            {
+                              "name": "fish",
+                              "type": "uint256",
+                              "internalType": "uint256"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "effectiveRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "derivedAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    }
+                  ]
+                },
+                {
+                  "name": "activeMission",
+                  "type": "tuple",
+                  "internalType": "struct Mission",
+                  "components": [
+                    {
+                      "name": "active",
+                      "type": "bool",
+                      "internalType": "bool"
+                    },
+                    {
+                      "name": "nonce",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "submittedAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "executesAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "settlesAtTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "clansmanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "startRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "targetRegion",
+                      "type": "uint8",
+                      "internalType": "uint8"
+                    },
+                    {
+                      "name": "action",
+                      "type": "uint8",
+                      "internalType": "enum ActionType"
+                    },
+                    {
+                      "name": "startTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "arrivalTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "actionStartTick",
+                      "type": "uint64",
+                      "internalType": "uint64"
+                    },
+                    {
+                      "name": "missionSeed",
+                      "type": "bytes32",
+                      "internalType": "bytes32"
+                    },
+                    {
+                      "name": "marketMode",
+                      "type": "uint8",
+                      "internalType": "enum MarketExecutionMode"
+                    },
+                    {
+                      "name": "targetClanId",
+                      "type": "uint32",
+                      "internalType": "uint32"
+                    },
+                    {
+                      "name": "marketToken",
+                      "type": "address",
+                      "internalType": "address"
+                    },
+                    {
+                      "name": "marketAmount",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "maxGoldIn",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "withdrawResources",
+                      "type": "tuple",
+                      "internalType": "struct WithdrawResourcesData",
+                      "components": [
+                        {
+                          "name": "wood",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "iron",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "wheat",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        },
+                        {
+                          "name": "fish",
+                          "type": "uint256",
+                          "internalType": "uint256"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "westPlot",
+              "type": "tuple",
+              "internalType": "struct WheatPlot",
+              "components": [
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum WheatPlotState"
+                },
+                {
+                  "name": "region",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "remainingWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "regrowUntilTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "eastPlot",
+              "type": "tuple",
+              "internalType": "struct WheatPlot",
+              "components": [
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum WheatPlotState"
+                },
+                {
+                  "name": "region",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "remainingWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "regrowUntilTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                }
+              ]
+            },
+            {
+              "name": "incomingDefenderIds",
+              "type": "uint32[]",
+              "internalType": "uint32[]"
+            },
+            {
+              "name": "thisClanDefendingBaseId",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getClanScore",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "score",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "monumentReachedAtTick",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "monumentLevel",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getDerivedClanState",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct DerivedClanState",
+          "components": [
+            {
+              "name": "clan",
+              "type": "tuple",
+              "internalType": "struct Clan",
+              "components": [
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "iftTokenId",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "owner",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "clanState",
+                  "type": "uint8",
+                  "internalType": "enum ClanState"
+                },
+                {
+                  "name": "baseRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "baseLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "wallLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "monumentLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "livingClansmen",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "lastSettledTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "starvationStartsAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "coldDamage",
+                  "type": "uint16",
+                  "internalType": "uint16"
+                },
+                {
+                  "name": "ownerNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "goldBalance",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "blueprintBalance",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultWood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultIron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "vaultFish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "isStarving",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "lootValue",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "derivedAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getDerivedClansmanState",
+      "inputs": [
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct DerivedClansmanState",
+          "components": [
+            {
+              "name": "clansman",
+              "type": "tuple",
+              "internalType": "struct Clansman",
+              "components": [
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum ClansmanState"
+                },
+                {
+                  "name": "currentRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "cooldownEndsAtTs",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "lastMissionNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "carryWood",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryIron",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryWheat",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "carryFish",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "activeMission",
+              "type": "tuple",
+              "internalType": "struct Mission",
+              "components": [
+                {
+                  "name": "active",
+                  "type": "bool",
+                  "internalType": "bool"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "submittedAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "executesAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "settlesAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "startRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "targetRegion",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "startTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "arrivalTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "actionStartTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "missionSeed",
+                  "type": "bytes32",
+                  "internalType": "bytes32"
+                },
+                {
+                  "name": "marketMode",
+                  "type": "uint8",
+                  "internalType": "enum MarketExecutionMode"
+                },
+                {
+                  "name": "targetClanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "withdrawResources",
+                  "type": "tuple",
+                  "internalType": "struct WithdrawResourcesData",
+                  "components": [
+                    {
+                      "name": "wood",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "iron",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "wheat",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    },
+                    {
+                      "name": "fish",
+                      "type": "uint256",
+                      "internalType": "uint256"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "effectiveRegion",
+              "type": "uint8",
+              "internalType": "uint8"
+            },
+            {
+              "name": "derivedAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMarketState",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct MarketState",
+          "components": [
+            {
+              "name": "wood",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "wheat",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "fish",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "iron",
+              "type": "tuple",
+              "internalType": "struct PoolReserves",
+              "components": [
+                {
+                  "name": "resourceToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "resourceReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "goldReserve",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "spotPriceGoldPerResource",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "currentTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "currentTickQueue",
+              "type": "tuple[]",
+              "internalType": "struct ScheduledMarketAction[]",
+              "components": [
+                {
+                  "name": "executeAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "commitSequence",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "missionNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "nextTickQueue",
+              "type": "tuple[]",
+              "internalType": "struct ScheduledMarketAction[]",
+              "components": [
+                {
+                  "name": "executeAtTick",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "commitSequence",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "missionNonce",
+                  "type": "uint64",
+                  "internalType": "uint64"
+                },
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "clansmanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "action",
+                  "type": "uint8",
+                  "internalType": "enum ActionType"
+                },
+                {
+                  "name": "marketToken",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "marketAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "maxGoldIn",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRankings",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "clanIdsRanked",
+          "type": "uint32[]",
+          "internalType": "uint32[]"
+        },
+        {
+          "name": "scores",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRegionPopulation",
+      "inputs": [
+        {
+          "name": "region",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct RegionOccupant[]",
+          "components": [
+            {
+              "name": "clansmanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "clanId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "state",
+              "type": "uint8",
+              "internalType": "enum ClansmanState"
+            },
+            {
+              "name": "currentAction",
+              "type": "uint8",
+              "internalType": "enum ActionType"
+            },
+            {
+              "name": "missionNonce",
+              "type": "uint64",
+              "internalType": "uint64"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getWorldSnapshot",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct WorldSnapshot",
+          "components": [
+            {
+              "name": "currentTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonStartTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonEndTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "seasonFinalized",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "currentSeasonNumber",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "nextHeartbeatAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "winterActive",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "winterStartsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "winterEndsAtTick",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "activeBanditId",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "currentTickSeed",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "leaderboard",
+              "type": "tuple[]",
+              "internalType": "struct LeaderboardEntry[]",
+              "components": [
+                {
+                  "name": "clanId",
+                  "type": "uint32",
+                  "internalType": "uint32"
+                },
+                {
+                  "name": "owner",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "monumentLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "baseLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "wallLevel",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "livingClansmen",
+                  "type": "uint8",
+                  "internalType": "uint8"
+                },
+                {
+                  "name": "state",
+                  "type": "uint8",
+                  "internalType": "enum ClanState"
+                },
+                {
+                  "name": "lootValue",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "quoteLootValueSettled",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "lootValue",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "world",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IClanWorld"
+        }
+      ],
+      "stateMutability": "view"
+    }
+  ]
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -3,12 +3,13 @@
   "private": true,
   "version": "0.0.0",
   "exports": {
-    "./abi/IClanWorld.json": "./abi/IClanWorld.json"
+    "./abi/IClanWorld.json": "./abi/IClanWorld.json",
+    "./abi/IClanWorldLens.json": "./abi/IClanWorldLens.json"
   },
   "scripts": {
     "build": "if command -v forge >/dev/null 2>&1; then forge build; else echo '[WARN] forge not installed - contracts NOT built. CI will fail. Install Foundry: https://getfoundry.sh' >&2; fi",
-    "codegen": "forge_bin=$(command -v forge || command -v \"$HOME/.foundry/bin/forge\" || true); if [ -n \"$forge_bin\" ]; then \"$forge_bin\" build src/IClanWorld.sol && node ../../scripts/gen-contract-abi.mjs; else echo 'forge not installed; cannot generate ABI'; exit 1; fi",
-    "check:abi": "bash -c 'forge_bin=$(command -v forge || command -v \"$HOME/.foundry/bin/forge\" || true); if [ -n \"$forge_bin\" ]; then command -v jq >/dev/null 2>&1 || { echo \"jq not installed; cannot check ABI\"; exit 1; }; \"$forge_bin\" build src/IClanWorld.sol && diff <(jq \".abi\" out/IClanWorld.sol/IClanWorld.json) <(jq \".abi\" abi/IClanWorld.json); else echo \"[WARN] forge not installed - ABI drift NOT checked. CI will fail. Install Foundry: https://getfoundry.sh\" >&2; fi'",
+    "codegen": "forge_bin=$(command -v forge || command -v \"$HOME/.foundry/bin/forge\" || true); if [ -n \"$forge_bin\" ]; then \"$forge_bin\" build src/IClanWorld.sol src/IClanWorldLens.sol && node ../../scripts/gen-contract-abi.mjs; else echo 'forge not installed; cannot generate ABI'; exit 1; fi",
+    "check:abi": "bash -c 'forge_bin=$(command -v forge || command -v \"$HOME/.foundry/bin/forge\" || true); if [ -n \"$forge_bin\" ]; then command -v jq >/dev/null 2>&1 || { echo \"jq not installed; cannot check ABI\"; exit 1; }; \"$forge_bin\" build src/IClanWorld.sol src/IClanWorldLens.sol && diff <(jq \".abi\" out/IClanWorld.sol/IClanWorld.json) <(jq \".abi\" abi/IClanWorld.json) && diff <(jq \".abi\" out/IClanWorldLens.sol/IClanWorldLens.json) <(jq \".abi\" abi/IClanWorldLens.json); else echo \"[WARN] forge not installed - ABI drift NOT checked. CI will fail. Install Foundry: https://getfoundry.sh\" >&2; fi'",
     "test": "forge_bin=$(command -v forge || command -v \"$HOME/.foundry/bin/forge\" || true); if [ -n \"$forge_bin\" ]; then pnpm run check:abi && \"$forge_bin\" test;  else echo '[WARN] forge not installed - contract tests NOT run. CI will fail. Install Foundry: https://getfoundry.sh' >&2; fi",
     "typecheck": "echo 'no TS in contracts package'",
     "lint": "echo 'lint stub'",

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.34;
 
 import {Script, console} from "forge-std/Script.sol";
 import {MinimalERC20} from "../src/MinimalERC20.sol";
 import {StubPool} from "../src/StubPool.sol";
 import {ClanWorld} from "../src/ClanWorld.sol";
+import {ClanWorldLens} from "../src/ClanWorldLens.sol";
+import {IClanWorld} from "../src/IClanWorld.sol";
 import {PoolSeedConfig} from "../src/IClanWorld.sol";
 
 contract Deploy is Script {
@@ -32,6 +34,8 @@ contract Deploy is Script {
         // 2. Deploy ClanWorld first (needed as engine arg for pools).
         ClanWorld game = new ClanWorld();
         console.log("CLAN_WORLD_CONTRACT_ADDRESS:", address(game));
+        ClanWorldLens lens = new ClanWorldLens(IClanWorld(address(game)));
+        console.log("CLAN_WORLD_LENS_ADDRESS:    ", address(lens));
 
         // 3. Deploy 4 AMM pools (Phase 6.2: constant-product pools).
         StubPool woodGold = new StubPool(address(wood), address(gold), address(game));

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -5235,6 +5235,18 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return _defendingClansByRegion[region];
     }
 
+    function getClanIds() external view override returns (uint32[] memory) {
+        return _allClanIds;
+    }
+
+    function getClanClansmanIds(uint32 clanId) external view override returns (uint32[] memory) {
+        return _clanClansmanIds[clanId];
+    }
+
+    function getClansmanDefendingRegion(uint32 clansmanId) external view override returns (uint8) {
+        return _clansmanDefendingRegion[clansmanId];
+    }
+
     // =========================================================================
     // DERIVED READ GETTERS (read-only, no storage mutation)
     // =========================================================================

--- a/packages/contracts/src/ClanWorldLens.sol
+++ b/packages/contracts/src/ClanWorldLens.sol
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {
+    IClanWorld,
+    ClanWorldConstants,
+    ClansmanState,
+    ActionType,
+    ResourceType,
+    Clan,
+    Clansman,
+    Mission,
+    BanditState,
+    BanditTroop,
+    WheatPlot,
+    WorldState,
+    LeaderboardEntry,
+    DerivedClanState,
+    DerivedClansmanState,
+    WorldSnapshot,
+    ClansmanFullView,
+    ClanFullView,
+    PoolReserves,
+    MarketState,
+    ActiveBanditView,
+    RegionOccupant
+} from "./IClanWorld.sol";
+import {IClanWorldLens} from "./IClanWorldLens.sol";
+import {LibScoring} from "./lib/LibScoring.sol";
+import {StubPool} from "./StubPool.sol";
+
+/// @notice Stateless reader contract for convenience views that should not live
+///         in the core game bytecode long term.
+contract ClanWorldLens is IClanWorldLens {
+    IClanWorld public immutable override world;
+
+    error ClanWorldLensZeroWorld();
+
+    constructor(IClanWorld world_) {
+        if (address(world_) == address(0)) {
+            revert ClanWorldLensZeroWorld();
+        }
+        world = world_;
+    }
+
+    function getDerivedClanState(uint32 clanId) external view override returns (DerivedClanState memory) {
+        return world.getDerivedClanState(clanId);
+    }
+
+    function getDerivedClansmanState(uint32 clansmanId) external view override returns (DerivedClansmanState memory) {
+        return world.getDerivedClansmanState(clansmanId);
+    }
+
+    function getBanditTargetPreview(uint32 banditId) external view override returns (uint32 previewClanId) {
+        return world.getBanditTargetPreview(banditId);
+    }
+
+    function quoteLootValueSettled(uint32 clanId) external view override returns (uint256 lootValue) {
+        return world.quoteLootValueSettled(clanId);
+    }
+
+    function getClanScore(uint32 clanId)
+        external
+        view
+        override
+        returns (uint256 score, uint64 monumentReachedAtTick, uint8 monumentLevel)
+    {
+        return world.getClanScore(clanId);
+    }
+
+    function getRankings() external view override returns (uint32[] memory clanIdsRanked, uint256[] memory scores) {
+        return world.getRankings();
+    }
+
+    function getWorldSnapshot() external view override returns (WorldSnapshot memory) {
+        uint32[] memory clanIds = world.getClanIds();
+        LeaderboardEntry[] memory leaderboard = new LeaderboardEntry[](clanIds.length);
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            uint32 clanId = clanIds[i];
+            Clan memory clan = world.getClan(clanId);
+            leaderboard[i] = LeaderboardEntry({
+                clanId: clanId,
+                owner: clan.owner,
+                monumentLevel: clan.monumentLevel,
+                baseLevel: clan.baseLevel,
+                wallLevel: clan.wallLevel,
+                livingClansmen: clan.livingClansmen,
+                state: clan.clanState,
+                lootValue: LibScoring.lootValue(clan)
+            });
+        }
+
+        return _worldSnapshotWithLeaderboard(leaderboard);
+    }
+
+    function getClanFullView(uint32 clanId) external view override returns (ClanFullView memory) {
+        DerivedClanState memory derivedClan = world.getDerivedClanState(clanId);
+        uint32[] memory clansmanIds = world.getClanClansmanIds(clanId);
+        ClansmanFullView[] memory clansmen = new ClansmanFullView[](clansmanIds.length);
+        uint32 thisClanDefendingBaseId = 0;
+
+        for (uint256 i = 0; i < clansmanIds.length; i++) {
+            DerivedClansmanState memory dcs = world.getDerivedClansmanState(clansmanIds[i]);
+            Mission memory mission = dcs.activeMission;
+            clansmen[i] = ClansmanFullView({clansman: dcs, activeMission: mission});
+            if (
+                thisClanDefendingBaseId == 0 && mission.active && mission.action == ActionType.DefendBase
+                    && dcs.clansman.state == ClansmanState.ACTING
+            ) {
+                thisClanDefendingBaseId = mission.targetRegion;
+            }
+        }
+
+        if (thisClanDefendingBaseId == 0) {
+            for (uint256 i = 0; i < clansmanIds.length; i++) {
+                uint8 region = world.getClansmanDefendingRegion(clansmanIds[i]);
+                if (region != 0) {
+                    thisClanDefendingBaseId = region;
+                    break;
+                }
+            }
+        }
+
+        (WheatPlot memory westPlot, WheatPlot memory eastPlot) = world.getWheatPlots(clanId);
+        return ClanFullView({
+            clan: derivedClan,
+            clansmen: clansmen,
+            westPlot: westPlot,
+            eastPlot: eastPlot,
+            incomingDefenderIds: world.getDefendingClans(derivedClan.clan.baseRegion),
+            thisClanDefendingBaseId: thisClanDefendingBaseId
+        });
+    }
+
+    /// @dev This one composes entirely from raw core reads, so it is already
+    ///      safe to remove from core once consumers migrate to the lens.
+    function getMarketState() external view override returns (MarketState memory) {
+        uint64 currentTick = world.getWorldState().currentTick;
+        return MarketState({
+            wood: _poolReserves(uint8(ResourceType.Wood)),
+            wheat: _poolReserves(uint8(ResourceType.Wheat)),
+            fish: _poolReserves(uint8(ResourceType.Fish)),
+            iron: _poolReserves(uint8(ResourceType.Iron)),
+            currentTick: currentTick,
+            currentTickQueue: world.getScheduledMarketActionsForTick(currentTick),
+            nextTickQueue: world.getScheduledMarketActionsForTick(currentTick + 1)
+        });
+    }
+
+    function getActiveBanditView() external view override returns (ActiveBanditView memory) {
+        uint32 activeBanditId = world.getWorldState().activeBanditId;
+        BanditTroop memory bandit = world.getBandit(activeBanditId);
+        uint64 nextActionTick = 0;
+        uint8 maxAttemptsRemaining = 0;
+        bool exists = bandit.id != ClanWorldConstants.BANDIT_ID_NULL && bandit.state != BanditState.None;
+
+        if (exists) {
+            if (bandit.state == BanditState.Spawned) {
+                nextActionTick = bandit.tickEnteredState + 1;
+            } else if (bandit.state == BanditState.Camped) {
+                nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
+            } else if (bandit.state == BanditState.Resting) {
+                nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS;
+            }
+            if (bandit.attackAttemptsMade < ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
+                maxAttemptsRemaining = ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS - bandit.attackAttemptsMade;
+            }
+        }
+
+        return ActiveBanditView({
+            exists: exists,
+            banditId: bandit.id,
+            state: bandit.state,
+            currentRegion: bandit.region,
+            attackAttemptsMade: bandit.attackAttemptsMade,
+            maxAttemptsRemaining: maxAttemptsRemaining,
+            stateEnteredTick: bandit.tickEnteredState,
+            nextActionTick: nextActionTick,
+            tier: bandit.tier,
+            attackPower: LibScoring.banditAttackPower(bandit.strength),
+            carryWood: bandit.carryWood,
+            carryIron: bandit.carryIron,
+            carryWheat: bandit.carryWheat,
+            carryFish: bandit.carryFish,
+            projectedTargetClanId: bandit.targetClanId,
+            projectedTargetLootValue: 0
+        });
+    }
+
+    function getRegionPopulation(uint8 region) external view override returns (RegionOccupant[] memory) {
+        uint32[] memory clanIds = world.getClanIds();
+        uint256 count = 0;
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            uint32[] memory clansmanIds = world.getClanClansmanIds(clanIds[i]);
+            for (uint256 j = 0; j < clansmanIds.length; j++) {
+                Clansman memory clansman = world.getClansman(clansmanIds[j]);
+                if (clansman.state != ClansmanState.DEAD && clansman.currentRegion == region) {
+                    count++;
+                }
+            }
+        }
+
+        RegionOccupant[] memory occupants = new RegionOccupant[](count);
+        uint256 out = 0;
+        for (uint256 i = 0; i < clanIds.length; i++) {
+            uint32[] memory clansmanIds = world.getClanClansmanIds(clanIds[i]);
+            for (uint256 j = 0; j < clansmanIds.length; j++) {
+                uint32 clansmanId = clansmanIds[j];
+                Clansman memory clansman = world.getClansman(clansmanId);
+                if (clansman.state != ClansmanState.DEAD && clansman.currentRegion == region) {
+                    Mission memory mission = world.getActiveMission(clansmanId);
+                    occupants[out++] = RegionOccupant({
+                        clansmanId: clansmanId,
+                        clanId: clanIds[i],
+                        state: clansman.state,
+                        currentAction: mission.active ? mission.action : ActionType.None,
+                        missionNonce: clansman.lastMissionNonce
+                    });
+                }
+            }
+        }
+
+        return occupants;
+    }
+
+    function _poolReserves(uint8 resourceType) private view returns (PoolReserves memory pr) {
+        address resourceToken = world.getResourceToken(resourceType);
+        address poolAddr = world.getPool(resourceType);
+        pr.resourceToken = resourceToken;
+        if (poolAddr == address(0) || resourceToken == address(0)) {
+            return pr;
+        }
+
+        (uint256 resourceReserve, uint256 goldReserve) = StubPool(poolAddr).getReserves();
+        pr.resourceReserve = resourceReserve;
+        pr.goldReserve = goldReserve;
+        pr.spotPriceGoldPerResource = resourceReserve > 0 ? (goldReserve * 1e18) / resourceReserve : 0;
+    }
+
+    function _worldSnapshotWithLeaderboard(LeaderboardEntry[] memory leaderboard)
+        private
+        view
+        returns (WorldSnapshot memory)
+    {
+        WorldState memory ws = world.getWorldState();
+        return WorldSnapshot({
+            currentTick: ws.currentTick,
+            seasonStartTick: ws.seasonStartTick,
+            seasonEndTick: ws.seasonEndTick,
+            seasonFinalized: ws.seasonFinalized,
+            currentSeasonNumber: ws.currentSeasonNumber,
+            nextHeartbeatAtTick: ws.nextHeartbeatAtTick,
+            winterActive: ws.winterActive,
+            winterStartsAtTick: ws.winterStartsAtTick,
+            winterEndsAtTick: ws.winterEndsAtTick,
+            activeBanditId: ws.activeBanditId,
+            currentTickSeed: ws.currentTickSeed,
+            leaderboard: leaderboard
+        });
+    }
+
+}

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -446,6 +446,18 @@ contract ClanWorldStub is IClanWorld {
         return new uint32[](0);
     }
 
+    function getClanIds() external pure override returns (uint32[] memory) {
+        return new uint32[](0);
+    }
+
+    function getClanClansmanIds(uint32) external pure override returns (uint32[] memory) {
+        return new uint32[](0);
+    }
+
+    function getClansmanDefendingRegion(uint32) external pure override returns (uint8) {
+        return 0;
+    }
+
     // -------------------------------------------------------------------------
     // Derived read getters
     // -------------------------------------------------------------------------

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -848,6 +848,12 @@ interface IClanWorld is IClanWorldEvents {
 
     function getDefendingClans(uint8 region) external view returns (uint32[] memory clanIds);
 
+    function getClanIds() external view returns (uint32[] memory clanIds);
+
+    function getClanClansmanIds(uint32 clanId) external view returns (uint32[] memory clansmanIds);
+
+    function getClansmanDefendingRegion(uint32 clansmanId) external view returns (uint8 region);
+
     // -------------------------------------------------------------------------
     // Derived read getters (read-only simulation forward to current tick)
     //

--- a/packages/contracts/src/IClanWorldLens.sol
+++ b/packages/contracts/src/IClanWorldLens.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {
+    IClanWorld,
+    DerivedClanState,
+    DerivedClansmanState,
+    WorldSnapshot,
+    ClanFullView,
+    MarketState,
+    ActiveBanditView,
+    RegionOccupant
+} from "./IClanWorld.sol";
+
+/// @notice Stateless convenience-read surface for UI, indexers, and agents.
+/// @dev The lens is intentionally not proxied. Upgrade by deploying a new lens
+///      and updating off-chain config.
+interface IClanWorldLens {
+    function world() external view returns (IClanWorld);
+
+    function getDerivedClanState(uint32 clanId) external view returns (DerivedClanState memory);
+
+    function getDerivedClansmanState(uint32 clansmanId) external view returns (DerivedClansmanState memory);
+
+    function getBanditTargetPreview(uint32 banditId) external view returns (uint32 previewClanId);
+
+    function quoteLootValueSettled(uint32 clanId) external view returns (uint256 lootValue);
+
+    function getClanScore(uint32 clanId)
+        external
+        view
+        returns (uint256 score, uint64 monumentReachedAtTick, uint8 monumentLevel);
+
+    function getRankings() external view returns (uint32[] memory clanIdsRanked, uint256[] memory scores);
+
+    function getWorldSnapshot() external view returns (WorldSnapshot memory);
+
+    function getClanFullView(uint32 clanId) external view returns (ClanFullView memory);
+
+    function getMarketState() external view returns (MarketState memory);
+
+    function getActiveBanditView() external view returns (ActiveBanditView memory);
+
+    function getRegionPopulation(uint8 region) external view returns (RegionOccupant[] memory);
+}

--- a/packages/contracts/src/diamond/Diamond.sol
+++ b/packages/contracts/src/diamond/Diamond.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {IDiamondCut} from "./IDiamondCut.sol";
+import {LibDiamond} from "./lib/LibDiamond.sol";
+
+contract Diamond {
+    constructor(address contractOwner, address diamondCutFacet) payable {
+        LibDiamond.setContractOwner(contractOwner);
+
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = IDiamondCut.diamondCut.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: diamondCutFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: selectors
+        });
+
+        LibDiamond.diamondCut(cut, address(0), "");
+    }
+
+    receive() external payable {}
+
+    fallback() external payable {
+        LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
+        address facet = ds.selectorToFacetAndPosition[msg.sig].facetAddress;
+        require(facet != address(0), "Diamond: function does not exist");
+
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+            let result := delegatecall(gas(), facet, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+}

--- a/packages/contracts/src/diamond/IDiamondCut.sol
+++ b/packages/contracts/src/diamond/IDiamondCut.sol
@@ -14,7 +14,7 @@ interface IDiamondCut {
         bytes4[] functionSelectors;
     }
 
-    event DiamondCut(FacetCut[] diamondCut, address init, bytes calldata data);
+    event DiamondCut(FacetCut[] diamondCut, address init, bytes data);
 
     function diamondCut(FacetCut[] calldata diamondCut_, address init, bytes calldata data) external;
 }

--- a/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
+++ b/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+contract WorldClockFacet {}
+contract SeasonFacet {}
+contract ClanLifecycleFacet {}
+contract OrdersFacet {}
+contract SettlementFacet {}
+contract UpkeepFacet {}
+contract GatheringFacet {}
+contract DepositWithdrawFacet {}
+contract UpgradesFacet {}
+contract MarketFacet {}
+contract TreasuryFacet {}
+contract DirectTransfersFacet {}
+contract BanditStateFacet {}
+contract BanditTargetingFacet {}
+contract BanditCombatFacet {}
+contract RawViewsFacet {}
+contract MarketViewsFacet {}
+contract BanditViewsFacet {}

--- a/packages/contracts/src/diamond/facets/DerivedViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/DerivedViewsFacet.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+/// @notice Future diamond home for simulation-heavy derived reads.
+/// @dev Keep settlement simulation here once AppStorage migration is live. Pure
+///      scoring helpers belong in LibScoring so the lens and facet share exact
+///      score/loot semantics without copying tiny rule code.
+contract DerivedViewsFacet {
+    function derivedViewsFacetVersion() external pure returns (bytes4) {
+        return bytes4(keccak256("DerivedViewsFacet.v1"));
+    }
+}

--- a/packages/contracts/src/diamond/facets/DiamondCutFacet.sol
+++ b/packages/contracts/src/diamond/facets/DiamondCutFacet.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {IDiamondCut} from "../IDiamondCut.sol";
+import {LibDiamond} from "../lib/LibDiamond.sol";
+
+contract DiamondCutFacet is IDiamondCut {
+    function diamondCut(FacetCut[] calldata diamondCut_, address init, bytes calldata data) external override {
+        LibDiamond.enforceIsContractOwner();
+        LibDiamond.diamondCut(diamondCut_, init, data);
+    }
+}

--- a/packages/contracts/src/diamond/facets/DiamondLoupeFacet.sol
+++ b/packages/contracts/src/diamond/facets/DiamondLoupeFacet.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {IDiamondLoupe} from "../IDiamondLoupe.sol";
+import {LibDiamond} from "../lib/LibDiamond.sol";
+
+contract DiamondLoupeFacet is IDiamondLoupe {
+    function facets() external view override returns (Facet[] memory facets_) {
+        LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
+        uint256 facetCount = ds.facetAddresses.length;
+        facets_ = new Facet[](facetCount);
+
+        for (uint256 i = 0; i < facetCount; i++) {
+            address facetAddress_ = ds.facetAddresses[i];
+            facets_[i].facetAddress = facetAddress_;
+            facets_[i].functionSelectors = ds.facetFunctionSelectors[facetAddress_].functionSelectors;
+        }
+    }
+
+    function facetFunctionSelectors(address facet) external view override returns (bytes4[] memory selectors) {
+        selectors = LibDiamond.diamondStorage().facetFunctionSelectors[facet].functionSelectors;
+    }
+
+    function facetAddresses() external view override returns (address[] memory facetAddresses_) {
+        facetAddresses_ = LibDiamond.diamondStorage().facetAddresses;
+    }
+
+    function facetAddress(bytes4 selector) external view override returns (address facet) {
+        facet = LibDiamond.diamondStorage().selectorToFacetAndPosition[selector].facetAddress;
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibDiamond.sol
+++ b/packages/contracts/src/diamond/lib/LibDiamond.sol
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {IDiamondCut} from "../IDiamondCut.sol";
+
+library LibDiamond {
+    bytes32 internal constant DIAMOND_STORAGE_SLOT = keccak256("clan.world.diamond.storage.v1");
+
+    struct FacetAddressAndPosition {
+        address facetAddress;
+        uint96 selectorPosition;
+    }
+
+    struct FacetFunctionSelectors {
+        bytes4[] functionSelectors;
+        uint256 facetAddressPosition;
+    }
+
+    struct DiamondStorage {
+        mapping(bytes4 => FacetAddressAndPosition) selectorToFacetAndPosition;
+        mapping(address => FacetFunctionSelectors) facetFunctionSelectors;
+        address[] facetAddresses;
+        mapping(bytes4 => bool) supportedInterfaces;
+        address contractOwner;
+    }
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    error DiamondCutFacetCannotBeZero();
+    error DiamondCutSelectorCannotBeZero();
+    error DiamondCutSelectorAlreadyExists(bytes4 selector);
+    error DiamondCutSelectorDoesNotExist(bytes4 selector);
+    error DiamondCutReplaceFacetMustChange(bytes4 selector);
+    error DiamondCutRemoveFacetAddressMustBeZero();
+    error DiamondCutInvalidAction();
+    error DiamondInitFailed(address init, bytes data);
+    error DiamondNotOwner(address caller);
+
+    function diamondStorage() internal pure returns (DiamondStorage storage ds) {
+        bytes32 slot = DIAMOND_STORAGE_SLOT;
+        assembly {
+            ds.slot := slot
+        }
+    }
+
+    function setContractOwner(address newOwner) internal {
+        DiamondStorage storage ds = diamondStorage();
+        address previousOwner = ds.contractOwner;
+        ds.contractOwner = newOwner;
+        emit OwnershipTransferred(previousOwner, newOwner);
+    }
+
+    function enforceIsContractOwner() internal view {
+        address owner = diamondStorage().contractOwner;
+        if (msg.sender != owner) {
+            revert DiamondNotOwner(msg.sender);
+        }
+    }
+
+    function diamondCut(IDiamondCut.FacetCut[] memory cuts, address init, bytes memory data) internal {
+        for (uint256 i = 0; i < cuts.length; i++) {
+            IDiamondCut.FacetCutAction action = cuts[i].action;
+            if (action == IDiamondCut.FacetCutAction.Add) {
+                addFunctions(cuts[i].facetAddress, cuts[i].functionSelectors);
+            } else if (action == IDiamondCut.FacetCutAction.Replace) {
+                replaceFunctions(cuts[i].facetAddress, cuts[i].functionSelectors);
+            } else if (action == IDiamondCut.FacetCutAction.Remove) {
+                removeFunctions(cuts[i].facetAddress, cuts[i].functionSelectors);
+            } else {
+                revert DiamondCutInvalidAction();
+            }
+        }
+
+        emit IDiamondCut.DiamondCut(cuts, init, data);
+        initializeDiamondCut(init, data);
+    }
+
+    function addFunctions(address facetAddress, bytes4[] memory selectors) internal {
+        if (facetAddress == address(0)) {
+            revert DiamondCutFacetCannotBeZero();
+        }
+
+        DiamondStorage storage ds = diamondStorage();
+        uint96 selectorPosition = uint96(ds.facetFunctionSelectors[facetAddress].functionSelectors.length);
+        if (selectorPosition == 0) {
+            addFacet(ds, facetAddress);
+        }
+
+        for (uint256 i = 0; i < selectors.length; i++) {
+            bytes4 selector = selectors[i];
+            if (selector == bytes4(0)) {
+                revert DiamondCutSelectorCannotBeZero();
+            }
+            if (ds.selectorToFacetAndPosition[selector].facetAddress != address(0)) {
+                revert DiamondCutSelectorAlreadyExists(selector);
+            }
+            addFunction(ds, selector, selectorPosition, facetAddress);
+            selectorPosition++;
+        }
+    }
+
+    function replaceFunctions(address facetAddress, bytes4[] memory selectors) internal {
+        if (facetAddress == address(0)) {
+            revert DiamondCutFacetCannotBeZero();
+        }
+
+        DiamondStorage storage ds = diamondStorage();
+        uint96 selectorPosition = uint96(ds.facetFunctionSelectors[facetAddress].functionSelectors.length);
+        if (selectorPosition == 0) {
+            addFacet(ds, facetAddress);
+        }
+
+        for (uint256 i = 0; i < selectors.length; i++) {
+            bytes4 selector = selectors[i];
+            address oldFacetAddress = ds.selectorToFacetAndPosition[selector].facetAddress;
+            if (oldFacetAddress == address(0)) {
+                revert DiamondCutSelectorDoesNotExist(selector);
+            }
+            if (oldFacetAddress == facetAddress) {
+                revert DiamondCutReplaceFacetMustChange(selector);
+            }
+            removeFunction(ds, oldFacetAddress, selector);
+            addFunction(ds, selector, selectorPosition, facetAddress);
+            selectorPosition++;
+        }
+    }
+
+    function removeFunctions(address facetAddress, bytes4[] memory selectors) internal {
+        if (facetAddress != address(0)) {
+            revert DiamondCutRemoveFacetAddressMustBeZero();
+        }
+
+        DiamondStorage storage ds = diamondStorage();
+        for (uint256 i = 0; i < selectors.length; i++) {
+            bytes4 selector = selectors[i];
+            address oldFacetAddress = ds.selectorToFacetAndPosition[selector].facetAddress;
+            if (oldFacetAddress == address(0)) {
+                revert DiamondCutSelectorDoesNotExist(selector);
+            }
+            removeFunction(ds, oldFacetAddress, selector);
+        }
+    }
+
+    function addFacet(DiamondStorage storage ds, address facetAddress) private {
+        ds.facetFunctionSelectors[facetAddress].facetAddressPosition = ds.facetAddresses.length;
+        ds.facetAddresses.push(facetAddress);
+    }
+
+    function addFunction(
+        DiamondStorage storage ds,
+        bytes4 selector,
+        uint96 selectorPosition,
+        address facetAddress
+    ) private {
+        ds.selectorToFacetAndPosition[selector].selectorPosition = selectorPosition;
+        ds.facetFunctionSelectors[facetAddress].functionSelectors.push(selector);
+        ds.selectorToFacetAndPosition[selector].facetAddress = facetAddress;
+    }
+
+    function removeFunction(DiamondStorage storage ds, address facetAddress, bytes4 selector) private {
+        FacetFunctionSelectors storage facet = ds.facetFunctionSelectors[facetAddress];
+        uint256 selectorPosition = ds.selectorToFacetAndPosition[selector].selectorPosition;
+        uint256 lastSelectorPosition = facet.functionSelectors.length - 1;
+
+        if (selectorPosition != lastSelectorPosition) {
+            bytes4 lastSelector = facet.functionSelectors[lastSelectorPosition];
+            facet.functionSelectors[selectorPosition] = lastSelector;
+            ds.selectorToFacetAndPosition[lastSelector].selectorPosition = uint96(selectorPosition);
+        }
+
+        facet.functionSelectors.pop();
+        delete ds.selectorToFacetAndPosition[selector];
+
+        if (facet.functionSelectors.length == 0) {
+            uint256 lastFacetAddressPosition = ds.facetAddresses.length - 1;
+            uint256 facetAddressPosition = facet.facetAddressPosition;
+            if (facetAddressPosition != lastFacetAddressPosition) {
+                address lastFacetAddress = ds.facetAddresses[lastFacetAddressPosition];
+                ds.facetAddresses[facetAddressPosition] = lastFacetAddress;
+                ds.facetFunctionSelectors[lastFacetAddress].facetAddressPosition = facetAddressPosition;
+            }
+            ds.facetAddresses.pop();
+            delete ds.facetFunctionSelectors[facetAddress].facetAddressPosition;
+        }
+    }
+
+    function initializeDiamondCut(address init, bytes memory data) private {
+        if (init == address(0)) {
+            return;
+        }
+
+        (bool success,) = init.delegatecall(data);
+        if (!success) {
+            revert DiamondInitFailed(init, data);
+        }
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibStorage.sol
+++ b/packages/contracts/src/diamond/lib/LibStorage.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {
+    TreasuryState,
+    Clan,
+    Clansman,
+    Mission,
+    WheatPlot,
+    BanditTroop,
+    ScheduledMarketAction
+} from "../../IClanWorld.sol";
+
+library LibStorage {
+    bytes32 internal constant APP_STORAGE_SLOT = keccak256("clan.world.app.storage.v1");
+
+    uint256 internal constant NOT_ENTERED = 1;
+    uint256 internal constant ENTERED = 2;
+
+    /// @dev Mirrors ClanWorld.sol's stored world fields, excluding derived view fields.
+    struct StoredWorldState {
+        uint64 currentTick;
+        uint64 seasonStartTick;
+        uint64 seasonEndTick;
+        bool seasonFinalized;
+        uint64 currentSeasonNumber;
+        uint64 nextHeartbeatAtTick;
+        uint64 nextHeartbeatAtTs;
+        uint64 nextBanditSpawnEligibleTick;
+        uint16 currentBanditSpawnChanceBps;
+        bytes32 currentTickSeed;
+        uint32 activeBanditId;
+        uint64 nextCommitSequence;
+    }
+
+    struct BanditSpawnState {
+        uint64 lastSpawnTick;
+        uint16 probabilityAccum;
+    }
+
+    struct WallUpgradeReservation {
+        bool active;
+        uint32 clanId;
+        uint64 missionNonce;
+        uint8 fromLevel;
+        uint8 toLevel;
+        uint256 woodCost;
+        uint256 ironCost;
+    }
+
+    struct BaseUpgradeReservation {
+        bool active;
+        uint32 clanId;
+        uint64 missionNonce;
+        uint8 fromLevel;
+        uint8 toLevel;
+        uint256 woodCost;
+        uint256 ironCost;
+        uint256 wheatCost;
+    }
+
+    struct MonumentUpgradeReservation {
+        bool active;
+        uint32 clanId;
+        uint64 missionNonce;
+        uint8 fromLevel;
+        uint8 toLevel;
+        uint256 woodCost;
+        uint256 ironCost;
+        uint256 wheatCost;
+        uint256 blueprintCost;
+    }
+
+    struct AppStorage {
+        uint256 reentrancyStatus;
+        bool initialized;
+        StoredWorldState world;
+        TreasuryState treasury;
+        mapping(uint32 => Clan) clans;
+        mapping(uint32 => Clansman) clansmen;
+        mapping(uint32 => Mission) missions;
+        mapping(uint32 => WheatPlot[2]) wheatPlots;
+        mapping(uint64 => ScheduledMarketAction[]) scheduledMarketActions;
+        mapping(uint32 => uint64) marketMissionCommitSequence;
+        mapping(uint8 => uint32[]) defendingClansByRegion;
+        mapping(uint8 => mapping(uint32 => uint256)) defenderCountByRegionClan;
+        mapping(uint32 => uint8) clansmanDefendingRegion;
+        mapping(uint32 => BanditTroop) bandits;
+        mapping(uint8 => uint32[]) banditsByRegion;
+        mapping(uint8 => BanditSpawnState) banditSpawnByRegion;
+        mapping(uint64 => bytes32) tickSeeds;
+        mapping(uint32 => WallUpgradeReservation) wallUpgradeReservations;
+        mapping(uint32 => uint8) pendingWallUpgradesByClan;
+        mapping(uint32 => BaseUpgradeReservation) baseUpgradeReservations;
+        mapping(uint32 => uint8) pendingBaseUpgradesByClan;
+        mapping(uint32 => MonumentUpgradeReservation) monumentUpgradeReservations;
+        mapping(uint32 => uint8) pendingMonumentUpgradesByClan;
+        mapping(uint32 => uint256) reservedWoodByClan;
+        mapping(uint32 => uint256) reservedIronByClan;
+        mapping(uint32 => uint256) reservedWheatByClan;
+        mapping(uint32 => uint256) reservedBlueprintByClan;
+        mapping(uint32 => mapping(uint8 => uint64)) monumentLevelReachedAt;
+        uint32 nextClanId;
+        uint32 nextClansmanId;
+        uint32 nextBanditId;
+        uint32 activeBanditCount;
+        uint32[] allClanIds;
+        mapping(uint32 => uint32[]) clanClansmanIds;
+    }
+
+    error ReentrantCall();
+
+    function appStorage() internal pure returns (AppStorage storage s) {
+        bytes32 slot = APP_STORAGE_SLOT;
+        assembly {
+            s.slot := slot
+        }
+    }
+
+    function enterNonReentrant(AppStorage storage s) internal {
+        if (s.reentrancyStatus == ENTERED) {
+            revert ReentrantCall();
+        }
+        s.reentrancyStatus = ENTERED;
+    }
+
+    function exitNonReentrant(AppStorage storage s) internal {
+        s.reentrancyStatus = NOT_ENTERED;
+    }
+}

--- a/packages/contracts/src/lib/LibScoring.sol
+++ b/packages/contracts/src/lib/LibScoring.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Clan} from "../IClanWorld.sol";
+
+library LibScoring {
+    function lootValue(Clan memory clan) internal pure returns (uint256) {
+        return clan.vaultWood + clan.vaultWheat + clan.vaultFish * 2 + clan.vaultIron * 4;
+    }
+
+    function packClanScore(Clan memory clan, uint64 monumentReachedAtTick, uint8 monumentLevel)
+        internal
+        pure
+        returns (uint256 score, uint64, uint8)
+    {
+        uint256 loot = lootValue(clan);
+        uint256 maxLootComponent = (uint256(1) << 176) - 1;
+        if (loot > maxLootComponent) {
+            loot = maxLootComponent;
+        }
+
+        uint256 timeComponent;
+        if (monumentLevel > 0) {
+            timeComponent = uint256(type(uint64).max) - uint256(monumentReachedAtTick);
+        }
+
+        score = (uint256(monumentLevel) << 248) | (timeComponent << 184) | (loot << 8) | clan.wallLevel;
+        return (score, monumentReachedAtTick, monumentLevel);
+    }
+
+    function rankingComesAfter(uint32 leftClanId, uint256 leftScore, uint32 rightClanId, uint256 rightScore)
+        internal
+        pure
+        returns (bool)
+    {
+        if (leftScore != rightScore) {
+            return leftScore < rightScore;
+        }
+        return leftClanId > rightClanId;
+    }
+
+    function banditAttackPower(uint32 strength) internal pure returns (uint16) {
+        if (strength > type(uint16).max) return type(uint16).max;
+        return uint16(strength);
+    }
+}

--- a/packages/contracts/test/ClanWorldLens.t.sol
+++ b/packages/contracts/test/ClanWorldLens.t.sol
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {ClanWorld} from "../src/ClanWorld.sol";
+import {ClanWorldLens} from "../src/ClanWorldLens.sol";
+import {
+    IClanWorld,
+    ClanWorldConstants,
+    ActionType,
+    BanditState,
+    ClansmanState,
+    Clan,
+    Clansman,
+    Mission,
+    WheatPlot,
+    LeaderboardEntry,
+    WorldSnapshot,
+    ClanFullView,
+    ClansmanFullView,
+    DerivedClanState,
+    DerivedClansmanState,
+    MarketState,
+    PoolReserves,
+    ActiveBanditView,
+    RegionOccupant
+} from "../src/IClanWorld.sol";
+
+contract ClanWorldLensHarness is ClanWorld {
+    function spawnBandit(uint8 region, uint32 strength) external returns (uint32) {
+        return _spawnBandit(region, strength);
+    }
+
+    function setCurrentTick(uint64 tick) external {
+        _world.currentTick = tick;
+        _world.nextHeartbeatAtTick = tick + 1;
+    }
+
+    function setVault(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        _clans[clanId].vaultWood = wood;
+        _clans[clanId].vaultIron = iron;
+        _clans[clanId].vaultWheat = wheat;
+        _clans[clanId].vaultFish = fish;
+    }
+}
+
+contract ClanWorldLensTest is Test {
+    ClanWorldLensHarness world;
+    ClanWorldLens lens;
+    address elder = address(0xA11CE);
+    address elder2 = address(0xB0B);
+
+    function setUp() public {
+        world = new ClanWorldLensHarness();
+        lens = new ClanWorldLens(IClanWorld(address(world)));
+    }
+
+    function test_constructorRejectsZeroWorld() public {
+        vm.expectRevert(ClanWorldLens.ClanWorldLensZeroWorld.selector);
+        new ClanWorldLens(IClanWorld(address(0)));
+    }
+
+    function test_lensWorldSnapshotMatchesCore() public {
+        vm.prank(elder);
+        (uint32 clanId,) = world.mintClan(elder);
+        assertGt(clanId, 0);
+
+        WorldSnapshot memory core = world.getWorldSnapshot();
+        WorldSnapshot memory fromLens = lens.getWorldSnapshot();
+
+        _assertWorldSnapshotEq(fromLens, core);
+    }
+
+    function test_lensClanFullViewMatchesCore() public {
+        vm.prank(elder);
+        (uint32 clanId,) = world.mintClan(elder);
+
+        ClanFullView memory core = world.getClanFullView(clanId);
+        ClanFullView memory fromLens = lens.getClanFullView(clanId);
+
+        _assertClanFullViewEq(fromLens, core);
+    }
+
+    function test_lensRankingsAndScoreMatchCore() public {
+        vm.prank(elder);
+        (uint32 clanId,) = world.mintClan(elder);
+
+        (uint256 coreScore, uint64 coreReached, uint8 coreLevel) = world.getClanScore(clanId);
+        (uint256 lensScore, uint64 lensReached, uint8 lensLevel) = lens.getClanScore(clanId);
+        assertEq(lensScore, coreScore);
+        assertEq(lensReached, coreReached);
+        assertEq(lensLevel, coreLevel);
+
+        (uint32[] memory coreRanked, uint256[] memory coreScores) = world.getRankings();
+        (uint32[] memory lensRanked, uint256[] memory lensScores) = lens.getRankings();
+        assertEq(lensRanked.length, coreRanked.length);
+        assertEq(lensScores.length, coreScores.length);
+        assertEq(lensRanked[0], coreRanked[0]);
+        assertEq(lensScores[0], coreScores[0]);
+    }
+
+    function test_lensMarketStateMatchesCore() public view {
+        MarketState memory core = world.getMarketState();
+        MarketState memory fromLens = lens.getMarketState();
+
+        _assertMarketStateEq(fromLens, core);
+    }
+
+    function test_lensBanditAndRegionViewsMatchCore() public {
+        world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+
+        ActiveBanditView memory coreBandit = world.getActiveBanditView();
+        ActiveBanditView memory lensBandit = lens.getActiveBanditView();
+        _assertActiveBanditViewEq(lensBandit, coreBandit);
+
+        RegionOccupant[] memory corePopulation = world.getRegionPopulation(ClanWorldConstants.REGION_FOREST);
+        RegionOccupant[] memory lensPopulation = lens.getRegionPopulation(ClanWorldConstants.REGION_FOREST);
+        _assertRegionPopulationEq(lensPopulation, corePopulation);
+    }
+
+    function test_lensAggregatesMatchCoreAfterMultipleClansAndStateChanges() public {
+        vm.prank(elder);
+        (uint32 clanA,) = world.mintClan(elder);
+        vm.prank(elder2);
+        (uint32 clanB,) = world.mintClan(elder2);
+        world.setVault(clanA, 100e18, 5e18, 40e18, 3e18);
+        world.setVault(clanB, 75e18, 7e18, 50e18, 2e18);
+        world.setCurrentTick(3);
+
+        _assertWorldSnapshotEq(lens.getWorldSnapshot(), world.getWorldSnapshot());
+        _assertClanFullViewEq(lens.getClanFullView(clanA), world.getClanFullView(clanA));
+        _assertClanFullViewEq(lens.getClanFullView(clanB), world.getClanFullView(clanB));
+
+        (uint32[] memory lensRanked, uint256[] memory lensScores) = lens.getRankings();
+        (uint32[] memory coreRanked, uint256[] memory coreScores) = world.getRankings();
+        assertEq(lensRanked.length, coreRanked.length, "ranked length");
+        assertEq(lensScores.length, coreScores.length, "score length");
+        for (uint256 i = 0; i < coreRanked.length; i++) {
+            assertEq(lensRanked[i], coreRanked[i], "ranked clan id");
+            assertEq(lensScores[i], coreScores[i], "ranked score");
+        }
+    }
+
+    function test_lensViewsDoNotMutateCoreSettlementState() public {
+        vm.prank(elder);
+        (uint32 clanId,) = world.mintClan(elder);
+        world.setCurrentTick(5);
+        uint64 beforeSettled = world.getClan(clanId).lastSettledTick;
+        uint32 csId = lens.getClanFullView(clanId).clansmen[0].clansman.clansman.clansmanId;
+        ClansmanState beforeState = world.getClansman(csId).state;
+
+        lens.getWorldSnapshot();
+        lens.getClanFullView(clanId);
+        lens.getMarketState();
+        lens.getActiveBanditView();
+        lens.getRegionPopulation(world.getClan(clanId).baseRegion);
+
+        assertEq(world.getClan(clanId).lastSettledTick, beforeSettled, "lens must not settle clan");
+        assertEq(uint8(world.getClansman(csId).state), uint8(beforeState), "lens must not mutate clansman");
+    }
+
+    function _assertWorldSnapshotEq(WorldSnapshot memory actual, WorldSnapshot memory expected) internal pure {
+        assertEq(actual.currentTick, expected.currentTick, "snapshot currentTick");
+        assertEq(actual.seasonStartTick, expected.seasonStartTick, "snapshot seasonStartTick");
+        assertEq(actual.seasonEndTick, expected.seasonEndTick, "snapshot seasonEndTick");
+        assertEq(actual.seasonFinalized, expected.seasonFinalized, "snapshot seasonFinalized");
+        assertEq(actual.currentSeasonNumber, expected.currentSeasonNumber, "snapshot season");
+        assertEq(actual.nextHeartbeatAtTick, expected.nextHeartbeatAtTick, "snapshot next heartbeat");
+        assertEq(actual.winterActive, expected.winterActive, "snapshot winterActive");
+        assertEq(actual.winterStartsAtTick, expected.winterStartsAtTick, "snapshot winter start");
+        assertEq(actual.winterEndsAtTick, expected.winterEndsAtTick, "snapshot winter end");
+        assertEq(actual.activeBanditId, expected.activeBanditId, "snapshot active bandit");
+        assertEq(actual.currentTickSeed, expected.currentTickSeed, "snapshot seed");
+        assertEq(actual.leaderboard.length, expected.leaderboard.length, "leaderboard length");
+        for (uint256 i = 0; i < expected.leaderboard.length; i++) {
+            _assertLeaderboardEntryEq(actual.leaderboard[i], expected.leaderboard[i]);
+        }
+    }
+
+    function _assertLeaderboardEntryEq(LeaderboardEntry memory actual, LeaderboardEntry memory expected) internal pure {
+        assertEq(actual.clanId, expected.clanId, "leaderboard clanId");
+        assertEq(actual.owner, expected.owner, "leaderboard owner");
+        assertEq(actual.monumentLevel, expected.monumentLevel, "leaderboard monument");
+        assertEq(actual.baseLevel, expected.baseLevel, "leaderboard base");
+        assertEq(actual.wallLevel, expected.wallLevel, "leaderboard wall");
+        assertEq(actual.livingClansmen, expected.livingClansmen, "leaderboard living");
+        assertEq(uint8(actual.state), uint8(expected.state), "leaderboard state");
+        assertEq(actual.lootValue, expected.lootValue, "leaderboard loot");
+    }
+
+    function _assertClanFullViewEq(ClanFullView memory actual, ClanFullView memory expected) internal pure {
+        _assertDerivedClanStateEq(actual.clan, expected.clan);
+        assertEq(actual.clansmen.length, expected.clansmen.length, "full clansmen length");
+        for (uint256 i = 0; i < expected.clansmen.length; i++) {
+            _assertClansmanFullViewEq(actual.clansmen[i], expected.clansmen[i]);
+        }
+        _assertWheatPlotEq(actual.westPlot, expected.westPlot, "west");
+        _assertWheatPlotEq(actual.eastPlot, expected.eastPlot, "east");
+        assertEq(actual.incomingDefenderIds.length, expected.incomingDefenderIds.length, "incoming defenders length");
+        for (uint256 i = 0; i < expected.incomingDefenderIds.length; i++) {
+            assertEq(actual.incomingDefenderIds[i], expected.incomingDefenderIds[i], "incoming defender");
+        }
+        assertEq(actual.thisClanDefendingBaseId, expected.thisClanDefendingBaseId, "defending base");
+    }
+
+    function _assertDerivedClanStateEq(DerivedClanState memory actual, DerivedClanState memory expected) internal pure {
+        _assertClanEq(actual.clan, expected.clan);
+        assertEq(actual.isStarving, expected.isStarving, "derived clan starving");
+        assertEq(actual.lootValue, expected.lootValue, "derived clan loot");
+        assertEq(actual.derivedAtTick, expected.derivedAtTick, "derived clan tick");
+    }
+
+    function _assertClansmanFullViewEq(ClansmanFullView memory actual, ClansmanFullView memory expected)
+        internal
+        pure
+    {
+        _assertDerivedClansmanStateEq(actual.clansman, expected.clansman);
+        _assertMissionEq(actual.activeMission, expected.activeMission);
+    }
+
+    function _assertDerivedClansmanStateEq(DerivedClansmanState memory actual, DerivedClansmanState memory expected)
+        internal
+        pure
+    {
+        _assertClansmanEq(actual.clansman, expected.clansman);
+        _assertMissionEq(actual.activeMission, expected.activeMission);
+        assertEq(actual.effectiveRegion, expected.effectiveRegion, "effective region");
+        assertEq(actual.derivedAtTick, expected.derivedAtTick, "derived clansman tick");
+    }
+
+    function _assertClanEq(Clan memory actual, Clan memory expected) internal pure {
+        assertEq(actual.clanId, expected.clanId, "clan id");
+        assertEq(actual.owner, expected.owner, "clan owner");
+        assertEq(uint8(actual.clanState), uint8(expected.clanState), "clan state");
+        assertEq(actual.baseRegion, expected.baseRegion, "clan base region");
+        assertEq(actual.baseLevel, expected.baseLevel, "clan base");
+        assertEq(actual.wallLevel, expected.wallLevel, "clan wall");
+        assertEq(actual.monumentLevel, expected.monumentLevel, "clan monument");
+        assertEq(actual.livingClansmen, expected.livingClansmen, "clan living");
+        assertEq(actual.lastSettledTick, expected.lastSettledTick, "clan settled tick");
+        assertEq(actual.goldBalance, expected.goldBalance, "clan gold");
+        assertEq(actual.blueprintBalance, expected.blueprintBalance, "clan blueprint");
+        assertEq(actual.vaultWood, expected.vaultWood, "clan wood");
+        assertEq(actual.vaultIron, expected.vaultIron, "clan iron");
+        assertEq(actual.vaultWheat, expected.vaultWheat, "clan wheat");
+        assertEq(actual.vaultFish, expected.vaultFish, "clan fish");
+    }
+
+    function _assertClansmanEq(Clansman memory actual, Clansman memory expected) internal pure {
+        assertEq(actual.clansmanId, expected.clansmanId, "clansman id");
+        assertEq(actual.clanId, expected.clanId, "clansman clan");
+        assertEq(uint8(actual.state), uint8(expected.state), "clansman state");
+        assertEq(actual.currentRegion, expected.currentRegion, "clansman region");
+        assertEq(actual.cooldownEndsAtTs, expected.cooldownEndsAtTs, "clansman cooldown");
+        assertEq(actual.lastMissionNonce, expected.lastMissionNonce, "clansman nonce");
+        assertEq(actual.carryWood, expected.carryWood, "clansman wood");
+        assertEq(actual.carryIron, expected.carryIron, "clansman iron");
+        assertEq(actual.carryWheat, expected.carryWheat, "clansman wheat");
+        assertEq(actual.carryFish, expected.carryFish, "clansman fish");
+    }
+
+    function _assertMissionEq(Mission memory actual, Mission memory expected) internal pure {
+        assertEq(actual.active, expected.active, "mission active");
+        assertEq(actual.nonce, expected.nonce, "mission nonce");
+        assertEq(actual.submittedAtTick, expected.submittedAtTick, "mission submitted");
+        assertEq(actual.executesAtTick, expected.executesAtTick, "mission executes");
+        assertEq(actual.settlesAtTick, expected.settlesAtTick, "mission settles");
+        assertEq(actual.clansmanId, expected.clansmanId, "mission clansman");
+        assertEq(actual.startRegion, expected.startRegion, "mission start");
+        assertEq(actual.targetRegion, expected.targetRegion, "mission target");
+        assertEq(uint8(actual.action), uint8(expected.action), "mission action");
+        assertEq(actual.marketToken, expected.marketToken, "mission token");
+        assertEq(actual.marketAmount, expected.marketAmount, "mission amount");
+    }
+
+    function _assertWheatPlotEq(WheatPlot memory actual, WheatPlot memory expected, string memory label) internal pure {
+        assertEq(uint8(actual.state), uint8(expected.state), label);
+        assertEq(actual.region, expected.region, label);
+        assertEq(actual.remainingWheat, expected.remainingWheat, label);
+        assertEq(actual.regrowUntilTick, expected.regrowUntilTick, label);
+    }
+
+    function _assertMarketStateEq(MarketState memory actual, MarketState memory expected) internal pure {
+        _assertPoolReservesEq(actual.wood, expected.wood, "wood");
+        _assertPoolReservesEq(actual.wheat, expected.wheat, "wheat");
+        _assertPoolReservesEq(actual.fish, expected.fish, "fish");
+        _assertPoolReservesEq(actual.iron, expected.iron, "iron");
+        assertEq(actual.currentTick, expected.currentTick, "market tick");
+        assertEq(actual.currentTickQueue.length, expected.currentTickQueue.length, "current queue");
+        assertEq(actual.nextTickQueue.length, expected.nextTickQueue.length, "next queue");
+    }
+
+    function _assertPoolReservesEq(PoolReserves memory actual, PoolReserves memory expected, string memory label)
+        internal
+        pure
+    {
+        assertEq(actual.resourceToken, expected.resourceToken, label);
+        assertEq(actual.resourceReserve, expected.resourceReserve, label);
+        assertEq(actual.goldReserve, expected.goldReserve, label);
+        assertEq(actual.spotPriceGoldPerResource, expected.spotPriceGoldPerResource, label);
+    }
+
+    function _assertActiveBanditViewEq(ActiveBanditView memory actual, ActiveBanditView memory expected) internal pure {
+        assertEq(actual.exists, expected.exists, "bandit exists");
+        assertEq(actual.banditId, expected.banditId, "bandit id");
+        assertEq(uint8(actual.state), uint8(expected.state), "bandit state");
+        assertEq(actual.currentRegion, expected.currentRegion, "bandit region");
+        assertEq(actual.attackAttemptsMade, expected.attackAttemptsMade, "bandit attempts");
+        assertEq(actual.maxAttemptsRemaining, expected.maxAttemptsRemaining, "bandit remaining");
+        assertEq(actual.stateEnteredTick, expected.stateEnteredTick, "bandit entered");
+        assertEq(actual.nextActionTick, expected.nextActionTick, "bandit next");
+        assertEq(actual.tier, expected.tier, "bandit tier");
+        assertEq(actual.attackPower, expected.attackPower, "bandit power");
+        assertEq(actual.carryWood, expected.carryWood, "bandit wood");
+        assertEq(actual.carryIron, expected.carryIron, "bandit iron");
+        assertEq(actual.carryWheat, expected.carryWheat, "bandit wheat");
+        assertEq(actual.carryFish, expected.carryFish, "bandit fish");
+        assertEq(actual.projectedTargetClanId, expected.projectedTargetClanId, "bandit target");
+        assertEq(actual.projectedTargetLootValue, expected.projectedTargetLootValue, "bandit target loot");
+    }
+
+    function _assertRegionPopulationEq(RegionOccupant[] memory actual, RegionOccupant[] memory expected)
+        internal
+        pure
+    {
+        assertEq(actual.length, expected.length, "population length");
+        for (uint256 i = 0; i < expected.length; i++) {
+            assertEq(actual[i].clansmanId, expected[i].clansmanId, "population clansman");
+            assertEq(actual[i].clanId, expected[i].clanId, "population clan");
+            assertEq(uint8(actual[i].state), uint8(expected[i].state), "population state");
+            assertEq(uint8(actual[i].currentAction), uint8(expected[i].currentAction), "population action");
+            assertEq(actual[i].missionNonce, expected[i].missionNonce, "population nonce");
+        }
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {Diamond} from "../../src/diamond/Diamond.sol";
+import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
+import {IDiamondLoupe} from "../../src/diamond/IDiamondLoupe.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+
+contract PingFacet {
+    function ping() external pure returns (uint256) {
+        return 42;
+    }
+}
+
+interface IPing {
+    function ping() external view returns (uint256);
+}
+
+contract DiamondSkeletonTest is Test {
+    Diamond diamond;
+    DiamondCutFacet cutFacet;
+
+    function setUp() public {
+        cutFacet = new DiamondCutFacet();
+        diamond = new Diamond(address(this), address(cutFacet));
+    }
+
+    function testOwnerCanAddAndRouteFacetSelector() public {
+        PingFacet pingFacet = new PingFacet();
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = PingFacet.ping.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(pingFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: selectors
+        });
+
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+
+        assertEq(IPing(address(diamond)).ping(), 42);
+    }
+
+    function testLoupeReportsAddedSelector() public {
+        DiamondLoupeFacet loupeFacet = new DiamondLoupeFacet();
+        bytes4[] memory selectors = new bytes4[](4);
+        selectors[0] = IDiamondLoupe.facets.selector;
+        selectors[1] = IDiamondLoupe.facetFunctionSelectors.selector;
+        selectors[2] = IDiamondLoupe.facetAddresses.selector;
+        selectors[3] = IDiamondLoupe.facetAddress.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: selectors
+        });
+
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+
+        assertEq(IDiamondLoupe(address(diamond)).facetAddress(IDiamondLoupe.facets.selector), address(loupeFacet));
+        assertEq(IDiamondLoupe(address(diamond)).facetAddresses().length, 2);
+    }
+
+    function testOnlyOwnerCanDiamondCut() public {
+        PingFacet pingFacet = new PingFacet();
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = PingFacet.ping.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(pingFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: selectors
+        });
+
+        vm.prank(address(0xBEEF));
+        vm.expectRevert();
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+}

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import clanWorldLensAbi from '@clan-world/contracts/abi/IClanWorldLens.json' with { type: 'json' };
 import {
   createPublicClient,
   createWalletClient,
@@ -12,6 +13,8 @@ import { privateKeyToAccount } from 'viem/accounts';
 import type { ClanFullView, ClanOrder, Tick } from '../types';
 import { ActionType } from '../generated/enums';
 import { readEnv } from './_env';
+
+const CLAN_WORLD_LENS_ABI = clanWorldLensAbi.abi;
 
 export interface SubmitOrderResult {
   clansmanId: number;
@@ -4044,6 +4047,7 @@ class StubChainClient implements IChainClient {
 class RealChainClient implements IChainClient {
   private readonly client: ReturnType<typeof createPublicClient>;
   private readonly contractAddress: `0x${string}`;
+  private readonly lensAddress: `0x${string}`;
   private readonly transport:
     | ReturnType<typeof http>
     | ReturnType<typeof fallback>;
@@ -4057,8 +4061,18 @@ class RealChainClient implements IChainClient {
         ? fallback([http(primaryRpc), http(fallbackRpc)])
         : http(primaryRpc ?? fallbackRpc);
 
-    this.contractAddress = (readEnv('CLAN_WORLD_CONTRACT_ADDRESS') ??
-      DEFAULT_CONTRACT_ADDRESS) as `0x${string}`;
+    const configuredContractAddress = readEnv('CLAN_WORLD_CONTRACT_ADDRESS');
+    const configuredLensAddress = readEnv('CLAN_WORLD_LENS_ADDRESS');
+    this.contractAddress = (
+      configuredContractAddress && configuredContractAddress.trim()
+        ? configuredContractAddress
+        : DEFAULT_CONTRACT_ADDRESS
+    ) as `0x${string}`;
+    this.lensAddress = (
+      configuredLensAddress && configuredLensAddress.trim()
+        ? configuredLensAddress
+        : this.contractAddress
+    ) as `0x${string}`;
 
     this.client = createPublicClient({
       chain: baseSepolia,
@@ -4068,8 +4082,8 @@ class RealChainClient implements IChainClient {
 
   async getCurrentTick(): Promise<Tick> {
     const snapshot = await this.client.readContract({
-      address: this.contractAddress,
-      abi: CLAN_WORLD_ABI,
+      address: this.lensAddress,
+      abi: CLAN_WORLD_LENS_ABI as unknown as typeof CLAN_WORLD_ABI,
       functionName: 'getWorldSnapshot',
     });
     return Number(snapshot.currentTick); // safe: tick values are small enough to fit Number precisely in Wave 0
@@ -4207,8 +4221,8 @@ class RealChainClient implements IChainClient {
 
   async getClanFullView(clanId: string): Promise<ClanFullView> {
     const result = await this.client.readContract({
-      address: this.contractAddress,
-      abi: CLAN_WORLD_ABI,
+      address: this.lensAddress,
+      abi: CLAN_WORLD_LENS_ABI as unknown as typeof CLAN_WORLD_ABI,
       functionName: 'getClanFullView',
       args: [parseClanId(clanId, 'getClanFullView')],
     });
@@ -4259,8 +4273,8 @@ class RealChainClient implements IChainClient {
 
   async getClanScore(clanId: string): Promise<{ score: bigint; monumentReachedAtTick: bigint; monumentLevel: number }> {
     const [score, monumentReachedAtTick, monumentLevel] = await this.client.readContract({
-      address: this.contractAddress,
-      abi: CLAN_WORLD_ABI,
+      address: this.lensAddress,
+      abi: CLAN_WORLD_LENS_ABI as unknown as typeof CLAN_WORLD_ABI,
       functionName: 'getClanScore',
       args: [parseClanId(clanId, 'getClanScore')],
     });
@@ -4269,8 +4283,8 @@ class RealChainClient implements IChainClient {
 
   async getRankings(): Promise<{ clanIdsRanked: readonly number[]; scores: readonly bigint[] }> {
     const [clanIdsRanked, scores] = await this.client.readContract({
-      address: this.contractAddress,
-      abi: CLAN_WORLD_ABI,
+      address: this.lensAddress,
+      abi: CLAN_WORLD_LENS_ABI as unknown as typeof CLAN_WORLD_ABI,
       functionName: 'getRankings',
     });
     return { clanIdsRanked: clanIdsRanked as readonly number[], scores };

--- a/scripts/gen-contract-abi.mjs
+++ b/scripts/gen-contract-abi.mjs
@@ -5,19 +5,29 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
-const artifactPath = path.join(repoRoot, 'packages/contracts/out/IClanWorld.sol/IClanWorld.json');
-const targetPath = path.join(repoRoot, 'packages/contracts/abi/IClanWorld.json');
+const abiTargets = [
+  {
+    artifactPath: path.join(repoRoot, 'packages/contracts/out/IClanWorld.sol/IClanWorld.json'),
+    targetPath: path.join(repoRoot, 'packages/contracts/abi/IClanWorld.json'),
+  },
+  {
+    artifactPath: path.join(repoRoot, 'packages/contracts/out/IClanWorldLens.sol/IClanWorldLens.json'),
+    targetPath: path.join(repoRoot, 'packages/contracts/abi/IClanWorldLens.json'),
+  },
+];
 
-if (!fs.existsSync(artifactPath)) {
-  throw new Error(`Missing ${path.relative(repoRoot, artifactPath)}. Run forge build first.`);
+for (const { artifactPath, targetPath } of abiTargets) {
+  if (!fs.existsSync(artifactPath)) {
+    throw new Error(`Missing ${path.relative(repoRoot, artifactPath)}. Run forge build first.`);
+  }
+
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
+  if (!Array.isArray(artifact.abi)) {
+    throw new Error(`${path.relative(repoRoot, artifactPath)} must contain an "abi" array`);
+  }
+
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, `${JSON.stringify({ abi: artifact.abi }, null, 2)}\n`);
+
+  console.log(`Updated ${path.relative(repoRoot, targetPath)} from ${path.relative(repoRoot, artifactPath)}.`);
 }
-
-const artifact = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
-if (!Array.isArray(artifact.abi)) {
-  throw new Error(`${path.relative(repoRoot, artifactPath)} must contain an "abi" array`);
-}
-
-fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-fs.writeFileSync(targetPath, `${JSON.stringify({ abi: artifact.abi }, null, 2)}\n`);
-
-console.log(`Updated ${path.relative(repoRoot, targetPath)} from ${path.relative(repoRoot, artifactPath)}.`);


### PR DESCRIPTION
## Summary

- add the stateless `ClanWorldLens` plus `IClanWorldLens` ABI/export/deploy wiring
- add public raw list/bookkeeping getters needed by the lens
- add parity/non-mutation tests proving lens-owned aggregators match the existing core views
- add the initial EIP-2535 diamond shell, cut/loupe facets, storage library, and facet placeholders
- add `LibScoring` for small pure score/loot/bandit-display helpers and split out a `DerivedViewsFacet` skeleton
- route shared `RealChainClient` convenience reads through `CLAN_WORLD_LENS_ADDRESS` when configured

## Notes

The existing core view methods intentionally remain in `ClanWorld` as the migration oracle. A throwaway measurement deleting only the moved UI aggregators from core shaved about 4.8 KB from `ClanWorld`, but this PR keeps them for parity during the diamond migration.

## Validation

- `forge test --match-path test/ClanWorldLens.t.sol`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`

Full `forge test` and `forge build --sizes` were attempted earlier in the workflow but the forge process hung at ~0% CPU after compilation started, so this PR uses focused Foundry gates plus ABI/shared checks.
