### PR TITLE
[codex] extend lens scoring reads

### DIFF
--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -1959,6 +1959,30 @@
     },
     {
       "type": "function",
+      "name": "getMonumentLevelReachedAt",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "level",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "reachedAtTick",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "getMonumentUpgradeCost",
       "inputs": [
         {

--- a/packages/contracts/abi/IClanWorldLens.json
+++ b/packages/contracts/abi/IClanWorldLens.json
@@ -1446,6 +1446,25 @@
     },
     {
       "type": "function",
+      "name": "quoteLootValueRaw",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "lootValue",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "quoteLootValueSettled",
       "inputs": [
         {

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -5247,6 +5247,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return _clansmanDefendingRegion[clansmanId];
     }
 
+    function getMonumentLevelReachedAt(uint32 clanId, uint8 level) external view override returns (uint64) {
+        return _monumentLevelReachedAt[clanId][level];
+    }
+
     // =========================================================================
     // DERIVED READ GETTERS (read-only, no storage mutation)
     // =========================================================================

--- a/packages/contracts/src/ClanWorldLens.sol
+++ b/packages/contracts/src/ClanWorldLens.sol
@@ -55,6 +55,10 @@ contract ClanWorldLens is IClanWorldLens {
         return world.getBanditTargetPreview(banditId);
     }
 
+    function quoteLootValueRaw(uint32 clanId) external view override returns (uint256 lootValue) {
+        return LibScoring.lootValue(world.getClan(clanId));
+    }
+
     function quoteLootValueSettled(uint32 clanId) external view override returns (uint256 lootValue) {
         return world.quoteLootValueSettled(clanId);
     }

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -458,6 +458,10 @@ contract ClanWorldStub is IClanWorld {
         return 0;
     }
 
+    function getMonumentLevelReachedAt(uint32, uint8) external pure override returns (uint64) {
+        return 0;
+    }
+
     // -------------------------------------------------------------------------
     // Derived read getters
     // -------------------------------------------------------------------------

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -854,6 +854,8 @@ interface IClanWorld is IClanWorldEvents {
 
     function getClansmanDefendingRegion(uint32 clansmanId) external view returns (uint8 region);
 
+    function getMonumentLevelReachedAt(uint32 clanId, uint8 level) external view returns (uint64 reachedAtTick);
+
     // -------------------------------------------------------------------------
     // Derived read getters (read-only simulation forward to current tick)
     //

--- a/packages/contracts/src/IClanWorldLens.sol
+++ b/packages/contracts/src/IClanWorldLens.sol
@@ -24,6 +24,8 @@ interface IClanWorldLens {
 
     function getBanditTargetPreview(uint32 banditId) external view returns (uint32 previewClanId);
 
+    function quoteLootValueRaw(uint32 clanId) external view returns (uint256 lootValue);
+
     function quoteLootValueSettled(uint32 clanId) external view returns (uint256 lootValue);
 
     function getClanScore(uint32 clanId)

--- a/packages/contracts/test/ClanWorldLens.t.sol
+++ b/packages/contracts/test/ClanWorldLens.t.sol
@@ -42,6 +42,11 @@ contract ClanWorldLensHarness is ClanWorld {
         _clans[clanId].vaultWheat = wheat;
         _clans[clanId].vaultFish = fish;
     }
+
+    function setMonumentLevelReachedAt(uint32 clanId, uint8 level, uint64 reachedAtTick) external {
+        _clans[clanId].monumentLevel = level;
+        _monumentLevelReachedAt[clanId][level] = reachedAtTick;
+    }
 }
 
 contract ClanWorldLensTest is Test {
@@ -99,6 +104,24 @@ contract ClanWorldLensTest is Test {
         assertEq(lensScores[0], coreScores[0]);
     }
 
+    function test_lensQuoteLootValueRawMatchesCore() public {
+        vm.prank(elder);
+        (uint32 clanId,) = world.mintClan(elder);
+        world.setVault(clanId, 100e18, 5e18, 40e18, 3e18);
+
+        assertEq(lens.quoteLootValueRaw(clanId), world.quoteLootValueRaw(clanId));
+    }
+
+    function test_coreRawMonumentReachedAtGetter() public {
+        vm.prank(elder);
+        (uint32 clanId,) = world.mintClan(elder);
+
+        world.setMonumentLevelReachedAt(clanId, 1, 42);
+
+        assertEq(world.getMonumentLevelReachedAt(clanId, 1), 42);
+        assertEq(world.getMonumentLevelReachedAt(clanId, 2), 0);
+    }
+
     function test_lensMarketStateMatchesCore() public view {
         MarketState memory core = world.getMarketState();
         MarketState memory fromLens = lens.getMarketState();
@@ -154,6 +177,7 @@ contract ClanWorldLensTest is Test {
         lens.getMarketState();
         lens.getActiveBanditView();
         lens.getRegionPopulation(world.getClan(clanId).baseRegion);
+        lens.quoteLootValueRaw(clanId);
 
         assertEq(world.getClan(clanId).lastSettledTick, beforeSettled, "lens must not settle clan");
         assertEq(uint8(world.getClansman(csId).state), uint8(beforeState), "lens must not mutate clansman");


### PR DESCRIPTION
## Summary

Stacked on #422.

- adds a raw `getMonumentLevelReachedAt` getter on `IClanWorld` so future scoring/ranking extraction can read monument tie-breaker state without reaching into storage
- moves `quoteLootValueRaw` computation into `ClanWorldLens` via `LibScoring`
- keeps score/rankings delegated for now because simulated monument timing is still coupled to core derived state
- extends lens parity coverage for raw loot value and the new monument timestamp getter

## Validation

- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
