### PR TITLE
[codex] add diamond settlement math helpers

### DIFF
--- a/packages/contracts/src/diamond/lib/LibSettlementMath.sol
+++ b/packages/contracts/src/diamond/lib/LibSettlementMath.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {WithdrawResourcesData} from "../../IClanWorld.sol";
+
+library LibSettlementMath {
+    function addTicksClamped(uint64 tick, uint64 delta) internal pure returns (uint64) {
+        if (type(uint64).max - tick < delta) return type(uint64).max;
+        return tick + delta;
+    }
+
+    function hasWithdrawRequest(WithdrawResourcesData memory req) internal pure returns (bool) {
+        return req.wood > 0 || req.iron > 0 || req.wheat > 0 || req.fish > 0;
+    }
+
+    function remainingCapacity(uint256 carried, uint256 cap) internal pure returns (uint256) {
+        if (carried >= cap) return 0;
+        return cap - carried;
+    }
+
+    function spendableAfterReleasing(uint256 vault, uint256 reserved, uint256 released)
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 adjustedReserved = subtractHeld(reserved, released);
+        if (vault <= adjustedReserved) return 0;
+        return vault - adjustedReserved;
+    }
+
+    function subtractHeld(uint256 held, uint256 amount) internal pure returns (uint256) {
+        return held > amount ? held - amount : 0;
+    }
+
+    function min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+}

--- a/packages/contracts/test/diamond/LibSettlementMath.t.sol
+++ b/packages/contracts/test/diamond/LibSettlementMath.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {WithdrawResourcesData} from "../../src/IClanWorld.sol";
+import {LibSettlementMath} from "../../src/diamond/lib/LibSettlementMath.sol";
+
+contract LibSettlementMathTest is Test {
+    function testAddTicksClamped() public pure {
+        assertEq(LibSettlementMath.addTicksClamped(10, 5), 15);
+        assertEq(LibSettlementMath.addTicksClamped(type(uint64).max - 1, 2), type(uint64).max);
+    }
+
+    function testSpendableAfterReleasing() public pure {
+        assertEq(LibSettlementMath.spendableAfterReleasing(100, 40, 10), 70);
+        assertEq(LibSettlementMath.spendableAfterReleasing(100, 40, 50), 100);
+        assertEq(LibSettlementMath.spendableAfterReleasing(30, 40, 0), 0);
+    }
+
+    function testWithdrawRequestAndCapacityHelpers() public pure {
+        WithdrawResourcesData memory empty;
+        assertFalse(LibSettlementMath.hasWithdrawRequest(empty));
+
+        WithdrawResourcesData memory req = WithdrawResourcesData({wood: 1, iron: 0, wheat: 0, fish: 0});
+        assertTrue(LibSettlementMath.hasWithdrawRequest(req));
+        assertEq(LibSettlementMath.remainingCapacity(3, 10), 7);
+        assertEq(LibSettlementMath.remainingCapacity(10, 10), 0);
+        assertEq(LibSettlementMath.remainingCapacity(11, 10), 0);
+    }
+
+    function testSubtractHeldAndMin() public pure {
+        assertEq(LibSettlementMath.subtractHeld(10, 3), 7);
+        assertEq(LibSettlementMath.subtractHeld(10, 11), 0);
+        assertEq(LibSettlementMath.min(2, 5), 2);
+        assertEq(LibSettlementMath.min(9, 4), 4);
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #429.

- adds `LibSettlementMath` for reusable settlement/order arithmetic helpers
- covers clamped tick addition, reservation-aware spendability, held subtraction, min, withdraw request detection, and carry capacity math
- keeps the helper layer separate from transactional settlement so later facets can reuse tested primitives

## Validation

- `forge test --match-path test/diamond/LibSettlementMath.t.sol`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
