### PR TITLE
[codex] add diamond scoring views

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -19,6 +19,7 @@ import {RawClanViewsFacet} from "../src/diamond/facets/RawClanViewsFacet.sol";
 import {RawTreasuryViewsFacet} from "../src/diamond/facets/RawTreasuryViewsFacet.sol";
 import {RawWorldViewsFacet} from "../src/diamond/facets/RawWorldViewsFacet.sol";
 import {RegionViewsFacet} from "../src/diamond/facets/RegionViewsFacet.sol";
+import {ScoringViewsFacet} from "../src/diamond/facets/ScoringViewsFacet.sol";
 import {SnapshotViewsFacet} from "../src/diamond/facets/SnapshotViewsFacet.sol";
 import {TreasuryFacet} from "../src/diamond/facets/TreasuryFacet.sol";
 
@@ -45,6 +46,7 @@ contract DeployDiamond is Script {
         SnapshotViewsFacet snapshotViewsFacet = new SnapshotViewsFacet();
         ClanFullViewFacet clanFullViewFacet = new ClanFullViewFacet();
         QuoteViewsFacet quoteViewsFacet = new QuoteViewsFacet();
+        ScoringViewsFacet scoringViewsFacet = new ScoringViewsFacet();
         ClanWorldDiamondInit init = new ClanWorldDiamondInit();
 
         IDiamondCut(address(diamond))
@@ -63,7 +65,8 @@ contract DeployDiamond is Script {
                     address(regionViewsFacet),
                     address(snapshotViewsFacet),
                     address(clanFullViewFacet),
-                    address(quoteViewsFacet)
+                    address(quoteViewsFacet),
+                    address(scoringViewsFacet)
                 ),
                 address(init),
                 abi.encodeCall(ClanWorldDiamondInit.init, ())
@@ -85,6 +88,7 @@ contract DeployDiamond is Script {
         console.log("SNAPSHOT_VIEWS_FACET_ADDRESS:     ", address(snapshotViewsFacet));
         console.log("CLAN_FULL_VIEW_FACET_ADDRESS:     ", address(clanFullViewFacet));
         console.log("QUOTE_VIEWS_FACET_ADDRESS:        ", address(quoteViewsFacet));
+        console.log("SCORING_VIEWS_FACET_ADDRESS:      ", address(scoringViewsFacet));
         console.log("CLAN_WORLD_DIAMOND_INIT_ADDRESS:  ", address(init));
 
         vm.stopBroadcast();
@@ -104,9 +108,10 @@ contract DeployDiamond is Script {
         address regionViewsFacet,
         address snapshotViewsFacet,
         address clanFullViewFacet,
-        address quoteViewsFacet
+        address quoteViewsFacet,
+        address scoringViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](14);
+        cut = new IDiamondCut.FacetCut[](15);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -176,6 +181,11 @@ contract DeployDiamond is Script {
             facetAddress: quoteViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
+        });
+        cut[14] = IDiamondCut.FacetCut({
+            facetAddress: scoringViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.scoringViewsSelectors()
         });
     }
 }

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -133,4 +133,11 @@ library DiamondSelectors {
         selectors[1] = IClanWorld.quoteTravel.selector;
         selectors[2] = IClanWorld.quoteLootValueRaw.selector;
     }
+
+    function scoringViewsSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](3);
+        selectors[0] = IClanWorld.quoteLootValueSettled.selector;
+        selectors[1] = IClanWorld.getClanScore.selector;
+        selectors[2] = IClanWorld.getRankings.selector;
+    }
 }

