### PR TITLE
[codex] share diamond rule helpers

### DIFF
--- a/packages/contracts/src/diamond/facets/ClanLifecycleFacet.sol
+++ b/packages/contracts/src/diamond/facets/ClanLifecycleFacet.sol
@@ -12,18 +12,17 @@ import {
     WheatPlotState
 } from "../../IClanWorld.sol";
 import {LibSeason} from "../lib/LibSeason.sol";
+import {LibGameRules} from "../lib/LibGameRules.sol";
 import {LibStorage} from "../lib/LibStorage.sol";
 
 contract ClanLifecycleFacet is IClanWorldEvents {
-    uint8 private constant MAX_CLANS = 12;
-
     function mintClan(address to) external returns (uint32 clanId, uint256 iftTokenId) {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
 
-        _requireNoPendingSeasonFinalization(s);
+        LibGameRules.requireNoPendingSeasonFinalization(s);
         require(to != address(0), "ClanWorld: zero address");
-        require(s.allClanIds.length < MAX_CLANS, "ClanWorld: max clans");
+        require(s.allClanIds.length < LibGameRules.MAX_CLANS, "ClanWorld: max clans");
 
         clanId = s.nextClanId++;
         iftTokenId = uint256(clanId);
@@ -87,12 +86,5 @@ contract ClanLifecycleFacet is IClanWorldEvents {
             ClanWorldConstants.REGION_EAST_DOCKS
         ];
         return spawnRegions[(clanId - 1) % 6];
-    }
-
-    function _requireNoPendingSeasonFinalization(LibStorage.AppStorage storage s) private view {
-        require(
-            !(s.world.currentTick + 1 >= s.world.seasonEndTick && !s.world.seasonFinalized),
-            "ClanWorld: finalize season first"
-        );
     }
 }

--- a/packages/contracts/src/diamond/facets/RawViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/RawViewsFacet.sol
@@ -16,15 +16,12 @@ import {
     WorldState
 } from "../../IClanWorld.sol";
 import {LibSeason} from "../lib/LibSeason.sol";
