### PR TITLE
[codex] add diamond treasury facet

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -19,6 +19,7 @@ import {RawTreasuryViewsFacet} from "../src/diamond/facets/RawTreasuryViewsFacet
 import {RawWorldViewsFacet} from "../src/diamond/facets/RawWorldViewsFacet.sol";
 import {RegionViewsFacet} from "../src/diamond/facets/RegionViewsFacet.sol";
 import {SnapshotViewsFacet} from "../src/diamond/facets/SnapshotViewsFacet.sol";
+import {TreasuryFacet} from "../src/diamond/facets/TreasuryFacet.sol";
 
 contract DeployDiamond is Script {
     function run() external {
@@ -35,6 +36,7 @@ contract DeployDiamond is Script {
         RawClanViewsFacet rawClanViewsFacet = new RawClanViewsFacet();
         RawBanditViewsFacet rawBanditViewsFacet = new RawBanditViewsFacet();
         ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        TreasuryFacet treasuryFacet = new TreasuryFacet();
         DerivedViewsFacet derivedViewsFacet = new DerivedViewsFacet();
         MarketViewsFacet marketViewsFacet = new MarketViewsFacet();
         BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
@@ -52,6 +54,7 @@ contract DeployDiamond is Script {
                     address(rawClanViewsFacet),
                     address(rawBanditViewsFacet),
                     address(lifecycleFacet),
+                    address(treasuryFacet),
                     address(derivedViewsFacet),
                     address(marketViewsFacet),
                     address(banditViewsFacet),
@@ -72,6 +75,7 @@ contract DeployDiamond is Script {
         console.log("RAW_CLAN_VIEWS_FACET_ADDRESS:     ", address(rawClanViewsFacet));
         console.log("RAW_BANDIT_VIEWS_FACET_ADDRESS:   ", address(rawBanditViewsFacet));
         console.log("DERIVED_VIEWS_FACET_ADDRESS:      ", address(derivedViewsFacet));
+        console.log("TREASURY_FACET_ADDRESS:           ", address(treasuryFacet));
         console.log("MARKET_VIEWS_FACET_ADDRESS:       ", address(marketViewsFacet));
         console.log("BANDIT_VIEWS_FACET_ADDRESS:       ", address(banditViewsFacet));
         console.log("REGION_VIEWS_FACET_ADDRESS:       ", address(regionViewsFacet));
@@ -89,6 +93,7 @@ contract DeployDiamond is Script {
         address rawClanViewsFacet,
         address rawBanditViewsFacet,
         address lifecycleFacet,
+        address treasuryFacet,
         address derivedViewsFacet,
         address marketViewsFacet,
         address banditViewsFacet,
@@ -96,7 +101,7 @@ contract DeployDiamond is Script {
         address snapshotViewsFacet,
         address quoteViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](12);
+        cut = new IDiamondCut.FacetCut[](13);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -128,31 +133,36 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.lifecycleSelectors()
         });
         cut[6] = IDiamondCut.FacetCut({
+            facetAddress: treasuryFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.treasurySelectors()
+        });
+        cut[7] = IDiamondCut.FacetCut({
             facetAddress: derivedViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-        cut[7] = IDiamondCut.FacetCut({
+        cut[8] = IDiamondCut.FacetCut({
             facetAddress: marketViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
-        cut[8] = IDiamondCut.FacetCut({
+        cut[9] = IDiamondCut.FacetCut({
             facetAddress: banditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
-        cut[9] = IDiamondCut.FacetCut({
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: regionViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
-        cut[10] = IDiamondCut.FacetCut({
+        cut[11] = IDiamondCut.FacetCut({
             facetAddress: snapshotViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
-        cut[11] = IDiamondCut.FacetCut({
+        cut[12] = IDiamondCut.FacetCut({
             facetAddress: quoteViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -90,6 +90,12 @@ library DiamondSelectors {
         selectors[0] = IClanWorld.mintClan.selector;
     }
 
+    function treasurySelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](2);
+        selectors[0] = IClanWorld.initTreasury.selector;
+        selectors[1] = IClanWorld.seedPools.selector;
+    }
+
     function derivedViewsSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](2);
         selectors[0] = IClanWorld.getDerivedClanState.selector;

--- a/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
+++ b/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
@@ -19,8 +19,6 @@ contract UpgradesFacet {}
 
 contract MarketFacet {}
 
-contract TreasuryFacet {}
-
 contract DirectTransfersFacet {}
 
 contract BanditStateFacet {}

--- a/packages/contracts/src/diamond/facets/TreasuryFacet.sol
+++ b/packages/contracts/src/diamond/facets/TreasuryFacet.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {IClanWorldEvents, PoolSeedConfig} from "../../IClanWorld.sol";
+import {MinimalERC20} from "../../MinimalERC20.sol";
+import {StubPool} from "../../StubPool.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract TreasuryFacet is IClanWorldEvents {
+    modifier nonReentrant() {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        _;
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function initTreasury(address[6] calldata tokens, address[4] calldata pools) external nonReentrant {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        require(!s.treasury.poolsSeeded && s.treasury.woodToken == address(0), "ClanWorld: treasury already init");
+        require(msg.sender == s.treasury.treasuryOwner, "ClanWorld: not owner");
+        _validateTreasuryInit(tokens, pools);
+
+        s.treasury.woodToken = tokens[0];
+        s.treasury.ironToken = tokens[1];
+        s.treasury.wheatToken = tokens[2];
+        s.treasury.fishToken = tokens[3];
+        s.treasury.goldToken = tokens[4];
+        s.treasury.blueprintToken = tokens[5];
+
+        s.treasury.woodGoldPool = pools[0];
+        s.treasury.wheatGoldPool = pools[1];
+        s.treasury.fishGoldPool = pools[2];
+        s.treasury.ironGoldPool = pools[3];
+    }
+
+    function seedPools(PoolSeedConfig calldata cfg) external nonReentrant {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        require(msg.sender == s.treasury.treasuryOwner, "ClanWorld: not owner");
+        require(!s.treasury.poolsSeeded, "ClanWorld: pools already seeded");
+        require(s.treasury.woodToken != address(0), "ClanWorld: treasury not init");
+
+        _transferSeed(s.treasury.woodToken, s.treasury.woodGoldPool, cfg.woodSeed);
+        _transferSeed(s.treasury.goldToken, s.treasury.woodGoldPool, cfg.goldSeedForWood);
+        _transferSeed(s.treasury.wheatToken, s.treasury.wheatGoldPool, cfg.wheatSeed);
+        _transferSeed(s.treasury.goldToken, s.treasury.wheatGoldPool, cfg.goldSeedForWheat);
+        _transferSeed(s.treasury.fishToken, s.treasury.fishGoldPool, cfg.fishSeed);
+        _transferSeed(s.treasury.goldToken, s.treasury.fishGoldPool, cfg.goldSeedForFish);
+        _transferSeed(s.treasury.ironToken, s.treasury.ironGoldPool, cfg.ironSeed);
+        _transferSeed(s.treasury.goldToken, s.treasury.ironGoldPool, cfg.goldSeedForIron);
+
+        StubPool(s.treasury.woodGoldPool).seed(cfg.woodSeed, cfg.goldSeedForWood);
+        StubPool(s.treasury.wheatGoldPool).seed(cfg.wheatSeed, cfg.goldSeedForWheat);
+        StubPool(s.treasury.fishGoldPool).seed(cfg.fishSeed, cfg.goldSeedForFish);
+        StubPool(s.treasury.ironGoldPool).seed(cfg.ironSeed, cfg.goldSeedForIron);
+
+        s.treasury.poolsSeeded = true;
+
+        emit PoolsSeeded(
+            s.treasury.woodGoldPool, s.treasury.wheatGoldPool, s.treasury.fishGoldPool, s.treasury.ironGoldPool
+        );
+    }
+
+    function _validateTreasuryInit(address[6] calldata tokens, address[4] calldata pools) private view {
+        for (uint256 i = 0; i < tokens.length; i++) {
+            require(tokens[i] != address(0), "ClanWorld: zero treasury token");
+            _requireContract(tokens[i], "ClanWorld: treasury token not contract");
+            for (uint256 j = i + 1; j < tokens.length; j++) {
+                require(tokens[i] != tokens[j], "ClanWorld: duplicate treasury token");
+            }
+        }
+
+        for (uint256 i = 0; i < pools.length; i++) {
+            require(pools[i] != address(0), "ClanWorld: zero treasury pool");
+            _requireContract(pools[i], "ClanWorld: treasury pool not contract");
+            for (uint256 j = i + 1; j < pools.length; j++) {
+                require(pools[i] != pools[j], "ClanWorld: duplicate treasury pool");
+            }
+        }
+
+        _requirePoolWiring(pools[0], tokens[0], tokens[4]);
+        _requirePoolWiring(pools[1], tokens[2], tokens[4]);
+        _requirePoolWiring(pools[2], tokens[3], tokens[4]);
+        _requirePoolWiring(pools[3], tokens[1], tokens[4]);
+    }
+
+    function _requirePoolWiring(address pool, address tokenA, address tokenB) private view {
+        require(StubPool(pool).TOKEN_A() == tokenA, "ClanWorld: treasury pool token A mismatch");
+        require(StubPool(pool).TOKEN_B() == tokenB, "ClanWorld: treasury pool token B mismatch");
+        require(StubPool(pool).ENGINE() == address(this), "ClanWorld: treasury pool engine mismatch");
+    }
+
+    function _requireContract(address target, string memory message) private view {
+        uint256 size;
+        assembly {
+            size := extcodesize(target)
+        }
+        require(size > 0, message);
+    }
+
+    function _transferSeed(address token, address pool, uint256 amount) private {
+        require(token != address(0) && pool != address(0), "ClanWorld: treasury not init");
+        require(MinimalERC20(token).transferFrom(msg.sender, pool, amount), "ClanWorld: seed transfer failed");
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -15,6 +15,7 @@ import {
     DerivedClanState,
     DerivedClansmanState,
     MarketState,
+    PoolSeedConfig,
     RegionOccupant,
     TreasuryState,
     WheatPlot,
@@ -29,6 +30,7 @@ import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.so
 import {DerivedViewsFacet} from "../../src/diamond/facets/DerivedViewsFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {MarketViewsFacet} from "../../src/diamond/facets/MarketViewsFacet.sol";
+import {MinimalERC20} from "../../src/MinimalERC20.sol";
 import {QuoteViewsFacet} from "../../src/diamond/facets/QuoteViewsFacet.sol";
 import {RawBanditViewsFacet} from "../../src/diamond/facets/RawBanditViewsFacet.sol";
 import {RawClanViewsFacet} from "../../src/diamond/facets/RawClanViewsFacet.sol";
@@ -36,6 +38,8 @@ import {RawTreasuryViewsFacet} from "../../src/diamond/facets/RawTreasuryViewsFa
 import {RawWorldViewsFacet} from "../../src/diamond/facets/RawWorldViewsFacet.sol";
 import {RegionViewsFacet} from "../../src/diamond/facets/RegionViewsFacet.sol";
 import {SnapshotViewsFacet} from "../../src/diamond/facets/SnapshotViewsFacet.sol";
+import {StubPool} from "../../src/StubPool.sol";
+import {TreasuryFacet} from "../../src/diamond/facets/TreasuryFacet.sol";
 
 contract PingFacet {
     function ping() external pure returns (uint256) {
@@ -180,6 +184,41 @@ contract DiamondSkeletonTest is Test {
         (WheatPlot memory coreWest, WheatPlot memory coreEast) = core.getWheatPlots(coreClanId);
         _assertWheatPlotEq(diamondWest, coreWest);
         _assertWheatPlotEq(diamondEast, coreEast);
+    }
+
+    function testDiamondTreasuryInitAndSeedPools() public {
+        TreasuryFacet treasuryFacet = new TreasuryFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_treasuryCut(address(treasuryFacet)), address(0), "");
+
+        (address[6] memory tokens, address[4] memory pools) = _deployTreasuryBoundary(address(diamond));
+        PoolSeedConfig memory cfg = _seedConfig();
+        _seedAndApproveTreasury(tokens, address(diamond), cfg);
+
+        IClanWorld diamondWorld = IClanWorld(address(diamond));
+        diamondWorld.initTreasury(tokens, pools);
+        TreasuryState memory initialized = diamondWorld.getTreasuryState();
+        assertEq(initialized.woodToken, tokens[0], "wood token");
+        assertEq(initialized.ironToken, tokens[1], "iron token");
+        assertEq(initialized.wheatToken, tokens[2], "wheat token");
+        assertEq(initialized.fishToken, tokens[3], "fish token");
+        assertEq(initialized.goldToken, tokens[4], "gold token");
+        assertEq(initialized.blueprintToken, tokens[5], "blueprint token");
+        assertEq(initialized.woodGoldPool, pools[0], "wood pool");
+        assertEq(initialized.wheatGoldPool, pools[1], "wheat pool");
+        assertEq(initialized.fishGoldPool, pools[2], "fish pool");
+        assertEq(initialized.ironGoldPool, pools[3], "iron pool");
+        assertEq(initialized.poolsSeeded, false, "seeded before seedPools");
+
+        diamondWorld.seedPools(cfg);
+        assertEq(diamondWorld.getTreasuryState().poolsSeeded, true, "pools seeded");
+        _assertPoolReserves(pools[0], cfg.woodSeed, cfg.goldSeedForWood);
+        _assertPoolReserves(pools[1], cfg.wheatSeed, cfg.goldSeedForWheat);
+        _assertPoolReserves(pools[2], cfg.fishSeed, cfg.goldSeedForFish);
+        _assertPoolReserves(pools[3], cfg.ironSeed, cfg.goldSeedForIron);
     }
 
     function testDiamondBasicDerivedViewsMatchCoreAfterMint() public {
@@ -349,6 +388,15 @@ contract DiamondSkeletonTest is Test {
         });
     }
 
+    function _treasuryCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.treasurySelectors()
+        });
+    }
+
     function _derivedViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
         cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -435,6 +483,58 @@ contract DiamondSkeletonTest is Test {
         assertEq(actual.wheatGoldPool, expected.wheatGoldPool, "wheatGoldPool");
         assertEq(actual.fishGoldPool, expected.fishGoldPool, "fishGoldPool");
         assertEq(actual.ironGoldPool, expected.ironGoldPool, "ironGoldPool");
+    }
+
+    function _deployTreasuryBoundary(address engine)
+        internal
+        returns (address[6] memory tokens, address[4] memory pools)
+    {
+        tokens[0] = address(new MinimalERC20("Wood", "WOOD"));
+        tokens[1] = address(new MinimalERC20("Iron", "IRON"));
+        tokens[2] = address(new MinimalERC20("Wheat", "WHEAT"));
+        tokens[3] = address(new MinimalERC20("Fish", "FISH"));
+        tokens[4] = address(new MinimalERC20("Gold", "GOLD"));
+        tokens[5] = address(new MinimalERC20("Blueprint", "BPRT"));
+
+        pools[0] = address(new StubPool(tokens[0], tokens[4], engine));
+        pools[1] = address(new StubPool(tokens[2], tokens[4], engine));
+        pools[2] = address(new StubPool(tokens[3], tokens[4], engine));
+        pools[3] = address(new StubPool(tokens[1], tokens[4], engine));
+    }
+
+    function _seedAndApproveTreasury(address[6] memory tokens, address spender, PoolSeedConfig memory cfg) internal {
+        MinimalERC20(tokens[0]).seedTreasury(address(this), cfg.woodSeed);
+        MinimalERC20(tokens[1]).seedTreasury(address(this), cfg.ironSeed);
+        MinimalERC20(tokens[2]).seedTreasury(address(this), cfg.wheatSeed);
+        MinimalERC20(tokens[3]).seedTreasury(address(this), cfg.fishSeed);
+        MinimalERC20(tokens[4])
+            .seedTreasury(
+                address(this), cfg.goldSeedForWood + cfg.goldSeedForWheat + cfg.goldSeedForFish + cfg.goldSeedForIron
+            );
+        MinimalERC20(tokens[5]).seedTreasury(address(this), 1);
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            MinimalERC20(tokens[i]).approve(spender, type(uint256).max);
+        }
+    }
+
+    function _seedConfig() internal pure returns (PoolSeedConfig memory) {
+        return PoolSeedConfig({
+            woodSeed: 1_000,
+            wheatSeed: 700,
+            fishSeed: 500,
+            ironSeed: 250,
+            goldSeedForWood: 100,
+            goldSeedForWheat: 120,
+            goldSeedForFish: 140,
+            goldSeedForIron: 160
+        });
+    }
+
+    function _assertPoolReserves(address pool, uint256 reserveA, uint256 reserveB) internal view {
+        (uint256 actualA, uint256 actualB) = StubPool(pool).getReserves();
+        assertEq(actualA, reserveA, "reserve A");
+        assertEq(actualB, reserveB, "reserve B");
     }
 
     function _assertClanEq(Clan memory actual, Clan memory expected) internal pure {


### PR DESCRIPTION
## Summary
- adds `TreasuryFacet` for `initTreasury` and `seedPools`
- wires treasury selectors into the diamond deploy path
- exercises real ERC20/pool seeding through the diamond address as the pool engine
- removes the old placeholder `TreasuryFacet` name to avoid duplicate artifacts

## Size Signal
- `TreasuryFacet` runtime: 4,925 bytes
- size check still reports the legacy `ClanWorld` monolith as oversized, as expected during migration

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
- `forge build --sizes --skip test script` (expected monolith oversize; facet sizes inspected)
