### PR TITLE
[codex] add diamond market views

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -10,6 +10,7 @@ import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
 import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
 import {DerivedViewsFacet} from "../src/diamond/facets/DerivedViewsFacet.sol";
+import {MarketViewsFacet} from "../src/diamond/facets/MarketViewsFacet.sol";
 import {RawViewsFacet} from "../src/diamond/facets/RawViewsFacet.sol";
 
 contract DeployDiamond is Script {
@@ -25,12 +26,17 @@ contract DeployDiamond is Script {
         RawViewsFacet rawViewsFacet = new RawViewsFacet();
         ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
         DerivedViewsFacet derivedViewsFacet = new DerivedViewsFacet();
+        MarketViewsFacet marketViewsFacet = new MarketViewsFacet();
         ClanWorldDiamondInit init = new ClanWorldDiamondInit();
 
         IDiamondCut(address(diamond))
             .diamondCut(
                 _initialFacetCuts(
-                    address(loupeFacet), address(rawViewsFacet), address(lifecycleFacet), address(derivedViewsFacet)
+                    address(loupeFacet),
+                    address(rawViewsFacet),
+                    address(lifecycleFacet),
+                    address(derivedViewsFacet),
+                    address(marketViewsFacet)
                 ),
                 address(init),
                 abi.encodeCall(ClanWorldDiamondInit.init, ())
@@ -42,6 +48,7 @@ contract DeployDiamond is Script {
         console.log("CLAN_LIFECYCLE_FACET_ADDRESS:     ", address(lifecycleFacet));
         console.log("RAW_VIEWS_FACET_ADDRESS:          ", address(rawViewsFacet));
         console.log("DERIVED_VIEWS_FACET_ADDRESS:      ", address(derivedViewsFacet));
+        console.log("MARKET_VIEWS_FACET_ADDRESS:       ", address(marketViewsFacet));
         console.log("CLAN_WORLD_DIAMOND_INIT_ADDRESS:  ", address(init));
 
         vm.stopBroadcast();
@@ -51,9 +58,10 @@ contract DeployDiamond is Script {
         address loupeFacet,
         address rawViewsFacet,
         address lifecycleFacet,
-        address derivedViewsFacet
+        address derivedViewsFacet,
+        address marketViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](4);
+        cut = new IDiamondCut.FacetCut[](5);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -73,6 +81,11 @@ contract DeployDiamond is Script {
             facetAddress: derivedViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
+        });
+        cut[4] = IDiamondCut.FacetCut({
+            facetAddress: marketViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
     }
 }

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -53,4 +53,9 @@ library DiamondSelectors {
         selectors[0] = IClanWorld.getDerivedClanState.selector;
         selectors[1] = IClanWorld.getDerivedClansmanState.selector;
     }
+
+    function marketViewsSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.getMarketState.selector;
+    }
 }

--- a/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
+++ b/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
@@ -29,6 +29,4 @@ contract BanditTargetingFacet {}
 
 contract BanditCombatFacet {}
 
-contract MarketViewsFacet {}
-
 contract BanditViewsFacet {}

--- a/packages/contracts/src/diamond/facets/MarketViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/MarketViewsFacet.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {MarketState, PoolReserves} from "../../IClanWorld.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+import {StubPool} from "../../StubPool.sol";
+
+contract MarketViewsFacet {
+    function getMarketState() external view returns (MarketState memory) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        return MarketState({
+            wood: _poolReserves(s.treasury.woodToken, s.treasury.woodGoldPool),
+            wheat: _poolReserves(s.treasury.wheatToken, s.treasury.wheatGoldPool),
+            fish: _poolReserves(s.treasury.fishToken, s.treasury.fishGoldPool),
+            iron: _poolReserves(s.treasury.ironToken, s.treasury.ironGoldPool),
+            currentTick: s.world.currentTick,
+            currentTickQueue: s.scheduledMarketActions[s.world.currentTick],
+            nextTickQueue: s.scheduledMarketActions[s.world.currentTick + 1]
+        });
+    }
+
+    function _poolReserves(address resourceToken, address poolAddr) private view returns (PoolReserves memory pr) {
+        pr.resourceToken = resourceToken;
+        if (poolAddr == address(0) || resourceToken == address(0)) {
+            return pr;
+        }
+        (uint256 rA, uint256 rB) = StubPool(poolAddr).getReserves();
+        pr.resourceReserve = rA;
+        pr.goldReserve = rB;
+        pr.spotPriceGoldPerResource = rA > 0 ? (rB * 1e18) / rA : 0;
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -13,6 +13,7 @@ import {
     Clansman,
     DerivedClanState,
     DerivedClansmanState,
+    MarketState,
     WheatPlot,
     WorldState
 } from "../../src/IClanWorld.sol";
@@ -22,6 +23,7 @@ import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.sol";
 import {DerivedViewsFacet} from "../../src/diamond/facets/DerivedViewsFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {MarketViewsFacet} from "../../src/diamond/facets/MarketViewsFacet.sol";
 import {RawViewsFacet} from "../../src/diamond/facets/RawViewsFacet.sol";
 
 contract PingFacet {
@@ -211,6 +213,21 @@ contract DiamondSkeletonTest is Test {
         assertEq(missing.derivedAtTick, core.getWorldState().currentTick);
     }
 
+    function testDiamondMarketStateMatchesCoreDefaults() public {
+        ClanWorld core = new ClanWorld();
+        RawViewsFacet rawViewsFacet = new RawViewsFacet();
+        MarketViewsFacet marketViewsFacet = new MarketViewsFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                _rawViewsCut(address(rawViewsFacet)), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ())
+            );
+        IDiamondCut(address(diamond)).diamondCut(_marketViewsCut(address(marketViewsFacet)), address(0), "");
+
+        _assertMarketStateEq(IClanWorld(address(diamond)).getMarketState(), core.getMarketState());
+    }
+
     function _rawViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
         cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -235,6 +252,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
+        });
+    }
+
+    function _marketViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
     }
 
@@ -314,5 +340,15 @@ contract DiamondSkeletonTest is Test {
         assertEq(actual.derivedAtTick, expected.derivedAtTick, "derived clansman tick");
         assertEq(actual.activeMission.active, expected.activeMission.active, "mission active");
         assertEq(actual.activeMission.nonce, expected.activeMission.nonce, "mission nonce");
+    }
+
+    function _assertMarketStateEq(MarketState memory actual, MarketState memory expected) internal pure {
+        assertEq(actual.wood.resourceToken, expected.wood.resourceToken, "wood token");
+        assertEq(actual.wheat.resourceToken, expected.wheat.resourceToken, "wheat token");
+        assertEq(actual.fish.resourceToken, expected.fish.resourceToken, "fish token");
+        assertEq(actual.iron.resourceToken, expected.iron.resourceToken, "iron token");
+        assertEq(actual.currentTick, expected.currentTick, "market tick");
+        assertEq(actual.currentTickQueue.length, expected.currentTickQueue.length, "current queue");
+        assertEq(actual.nextTickQueue.length, expected.nextTickQueue.length, "next queue");
     }
 }


### PR DESCRIPTION
## Summary

Stacked on #434.

- adds `MarketViewsFacet.getMarketState`
- registers market view selector in shared `DiamondSelectors` and `DeployDiamond.s.sol`
- removes the market view placeholder
- validates default market state parity against core

## Validation

- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
