### PR TITLE
[codex] complete diamond raw views

### DIFF
--- a/packages/contracts/src/diamond/facets/RawViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/RawViewsFacet.sol
@@ -9,6 +9,7 @@ import {
     ClanWorldConstants,
     Clansman,
     Mission,
+    ResourceType,
     ScheduledMarketAction,
     TreasuryState,
     WheatPlot,
@@ -17,6 +18,7 @@ import {
 import {LibSeason} from "../lib/LibSeason.sol";
 import {LibStorage} from "../lib/LibStorage.sol";
 import {LibTravel} from "../../lib/LibTravel.sol";
+import {StubPool} from "../../StubPool.sol";
 
 contract RawViewsFacet {
     uint64 private constant DEPOSIT_DURATION_TICKS = 1;
@@ -43,6 +45,23 @@ contract RawViewsFacet {
 
     function getTreasuryState() external view returns (TreasuryState memory) {
         return LibStorage.appStorage().treasury;
+    }
+
+    function getResourceToken(uint8 resourceType) external view returns (address) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        if (resourceType == uint8(ResourceType.Wood)) return s.treasury.woodToken;
+        if (resourceType == uint8(ResourceType.Iron)) return s.treasury.ironToken;
+        if (resourceType == uint8(ResourceType.Wheat)) return s.treasury.wheatToken;
+        if (resourceType == uint8(ResourceType.Fish)) return s.treasury.fishToken;
+        revert("ClanWorld: invalid resource");
+    }
+
+    function getPool(uint8 resourceType) external view returns (address) {
+        return _poolForResourceType(resourceType);
+    }
+
+    function getPrice(uint8 resourceType, uint256 amountIn) external view returns (uint256 amountOut) {
+        amountOut = StubPool(_poolForResourceType(resourceType)).getAmountOutForExactIn(amountIn);
     }
 
     function getClan(uint32 clanId) external view returns (Clan memory) {
@@ -175,6 +194,35 @@ contract RawViewsFacet {
         return LibStorage.appStorage().scheduledMarketActions[tick];
     }
 
+    function getActiveDefenders(uint32 targetClanId) external view returns (uint32[] memory clansmanIds) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        uint32[] storage defendingClans = s.defendingClansByRegion[s.clans[targetClanId].baseRegion];
+        uint256 count = 0;
+
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            uint32[] storage clanClansmen = s.clanClansmanIds[defendingClans[i]];
+            for (uint256 j = 0; j < clanClansmen.length; j++) {
+                Mission storage mission = s.missions[clanClansmen[j]];
+                if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId) {
+                    count++;
+                }
+            }
+        }
+
+        clansmanIds = new uint32[](count);
+        uint256 out = 0;
+        for (uint256 i = 0; i < defendingClans.length; i++) {
+            uint32[] storage clanClansmen = s.clanClansmanIds[defendingClans[i]];
+            for (uint256 j = 0; j < clanClansmen.length; j++) {
+                uint32 clansmanId = clanClansmen[j];
+                Mission storage mission = s.missions[clansmanId];
+                if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId) {
+                    clansmanIds[out++] = clansmanId;
+                }
+            }
+        }
+    }
+
     function getDefendingClans(uint8 region) external view returns (uint32[] memory clanIds) {
         return LibStorage.appStorage().defendingClansByRegion[region];
     }
