### PR TITLE
[codex] add diamond quote views

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -12,6 +12,7 @@ import {BanditViewsFacet} from "../src/diamond/facets/BanditViewsFacet.sol";
 import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
 import {DerivedViewsFacet} from "../src/diamond/facets/DerivedViewsFacet.sol";
 import {MarketViewsFacet} from "../src/diamond/facets/MarketViewsFacet.sol";
+import {QuoteViewsFacet} from "../src/diamond/facets/QuoteViewsFacet.sol";
 import {RawViewsFacet} from "../src/diamond/facets/RawViewsFacet.sol";
 import {RegionViewsFacet} from "../src/diamond/facets/RegionViewsFacet.sol";
 import {SnapshotViewsFacet} from "../src/diamond/facets/SnapshotViewsFacet.sol";
@@ -33,6 +34,7 @@ contract DeployDiamond is Script {
         BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
         RegionViewsFacet regionViewsFacet = new RegionViewsFacet();
         SnapshotViewsFacet snapshotViewsFacet = new SnapshotViewsFacet();
+        QuoteViewsFacet quoteViewsFacet = new QuoteViewsFacet();
         ClanWorldDiamondInit init = new ClanWorldDiamondInit();
 
         IDiamondCut(address(diamond))
@@ -45,7 +47,8 @@ contract DeployDiamond is Script {
                     address(marketViewsFacet),
                     address(banditViewsFacet),
                     address(regionViewsFacet),
-                    address(snapshotViewsFacet)
+                    address(snapshotViewsFacet),
+                    address(quoteViewsFacet)
                 ),
                 address(init),
                 abi.encodeCall(ClanWorldDiamondInit.init, ())
@@ -61,6 +64,7 @@ contract DeployDiamond is Script {
         console.log("BANDIT_VIEWS_FACET_ADDRESS:       ", address(banditViewsFacet));
         console.log("REGION_VIEWS_FACET_ADDRESS:       ", address(regionViewsFacet));
         console.log("SNAPSHOT_VIEWS_FACET_ADDRESS:     ", address(snapshotViewsFacet));
+        console.log("QUOTE_VIEWS_FACET_ADDRESS:        ", address(quoteViewsFacet));
         console.log("CLAN_WORLD_DIAMOND_INIT_ADDRESS:  ", address(init));
 
         vm.stopBroadcast();
@@ -74,9 +78,10 @@ contract DeployDiamond is Script {
         address marketViewsFacet,
         address banditViewsFacet,
         address regionViewsFacet,
-        address snapshotViewsFacet
+        address snapshotViewsFacet,
+        address quoteViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](8);
+        cut = new IDiamondCut.FacetCut[](9);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -116,6 +121,11 @@ contract DeployDiamond is Script {
             facetAddress: snapshotViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
+        });
+        cut[8] = IDiamondCut.FacetCut({
+            facetAddress: quoteViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
     }
 }

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -73,4 +73,11 @@ library DiamondSelectors {
         selectors = new bytes4[](1);
         selectors[0] = IClanWorld.getWorldSnapshot.selector;
     }
+
+    function quoteViewsSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](3);
+        selectors[0] = IClanWorld.getBanditTargetPreview.selector;
+        selectors[1] = IClanWorld.quoteTravel.selector;
+        selectors[2] = IClanWorld.quoteLootValueRaw.selector;
+    }
 }

--- a/packages/contracts/src/diamond/facets/QuoteViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/QuoteViewsFacet.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {LibScoring} from "../../lib/LibScoring.sol";
+import {LibTravel} from "../../lib/LibTravel.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract QuoteViewsFacet {
+    function getBanditTargetPreview(uint32 banditId) external view returns (uint32 previewClanId) {
+        return LibStorage.appStorage().bandits[banditId].targetClanId;
+    }
+
+    function quoteTravel(uint8 srcRegion, uint8 dstRegion) external pure returns (uint8 travelTicks, bytes8 path) {
+        return LibTravel.quoteTravel(srcRegion, dstRegion);
+    }
+
+    function quoteLootValueRaw(uint32 clanId) external view returns (uint256 lootValue) {
+        return LibScoring.lootValue(LibStorage.appStorage().clans[clanId]);
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -28,6 +28,7 @@ import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.so
 import {DerivedViewsFacet} from "../../src/diamond/facets/DerivedViewsFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {MarketViewsFacet} from "../../src/diamond/facets/MarketViewsFacet.sol";
+import {QuoteViewsFacet} from "../../src/diamond/facets/QuoteViewsFacet.sol";
 import {RawViewsFacet} from "../../src/diamond/facets/RawViewsFacet.sol";
 import {RegionViewsFacet} from "../../src/diamond/facets/RegionViewsFacet.sol";
 import {SnapshotViewsFacet} from "../../src/diamond/facets/SnapshotViewsFacet.sol";
@@ -299,6 +300,39 @@ contract DiamondSkeletonTest is Test {
         _assertWorldSnapshotEq(IClanWorld(address(diamond)).getWorldSnapshot(), core.getWorldSnapshot());
     }
 
+    function testDiamondQuoteViewsMatchCoreAfterMint() public {
+        ClanWorld core = new ClanWorld();
+        RawViewsFacet rawViewsFacet = new RawViewsFacet();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        QuoteViewsFacet quoteViewsFacet = new QuoteViewsFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                _rawViewsCut(address(rawViewsFacet)), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ())
+            );
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_quoteViewsCut(address(quoteViewsFacet)), address(0), "");
+
+        address elder = address(0xA11CE);
+        vm.prank(elder);
+        (uint32 coreClanId,) = core.mintClan(elder);
+        vm.prank(elder);
+        (uint32 diamondClanId,) = IClanWorld(address(diamond)).mintClan(elder);
+
+        assertEq(IClanWorld(address(diamond)).quoteLootValueRaw(diamondClanId), core.quoteLootValueRaw(coreClanId));
+        assertEq(IClanWorld(address(diamond)).getBanditTargetPreview(1), core.getBanditTargetPreview(1));
+
+        for (uint8 src = 0; src <= 8; src++) {
+            for (uint8 dst = 0; dst <= 8; dst++) {
+                (uint8 diamondTicks, bytes8 diamondPath) = IClanWorld(address(diamond)).quoteTravel(src, dst);
+                (uint8 coreTicks, bytes8 corePath) = core.quoteTravel(src, dst);
+                assertEq(diamondTicks, coreTicks, "travel ticks");
+                assertEq(diamondPath, corePath, "travel path");
+            }
+        }
+    }
+
     function _rawViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
         cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -359,6 +393,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
+        });
+    }
+
+    function _quoteViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
     }
 


### PR DESCRIPTION
## Summary
- adds `QuoteViewsFacet` for non-settling quote/preview selectors
- wires quote selectors into the shared selector library and deploy script
- verifies diamond output against the monolith for raw loot, bandit target preview, and all travel quotes

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
