### PR TITLE
[codex] share diamond selector lists

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -2,16 +2,15 @@
 pragma solidity ^0.8.34;
 
 import {Script, console} from "forge-std/Script.sol";
+import {DiamondSelectors} from "./DiamondSelectors.sol";
 import {Diamond} from "../src/diamond/Diamond.sol";
 import {ClanWorldDiamondInit} from "../src/diamond/ClanWorldDiamondInit.sol";
 import {IDiamondCut} from "../src/diamond/IDiamondCut.sol";
-import {IDiamondLoupe} from "../src/diamond/IDiamondLoupe.sol";
 import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
 import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
 import {DerivedViewsFacet} from "../src/diamond/facets/DerivedViewsFacet.sol";
 import {RawViewsFacet} from "../src/diamond/facets/RawViewsFacet.sol";
-import {IClanWorld} from "../src/IClanWorld.sol";
 
 contract DeployDiamond is Script {
     function run() external {
@@ -56,69 +55,24 @@ contract DeployDiamond is Script {
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
         cut = new IDiamondCut.FacetCut[](4);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: loupeFacet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: _loupeSelectors()
+            facetAddress: loupeFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.loupeSelectors()
         });
         cut[1] = IDiamondCut.FacetCut({
-            facetAddress: rawViewsFacet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: _rawViewsSelectors()
+            facetAddress: rawViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.rawViewsSelectors()
         });
         cut[2] = IDiamondCut.FacetCut({
             facetAddress: lifecycleFacet,
             action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: _lifecycleSelectors()
+            functionSelectors: DiamondSelectors.lifecycleSelectors()
         });
         cut[3] = IDiamondCut.FacetCut({
             facetAddress: derivedViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: _derivedViewsSelectors()
+            functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-    }
-
-    function _loupeSelectors() private pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](4);
-        selectors[0] = IDiamondLoupe.facets.selector;
-        selectors[1] = IDiamondLoupe.facetFunctionSelectors.selector;
-        selectors[2] = IDiamondLoupe.facetAddresses.selector;
-        selectors[3] = IDiamondLoupe.facetAddress.selector;
-    }
-
-    function _rawViewsSelectors() private pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](26);
-        selectors[0] = IClanWorld.getWorldState.selector;
-        selectors[1] = IClanWorld.getTreasuryState.selector;
-        selectors[2] = IClanWorld.getResourceToken.selector;
-        selectors[3] = IClanWorld.getPool.selector;
-        selectors[4] = IClanWorld.getPrice.selector;
-        selectors[5] = IClanWorld.getClan.selector;
-        selectors[6] = IClanWorld.getClansman.selector;
-        selectors[7] = IClanWorld.getActiveMission.selector;
-        selectors[8] = IClanWorld.getMissionTiming.selector;
-        selectors[9] = IClanWorld.isWinter.selector;
-        selectors[10] = IClanWorld.getWallUpgradeCost.selector;
-        selectors[11] = IClanWorld.getBaseUpgradeCost.selector;
-        selectors[12] = IClanWorld.getMonumentUpgradeCost.selector;
-        selectors[13] = IClanWorld.getActionDuration.selector;
-        selectors[14] = IClanWorld.getTravelTicks.selector;
-        selectors[15] = IClanWorld.getBandit.selector;
-        selectors[16] = IClanWorld.getBanditTroop.selector;
-        selectors[17] = IClanWorld.getBanditsInRegion.selector;
-        selectors[18] = IClanWorld.getWheatPlots.selector;
-        selectors[19] = IClanWorld.getScheduledMarketActionsForTick.selector;
-        selectors[20] = IClanWorld.getActiveDefenders.selector;
-        selectors[21] = IClanWorld.getDefendingClans.selector;
-        selectors[22] = IClanWorld.getClanIds.selector;
-        selectors[23] = IClanWorld.getClanClansmanIds.selector;
-        selectors[24] = IClanWorld.getClansmanDefendingRegion.selector;
-        selectors[25] = IClanWorld.getMonumentLevelReachedAt.selector;
-    }
-
-    function _lifecycleSelectors() private pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](1);
-        selectors[0] = IClanWorld.mintClan.selector;
-    }
-
-    function _derivedViewsSelectors() private pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](2);
-        selectors[0] = IClanWorld.getDerivedClanState.selector;
-        selectors[1] = IClanWorld.getDerivedClansmanState.selector;
     }
 }

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {IDiamondLoupe} from "../src/diamond/IDiamondLoupe.sol";
+import {IClanWorld} from "../src/IClanWorld.sol";
+
+library DiamondSelectors {
+    function loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](4);
+        selectors[0] = IDiamondLoupe.facets.selector;
+        selectors[1] = IDiamondLoupe.facetFunctionSelectors.selector;
+        selectors[2] = IDiamondLoupe.facetAddresses.selector;
+        selectors[3] = IDiamondLoupe.facetAddress.selector;
+    }
+
+    function rawViewsSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](26);
+        selectors[0] = IClanWorld.getWorldState.selector;
+        selectors[1] = IClanWorld.getTreasuryState.selector;
+        selectors[2] = IClanWorld.getResourceToken.selector;
+        selectors[3] = IClanWorld.getPool.selector;
+        selectors[4] = IClanWorld.getPrice.selector;
+        selectors[5] = IClanWorld.getClan.selector;
+        selectors[6] = IClanWorld.getClansman.selector;
+        selectors[7] = IClanWorld.getActiveMission.selector;
+        selectors[8] = IClanWorld.getMissionTiming.selector;
+        selectors[9] = IClanWorld.isWinter.selector;
+        selectors[10] = IClanWorld.getWallUpgradeCost.selector;
+        selectors[11] = IClanWorld.getBaseUpgradeCost.selector;
+        selectors[12] = IClanWorld.getMonumentUpgradeCost.selector;
+        selectors[13] = IClanWorld.getActionDuration.selector;
+        selectors[14] = IClanWorld.getTravelTicks.selector;
+        selectors[15] = IClanWorld.getBandit.selector;
+        selectors[16] = IClanWorld.getBanditTroop.selector;
+        selectors[17] = IClanWorld.getBanditsInRegion.selector;
+        selectors[18] = IClanWorld.getWheatPlots.selector;
+        selectors[19] = IClanWorld.getScheduledMarketActionsForTick.selector;
+        selectors[20] = IClanWorld.getActiveDefenders.selector;
+        selectors[21] = IClanWorld.getDefendingClans.selector;
+        selectors[22] = IClanWorld.getClanIds.selector;
+        selectors[23] = IClanWorld.getClanClansmanIds.selector;
+        selectors[24] = IClanWorld.getClansmanDefendingRegion.selector;
+        selectors[25] = IClanWorld.getMonumentLevelReachedAt.selector;
+    }
+
+    function lifecycleSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.mintClan.selector;
+    }
+
+    function derivedViewsSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](2);
+        selectors[0] = IClanWorld.getDerivedClanState.selector;
+        selectors[1] = IClanWorld.getDerivedClansmanState.selector;
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
+import {DiamondSelectors} from "../../script/DiamondSelectors.sol";
 import {Diamond} from "../../src/diamond/Diamond.sol";
 import {ClanWorld} from "../../src/ClanWorld.sol";
 import {ClanWorldDiamondInit} from "../../src/diamond/ClanWorldDiamondInit.sol";
