### PR TITLE
[codex] add diamond snapshot views

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -14,6 +14,7 @@ import {DerivedViewsFacet} from "../src/diamond/facets/DerivedViewsFacet.sol";
 import {MarketViewsFacet} from "../src/diamond/facets/MarketViewsFacet.sol";
 import {RawViewsFacet} from "../src/diamond/facets/RawViewsFacet.sol";
 import {RegionViewsFacet} from "../src/diamond/facets/RegionViewsFacet.sol";
+import {SnapshotViewsFacet} from "../src/diamond/facets/SnapshotViewsFacet.sol";
 
 contract DeployDiamond is Script {
     function run() external {
@@ -31,6 +32,7 @@ contract DeployDiamond is Script {
         MarketViewsFacet marketViewsFacet = new MarketViewsFacet();
         BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
         RegionViewsFacet regionViewsFacet = new RegionViewsFacet();
+        SnapshotViewsFacet snapshotViewsFacet = new SnapshotViewsFacet();
         ClanWorldDiamondInit init = new ClanWorldDiamondInit();
 
         IDiamondCut(address(diamond))
@@ -42,7 +44,8 @@ contract DeployDiamond is Script {
                     address(derivedViewsFacet),
                     address(marketViewsFacet),
                     address(banditViewsFacet),
-                    address(regionViewsFacet)
+                    address(regionViewsFacet),
+                    address(snapshotViewsFacet)
                 ),
                 address(init),
                 abi.encodeCall(ClanWorldDiamondInit.init, ())
@@ -57,6 +60,7 @@ contract DeployDiamond is Script {
         console.log("MARKET_VIEWS_FACET_ADDRESS:       ", address(marketViewsFacet));
         console.log("BANDIT_VIEWS_FACET_ADDRESS:       ", address(banditViewsFacet));
         console.log("REGION_VIEWS_FACET_ADDRESS:       ", address(regionViewsFacet));
+        console.log("SNAPSHOT_VIEWS_FACET_ADDRESS:     ", address(snapshotViewsFacet));
         console.log("CLAN_WORLD_DIAMOND_INIT_ADDRESS:  ", address(init));
 
         vm.stopBroadcast();
@@ -69,9 +73,10 @@ contract DeployDiamond is Script {
         address derivedViewsFacet,
         address marketViewsFacet,
         address banditViewsFacet,
-        address regionViewsFacet
+        address regionViewsFacet,
+        address snapshotViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](7);
+        cut = new IDiamondCut.FacetCut[](8);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -106,6 +111,11 @@ contract DeployDiamond is Script {
             facetAddress: regionViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
+        });
+        cut[7] = IDiamondCut.FacetCut({
+            facetAddress: snapshotViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
     }
 }

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -68,4 +68,9 @@ library DiamondSelectors {
         selectors = new bytes4[](1);
         selectors[0] = IClanWorld.getRegionPopulation.selector;
     }
+
+    function snapshotViewsSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.getWorldSnapshot.selector;
+    }
 }

--- a/packages/contracts/src/diamond/facets/SnapshotViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/SnapshotViewsFacet.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Clan, LeaderboardEntry, WorldSnapshot} from "../../IClanWorld.sol";
+import {LibScoring} from "../../lib/LibScoring.sol";
+import {LibSeason} from "../lib/LibSeason.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract SnapshotViewsFacet {
+    function getWorldSnapshot() external view returns (WorldSnapshot memory) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LeaderboardEntry[] memory leaderboard = new LeaderboardEntry[](s.allClanIds.length);
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            Clan storage clan = s.clans[clanId];
+            leaderboard[i] = LeaderboardEntry({
+                clanId: clanId,
+                owner: clan.owner,
+                monumentLevel: clan.monumentLevel,
+                baseLevel: clan.baseLevel,
+                wallLevel: clan.wallLevel,
+                livingClansmen: clan.livingClansmen,
+                state: clan.clanState,
+                lootValue: LibScoring.lootValue(clan)
+            });
+        }
+
+        (bool winterActive, uint64 winterStartsAtTick, uint64 winterEndsAtTick) =
+            LibSeason.winterWindowForTick(s.world.currentTick);
+
+        return WorldSnapshot({
+            currentTick: s.world.currentTick,
+            seasonStartTick: s.world.seasonStartTick,
+            seasonEndTick: s.world.seasonEndTick,
+            seasonFinalized: s.world.seasonFinalized,
+            currentSeasonNumber: s.world.currentSeasonNumber,
+            nextHeartbeatAtTick: s.world.nextHeartbeatAtTick,
+            winterActive: winterActive,
+            winterStartsAtTick: winterStartsAtTick,
+            winterEndsAtTick: winterEndsAtTick,
+            activeBanditId: s.world.activeBanditId,
+            currentTickSeed: s.world.currentTickSeed,
+            leaderboard: leaderboard
+        });
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -17,6 +17,7 @@ import {
     MarketState,
     RegionOccupant,
     WheatPlot,
+    WorldSnapshot,
     WorldState
 } from "../../src/IClanWorld.sol";
 import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
