### PR TITLE
[codex] add diamond bandit views

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -8,6 +8,7 @@ import {ClanWorldDiamondInit} from "../src/diamond/ClanWorldDiamondInit.sol";
 import {IDiamondCut} from "../src/diamond/IDiamondCut.sol";
 import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {BanditViewsFacet} from "../src/diamond/facets/BanditViewsFacet.sol";
 import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
 import {DerivedViewsFacet} from "../src/diamond/facets/DerivedViewsFacet.sol";
 import {MarketViewsFacet} from "../src/diamond/facets/MarketViewsFacet.sol";
@@ -27,6 +28,7 @@ contract DeployDiamond is Script {
         ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
         DerivedViewsFacet derivedViewsFacet = new DerivedViewsFacet();
         MarketViewsFacet marketViewsFacet = new MarketViewsFacet();
+        BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
         ClanWorldDiamondInit init = new ClanWorldDiamondInit();
 
         IDiamondCut(address(diamond))
@@ -36,7 +38,8 @@ contract DeployDiamond is Script {
                     address(rawViewsFacet),
                     address(lifecycleFacet),
                     address(derivedViewsFacet),
-                    address(marketViewsFacet)
+                    address(marketViewsFacet),
+                    address(banditViewsFacet)
                 ),
                 address(init),
                 abi.encodeCall(ClanWorldDiamondInit.init, ())
@@ -49,6 +52,7 @@ contract DeployDiamond is Script {
         console.log("RAW_VIEWS_FACET_ADDRESS:          ", address(rawViewsFacet));
         console.log("DERIVED_VIEWS_FACET_ADDRESS:      ", address(derivedViewsFacet));
         console.log("MARKET_VIEWS_FACET_ADDRESS:       ", address(marketViewsFacet));
+        console.log("BANDIT_VIEWS_FACET_ADDRESS:       ", address(banditViewsFacet));
         console.log("CLAN_WORLD_DIAMOND_INIT_ADDRESS:  ", address(init));
 
         vm.stopBroadcast();
@@ -59,9 +63,10 @@ contract DeployDiamond is Script {
         address rawViewsFacet,
         address lifecycleFacet,
         address derivedViewsFacet,
-        address marketViewsFacet
+        address marketViewsFacet,
+        address banditViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](5);
+        cut = new IDiamondCut.FacetCut[](6);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -86,6 +91,11 @@ contract DeployDiamond is Script {
             facetAddress: marketViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
+        });
+        cut[5] = IDiamondCut.FacetCut({
+            facetAddress: banditViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
     }
 }

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -58,4 +58,9 @@ library DiamondSelectors {
         selectors = new bytes4[](1);
         selectors[0] = IClanWorld.getMarketState.selector;
     }
+
+    function banditViewsSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.getActiveBanditView.selector;
+    }
 }

--- a/packages/contracts/src/diamond/facets/BanditViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/BanditViewsFacet.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ActiveBanditView, BanditState, BanditTroop, ClanWorldConstants} from "../../IClanWorld.sol";
+import {LibScoring} from "../../lib/LibScoring.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract BanditViewsFacet {
+    function getActiveBanditView() external view returns (ActiveBanditView memory) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        BanditTroop memory bandit = s.bandits[s.world.activeBanditId];
+        uint64 nextActionTick = 0;
+        uint8 maxAttemptsRemaining = 0;
+        bool exists = bandit.id != ClanWorldConstants.BANDIT_ID_NULL && bandit.state != BanditState.None;
+        if (exists) {
+            if (bandit.state == BanditState.Spawned) {
+                nextActionTick = bandit.tickEnteredState + 1;
+            } else if (bandit.state == BanditState.Camped) {
+                nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
+            } else if (bandit.state == BanditState.Resting) {
+                nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS;
+            }
+            if (bandit.attackAttemptsMade < ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
+                maxAttemptsRemaining = ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS - bandit.attackAttemptsMade;
+            }
+        }
+
+        return ActiveBanditView({
+            exists: exists,
+            banditId: bandit.id,
+            state: bandit.state,
+            currentRegion: bandit.region,
+            attackAttemptsMade: bandit.attackAttemptsMade,
+            maxAttemptsRemaining: maxAttemptsRemaining,
+            stateEnteredTick: bandit.tickEnteredState,
+            nextActionTick: nextActionTick,
+            tier: bandit.tier,
+            attackPower: LibScoring.banditAttackPower(bandit.strength),
+            carryWood: bandit.carryWood,
+            carryIron: bandit.carryIron,
+            carryWheat: bandit.carryWheat,
+            carryFish: bandit.carryFish,
+            projectedTargetClanId: bandit.targetClanId,
+            projectedTargetLootValue: 0
+        });
+    }
+}