--- a/packages/contracts/src/diamond/facets/ScoringViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/ScoringViewsFacet.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanState} from "../../IClanWorld.sol";
+import {LibScoring} from "../../lib/LibScoring.sol";
+import {LibSettlement} from "../lib/LibSettlement.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract ScoringViewsFacet {
+    uint256 internal constant MAX_CLAN_SCAN_FOR_RANKING = 24;
+
+    function quoteLootValueSettled(uint32 clanId) external view returns (uint256 lootValue) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, s.world.currentTick);
+        return LibScoring.lootValue(sim.clan);
+    }
+
+    function getClanScore(uint32 clanId)
+        external
+        view
+        returns (uint256 score, uint64 monumentReachedAtTick, uint8 monumentLevel)
+    {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, s.world.currentTick);
+        return _getClanScoreFromSimulation(s, clanId, sim);
+    }
+
+    function getRankings() external view returns (uint32[] memory clanIdsRanked, uint256[] memory scores) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        uint256 scanCount = s.allClanIds.length;
+        if (scanCount > MAX_CLAN_SCAN_FOR_RANKING) {
+            scanCount = MAX_CLAN_SCAN_FOR_RANKING;
+        }
+
+        uint32[] memory tempClanIds = new uint32[](scanCount);
+        uint256[] memory tempScores = new uint256[](scanCount);
+        uint256 liveCount;
+
+        for (uint256 i = 0; i < scanCount; i++) {
+            uint32 clanId = s.allClanIds[i];
+            LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, s.world.currentTick);
+            if (sim.clan.clanState != ClanState.ACTIVE) continue;
+
+            (uint256 score,,) = _getClanScoreFromSimulation(s, clanId, sim);
+            tempClanIds[liveCount] = clanId;
+            tempScores[liveCount] = score;
+            liveCount++;
+        }
+
+        for (uint256 i = 1; i < liveCount; i++) {
+            uint32 keyClanId = tempClanIds[i];
+            uint256 keyScore = tempScores[i];
+            uint256 j = i;
+            while (j > 0 && LibScoring.rankingComesAfter(tempClanIds[j - 1], tempScores[j - 1], keyClanId, keyScore)) {
+                tempClanIds[j] = tempClanIds[j - 1];
+                tempScores[j] = tempScores[j - 1];
+                j--;
+            }
+            tempClanIds[j] = keyClanId;
+            tempScores[j] = keyScore;
+        }
+
+        clanIdsRanked = new uint32[](liveCount);
+        scores = new uint256[](liveCount);
+        for (uint256 i = 0; i < liveCount; i++) {
+            clanIdsRanked[i] = tempClanIds[i];
+            scores[i] = tempScores[i];
+        }
+    }
+
+    function _getClanScoreFromSimulation(
+        LibStorage.AppStorage storage s,
+        uint32 clanId,
+        LibSettlement.SettlementSimulation memory sim
+    ) private view returns (uint256 score, uint64 monumentReachedAtTick, uint8 monumentLevel) {
+        monumentLevel = sim.clan.monumentLevel;
+        if (monumentLevel > 0) {
+            monumentReachedAtTick = s.monumentLevelReachedAt[clanId][monumentLevel];
+            if (monumentReachedAtTick == 0) {
+                monumentReachedAtTick = sim.simMonumentReachedAt[monumentLevel];
+            }
+        }
+
+        return LibScoring.packClanScore(sim.clan, monumentReachedAtTick, monumentLevel);
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -39,6 +39,7 @@ import {RawClanViewsFacet} from "../../src/diamond/facets/RawClanViewsFacet.sol"
 import {RawTreasuryViewsFacet} from "../../src/diamond/facets/RawTreasuryViewsFacet.sol";
 import {RawWorldViewsFacet} from "../../src/diamond/facets/RawWorldViewsFacet.sol";
 import {RegionViewsFacet} from "../../src/diamond/facets/RegionViewsFacet.sol";
+import {ScoringViewsFacet} from "../../src/diamond/facets/ScoringViewsFacet.sol";
 import {SnapshotViewsFacet} from "../../src/diamond/facets/SnapshotViewsFacet.sol";
 import {StubPool} from "../../src/StubPool.sol";
 import {TreasuryFacet} from "../../src/diamond/facets/TreasuryFacet.sol";
@@ -374,6 +375,46 @@ contract DiamondSkeletonTest is Test {
         }
     }
 
+    function testDiamondScoringViewsMatchCoreAfterMint() public {
+        ClanWorld core = new ClanWorld();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        ScoringViewsFacet scoringViewsFacet = new ScoringViewsFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_scoringViewsCut(address(scoringViewsFacet)), address(0), "");
+
+        address elder = address(0xA11CE);
+        vm.prank(elder);
+        (uint32 coreClanId,) = core.mintClan(elder);
+        vm.prank(elder);
+        (uint32 diamondClanId,) = IClanWorld(address(diamond)).mintClan(elder);
+
+        assertEq(
+            IClanWorld(address(diamond)).quoteLootValueSettled(diamondClanId),
+            core.quoteLootValueSettled(coreClanId),
+            "settled loot"
+        );
+
+        (uint256 diamondScore, uint64 diamondReached, uint8 diamondLevel) =
+            IClanWorld(address(diamond)).getClanScore(diamondClanId);
+        (uint256 coreScore, uint64 coreReached, uint8 coreLevel) = core.getClanScore(coreClanId);
+        assertEq(diamondScore, coreScore, "score");
+        assertEq(diamondReached, coreReached, "monument reached");
+        assertEq(diamondLevel, coreLevel, "monument level");
+
+        (uint32[] memory diamondRanked, uint256[] memory diamondScores) = IClanWorld(address(diamond)).getRankings();
+        (uint32[] memory coreRanked, uint256[] memory coreScores) = core.getRankings();
+        assertEq(diamondRanked.length, coreRanked.length, "ranked length");
+        assertEq(diamondScores.length, coreScores.length, "rank scores length");
+        for (uint256 i = 0; i < coreRanked.length; i++) {
+            assertEq(diamondRanked[i], coreRanked[i], "ranked clan");
+            assertEq(diamondScores[i], coreScores[i], "rank score");
+        }
+    }
+
     function _rawViewsCut() internal returns (IDiamondCut.FacetCut[] memory cut) {
         RawWorldViewsFacet rawWorldViewsFacet = new RawWorldViewsFacet();
         RawTreasuryViewsFacet rawTreasuryViewsFacet = new RawTreasuryViewsFacet();
@@ -481,6 +522,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
+        });
+    }
+
+    function _scoringViewsCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.scoringViewsSelectors()
         });
     }
 


### PR DESCRIPTION
## Summary
- adds `ScoringViewsFacet` for settled loot quotes, packed clan score, and rankings
- uses the shared settlement simulation path so monument reach ticks from simulated upgrades can feed score packing
- wires scoring selectors into deploy and tests monolith parity after mint

## Size Signal
- `ScoringViewsFacet` runtime: 13,865 bytes
- `DerivedViewsFacet` remains 14,307 bytes
- both are comfortably below EIP-170 after keeping scoring separate from derived views

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `forge build --sizes --skip test script` (expected monolith oversize; facet sizes inspected)
