### PR TITLE
[codex] add diamond region views

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -13,6 +13,7 @@ import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
 import {DerivedViewsFacet} from "../src/diamond/facets/DerivedViewsFacet.sol";
 import {MarketViewsFacet} from "../src/diamond/facets/MarketViewsFacet.sol";
 import {RawViewsFacet} from "../src/diamond/facets/RawViewsFacet.sol";
+import {RegionViewsFacet} from "../src/diamond/facets/RegionViewsFacet.sol";
 
 contract DeployDiamond is Script {
     function run() external {
@@ -29,6 +30,7 @@ contract DeployDiamond is Script {
         DerivedViewsFacet derivedViewsFacet = new DerivedViewsFacet();
         MarketViewsFacet marketViewsFacet = new MarketViewsFacet();
         BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
+        RegionViewsFacet regionViewsFacet = new RegionViewsFacet();
         ClanWorldDiamondInit init = new ClanWorldDiamondInit();
 
         IDiamondCut(address(diamond))
@@ -39,7 +41,8 @@ contract DeployDiamond is Script {
                     address(lifecycleFacet),
                     address(derivedViewsFacet),
                     address(marketViewsFacet),
-                    address(banditViewsFacet)
+                    address(banditViewsFacet),
+                    address(regionViewsFacet)
                 ),
                 address(init),
                 abi.encodeCall(ClanWorldDiamondInit.init, ())
@@ -53,6 +56,7 @@ contract DeployDiamond is Script {
         console.log("DERIVED_VIEWS_FACET_ADDRESS:      ", address(derivedViewsFacet));
         console.log("MARKET_VIEWS_FACET_ADDRESS:       ", address(marketViewsFacet));
         console.log("BANDIT_VIEWS_FACET_ADDRESS:       ", address(banditViewsFacet));
+        console.log("REGION_VIEWS_FACET_ADDRESS:       ", address(regionViewsFacet));
         console.log("CLAN_WORLD_DIAMOND_INIT_ADDRESS:  ", address(init));
 
         vm.stopBroadcast();
@@ -64,9 +68,10 @@ contract DeployDiamond is Script {
         address lifecycleFacet,
         address derivedViewsFacet,
         address marketViewsFacet,
-        address banditViewsFacet
+        address banditViewsFacet,
+        address regionViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](6);
+        cut = new IDiamondCut.FacetCut[](7);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -96,6 +101,11 @@ contract DeployDiamond is Script {
             facetAddress: banditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
+        });
+        cut[6] = IDiamondCut.FacetCut({
+            facetAddress: regionViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
     }
 }

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -63,4 +63,9 @@ library DiamondSelectors {
         selectors = new bytes4[](1);
         selectors[0] = IClanWorld.getActiveBanditView.selector;
     }
+
+    function regionViewsSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.getRegionPopulation.selector;
+    }
 }

--- a/packages/contracts/src/diamond/facets/RegionViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/RegionViewsFacet.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ActionType, ClansmanState, Mission, RegionOccupant} from "../../IClanWorld.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract RegionViewsFacet {
+    function getRegionPopulation(uint8 region) external view returns (RegionOccupant[] memory) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        uint256 count = 0;
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            uint32[] storage clansmanIds = s.clanClansmanIds[clanId];
+            for (uint256 j = 0; j < clansmanIds.length; j++) {
+                uint32 clansmanId = clansmanIds[j];
+                if (
+                    s.clansmen[clansmanId].state != ClansmanState.DEAD && s.clansmen[clansmanId].currentRegion == region
+                ) {
+                    count++;
+                }
+            }
+        }
+
+        RegionOccupant[] memory occupants = new RegionOccupant[](count);
+        uint256 out = 0;
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            uint32[] storage clansmanIds = s.clanClansmanIds[clanId];
+            for (uint256 j = 0; j < clansmanIds.length; j++) {
+                uint32 clansmanId = clansmanIds[j];
+                if (
+                    s.clansmen[clansmanId].state != ClansmanState.DEAD && s.clansmen[clansmanId].currentRegion == region
+                ) {
+                    Mission storage mission = s.missions[clansmanId];
+                    occupants[out++] = RegionOccupant({
+                        clansmanId: clansmanId,
+                        clanId: clanId,
+                        state: s.clansmen[clansmanId].state,
+                        currentAction: mission.active ? mission.action : ActionType.None,
+                        missionNonce: s.clansmen[clansmanId].lastMissionNonce
+                    });
+                }
+            }
+        }
+        return occupants;
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -15,6 +15,7 @@ import {
     DerivedClanState,
     DerivedClansmanState,
     MarketState,
+    RegionOccupant,
     WheatPlot,
     WorldState
 } from "../../src/IClanWorld.sol";