@@ -29,6 +30,7 @@ import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol"
 import {MarketViewsFacet} from "../../src/diamond/facets/MarketViewsFacet.sol";
 import {RawViewsFacet} from "../../src/diamond/facets/RawViewsFacet.sol";
 import {RegionViewsFacet} from "../../src/diamond/facets/RegionViewsFacet.sol";
+import {SnapshotViewsFacet} from "../../src/diamond/facets/SnapshotViewsFacet.sol";
 
 contract PingFacet {
     function ping() external pure returns (uint256) {
@@ -274,6 +276,29 @@ contract DiamondSkeletonTest is Test {
         );
     }
 
+    function testDiamondWorldSnapshotMatchesCoreAfterMint() public {
+        ClanWorld core = new ClanWorld();
+        RawViewsFacet rawViewsFacet = new RawViewsFacet();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        SnapshotViewsFacet snapshotViewsFacet = new SnapshotViewsFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                _rawViewsCut(address(rawViewsFacet)), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ())
+            );
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_snapshotViewsCut(address(snapshotViewsFacet)), address(0), "");
+
+        address elder = address(0xA11CE);
+        vm.prank(elder);
+        core.mintClan(elder);
+        vm.prank(elder);
+        IClanWorld(address(diamond)).mintClan(elder);
+
+        _assertWorldSnapshotEq(IClanWorld(address(diamond)).getWorldSnapshot(), core.getWorldSnapshot());
+    }
+
     function _rawViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
         cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -325,6 +350,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
+        });
+    }
+
+    function _snapshotViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
     }
 
@@ -443,6 +477,31 @@ contract DiamondSkeletonTest is Test {
             assertEq(uint8(actual[i].state), uint8(expected[i].state), "population state");
             assertEq(uint8(actual[i].currentAction), uint8(expected[i].currentAction), "population action");
             assertEq(actual[i].missionNonce, expected[i].missionNonce, "population nonce");
+        }
+    }
+
+    function _assertWorldSnapshotEq(WorldSnapshot memory actual, WorldSnapshot memory expected) internal pure {
+        assertEq(actual.currentTick, expected.currentTick, "snapshot currentTick");
+        assertEq(actual.seasonStartTick, expected.seasonStartTick, "snapshot seasonStartTick");
+        assertEq(actual.seasonEndTick, expected.seasonEndTick, "snapshot seasonEndTick");
+        assertEq(actual.seasonFinalized, expected.seasonFinalized, "snapshot seasonFinalized");
+        assertEq(actual.currentSeasonNumber, expected.currentSeasonNumber, "snapshot season");
+        assertEq(actual.nextHeartbeatAtTick, expected.nextHeartbeatAtTick, "snapshot next heartbeat");
+        assertEq(actual.winterActive, expected.winterActive, "snapshot winterActive");
+        assertEq(actual.winterStartsAtTick, expected.winterStartsAtTick, "snapshot winter start");
+        assertEq(actual.winterEndsAtTick, expected.winterEndsAtTick, "snapshot winter end");
+        assertEq(actual.activeBanditId, expected.activeBanditId, "snapshot active bandit");
+        assertEq(actual.currentTickSeed, expected.currentTickSeed, "snapshot seed");
+        assertEq(actual.leaderboard.length, expected.leaderboard.length, "leaderboard length");
+        for (uint256 i = 0; i < expected.leaderboard.length; i++) {
+            assertEq(actual.leaderboard[i].clanId, expected.leaderboard[i].clanId, "leaderboard clanId");
+            assertEq(actual.leaderboard[i].owner, expected.leaderboard[i].owner, "leaderboard owner");
+            assertEq(actual.leaderboard[i].monumentLevel, expected.leaderboard[i].monumentLevel, "leaderboard monument");
+            assertEq(actual.leaderboard[i].baseLevel, expected.leaderboard[i].baseLevel, "leaderboard base");
+            assertEq(actual.leaderboard[i].wallLevel, expected.leaderboard[i].wallLevel, "leaderboard wall");
+            assertEq(actual.leaderboard[i].livingClansmen, expected.leaderboard[i].livingClansmen, "leaderboard living");
+            assertEq(uint8(actual.leaderboard[i].state), uint8(expected.leaderboard[i].state), "leaderboard state");
+            assertEq(actual.leaderboard[i].lootValue, expected.leaderboard[i].lootValue, "leaderboard loot");
         }
     }
 }


### PR DESCRIPTION
## Summary
- adds `SnapshotViewsFacet` for the `getWorldSnapshot` selector
- wires the snapshot facet into shared diamond selectors and the diamond deploy script
- adds monolith parity coverage for snapshot output after minting a clan

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
