### PR TITLE
v1.1.4 hotfix: cockpit client auth + readiness export auth + bandit liveTick

### DIFF
--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -291,8 +291,6 @@ export function WorldMap() {
 
   const logs = useAgentLogs();
   const snapshot = useQuery(api.getSnapshot.getSnapshot);
-  const banditTicksUntil = DEMO_BANDIT.attacksAtTick - (snapshot?.tick ?? 0);
-  const shouldPulseBandit = DEMO_MODE && banditTicksUntil <= 2 && banditTicksUntil >= 0;
 
   // Derived live tick counter — the worldSnapshot.tick field is currently
   // unwritten by the orchestrator script (it only writes to agentLogs), so
@@ -301,6 +299,8 @@ export function WorldMap() {
   const liveTick = useMemo(() => {
     return Math.max(snapshot?.tick ?? 0, logs.length);
   }, [logs, snapshot?.tick]);
+  const banditTicksUntil = DEMO_BANDIT.attacksAtTick - liveTick;
+  const shouldPulseBandit = DEMO_MODE && banditTicksUntil <= 2 && banditTicksUntil >= 0;
 
   // ---- Pixi init ------------------------------------------------------------
   useEffect(() => {
@@ -1046,8 +1046,7 @@ export function WorldMap() {
       sprite.alpha = 1;
     }
 
-    const tick = snapshot?.tick ?? 0;
-    const ticksUntil = Math.max(0, DEMO_BANDIT.attacksAtTick - tick);
+    const ticksUntil = Math.max(0, DEMO_BANDIT.attacksAtTick - liveTick);
     text.text = `${ticksUntil}t`;
     text.style.fontSize = Math.max(10, Math.round(12 * scale));
     // Anchor the countdown to the right edge of whichever marker is active.
@@ -1061,7 +1060,7 @@ export function WorldMap() {
     if (!pixiReady || !DEMO_MODE) return;
     redrawBandit();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [snapshot?.tick, pixiReady]);
+  }, [liveTick, pixiReady]);
 
   // Snapshot clan changes: re-layout so monument heights track live treasury.
   useEffect(() => {

--- a/gold-bridge-monorepo/.env.template
+++ b/gold-bridge-monorepo/.env.template
@@ -91,4 +91,7 @@ COCKPIT_CORS_ORIGIN=http://localhost:5173
 # REQUIRED for any cockpit operation involving on-chain actions.
 # Generate via: openssl rand -hex 32
 # COCKPIT_API_TOKEN=
+# Optional: for development convenience, you can set the cockpit API token at build time.
+# Production operators should use the runtime settings UI instead.
+# VITE_COCKPIT_API_TOKEN=
 VITE_COCKPIT_API_URL=http://127.0.0.1:8787

--- a/gold-bridge-monorepo/apps/web/src/components/CockpitDashboard.tsx
+++ b/gold-bridge-monorepo/apps/web/src/components/CockpitDashboard.tsx
@@ -8,6 +8,8 @@ import {
   fetchCockpitState,
   fetchDeploymentGuide,
   fetchReadinessReport,
+  COCKPIT_TOKEN_STORAGE_KEY,
+  getCockpitToken,
   previewCockpitAction,
   previewCockpitIntent,
   reconcileCockpitIntent,
@@ -40,6 +42,7 @@ export function CockpitDashboard() {
   const [intents, setIntents] = useState<CockpitIntent[]>([]);
   const [solanaWallet, setSolanaWallet] = useState('');
   const [error, setError] = useState('');
+  const [hasCockpitToken, setHasCockpitToken] = useState(() => Boolean(getCockpitToken()));
   const [loading, setLoading] = useState(false);
   const evmAccount = useAccount();
   const chainId = useChainId();
@@ -75,6 +78,7 @@ export function CockpitDashboard() {
         </div>
         <div className="header-actions">
           <EnvironmentPill state={state} />
+          <CockpitTokenSettings hasToken={hasCockpitToken} onTokenChange={setHasCockpitToken} />
           <AppKitButton />
           <AppKitNetworkButton />
           <button onClick={() => void connectSolanaWallet(setSolanaWallet)}>{solanaWallet ? shortenAddress(solanaWallet) : 'Connect Solana'}</button>
@@ -82,7 +86,7 @@ export function CockpitDashboard() {
         </div>
       </header>
 
-      {error && <section className="banner warning">Cockpit API unavailable: {error}. Start it with <code>pnpm cockpit:api</code>.</section>}
+      {error && <section className="banner warning">{cockpitErrorMessage(error)}</section>}
 
       <nav className="tab-bar" aria-label="Cockpit sections">
         {tabs.map((item) => (
@@ -106,6 +110,61 @@ export function CockpitDashboard() {
         </>
       )}
     </main>
+  );
+}
+
+function cockpitErrorMessage(error: string) {
+  if (error.includes('COCKPIT_API_TOKEN') || error.includes('Invalid cockpit API token')) {
+    return <>Set your <code>COCKPIT_API_TOKEN</code> in the operator settings, then retry the cockpit action.</>;
+  }
+  return <>Cockpit API unavailable: {error}. Start it with <code>pnpm cockpit:api</code>.</>;
+}
+
+function CockpitTokenSettings({ hasToken, onTokenChange }: { hasToken: boolean; onTokenChange: (hasToken: boolean) => void }) {
+  const [open, setOpen] = useState(false);
+  const [tokenInput, setTokenInput] = useState('');
+  const envTokenConfigured = Boolean((import.meta.env.VITE_COCKPIT_API_TOKEN as string | undefined) ?? '');
+
+  function saveToken() {
+    const nextToken = tokenInput.trim();
+    if (nextToken) {
+      window.localStorage.setItem(COCKPIT_TOKEN_STORAGE_KEY, nextToken);
+      onTokenChange(true);
+    }
+    setTokenInput('');
+    setOpen(false);
+  }
+
+  function clearToken() {
+    window.localStorage.removeItem(COCKPIT_TOKEN_STORAGE_KEY);
+    onTokenChange(envTokenConfigured);
+    setTokenInput('');
+  }
+
+  return (
+    <div className="token-settings">
+      <button type="button" onClick={() => setOpen((value) => !value)}>
+        {hasToken ? 'Token set' : 'Set token'}
+      </button>
+      {open && (
+        <div className="token-settings-popover">
+          <label className="confirm-field">
+            <span>Cockpit API Token</span>
+            <input
+              type="password"
+              value={tokenInput}
+              onChange={(event) => setTokenInput(event.target.value)}
+              placeholder={hasToken ? 'Token currently set' : 'Paste COCKPIT_API_TOKEN'}
+            />
+          </label>
+          <div className="button-row">
+            <button type="button" onClick={saveToken} disabled={!tokenInput.trim()}>Save</button>
+            <button type="button" onClick={clearToken} disabled={!hasToken}>Clear</button>
+          </div>
+          <p className={hasToken ? 'muted' : 'warning'}>{hasToken ? 'Cockpit token is available for protected operations.' : 'Protected operations will return 401 until a token is set.'}</p>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/gold-bridge-monorepo/apps/web/src/lib/cockpitApi.ts
+++ b/gold-bridge-monorepo/apps/web/src/lib/cockpitApi.ts
@@ -10,17 +10,34 @@ import type {
 } from '../types';
 
 const API_BASE = import.meta.env.VITE_COCKPIT_API_URL || 'http://127.0.0.1:8787';
+export const COCKPIT_TOKEN_STORAGE_KEY = 'cockpit:apiToken';
+
+export function getCockpitToken(): string {
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem(COCKPIT_TOKEN_STORAGE_KEY);
+    if (stored) return stored;
+  }
+  return (import.meta.env.VITE_COCKPIT_API_TOKEN as string | undefined) ?? '';
+}
 
 async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = getCockpitToken();
+  const headers = new Headers(init?.headers);
+  if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+  if (token) headers.set('x-cockpit-token', token);
+
   const res = await fetch(`${API_BASE}${path}`, {
     ...init,
-    headers: {
-      'content-type': 'application/json',
-      ...(init?.headers || {})
-    }
+    headers
   });
   const json = await res.json();
-  if (!res.ok) throw new Error(json.error || `Cockpit API HTTP ${res.status}`);
+  if (!res.ok) {
+    if (res.status === 401) {
+      const hint = 'Set it via the operator settings UI or VITE_COCKPIT_API_TOKEN.';
+      throw new Error(json.error ? `${json.error} ${hint}` : `Cockpit API requires COCKPIT_API_TOKEN. ${hint}`);
+    }
+    throw new Error(json.error || `Cockpit API HTTP ${res.status}`);
+  }
   return json as T;
 }
 

--- a/gold-bridge-monorepo/apps/web/src/styles.css
+++ b/gold-bridge-monorepo/apps/web/src/styles.css
@@ -63,6 +63,22 @@ pre {
 .cockpit-header p { max-width: 760px; color: #aab6c4; margin: 0.55rem 0 0; }
 .eyebrow { color: #84d9b6; text-transform: uppercase; letter-spacing: 0.12em; font-weight: 700; font-size: 0.78rem; margin: 0 0 0.45rem; }
 .header-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
+.token-settings { position: relative; }
+.token-settings-popover {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  z-index: 20;
+  width: min(340px, calc(100vw - 32px));
+  display: grid;
+  gap: 10px;
+  border: 1px solid #3b4656;
+  border-radius: 8px;
+  background: #151b23;
+  padding: 12px;
+  box-shadow: 0 18px 48px rgb(0 0 0 / 0.35);
+}
+.token-settings-popover .button-row { margin-top: 0; }
 .network-pill {
   border: 1px solid #3b4656;
   border-radius: 999px;

--- a/gold-bridge-monorepo/scripts/20-cockpit-api.mjs
+++ b/gold-bridge-monorepo/scripts/20-cockpit-api.mjs
@@ -1518,6 +1518,7 @@ const server = http.createServer(async (req, res) => {
     if (req.method === 'GET' && url.pathname === '/api/guide') return send(res, 200, await buildDeploymentGuide(), cors);
     if (req.method === 'GET' && url.pathname === '/api/readiness') return send(res, 200, await buildReadinessReport(), cors);
     if (req.method === 'POST' && url.pathname === '/api/readiness/export') {
+      requireCockpitToken(req);
       const body = await parseBody(req);
       return send(res, 200, await buildReadinessReport({ write: true, manualNotes: body.manualNotes || {} }), cors);
     }


### PR DESCRIPTION
## Summary

v1.1.4 final pre-demo hotfix. Final super-swarm on cumulative v1.1.0→v1.1.3 main caught a v1.1.1 regression + 2 SHOULDs.

Hackathon deadline: **May 3 noon ET** (~28h from this PR).

## DEMO-BLOCKING (codex 5-5, verified by orch)

**v1.1.1 broke the cockpit UI in production.** v1.1.1 added server-side `requireCockpitToken` to mutating endpoints, but the cockpit React client (`gold-bridge-monorepo/apps/web/src/lib/cockpitApi.ts:14`) never sent any auth header. Every Preview/Run/Reconcile from the cockpit UI returned 401.

### Fix

- **`api()` helper** now reads `cockpit:apiToken` from `localStorage` (with `VITE_COCKPIT_API_TOKEN` env fallback) and attaches `x-cockpit-token` header on all requests
- **401 responses** surface a clear "set token in operator settings" message
- **Cockpit settings popover** added to header — password input + Save/Clear + visual status indicator
- **`.env.template`** updated with `VITE_COCKPIT_API_TOKEN` dev-mode guidance

## SHOULD-FIXES (3-way convergent + codex 5-4 specific)

### `/api/readiness/export` missing `requireCockpitToken`

Convergent across codex 5-4 + 5-5 + Claude. Was the only POST endpoint missing the guard. Added the call.

### Bandit pulse/countdown should use `liveTick`

Caught by codex 5-4. Bandit countdown + pulse currently driven by `snapshot?.tick` directly, but `liveTick` (max of `snapshot?.tick` and `agentLogs.length`) is the unified fallback when the backend isn't writing snapshot ticks. Without this fix, bandit UI would freeze on stage while the visible tick advances — exactly the kind of inconsistency that reads as a bug. Fixed all bandit-related tick reads to use `liveTick`.

## Verification

- [x] `node --check scripts/20-cockpit-api.mjs` green
- [x] `pnpm typecheck` (gold-bridge-monorepo + @clan-world/web) green
- [x] `pnpm --filter @clan-world/web build` green
- [x] `pnpm --filter @gold-bridge/web build` green

Sandbox blocked live HTTP smoke (EPERM on `127.0.0.1:8787`). Changes are minimal-shape (auth header attachment, single guard add, variable rename).

## Test plan post-merge

- [ ] Operator runs `pnpm cockpit:api` with `COCKPIT_API_TOKEN=test123`. Cockpit UI prompts for token via settings popover. After saving, Preview/Run work as expected.
- [ ] Without token set, cockpit UI shows clear error message instead of generic 401.
- [ ] Bandit countdown advances in lockstep with visible tick on stage (not frozen).
- [ ] `/api/readiness/export` returns 401 without token; works with valid token.

## Source

- Final super-swarm: `/tmp/main-v113-final-codex-5-4.log`, `/tmp/main-v113-final-codex-5-5.log`, Claude reviewer output
- Tag chain: v1.0.0 → v1.1.0 → v1.1.1 → v1.1.2 → v1.1.3 → **v1.1.4** (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)