--- a/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
+++ b/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
@@ -28,5 +28,3 @@ contract BanditStateFacet {}
 contract BanditTargetingFacet {}
 
 contract BanditCombatFacet {}
-
-contract BanditViewsFacet {}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -8,6 +8,7 @@ import {ClanWorld} from "../../src/ClanWorld.sol";
 import {ClanWorldDiamondInit} from "../../src/diamond/ClanWorldDiamondInit.sol";
 import {
     IClanWorld,
+    ActiveBanditView,
     ActionType,
     Clan,
     Clansman,
@@ -20,6 +21,7 @@ import {
 import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
 import {IDiamondLoupe} from "../../src/diamond/IDiamondLoupe.sol";
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {BanditViewsFacet} from "../../src/diamond/facets/BanditViewsFacet.sol";
 import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.sol";
 import {DerivedViewsFacet} from "../../src/diamond/facets/DerivedViewsFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
@@ -228,6 +230,21 @@ contract DiamondSkeletonTest is Test {
         _assertMarketStateEq(IClanWorld(address(diamond)).getMarketState(), core.getMarketState());
     }
 
+    function testDiamondActiveBanditViewMatchesCoreDefault() public {
+        ClanWorld core = new ClanWorld();
+        RawViewsFacet rawViewsFacet = new RawViewsFacet();
+        BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                _rawViewsCut(address(rawViewsFacet)), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ())
+            );
+        IDiamondCut(address(diamond)).diamondCut(_banditViewsCut(address(banditViewsFacet)), address(0), "");
+
+        _assertActiveBanditViewEq(IClanWorld(address(diamond)).getActiveBanditView(), core.getActiveBanditView());
+    }
+
     function _rawViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
         cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -261,6 +278,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
+        });
+    }
+
+    function _banditViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
     }
 
@@ -350,5 +376,24 @@ contract DiamondSkeletonTest is Test {
         assertEq(actual.currentTick, expected.currentTick, "market tick");
         assertEq(actual.currentTickQueue.length, expected.currentTickQueue.length, "current queue");
         assertEq(actual.nextTickQueue.length, expected.nextTickQueue.length, "next queue");
+    }
+
+    function _assertActiveBanditViewEq(ActiveBanditView memory actual, ActiveBanditView memory expected) internal pure {
+        assertEq(actual.exists, expected.exists, "bandit exists");
+        assertEq(actual.banditId, expected.banditId, "bandit id");
+        assertEq(uint8(actual.state), uint8(expected.state), "bandit state");
+        assertEq(actual.currentRegion, expected.currentRegion, "bandit region");
+        assertEq(actual.attackAttemptsMade, expected.attackAttemptsMade, "bandit attempts");
+        assertEq(actual.maxAttemptsRemaining, expected.maxAttemptsRemaining, "bandit remaining");
+        assertEq(actual.stateEnteredTick, expected.stateEnteredTick, "bandit entered");
+        assertEq(actual.nextActionTick, expected.nextActionTick, "bandit next");
+        assertEq(actual.tier, expected.tier, "bandit tier");
+        assertEq(actual.attackPower, expected.attackPower, "bandit power");
+        assertEq(actual.carryWood, expected.carryWood, "bandit wood");
+        assertEq(actual.carryIron, expected.carryIron, "bandit iron");
+        assertEq(actual.carryWheat, expected.carryWheat, "bandit wheat");
+        assertEq(actual.carryFish, expected.carryFish, "bandit fish");
+        assertEq(actual.projectedTargetClanId, expected.projectedTargetClanId, "bandit target");
+        assertEq(actual.projectedTargetLootValue, expected.projectedTargetLootValue, "bandit loot");
     }
 }


### PR DESCRIPTION
## Summary

Stacked on #435.

- adds `BanditViewsFacet.getActiveBanditView`
- registers bandit view selector in shared `DiamondSelectors` and deploy script
- removes the bandit view placeholder
- validates default active-bandit view parity against core

## Validation

- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
