### PR TITLE
[codex] add diamond mission helpers

### DIFF
--- a/packages/contracts/src/diamond/lib/LibMission.sol
+++ b/packages/contracts/src/diamond/lib/LibMission.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Clansman, ClansmanState, Mission} from "../../IClanWorld.sol";
+
+library LibMission {
+    function effectiveRegion(Clansman memory cs, Mission memory mission, uint64 tick) internal pure returns (uint8) {
+        if (cs.state == ClansmanState.TRAVELING && mission.active) {
+            return tick >= mission.arrivalTick ? mission.targetRegion : mission.startRegion;
+        }
+        return cs.currentRegion;
+    }
+}

--- a/packages/contracts/test/diamond/LibMission.t.sol
+++ b/packages/contracts/test/diamond/LibMission.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {Clansman, ClansmanState, Mission} from "../../src/IClanWorld.sol";
+import {LibMission} from "../../src/diamond/lib/LibMission.sol";
+
+contract LibMissionTest is Test {
+    function testEffectiveRegionForTravelingMission() public pure {
+        Clansman memory cs;
+        cs.state = ClansmanState.TRAVELING;
+        cs.currentRegion = 1;
+
+        Mission memory mission;
+        mission.active = true;
+        mission.startRegion = 1;
+        mission.targetRegion = 4;
+        mission.arrivalTick = 10;
+
+        assertEq(LibMission.effectiveRegion(cs, mission, 9), 1);
+        assertEq(LibMission.effectiveRegion(cs, mission, 10), 4);
+        assertEq(LibMission.effectiveRegion(cs, mission, 11), 4);
+    }
+
+    function testEffectiveRegionFallsBackToCurrentRegion() public pure {
+        Clansman memory cs;
+        cs.state = ClansmanState.WAITING;
+        cs.currentRegion = 6;
+
+        Mission memory mission;
+        mission.active = true;
+        mission.startRegion = 1;
+        mission.targetRegion = 4;
+        mission.arrivalTick = 10;
+
+        assertEq(LibMission.effectiveRegion(cs, mission, 9), 6);
+
+        cs.state = ClansmanState.TRAVELING;
+        mission.active = false;
+        assertEq(LibMission.effectiveRegion(cs, mission, 9), 6);
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #430.

- adds `LibMission.effectiveRegion` for shared mission movement/region derivation
- covers traveling before/at/after arrival and inactive/non-traveling fallbacks
- prepares derived view and order facets to share the same mission-location logic

## Validation

- `forge test --match-path test/diamond/LibMission.t.sol`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
