### PR TITLE
[codex] initialize diamond raw views

### DIFF
--- a/packages/contracts/src/diamond/ClanWorldDiamondInit.sol
+++ b/packages/contracts/src/diamond/ClanWorldDiamondInit.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanWorldConstants} from "../IClanWorld.sol";
+import {LibStorage} from "./lib/LibStorage.sol";
+
+contract ClanWorldDiamondInit {
+    error ClanWorldDiamondAlreadyInitialized();
+
+    function init() external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        if (s.initialized) {
+            revert ClanWorldDiamondAlreadyInitialized();
+        }
+
+        s.initialized = true;
+        s.reentrancyStatus = LibStorage.NOT_ENTERED;
+        s.world.currentTick = 0;
+        s.world.nextHeartbeatAtTs = uint64(block.timestamp);
+        s.world.seasonStartTick = 0;
+        s.world.seasonEndTick = ClanWorldConstants.SEASON_DURATION_TICKS;
+        s.world.currentSeasonNumber = 1;
+        s.world.nextHeartbeatAtTick = 1;
+    }
+}

--- a/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
+++ b/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
@@ -16,6 +16,5 @@ contract DirectTransfersFacet {}
 contract BanditStateFacet {}
 contract BanditTargetingFacet {}
 contract BanditCombatFacet {}
-contract RawViewsFacet {}
 contract MarketViewsFacet {}
 contract BanditViewsFacet {}

