### PR TITLE
[codex] scaffold diamond settlement simulation

### DIFF
--- a/packages/contracts/src/diamond/facets/DerivedViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/DerivedViewsFacet.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.34;
 import {DerivedClanState, DerivedClansmanState, Mission} from "../../IClanWorld.sol";
 import {LibMission} from "../lib/LibMission.sol";
 import {LibScoring} from "../../lib/LibScoring.sol";
+import {LibSettlement} from "../lib/LibSettlement.sol";
 import {LibStorage} from "../lib/LibStorage.sol";
 
 /// @notice Future diamond home for simulation-heavy derived reads.
@@ -17,11 +18,11 @@ contract DerivedViewsFacet {
 
     function getDerivedClanState(uint32 clanId) external view returns (DerivedClanState memory) {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibSettlement.SettlementSimulation memory sim = LibSettlement.loadSimulation(s, clanId);
         return DerivedClanState({
-            clan: s.clans[clanId],
-            isStarving: s.clans[clanId].starvationStartsAtTick != 0
-                && s.clans[clanId].starvationStartsAtTick <= s.world.currentTick,
-            lootValue: LibScoring.lootValue(s.clans[clanId]),
+            clan: sim.clan,
+            isStarving: sim.clan.starvationStartsAtTick != 0 && sim.clan.starvationStartsAtTick <= s.world.currentTick,
+            lootValue: LibScoring.lootValue(sim.clan),
             derivedAtTick: s.world.currentTick
         });
     }
@@ -38,11 +39,36 @@ contract DerivedViewsFacet {
             });
         }
 
+        LibSettlement.SettlementSimulation memory sim = LibSettlement.loadSimulation(s, s.clansmen[clansmanId].clanId);
+        (bool found, uint256 index) = _findSimulatedClansman(sim, clansmanId);
+        if (found) {
+            return DerivedClansmanState({
+                clansman: sim.clansmen[index],
+                activeMission: sim.missions[index],
+                effectiveRegion: LibMission.effectiveRegion(
+                    sim.clansmen[index], sim.missions[index], s.world.currentTick
+                ),
+                derivedAtTick: s.world.currentTick
+            });
+        }
+
         return DerivedClansmanState({
             clansman: s.clansmen[clansmanId],
             activeMission: mission,
             effectiveRegion: LibMission.effectiveRegion(s.clansmen[clansmanId], mission, s.world.currentTick),
             derivedAtTick: s.world.currentTick
         });
+    }
+
+    function _findSimulatedClansman(LibSettlement.SettlementSimulation memory sim, uint32 clansmanId)
+        private
+        pure
+        returns (bool found, uint256 index)
+    {
+        for (uint256 i = 0; i < sim.clansmen.length; i++) {
+            if (sim.clansmen[i].clansmanId == clansmanId) {
+                return (true, i);
+            }
+        }
     }
 }

--- a/packages/contracts/src/diamond/lib/LibSettlement.sol
+++ b/packages/contracts/src/diamond/lib/LibSettlement.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Clan, ClanWorldConstants, Clansman, Mission, WheatPlot} from "../../IClanWorld.sol";
+import {LibStorage} from "./LibStorage.sol";
+
+library LibSettlement {
+    struct SettlementSimulation {
+        Clan clan;
+        Clansman[] clansmen;
+        Mission[] missions;
+        WheatPlot[2] wheatPlots;
+        uint64[11] simMonumentReachedAt;
+        bool[] simWallReservationCleared;
+        bool[] simBaseReservationCleared;
+        bool[] simMonumentReservationCleared;
+        uint256 reservedWheat;
+    }
+
+    function loadSimulation(LibStorage.AppStorage storage s, uint32 clanId)
+        internal
+        view
+        returns (SettlementSimulation memory sim)
+    {
+        sim.clan = s.clans[clanId];
+        if (sim.clan.clanId == ClanWorldConstants.CLAN_ID_NULL) return sim;
+
+        uint32[] storage clansmanIds = s.clanClansmanIds[clanId];
+        sim.clansmen = new Clansman[](clansmanIds.length);
+        sim.missions = new Mission[](clansmanIds.length);
+        sim.simWallReservationCleared = new bool[](clansmanIds.length);
+        sim.simBaseReservationCleared = new bool[](clansmanIds.length);
+        sim.simMonumentReservationCleared = new bool[](clansmanIds.length);
+
+        for (uint256 i = 0; i < clansmanIds.length; i++) {
+            uint32 clansmanId = clansmanIds[i];
+            sim.clansmen[i] = s.clansmen[clansmanId];
+            sim.missions[i] = s.missions[clansmanId];
+        }
+
+        sim.wheatPlots[0] = s.wheatPlots[clanId][0];
+        sim.wheatPlots[1] = s.wheatPlots[clanId][1];
+        sim.reservedWheat = s.reservedWheatByClan[clanId];
+    }
+}


### PR DESCRIPTION
## Summary
- adds `LibSettlement` with the shared settlement simulation struct and storage-loading scaffold
- routes `DerivedViewsFacet` through the scaffold without changing current behavior
- preserves parity for the existing minted/no-pending-settlement diamond view tests

## Size Signal
- `DerivedViewsFacet` runtime after scaffold: 4,314 bytes
- `LibSettlement` remains an internal library artifact at 57 bytes

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `forge build --sizes --skip test script` (expected monolith oversize; facet sizes inspected)