@@ -193,5 +241,14 @@ contract RawViewsFacet {
 
     function getMonumentLevelReachedAt(uint32 clanId, uint8 level) external view returns (uint64 reachedAtTick) {
         return LibStorage.appStorage().monumentLevelReachedAt[clanId][level];
+    }
+
+    function _poolForResourceType(uint8 resourceType) private view returns (address) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        if (resourceType == uint8(ResourceType.Wood)) return s.treasury.woodGoldPool;
+        if (resourceType == uint8(ResourceType.Iron)) return s.treasury.ironGoldPool;
+        if (resourceType == uint8(ResourceType.Wheat)) return s.treasury.wheatGoldPool;
+        if (resourceType == uint8(ResourceType.Fish)) return s.treasury.fishGoldPool;
+        revert("ClanWorld: invalid resource");
     }
 }

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -99,6 +99,8 @@ contract DiamondSkeletonTest is Test {
         assertEq(diamondWorld.isWinter(), core.isWinter());
         assertEq(diamondWorld.getActionDuration(ActionType.ChopWood), core.getActionDuration(ActionType.ChopWood));
         assertEq(diamondWorld.getTravelTicks(1, 8), core.getTravelTicks(1, 8));
+        assertEq(diamondWorld.getResourceToken(0), core.getResourceToken(0));
+        assertEq(diamondWorld.getPool(0), core.getPool(0));
 
         (uint256 wallWood, uint256 wallIron) = diamondWorld.getWallUpgradeCost(2);
         (uint256 coreWallWood, uint256 coreWallIron) = core.getWallUpgradeCost(2);
@@ -145,6 +147,7 @@ contract DiamondSkeletonTest is Test {
         assertEq(diamondIftTokenId, coreIftTokenId);
         _assertClanEq(IClanWorld(address(diamond)).getClan(diamondClanId), core.getClan(coreClanId));
         assertEq(IClanWorld(address(diamond)).getClanIds().length, core.getClanIds().length);
+        assertEq(IClanWorld(address(diamond)).getActiveDefenders(diamondClanId).length, 0);
 
         uint32[] memory diamondClansmen = IClanWorld(address(diamond)).getClanClansmanIds(diamondClanId);
         uint32[] memory coreClansmen = core.getClanClansmanIds(coreClanId);
@@ -164,29 +167,33 @@ contract DiamondSkeletonTest is Test {
     }
 
     function _rawViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
-        bytes4[] memory selectors = new bytes4[](22);
+        bytes4[] memory selectors = new bytes4[](26);
         selectors[0] = IClanWorld.getWorldState.selector;
         selectors[1] = IClanWorld.getTreasuryState.selector;
-        selectors[2] = IClanWorld.getClan.selector;
-        selectors[3] = IClanWorld.getClansman.selector;
-        selectors[4] = IClanWorld.getActiveMission.selector;
-        selectors[5] = IClanWorld.getMissionTiming.selector;
-        selectors[6] = IClanWorld.isWinter.selector;
-        selectors[7] = IClanWorld.getWallUpgradeCost.selector;
-        selectors[8] = IClanWorld.getBaseUpgradeCost.selector;
-        selectors[9] = IClanWorld.getMonumentUpgradeCost.selector;
-        selectors[10] = IClanWorld.getActionDuration.selector;
-        selectors[11] = IClanWorld.getTravelTicks.selector;
-        selectors[12] = IClanWorld.getBandit.selector;
-        selectors[13] = IClanWorld.getBanditTroop.selector;
-        selectors[14] = IClanWorld.getBanditsInRegion.selector;
-        selectors[15] = IClanWorld.getWheatPlots.selector;
-        selectors[16] = IClanWorld.getScheduledMarketActionsForTick.selector;
-        selectors[17] = IClanWorld.getDefendingClans.selector;
-        selectors[18] = IClanWorld.getClanIds.selector;
-        selectors[19] = IClanWorld.getClanClansmanIds.selector;
-        selectors[20] = IClanWorld.getClansmanDefendingRegion.selector;
-        selectors[21] = IClanWorld.getMonumentLevelReachedAt.selector;
+        selectors[2] = IClanWorld.getResourceToken.selector;
+        selectors[3] = IClanWorld.getPool.selector;
+        selectors[4] = IClanWorld.getPrice.selector;
+        selectors[5] = IClanWorld.getClan.selector;
+        selectors[6] = IClanWorld.getClansman.selector;
+        selectors[7] = IClanWorld.getActiveMission.selector;
+        selectors[8] = IClanWorld.getMissionTiming.selector;
+        selectors[9] = IClanWorld.isWinter.selector;
+        selectors[10] = IClanWorld.getWallUpgradeCost.selector;
+        selectors[11] = IClanWorld.getBaseUpgradeCost.selector;
+        selectors[12] = IClanWorld.getMonumentUpgradeCost.selector;
+        selectors[13] = IClanWorld.getActionDuration.selector;
+        selectors[14] = IClanWorld.getTravelTicks.selector;
+        selectors[15] = IClanWorld.getBandit.selector;
+        selectors[16] = IClanWorld.getBanditTroop.selector;
+        selectors[17] = IClanWorld.getBanditsInRegion.selector;
+        selectors[18] = IClanWorld.getWheatPlots.selector;
+        selectors[19] = IClanWorld.getScheduledMarketActionsForTick.selector;
+        selectors[20] = IClanWorld.getActiveDefenders.selector;
+        selectors[21] = IClanWorld.getDefendingClans.selector;
+        selectors[22] = IClanWorld.getClanIds.selector;
+        selectors[23] = IClanWorld.getClanClansmanIds.selector;
+        selectors[24] = IClanWorld.getClansmanDefendingRegion.selector;
+        selectors[25] = IClanWorld.getMonumentLevelReachedAt.selector;
 
         cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({


### PR DESCRIPTION
## Summary

Stacked on #427.

- completes `RawViewsFacet` with resource token, pool, price, and active defender read selectors
- registers the remaining raw selectors in the diamond parity helper
- extends tests to confirm default resource/pool reads and empty active defender reads match core

## Validation

- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