@@ -27,6 +28,7 @@ import {DerivedViewsFacet} from "../../src/diamond/facets/DerivedViewsFacet.sol"
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {MarketViewsFacet} from "../../src/diamond/facets/MarketViewsFacet.sol";
 import {RawViewsFacet} from "../../src/diamond/facets/RawViewsFacet.sol";
+import {RegionViewsFacet} from "../../src/diamond/facets/RegionViewsFacet.sol";
 
 contract PingFacet {
     function ping() external pure returns (uint256) {
@@ -245,6 +247,33 @@ contract DiamondSkeletonTest is Test {
         _assertActiveBanditViewEq(IClanWorld(address(diamond)).getActiveBanditView(), core.getActiveBanditView());
     }
 
+    function testDiamondRegionPopulationMatchesCoreAfterMint() public {
+        ClanWorld core = new ClanWorld();
+        RawViewsFacet rawViewsFacet = new RawViewsFacet();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        RegionViewsFacet regionViewsFacet = new RegionViewsFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                _rawViewsCut(address(rawViewsFacet)), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ())
+            );
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_regionViewsCut(address(regionViewsFacet)), address(0), "");
+
+        address elder = address(0xA11CE);
+        vm.prank(elder);
+        (uint32 coreClanId,) = core.mintClan(elder);
+        vm.prank(elder);
+        (uint32 diamondClanId,) = IClanWorld(address(diamond)).mintClan(elder);
+
+        uint8 baseRegion = core.getClan(coreClanId).baseRegion;
+        assertEq(baseRegion, IClanWorld(address(diamond)).getClan(diamondClanId).baseRegion);
+        _assertRegionPopulationEq(
+            IClanWorld(address(diamond)).getRegionPopulation(baseRegion), core.getRegionPopulation(baseRegion)
+        );
+    }
+
     function _rawViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
         cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -287,6 +316,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
+        });
+    }
+
+    function _regionViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
     }
 
@@ -395,5 +433,16 @@ contract DiamondSkeletonTest is Test {
         assertEq(actual.carryFish, expected.carryFish, "bandit fish");
         assertEq(actual.projectedTargetClanId, expected.projectedTargetClanId, "bandit target");
         assertEq(actual.projectedTargetLootValue, expected.projectedTargetLootValue, "bandit loot");
+    }
+
+    function _assertRegionPopulationEq(RegionOccupant[] memory actual, RegionOccupant[] memory expected) internal pure {
+        assertEq(actual.length, expected.length, "population length");
+        for (uint256 i = 0; i < expected.length; i++) {
+            assertEq(actual[i].clansmanId, expected[i].clansmanId, "population clansman");
+            assertEq(actual[i].clanId, expected[i].clanId, "population clan");
+            assertEq(uint8(actual[i].state), uint8(expected[i].state), "population state");
+            assertEq(uint8(actual[i].currentAction), uint8(expected[i].currentAction), "population action");
+            assertEq(actual[i].missionNonce, expected[i].missionNonce, "population nonce");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Stacked on #436.

- adds `RegionViewsFacet.getRegionPopulation`
- registers region view selector in shared `DiamondSelectors` and deploy script
- validates post-mint region population parity against core

## Validation

- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