@@ -211,58 +212,29 @@ contract DiamondSkeletonTest is Test {
     }
 
     function _rawViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
-        bytes4[] memory selectors = new bytes4[](26);
-        selectors[0] = IClanWorld.getWorldState.selector;
-        selectors[1] = IClanWorld.getTreasuryState.selector;
-        selectors[2] = IClanWorld.getResourceToken.selector;
-        selectors[3] = IClanWorld.getPool.selector;
-        selectors[4] = IClanWorld.getPrice.selector;
-        selectors[5] = IClanWorld.getClan.selector;
-        selectors[6] = IClanWorld.getClansman.selector;
-        selectors[7] = IClanWorld.getActiveMission.selector;
-        selectors[8] = IClanWorld.getMissionTiming.selector;
-        selectors[9] = IClanWorld.isWinter.selector;
-        selectors[10] = IClanWorld.getWallUpgradeCost.selector;
-        selectors[11] = IClanWorld.getBaseUpgradeCost.selector;
-        selectors[12] = IClanWorld.getMonumentUpgradeCost.selector;
-        selectors[13] = IClanWorld.getActionDuration.selector;
-        selectors[14] = IClanWorld.getTravelTicks.selector;
-        selectors[15] = IClanWorld.getBandit.selector;
-        selectors[16] = IClanWorld.getBanditTroop.selector;
-        selectors[17] = IClanWorld.getBanditsInRegion.selector;
-        selectors[18] = IClanWorld.getWheatPlots.selector;
-        selectors[19] = IClanWorld.getScheduledMarketActionsForTick.selector;
-        selectors[20] = IClanWorld.getActiveDefenders.selector;
-        selectors[21] = IClanWorld.getDefendingClans.selector;
-        selectors[22] = IClanWorld.getClanIds.selector;
-        selectors[23] = IClanWorld.getClanClansmanIds.selector;
-        selectors[24] = IClanWorld.getClansmanDefendingRegion.selector;
-        selectors[25] = IClanWorld.getMonumentLevelReachedAt.selector;
-
         cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: facet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.rawViewsSelectors()
         });
     }
 
     function _lifecycleCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
-        bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = IClanWorld.mintClan.selector;
-
         cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: facet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.lifecycleSelectors()
         });
     }
 
     function _derivedViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
-        bytes4[] memory selectors = new bytes4[](2);
-        selectors[0] = IClanWorld.getDerivedClanState.selector;
-        selectors[1] = IClanWorld.getDerivedClansmanState.selector;
-
         cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: facet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
     }
 


### PR DESCRIPTION
## Summary

Stacked on #433.

- adds `DiamondSelectors` as the shared selector-list source for current diamond deploy/test cuts
- updates `DeployDiamond.s.sol` to use the shared selectors
- updates diamond skeleton tests to use the same selector lists so deploy rehearsal and tests do not drift

## Validation

- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