+import {LibGameRules} from "../lib/LibGameRules.sol";
 import {LibStorage} from "../lib/LibStorage.sol";
 import {LibTravel} from "../../lib/LibTravel.sol";
 import {StubPool} from "../../StubPool.sol";
 
 contract RawViewsFacet {
-    uint64 private constant DEPOSIT_DURATION_TICKS = 1;
-    uint64 private constant BUILDING_DURATION_TICKS = 1;
-    uint8 private constant MONUMENT_MAX_LEVEL = 10;
-
     function getWorldState() external view returns (WorldState memory ws) {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         ws.currentTick = s.world.currentTick;
@@ -94,20 +91,11 @@ contract RawViewsFacet {
     }
 
     function getWallUpgradeCost(uint8 currentLevel) external pure returns (uint256 wood, uint256 iron) {
-        if (currentLevel == 0) return (20e18, 0);
-        if (currentLevel == 1) return (35e18, 0);
-        if (currentLevel == 2) return (30e18, 5e18);
-        if (currentLevel == 3) return (40e18, 10e18);
-        if (currentLevel == 4) return (50e18, 15e18);
-        return (0, 0);
+        return LibGameRules.wallUpgradeCost(currentLevel);
     }
 
     function getBaseUpgradeCost(uint8 currentLevel) external pure returns (uint256 wood, uint256 iron, uint256 wheat) {
-        if (currentLevel == 1) return (40e18, 0, 20e18);
-        if (currentLevel == 2) return (60e18, 5e18, 30e18);
-        if (currentLevel == 3) return (80e18, 10e18, 40e18);
-        if (currentLevel == 4) return (100e18, 15e18, 50e18);
-        return (0, 0, 0);
+        return LibGameRules.baseUpgradeCost(currentLevel);
     }
 
     function getMonumentUpgradeCost(uint8 currentLevel)
@@ -115,39 +103,11 @@ contract RawViewsFacet {
         pure
         returns (uint256 wood, uint256 iron, uint256 wheat, uint256 blueprint)
     {
-        if (currentLevel == 0) return (30e18, 0, 20e18, 0);
-        if (currentLevel == 1) return (50e18, 0, 30e18, 0);
-        if (currentLevel == 2) return (70e18, 5e18, 40e18, 0);
-        if (currentLevel == 3) return (90e18, 10e18, 50e18, 0);
-        if (currentLevel == 4) return (120e18, 15e18, 60e18, 0);
-        if (currentLevel == 5) return (150e18, 20e18, 80e18, 0);
-        if (currentLevel >= 6 && currentLevel < MONUMENT_MAX_LEVEL) return (200e18, 25e18, 100e18, 1e18);
-        return (0, 0, 0, 0);
+        return LibGameRules.monumentUpgradeCost(currentLevel);
     }
 
     function getActionDuration(ActionType action) external pure returns (uint64) {
-        if (
-            action == ActionType.ChopWood || action == ActionType.MineIron || action == ActionType.FishDocks
-                || action == ActionType.FishDeepSea || action == ActionType.HarvestWheat
-        ) {
-            return 4;
-        }
-
-        if (action == ActionType.DepositResources || action == ActionType.WithdrawResources) {
-            return DEPOSIT_DURATION_TICKS;
-        }
-
-        if (
-            action == ActionType.UpgradeWall || action == ActionType.UpgradeBase || action == ActionType.UpgradeMonument
-        ) {
-            return BUILDING_DURATION_TICKS;
-        }
-
-        if (action == ActionType.MarketBuy || action == ActionType.MarketSell) {
-            return 1;
-        }
-
-        return 0;
+        return LibGameRules.actionDuration(action);
     }
 
     function getTravelTicks(uint8 fromRegion, uint8 toRegion) external pure returns (uint64) {

--- a/packages/contracts/src/diamond/lib/LibGameRules.sol
+++ b/packages/contracts/src/diamond/lib/LibGameRules.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ActionType} from "../../IClanWorld.sol";
+import {LibStorage} from "./LibStorage.sol";
+
+library LibGameRules {
+    uint64 internal constant DEPOSIT_DURATION_TICKS = 1;
+    uint64 internal constant BUILDING_DURATION_TICKS = 1;
+    uint8 internal constant MAX_CLANS = 12;
+    uint8 internal constant MONUMENT_MAX_LEVEL = 10;
+    uint64 internal constant MAX_LAZY_SETTLE_BACKLOG = 200;
+
+    function requireNoPendingSeasonFinalization(LibStorage.AppStorage storage s) internal view {
+        require(
+            !(s.world.currentTick + 1 >= s.world.seasonEndTick && !s.world.seasonFinalized),
+            "ClanWorld: finalize season first"
+        );
+    }
+
+    function wallUpgradeCost(uint8 currentLevel) internal pure returns (uint256 wood, uint256 iron) {
+        if (currentLevel == 0) return (20e18, 0);
+        if (currentLevel == 1) return (35e18, 0);
+        if (currentLevel == 2) return (30e18, 5e18);
+        if (currentLevel == 3) return (40e18, 10e18);
+        if (currentLevel == 4) return (50e18, 15e18);
+        return (0, 0);
+    }
+
+    function baseUpgradeCost(uint8 currentLevel) internal pure returns (uint256 wood, uint256 iron, uint256 wheat) {
+        if (currentLevel == 1) return (40e18, 0, 20e18);
+        if (currentLevel == 2) return (60e18, 5e18, 30e18);
+        if (currentLevel == 3) return (80e18, 10e18, 40e18);
+        if (currentLevel == 4) return (100e18, 15e18, 50e18);
+        return (0, 0, 0);
+    }
+
+    function monumentUpgradeCost(uint8 currentLevel)
+        internal
+        pure
+        returns (uint256 wood, uint256 iron, uint256 wheat, uint256 blueprint)
+    {
+        if (currentLevel == 0) return (30e18, 0, 20e18, 0);
+        if (currentLevel == 1) return (50e18, 0, 30e18, 0);
+        if (currentLevel == 2) return (70e18, 5e18, 40e18, 0);
+        if (currentLevel == 3) return (90e18, 10e18, 50e18, 0);
+        if (currentLevel == 4) return (120e18, 15e18, 60e18, 0);
+        if (currentLevel == 5) return (150e18, 20e18, 80e18, 0);
+        if (currentLevel >= 6 && currentLevel < MONUMENT_MAX_LEVEL) return (200e18, 25e18, 100e18, 1e18);
+        return (0, 0, 0, 0);
+    }
+
+    function actionDuration(ActionType action) internal pure returns (uint64) {
+        if (
+            action == ActionType.ChopWood || action == ActionType.MineIron || action == ActionType.FishDocks
+                || action == ActionType.FishDeepSea || action == ActionType.HarvestWheat
+        ) {
+            return 4;
+        }
+
+        if (action == ActionType.DepositResources || action == ActionType.WithdrawResources) {
+            return DEPOSIT_DURATION_TICKS;
+        }
+
+        if (
+            action == ActionType.UpgradeWall || action == ActionType.UpgradeBase || action == ActionType.UpgradeMonument
+        ) {
+            return BUILDING_DURATION_TICKS;
+        }
+
+        if (action == ActionType.MarketBuy || action == ActionType.MarketSell) {
+            return 1;
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #428.

- adds `LibGameRules` for shared diamond rule helpers: season freeze guard, upgrade costs, action durations, and core caps
- updates `RawViewsFacet` to use the shared rule helpers instead of duplicating constants and cost tables
- updates `ClanLifecycleFacet` to use the shared season-finalization guard and clan cap

## Validation

- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