--- a/packages/contracts/src/diamond/facets/RawViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/RawViewsFacet.sol
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {
+    ActionType,
+    BanditState,
+    BanditTroop,
+    Clan,
+    ClanWorldConstants,
+    Clansman,
+    Mission,
+    ScheduledMarketAction,
+    TreasuryState,
+    WheatPlot,
+    WorldState
+} from "../../IClanWorld.sol";
+import {LibSeason} from "../lib/LibSeason.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+import {LibTravel} from "../../lib/LibTravel.sol";
+
+contract RawViewsFacet {
+    uint64 private constant DEPOSIT_DURATION_TICKS = 1;
+    uint64 private constant BUILDING_DURATION_TICKS = 1;
+    uint8 private constant MONUMENT_MAX_LEVEL = 10;
+
+    function getWorldState() external view returns (WorldState memory ws) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        ws.currentTick = s.world.currentTick;
+        ws.seasonStartTick = s.world.seasonStartTick;
+        ws.seasonEndTick = s.world.seasonEndTick;
+        ws.seasonFinalized = s.world.seasonFinalized;
+        ws.currentSeasonNumber = s.world.currentSeasonNumber;
+        ws.nextHeartbeatAtTick = s.world.nextHeartbeatAtTick;
+        ws.nextHeartbeatAtTs = s.world.nextHeartbeatAtTs;
+        ws.nextBanditSpawnEligibleTick = s.world.nextBanditSpawnEligibleTick;
+        ws.currentBanditSpawnChanceBps = s.world.currentBanditSpawnChanceBps;
+        ws.currentTickSeed = s.world.currentTickSeed;
+        ws.activeBanditId = s.world.activeBanditId;
+        ws.nextCommitSequence = s.world.nextCommitSequence;
+        (ws.winterActive, ws.winterStartsAtTick, ws.winterEndsAtTick) =
+            LibSeason.winterWindowForTick(s.world.currentTick);
+    }
+
+    function getTreasuryState() external view returns (TreasuryState memory) {
+        return LibStorage.appStorage().treasury;
+    }
+
+    function getClan(uint32 clanId) external view returns (Clan memory) {
+        return LibStorage.appStorage().clans[clanId];
+    }
+
+    function getClansman(uint32 clansmanId) external view returns (Clansman memory) {
+        return LibStorage.appStorage().clansmen[clansmanId];
+    }
+
+    function getActiveMission(uint32 clansmanId) external view returns (Mission memory) {
+        return LibStorage.appStorage().missions[clansmanId];
+    }
+
+    function getMissionTiming(uint32 clanId, uint32 clansmanId)
+        external
+        view
+        returns (uint64 submitted, uint64 executes, uint64 settles)
+    {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        Mission memory m = s.missions[clansmanId];
+        if (!m.active || s.clansmen[clansmanId].clanId != clanId) {
+            return (0, 0, 0);
+        }
+        return (m.submittedAtTick, m.executesAtTick, m.settlesAtTick);
+    }
+
+    function isWinter() external view returns (bool) {
+        return LibSeason.isWinterActiveAt(LibStorage.appStorage().world.currentTick);
+    }
+
+    function getWallUpgradeCost(uint8 currentLevel) external pure returns (uint256 wood, uint256 iron) {
+        if (currentLevel == 0) return (20e18, 0);
+        if (currentLevel == 1) return (35e18, 0);
+        if (currentLevel == 2) return (30e18, 5e18);
+        if (currentLevel == 3) return (40e18, 10e18);
+        if (currentLevel == 4) return (50e18, 15e18);
+        return (0, 0);
+    }
+
+    function getBaseUpgradeCost(uint8 currentLevel) external pure returns (uint256 wood, uint256 iron, uint256 wheat) {
+        if (currentLevel == 1) return (40e18, 0, 20e18);
+        if (currentLevel == 2) return (60e18, 5e18, 30e18);
+        if (currentLevel == 3) return (80e18, 10e18, 40e18);
+        if (currentLevel == 4) return (100e18, 15e18, 50e18);
+        return (0, 0, 0);
+    }
+
+    function getMonumentUpgradeCost(uint8 currentLevel)
+        external
+        pure
+        returns (uint256 wood, uint256 iron, uint256 wheat, uint256 blueprint)
+    {
+        if (currentLevel == 0) return (30e18, 0, 20e18, 0);
+        if (currentLevel == 1) return (50e18, 0, 30e18, 0);
+        if (currentLevel == 2) return (70e18, 5e18, 40e18, 0);
+        if (currentLevel == 3) return (90e18, 10e18, 50e18, 0);
+        if (currentLevel == 4) return (120e18, 15e18, 60e18, 0);
+        if (currentLevel == 5) return (150e18, 20e18, 80e18, 0);
+        if (currentLevel >= 6 && currentLevel < MONUMENT_MAX_LEVEL) return (200e18, 25e18, 100e18, 1e18);
+        return (0, 0, 0, 0);
+    }
+
+    function getActionDuration(ActionType action) external pure returns (uint64) {
+        if (
+            action == ActionType.ChopWood || action == ActionType.MineIron || action == ActionType.FishDocks
+                || action == ActionType.FishDeepSea || action == ActionType.HarvestWheat
+        ) {
+            return 4;
+        }
+
+        if (action == ActionType.DepositResources || action == ActionType.WithdrawResources) {
+            return DEPOSIT_DURATION_TICKS;
+        }
+
+        if (
+            action == ActionType.UpgradeWall || action == ActionType.UpgradeBase || action == ActionType.UpgradeMonument
+        ) {
+            return BUILDING_DURATION_TICKS;
+        }
+
+        if (action == ActionType.MarketBuy || action == ActionType.MarketSell) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    function getTravelTicks(uint8 fromRegion, uint8 toRegion) external pure returns (uint64) {
+        return uint64(LibTravel.travelTicksBetween(fromRegion, toRegion));
+    }
+
+    function getBandit(uint32 banditId) public view returns (BanditTroop memory) {
+        BanditTroop memory bandit = LibStorage.appStorage().bandits[banditId];
+        if (bandit.id == ClanWorldConstants.BANDIT_ID_NULL || bandit.state == BanditState.None) {
+            return BanditTroop({
+                id: 0,
+                region: 0,
+                state: BanditState.None,
+                targetClanId: 0,
+                tickEnteredState: 0,
+                strength: 0,
+                tier: 0,
+                attackAttemptsMade: 0,
+                carryWood: 0,
+                carryIron: 0,
+                carryWheat: 0,
+                carryFish: 0,
+                carryGold: 0
+            });
+        }
+        return bandit;
+    }
+
+    function getBanditTroop(uint32 banditId) external view returns (BanditTroop memory) {
+        return getBandit(banditId);
+    }
+
+    function getBanditsInRegion(uint8 region) external view returns (uint32[] memory) {
+        return LibStorage.appStorage().banditsByRegion[region];
+    }
+
+    function getWheatPlots(uint32 clanId) external view returns (WheatPlot memory west, WheatPlot memory east) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        west = s.wheatPlots[clanId][0];
+        east = s.wheatPlots[clanId][1];
+    }
+
+    function getScheduledMarketActionsForTick(uint64 tick) external view returns (ScheduledMarketAction[] memory) {
+        return LibStorage.appStorage().scheduledMarketActions[tick];
+    }
+
+    function getDefendingClans(uint8 region) external view returns (uint32[] memory clanIds) {
+        return LibStorage.appStorage().defendingClansByRegion[region];
+    }
+
+    function getClanIds() external view returns (uint32[] memory clanIds) {
+        return LibStorage.appStorage().allClanIds;
+    }
+
+    function getClanClansmanIds(uint32 clanId) external view returns (uint32[] memory clansmanIds) {
+        return LibStorage.appStorage().clanClansmanIds[clanId];
+    }
+
+    function getClansmanDefendingRegion(uint32 clansmanId) external view returns (uint8 region) {
+        return LibStorage.appStorage().clansmanDefendingRegion[clansmanId];
+    }
+
+    function getMonumentLevelReachedAt(uint32 clanId, uint8 level) external view returns (uint64 reachedAtTick) {
+        return LibStorage.appStorage().monumentLevelReachedAt[clanId][level];
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibDiamond.sol
+++ b/packages/contracts/src/diamond/lib/LibDiamond.sol
@@ -146,12 +146,9 @@ library LibDiamond {
         ds.facetAddresses.push(facetAddress);
     }
 
-    function addFunction(
-        DiamondStorage storage ds,
-        bytes4 selector,
-        uint96 selectorPosition,
-        address facetAddress
-    ) private {
+    function addFunction(DiamondStorage storage ds, bytes4 selector, uint96 selectorPosition, address facetAddress)
+        private
+    {
         ds.selectorToFacetAndPosition[selector].selectorPosition = selectorPosition;
         ds.facetFunctionSelectors[facetAddress].functionSelectors.push(selector);
         ds.selectorToFacetAndPosition[selector].facetAddress = facetAddress;
@@ -191,7 +188,10 @@ library LibDiamond {
 
         (bool success,) = init.delegatecall(data);
         if (!success) {
-            revert DiamondInitFailed(init, data);
+            assembly {
+                returndatacopy(0, 0, returndatasize())
+                revert(0, returndatasize())
+            }
         }
     }
 }

--- a/packages/contracts/src/diamond/lib/LibSeason.sol
+++ b/packages/contracts/src/diamond/lib/LibSeason.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanWorldConstants} from "../../IClanWorld.sol";
+
+library LibSeason {
+    function isWinterActiveAt(uint64 tick) internal pure returns (bool) {
+        if (tick < ClanWorldConstants.WINTER_START_TICK) {
+            return false;
+        }
+        uint64 elapsed = tick - ClanWorldConstants.WINTER_START_TICK;
+        return elapsed % ClanWorldConstants.WINTER_PERIOD_TICKS < ClanWorldConstants.WINTER_DURATION_TICKS;
+    }
+
+    function winterWindowForTick(uint64 tick)
+        internal
+        pure
+        returns (bool active, uint64 startsAtTick, uint64 endsAtTick)
+    {
+        if (tick < ClanWorldConstants.WINTER_START_TICK) {
+            startsAtTick = ClanWorldConstants.WINTER_START_TICK;
+            endsAtTick = ClanWorldConstants.WINTER_START_TICK + ClanWorldConstants.WINTER_DURATION_TICKS;
+            return (false, startsAtTick, endsAtTick);
+        }
+
+        uint64 elapsed = tick - ClanWorldConstants.WINTER_START_TICK;
+        uint64 cycleIndex = elapsed / ClanWorldConstants.WINTER_PERIOD_TICKS;
+        uint64 cycleStart = ClanWorldConstants.WINTER_START_TICK + cycleIndex * ClanWorldConstants.WINTER_PERIOD_TICKS;
+        active = elapsed % ClanWorldConstants.WINTER_PERIOD_TICKS < ClanWorldConstants.WINTER_DURATION_TICKS;
+        startsAtTick = active ? cycleStart : cycleStart + ClanWorldConstants.WINTER_PERIOD_TICKS;
+        endsAtTick = startsAtTick + ClanWorldConstants.WINTER_DURATION_TICKS;
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -3,10 +3,14 @@ pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
 import {Diamond} from "../../src/diamond/Diamond.sol";
+import {ClanWorld} from "../../src/ClanWorld.sol";
+import {ClanWorldDiamondInit} from "../../src/diamond/ClanWorldDiamondInit.sol";
+import {IClanWorld, ActionType, WorldState} from "../../src/IClanWorld.sol";
 import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
 import {IDiamondLoupe} from "../../src/diamond/IDiamondLoupe.sol";
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {RawViewsFacet} from "../../src/diamond/facets/RawViewsFacet.sol";
 
 contract PingFacet {
     function ping() external pure returns (uint256) {
@@ -34,9 +38,7 @@ contract DiamondSkeletonTest is Test {
 
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(pingFacet),
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: selectors
+            facetAddress: address(pingFacet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
         });
 
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
@@ -54,9 +56,7 @@ contract DiamondSkeletonTest is Test {
 
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(loupeFacet),
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: selectors
+            facetAddress: address(loupeFacet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
         });
 
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
@@ -72,13 +72,102 @@ contract DiamondSkeletonTest is Test {
 
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(pingFacet),
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: selectors
+            facetAddress: address(pingFacet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
         });
 
         vm.prank(address(0xBEEF));
         vm.expectRevert();
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function testCanInitializeDiamondAndReadRawWorldState() public {
+        ClanWorld core = new ClanWorld();
+        RawViewsFacet rawViewsFacet = new RawViewsFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                _rawViewsCut(address(rawViewsFacet)), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ())
+            );
+
+        IClanWorld diamondWorld = IClanWorld(address(diamond));
+        WorldState memory expected = core.getWorldState();
+        WorldState memory actual = diamondWorld.getWorldState();
+        _assertWorldStateEq(actual, expected);
+
+        assertEq(diamondWorld.isWinter(), core.isWinter());
+        assertEq(diamondWorld.getActionDuration(ActionType.ChopWood), core.getActionDuration(ActionType.ChopWood));
+        assertEq(diamondWorld.getTravelTicks(1, 8), core.getTravelTicks(1, 8));
+
+        (uint256 wallWood, uint256 wallIron) = diamondWorld.getWallUpgradeCost(2);
+        (uint256 coreWallWood, uint256 coreWallIron) = core.getWallUpgradeCost(2);
+        assertEq(wallWood, coreWallWood);
+        assertEq(wallIron, coreWallIron);
+
+        assertEq(diamondWorld.getClanIds().length, 0);
+        assertEq(uint8(diamondWorld.getBandit(1).state), 0);
+    }
+
+    function testDiamondInitCannotRunTwice() public {
+        RawViewsFacet rawViewsFacet = new RawViewsFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                _rawViewsCut(address(rawViewsFacet)), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ())
+            );
+
+        IDiamondCut.FacetCut[] memory emptyCut = new IDiamondCut.FacetCut[](0);
+        vm.expectRevert(ClanWorldDiamondInit.ClanWorldDiamondAlreadyInitialized.selector);
+        IDiamondCut(address(diamond)).diamondCut(emptyCut, address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+    }
+
+    function _rawViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        bytes4[] memory selectors = new bytes4[](22);
+        selectors[0] = IClanWorld.getWorldState.selector;
+        selectors[1] = IClanWorld.getTreasuryState.selector;
+        selectors[2] = IClanWorld.getClan.selector;
+        selectors[3] = IClanWorld.getClansman.selector;
+        selectors[4] = IClanWorld.getActiveMission.selector;
+        selectors[5] = IClanWorld.getMissionTiming.selector;
+        selectors[6] = IClanWorld.isWinter.selector;
+        selectors[7] = IClanWorld.getWallUpgradeCost.selector;
+        selectors[8] = IClanWorld.getBaseUpgradeCost.selector;
+        selectors[9] = IClanWorld.getMonumentUpgradeCost.selector;
+        selectors[10] = IClanWorld.getActionDuration.selector;
+        selectors[11] = IClanWorld.getTravelTicks.selector;
+        selectors[12] = IClanWorld.getBandit.selector;
+        selectors[13] = IClanWorld.getBanditTroop.selector;
+        selectors[14] = IClanWorld.getBanditsInRegion.selector;
+        selectors[15] = IClanWorld.getWheatPlots.selector;
+        selectors[16] = IClanWorld.getScheduledMarketActionsForTick.selector;
+        selectors[17] = IClanWorld.getDefendingClans.selector;
+        selectors[18] = IClanWorld.getClanIds.selector;
+        selectors[19] = IClanWorld.getClanClansmanIds.selector;
+        selectors[20] = IClanWorld.getClansmanDefendingRegion.selector;
+        selectors[21] = IClanWorld.getMonumentLevelReachedAt.selector;
+
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+    }
+
+    function _assertWorldStateEq(WorldState memory actual, WorldState memory expected) internal pure {
+        assertEq(actual.currentTick, expected.currentTick, "currentTick");
+        assertEq(actual.seasonStartTick, expected.seasonStartTick, "seasonStartTick");
+        assertEq(actual.seasonEndTick, expected.seasonEndTick, "seasonEndTick");
+        assertEq(actual.seasonFinalized, expected.seasonFinalized, "seasonFinalized");
+        assertEq(actual.currentSeasonNumber, expected.currentSeasonNumber, "currentSeasonNumber");
+        assertEq(actual.nextHeartbeatAtTick, expected.nextHeartbeatAtTick, "nextHeartbeatAtTick");
+        assertEq(actual.nextHeartbeatAtTs, expected.nextHeartbeatAtTs, "nextHeartbeatAtTs");
+        assertEq(actual.nextBanditSpawnEligibleTick, expected.nextBanditSpawnEligibleTick, "banditEligible");
+        assertEq(actual.currentBanditSpawnChanceBps, expected.currentBanditSpawnChanceBps, "banditChance");
+        assertEq(actual.currentTickSeed, expected.currentTickSeed, "currentTickSeed");
+        assertEq(actual.activeBanditId, expected.activeBanditId, "activeBanditId");
+        assertEq(actual.winterActive, expected.winterActive, "winterActive");
+        assertEq(actual.winterStartsAtTick, expected.winterStartsAtTick, "winterStartsAtTick");
+        assertEq(actual.winterEndsAtTick, expected.winterEndsAtTick, "winterEndsAtTick");
+        assertEq(actual.nextCommitSequence, expected.nextCommitSequence, "nextCommitSequence");
     }
 }


### PR DESCRIPTION
## Summary

Stacked on #424.

- adds `ClanWorldDiamondInit` to initialize diamond app storage with the same default world state as `ClanWorld`
- adds `RawViewsFacet` for initial raw/read-only selectors backed by `LibStorage.AppStorage`
- adds `LibSeason` for winter window derivation shared by diamond reads
- bubbles initializer revert data from `LibDiamond` so migration/init failures keep their real selector
- validates diamond init + raw world-state parity against `ClanWorld`

## Validation

- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
