### PR TITLE
[codex] add diamond clan full view

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -9,6 +9,7 @@ import {IDiamondCut} from "../src/diamond/IDiamondCut.sol";
 import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
 import {BanditViewsFacet} from "../src/diamond/facets/BanditViewsFacet.sol";
+import {ClanFullViewFacet} from "../src/diamond/facets/ClanFullViewFacet.sol";
 import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
 import {DerivedViewsFacet} from "../src/diamond/facets/DerivedViewsFacet.sol";
 import {MarketViewsFacet} from "../src/diamond/facets/MarketViewsFacet.sol";
@@ -42,6 +43,7 @@ contract DeployDiamond is Script {
         BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
         RegionViewsFacet regionViewsFacet = new RegionViewsFacet();
         SnapshotViewsFacet snapshotViewsFacet = new SnapshotViewsFacet();
+        ClanFullViewFacet clanFullViewFacet = new ClanFullViewFacet();
         QuoteViewsFacet quoteViewsFacet = new QuoteViewsFacet();
         ClanWorldDiamondInit init = new ClanWorldDiamondInit();
 
@@ -60,6 +62,7 @@ contract DeployDiamond is Script {
                     address(banditViewsFacet),
                     address(regionViewsFacet),
                     address(snapshotViewsFacet),
+                    address(clanFullViewFacet),
                     address(quoteViewsFacet)
                 ),
                 address(init),
@@ -80,6 +83,7 @@ contract DeployDiamond is Script {
         console.log("BANDIT_VIEWS_FACET_ADDRESS:       ", address(banditViewsFacet));
         console.log("REGION_VIEWS_FACET_ADDRESS:       ", address(regionViewsFacet));
         console.log("SNAPSHOT_VIEWS_FACET_ADDRESS:     ", address(snapshotViewsFacet));
+        console.log("CLAN_FULL_VIEW_FACET_ADDRESS:     ", address(clanFullViewFacet));
         console.log("QUOTE_VIEWS_FACET_ADDRESS:        ", address(quoteViewsFacet));
         console.log("CLAN_WORLD_DIAMOND_INIT_ADDRESS:  ", address(init));
 
@@ -99,9 +103,10 @@ contract DeployDiamond is Script {
         address banditViewsFacet,
         address regionViewsFacet,
         address snapshotViewsFacet,
+        address clanFullViewFacet,
         address quoteViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](13);
+        cut = new IDiamondCut.FacetCut[](14);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -163,6 +168,11 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
         cut[12] = IDiamondCut.FacetCut({
+            facetAddress: clanFullViewFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.clanFullViewSelectors()
+        });
+        cut[13] = IDiamondCut.FacetCut({
             facetAddress: quoteViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -122,6 +122,11 @@ library DiamondSelectors {
         selectors[0] = IClanWorld.getWorldSnapshot.selector;
     }
 
+    function clanFullViewSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.getClanFullView.selector;
+    }
+
     function quoteViewsSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](3);
         selectors[0] = IClanWorld.getBanditTargetPreview.selector;

--- a/packages/contracts/src/diamond/facets/ClanFullViewFacet.sol
+++ b/packages/contracts/src/diamond/facets/ClanFullViewFacet.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {
+    ActionType,
+    ClanFullView,
+    ClansmanFullView,
+    ClansmanState,
+    DerivedClanState,
+    DerivedClansmanState,
+    Mission,
+    WheatPlot
+} from "../../IClanWorld.sol";
+import {LibMission} from "../lib/LibMission.sol";
+import {LibScoring} from "../../lib/LibScoring.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract ClanFullViewFacet {
+    function getClanFullView(uint32 clanId) external view returns (ClanFullView memory) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        DerivedClanState memory derivedClan = DerivedClanState({
+            clan: s.clans[clanId],
+            isStarving: s.clans[clanId].starvationStartsAtTick != 0
+                && s.clans[clanId].starvationStartsAtTick <= s.world.currentTick,
+            lootValue: LibScoring.lootValue(s.clans[clanId]),
+            derivedAtTick: s.world.currentTick
+        });
+
+        uint32[] storage clansmanIds = s.clanClansmanIds[clanId];
+        ClansmanFullView[] memory clansmen = new ClansmanFullView[](clansmanIds.length);
+        uint32 thisClanDefendingBaseId = 0;
+
+        for (uint256 i = 0; i < clansmanIds.length; i++) {
+            uint32 clansmanId = clansmanIds[i];
+            Mission memory mission = s.missions[clansmanId];
+            DerivedClansmanState memory dcs = DerivedClansmanState({
+                clansman: s.clansmen[clansmanId],
+                activeMission: mission,
+                effectiveRegion: LibMission.effectiveRegion(s.clansmen[clansmanId], mission, s.world.currentTick),
+                derivedAtTick: s.world.currentTick
+            });
+            clansmen[i] = ClansmanFullView({clansman: dcs, activeMission: mission});
+            if (
+                thisClanDefendingBaseId == 0 && mission.active && mission.action == ActionType.DefendBase
+                    && dcs.clansman.state == ClansmanState.ACTING
+            ) {
+                thisClanDefendingBaseId = mission.targetRegion;
+            }
+        }
+
+        if (thisClanDefendingBaseId == 0) {
+            for (uint256 i = 0; i < clansmanIds.length; i++) {
+                uint8 region = s.clansmanDefendingRegion[clansmanIds[i]];
+                if (region != 0) {
+                    thisClanDefendingBaseId = region;
+                    break;
+                }
+            }
+        }
+
+        WheatPlot memory westPlot = s.wheatPlots[clanId][0];
+        WheatPlot memory eastPlot = s.wheatPlots[clanId][1];
+        return ClanFullView({
+            clan: derivedClan,
+            clansmen: clansmen,
+            westPlot: westPlot,
+            eastPlot: eastPlot,
+            incomingDefenderIds: s.defendingClansByRegion[derivedClan.clan.baseRegion],
+            thisClanDefendingBaseId: thisClanDefendingBaseId
+        });
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -11,6 +11,7 @@ import {
     ActiveBanditView,
     ActionType,
     Clan,
+    ClanFullView,
     Clansman,
     DerivedClanState,
     DerivedClansmanState,
@@ -26,6 +27,7 @@ import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
 import {IDiamondLoupe} from "../../src/diamond/IDiamondLoupe.sol";
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {BanditViewsFacet} from "../../src/diamond/facets/BanditViewsFacet.sol";
+import {ClanFullViewFacet} from "../../src/diamond/facets/ClanFullViewFacet.sol";
 import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.sol";
 import {DerivedViewsFacet} from "../../src/diamond/facets/DerivedViewsFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
@@ -320,6 +322,28 @@ contract DiamondSkeletonTest is Test {
         _assertWorldSnapshotEq(IClanWorld(address(diamond)).getWorldSnapshot(), core.getWorldSnapshot());
     }
 
+    function testDiamondClanFullViewMatchesCoreAfterMint() public {
+        ClanWorld core = new ClanWorld();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        ClanFullViewFacet clanFullViewFacet = new ClanFullViewFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_clanFullViewCut(address(clanFullViewFacet)), address(0), "");
+
+        address elder = address(0xA11CE);
+        vm.prank(elder);
+        (uint32 coreClanId,) = core.mintClan(elder);
+        vm.prank(elder);
+        (uint32 diamondClanId,) = IClanWorld(address(diamond)).mintClan(elder);
+
+        _assertClanFullViewEq(
+            IClanWorld(address(diamond)).getClanFullView(diamondClanId), core.getClanFullView(coreClanId)
+        );
+    }
+
     function testDiamondQuoteViewsMatchCoreAfterMint() public {
         ClanWorld core = new ClanWorld();
         ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
@@ -439,6 +463,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
+        });
+    }
+
+    function _clanFullViewCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.clanFullViewSelectors()
         });
     }
 
