### PR TITLE
[codex] add lens travel quotes

### DIFF
--- a/packages/contracts/abi/IClanWorldLens.json
+++ b/packages/contracts/abi/IClanWorldLens.json
@@ -1484,6 +1484,35 @@
     },
     {
       "type": "function",
+      "name": "quoteTravel",
+      "inputs": [
+        {
+          "name": "srcRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "dstRegion",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "travelTicks",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "path",
+          "type": "bytes8",
+          "internalType": "bytes8"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
       "name": "world",
       "inputs": [],
       "outputs": [

--- a/packages/contracts/src/ClanWorldLens.sol
+++ b/packages/contracts/src/ClanWorldLens.sol
@@ -27,6 +27,7 @@ import {
 } from "./IClanWorld.sol";
 import {IClanWorldLens} from "./IClanWorldLens.sol";
 import {LibScoring} from "./lib/LibScoring.sol";
+import {LibTravel} from "./lib/LibTravel.sol";
 import {StubPool} from "./StubPool.sol";
 
 /// @notice Stateless reader contract for convenience views that should not live
@@ -53,6 +54,15 @@ contract ClanWorldLens is IClanWorldLens {
 
     function getBanditTargetPreview(uint32 banditId) external view override returns (uint32 previewClanId) {
         return world.getBanditTargetPreview(banditId);
+    }
+
+    function quoteTravel(uint8 srcRegion, uint8 dstRegion)
+        external
+        pure
+        override
+        returns (uint8 travelTicks, bytes8 path)
+    {
+        return LibTravel.quoteTravel(srcRegion, dstRegion);
     }
 
     function quoteLootValueRaw(uint32 clanId) external view override returns (uint256 lootValue) {

--- a/packages/contracts/src/IClanWorldLens.sol
+++ b/packages/contracts/src/IClanWorldLens.sol
@@ -24,6 +24,8 @@ interface IClanWorldLens {
 
     function getBanditTargetPreview(uint32 banditId) external view returns (uint32 previewClanId);
 
+    function quoteTravel(uint8 srcRegion, uint8 dstRegion) external pure returns (uint8 travelTicks, bytes8 path);
+
     function quoteLootValueRaw(uint32 clanId) external view returns (uint256 lootValue);
 
     function quoteLootValueSettled(uint32 clanId) external view returns (uint256 lootValue);

--- a/packages/contracts/src/lib/LibTravel.sol
+++ b/packages/contracts/src/lib/LibTravel.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+library LibTravel {
+    function quoteTravel(uint8 srcRegion, uint8 dstRegion) internal pure returns (uint8 travelTicks, bytes8 path) {
+        if (srcRegion > 8 || dstRegion > 8) {
+            return (0, bytes8(0));
+        }
+        if (srcRegion == dstRegion || srcRegion == 0 || dstRegion == 0) {
+            travelTicks = 0;
+            path = bytes8(uint64(srcRegion) << 56);
+            return (travelTicks, path);
+        }
+        travelTicks = travelTicksBetween(srcRegion, dstRegion);
+        path = buildPath(srcRegion, dstRegion);
+    }
+
+    function travelTicksBetween(uint8 fromRegion, uint8 toRegion) internal pure returns (uint8) {
+        if (fromRegion == 0 || toRegion == 0) return 0;
+        if (fromRegion == toRegion) return 0;
+        if (fromRegion > 8 || toRegion > 8) return 0;
+        return distMatrix(fromRegion, toRegion);
+    }
+
+    function buildPath(uint8 src, uint8 dst) internal pure returns (bytes8) {
+        if (src == dst) {
+            return bytes8(uint64(src) << 56);
+        }
+
+        uint8[3][9] memory adj = [
+            [0, 0, 0],
+            [2, 4, 0],
+            [1, 3, 0],
+            [2, 4, 5],
+            [1, 3, 6],
+            [3, 7, 0],
+            [4, 8, 0],
+            [5, 8, 0],
+            [6, 7, 0]
+        ];
+
+        uint8[9] memory parent;
+        bool[9] memory visited;
+        uint8[9] memory queue;
+        uint256 head;
+        uint256 tail;
+
+        visited[src] = true;
+        queue[tail++] = src;
+
+        while (head < tail) {
+            uint8 curr = queue[head++];
+            if (curr == dst) break;
+            for (uint256 ni = 0; ni < 3; ni++) {
+                uint8 nb = adj[curr][ni];
+                if (nb == 0) break;
+                if (!visited[nb]) {
+                    visited[nb] = true;
+                    parent[nb] = curr;
+                    queue[tail++] = nb;
+                }
+            }
+        }
+
+        uint8[8] memory path;
+        uint256 pathLen;
+        uint8 cur = dst;
+        while (cur != src) {
+            path[pathLen++] = cur;
+            cur = parent[cur];
+        }
+        path[pathLen++] = src;
+
+        bytes8 packed;
+        uint64 byteShift = 56;
+        for (uint256 i = pathLen; i > 0; i--) {
+            packed = packed | bytes8(uint64(path[i - 1]) << byteShift);
+            if (byteShift >= 8) byteShift -= 8;
+        }
+        return packed;
+    }
+
+    function distMatrix(uint8 src, uint8 dst) internal pure returns (uint8) {
+        uint8[64] memory d = [
+            uint8(0),
+            1,
+            2,
+            1,
+            3,
+            2,
+            4,
+            3,
+            1,
+            0,
+            1,
+            2,
+            2,
+            3,
+            3,
+            4,
+            2,
+            1,
+            0,
+            1,
+            1,
+            2,
+            2,
+            3,
+            1,
+            2,
+            1,
+            0,
+            2,
+            1,
+            3,
+            2,
+            3,
+            2,
+            1,
+            2,
+            0,
+            3,
+            1,
+            2,
+            2,
+            3,
+            2,
+            1,
+            3,
+            0,
+            2,
+            1,
+            4,
+            3,
+            2,
+            3,
+            1,
+            2,
+            0,
+            1,
+            3,
+            4,
+            3,
+            2,
+            2,
+            1,
+            1,
+            0
+        ];
+        return d[uint8(src - 1) * 8 + uint8(dst - 1)];
+    }
+}

--- a/packages/contracts/test/ClanWorldLens.t.sol
+++ b/packages/contracts/test/ClanWorldLens.t.sol
@@ -112,6 +112,17 @@ contract ClanWorldLensTest is Test {
         assertEq(lens.quoteLootValueRaw(clanId), world.quoteLootValueRaw(clanId));
     }
 
+    function test_lensQuoteTravelMatchesCoreForAllRegions() public view {
+        for (uint8 src = 0; src <= 9; src++) {
+            for (uint8 dst = 0; dst <= 9; dst++) {
+                (uint8 coreTicks, bytes8 corePath) = world.quoteTravel(src, dst);
+                (uint8 lensTicks, bytes8 lensPath) = lens.quoteTravel(src, dst);
+                assertEq(lensTicks, coreTicks, "travel ticks");
+                assertEq(lensPath, corePath, "travel path");
+            }
+        }
+    }
+
     function test_coreRawMonumentReachedAtGetter() public {
         vm.prank(elder);
         (uint32 clanId,) = world.mintClan(elder);

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -106,6 +106,7 @@ export interface IChainClient {
   getWallUpgradeCost(currentLevel: number): Promise<{ wood: bigint; iron: bigint }>;
   getBaseUpgradeCost(currentLevel: number): Promise<{ wood: bigint; iron: bigint; wheat: bigint }>;
   getMonumentUpgradeCost(currentLevel: number): Promise<{ wood: bigint; iron: bigint; wheat: bigint; blueprint: bigint }>;
+  quoteTravel(srcRegion: number, dstRegion: number): Promise<{ travelTicks: number; path: `0x${string}` }>;
   getClanScore(clanId: string): Promise<{ score: bigint; monumentReachedAtTick: bigint; monumentLevel: number }>;
   getRankings(): Promise<{ clanIdsRanked: readonly number[]; scores: readonly bigint[] }>;
 }
@@ -4036,6 +4037,9 @@ class StubChainClient implements IChainClient {
   async getMonumentUpgradeCost(_currentLevel: number): Promise<{ wood: bigint; iron: bigint; wheat: bigint; blueprint: bigint }> {
     return { wood: 0n, iron: 0n, wheat: 0n, blueprint: 0n };
   }
+  async quoteTravel(_srcRegion: number, _dstRegion: number): Promise<{ travelTicks: number; path: `0x${string}` }> {
+    return { travelTicks: 0, path: '0x0000000000000000' };
+  }
   async getClanScore(_clanId: string): Promise<{ score: bigint; monumentReachedAtTick: bigint; monumentLevel: number }> {
     return { score: 0n, monumentReachedAtTick: 0n, monumentLevel: 0 };
   }
@@ -4269,6 +4273,16 @@ class RealChainClient implements IChainClient {
       args: [currentLevel],
     });
     return { wood, iron, wheat, blueprint };
+  }
+
+  async quoteTravel(srcRegion: number, dstRegion: number): Promise<{ travelTicks: number; path: `0x${string}` }> {
+    const [travelTicks, path] = await this.client.readContract({
+      address: this.lensAddress,
+      abi: CLAN_WORLD_LENS_ABI,
+      functionName: 'quoteTravel',
+      args: [srcRegion, dstRegion],
+    }) as readonly [number | bigint, `0x${string}`];
+    return { travelTicks: Number(travelTicks), path };
   }
 
   async getClanScore(clanId: string): Promise<{ score: bigint; monumentReachedAtTick: bigint; monumentLevel: number }> {

--- a/packages/shared/test/realChainClientSubmitOrders.test.ts
+++ b/packages/shared/test/realChainClientSubmitOrders.test.ts
@@ -3,6 +3,7 @@ import type { ClanOrder } from '../src/types';
 import { ActionType } from '../src/generated/enums';
 
 const mocks = vi.hoisted(() => {
+  const readContract = vi.fn(async () => [3, '0x0102030000000000']);
   const writeContract = vi.fn(
     async (_request: unknown) => `0x${'12'.repeat(32)}`,
   );
@@ -19,7 +20,7 @@ const mocks = vi.hoisted(() => {
     }),
   );
 
-  return { simulateContract, writeContract };
+  return { readContract, simulateContract, writeContract };
 });
 
 vi.mock('viem', async () => {
@@ -28,6 +29,7 @@ vi.mock('viem', async () => {
   return {
     ...actual,
     createPublicClient: vi.fn(() => ({
+      readContract: mocks.readContract,
       simulateContract: mocks.simulateContract,
     })),
     createWalletClient: vi.fn(() => ({
@@ -86,6 +88,7 @@ describe('RealChainClient.submitOrders order field mapping', () => {
     vi.clearAllMocks();
     process.env.CLAN_WORLD_USE_STUB_CHAIN = 'false';
     process.env.DEPLOYER_PRIVATE_KEY = '11'.repeat(32);
+    process.env.CLAN_WORLD_LENS_ADDRESS = '0x0000000000000000000000000000000000000abc';
     delete process.env.ELDER_WALLET_KEY_PATH;
   });
 
@@ -163,5 +166,23 @@ describe('RealChainClient.submitOrders order field mapping', () => {
       wheat: 3n,
       fish: 0n,
     });
+  });
+
+  it('reads quoteTravel from the configured lens address', async () => {
+    const client = createChainClient();
+
+    const result = await client.quoteTravel(1, 8);
+
+    expect(result).toEqual({
+      travelTicks: 3,
+      path: '0x0102030000000000',
+    });
+    expect(mocks.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: '0x0000000000000000000000000000000000000abc',
+        functionName: 'quoteTravel',
+        args: [1, 8],
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Stacked on #423.

- adds `quoteTravel` to `IClanWorldLens`
- moves the pure travel quote/path reconstruction into `LibTravel`
- has `ClanWorldLens` serve travel quotes without calling core storage
- adds all-region parity coverage against the core `quoteTravel`

## Validation

- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