@@ -660,5 +693,24 @@ contract DiamondSkeletonTest is Test {
             assertEq(uint8(actual.leaderboard[i].state), uint8(expected.leaderboard[i].state), "leaderboard state");
             assertEq(actual.leaderboard[i].lootValue, expected.leaderboard[i].lootValue, "leaderboard loot");
         }
+    }
+
+    function _assertClanFullViewEq(ClanFullView memory actual, ClanFullView memory expected) internal pure {
+        _assertDerivedClanStateEq(actual.clan, expected.clan);
+        assertEq(actual.clansmen.length, expected.clansmen.length, "full clansmen length");
+        for (uint256 i = 0; i < expected.clansmen.length; i++) {
+            _assertDerivedClansmanStateEq(actual.clansmen[i].clansman, expected.clansmen[i].clansman);
+            assertEq(actual.clansmen[i].activeMission.active, expected.clansmen[i].activeMission.active, "full active");
+            assertEq(actual.clansmen[i].activeMission.nonce, expected.clansmen[i].activeMission.nonce, "full nonce");
+            assertEq(
+                uint8(actual.clansmen[i].activeMission.action),
+                uint8(expected.clansmen[i].activeMission.action),
+                "full action"
+            );
+        }
+        _assertWheatPlotEq(actual.westPlot, expected.westPlot);
+        _assertWheatPlotEq(actual.eastPlot, expected.eastPlot);
+        assertEq(actual.incomingDefenderIds.length, expected.incomingDefenderIds.length, "incoming defenders");
+        assertEq(actual.thisClanDefendingBaseId, expected.thisClanDefendingBaseId, "defending base");
     }
 }


### PR DESCRIPTION
## Summary
- adds `ClanFullViewFacet` for `getClanFullView`
- wires the selector into deploy and selector helpers
- validates full clan view output against the monolith after minting a clan

## Notes
- this matches the current `DerivedViewsFacet` scope: parity is covered for minted/no-pending-settlement state while full settlement simulation is still being extracted
- `ClanFullViewFacet` runtime is 4,724 bytes

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `forge build --sizes --skip test script` (expected monolith oversize; facet sizes inspected)
