### PR TITLE
[codex] add diamond settlement facet

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -20,6 +20,7 @@ import {RawTreasuryViewsFacet} from "../src/diamond/facets/RawTreasuryViewsFacet
 import {RawWorldViewsFacet} from "../src/diamond/facets/RawWorldViewsFacet.sol";
 import {RegionViewsFacet} from "../src/diamond/facets/RegionViewsFacet.sol";
 import {ScoringViewsFacet} from "../src/diamond/facets/ScoringViewsFacet.sol";
+import {SettlementFacet} from "../src/diamond/facets/SettlementFacet.sol";
 import {SnapshotViewsFacet} from "../src/diamond/facets/SnapshotViewsFacet.sol";
 import {TreasuryFacet} from "../src/diamond/facets/TreasuryFacet.sol";
 
@@ -39,6 +40,7 @@ contract DeployDiamond is Script {
         RawBanditViewsFacet rawBanditViewsFacet = new RawBanditViewsFacet();
         ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
         TreasuryFacet treasuryFacet = new TreasuryFacet();
+        SettlementFacet settlementFacet = new SettlementFacet();
         DerivedViewsFacet derivedViewsFacet = new DerivedViewsFacet();
         MarketViewsFacet marketViewsFacet = new MarketViewsFacet();
         BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
@@ -59,6 +61,7 @@ contract DeployDiamond is Script {
                     address(rawBanditViewsFacet),
                     address(lifecycleFacet),
                     address(treasuryFacet),
+                    address(settlementFacet),
                     address(derivedViewsFacet),
                     address(marketViewsFacet),
                     address(banditViewsFacet),
@@ -82,6 +85,7 @@ contract DeployDiamond is Script {
         console.log("RAW_BANDIT_VIEWS_FACET_ADDRESS:   ", address(rawBanditViewsFacet));
         console.log("DERIVED_VIEWS_FACET_ADDRESS:      ", address(derivedViewsFacet));
         console.log("TREASURY_FACET_ADDRESS:           ", address(treasuryFacet));
+        console.log("SETTLEMENT_FACET_ADDRESS:         ", address(settlementFacet));
         console.log("MARKET_VIEWS_FACET_ADDRESS:       ", address(marketViewsFacet));
         console.log("BANDIT_VIEWS_FACET_ADDRESS:       ", address(banditViewsFacet));
         console.log("REGION_VIEWS_FACET_ADDRESS:       ", address(regionViewsFacet));
@@ -102,6 +106,7 @@ contract DeployDiamond is Script {
         address rawBanditViewsFacet,
         address lifecycleFacet,
         address treasuryFacet,
+        address settlementFacet,
         address derivedViewsFacet,
         address marketViewsFacet,
         address banditViewsFacet,
@@ -111,7 +116,7 @@ contract DeployDiamond is Script {
         address quoteViewsFacet,
         address scoringViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](15);
+        cut = new IDiamondCut.FacetCut[](16);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -148,41 +153,46 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.treasurySelectors()
         });
         cut[7] = IDiamondCut.FacetCut({
+            facetAddress: settlementFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.settlementSelectors()
+        });
+        cut[8] = IDiamondCut.FacetCut({
             facetAddress: derivedViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-        cut[8] = IDiamondCut.FacetCut({
+        cut[9] = IDiamondCut.FacetCut({
             facetAddress: marketViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
-        cut[9] = IDiamondCut.FacetCut({
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: banditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
-        cut[10] = IDiamondCut.FacetCut({
+        cut[11] = IDiamondCut.FacetCut({
             facetAddress: regionViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
-        cut[11] = IDiamondCut.FacetCut({
+        cut[12] = IDiamondCut.FacetCut({
             facetAddress: snapshotViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
-        cut[12] = IDiamondCut.FacetCut({
+        cut[13] = IDiamondCut.FacetCut({
             facetAddress: clanFullViewFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.clanFullViewSelectors()
         });
-        cut[13] = IDiamondCut.FacetCut({
+        cut[14] = IDiamondCut.FacetCut({
             facetAddress: quoteViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
-        cut[14] = IDiamondCut.FacetCut({
+        cut[15] = IDiamondCut.FacetCut({
             facetAddress: scoringViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.scoringViewsSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -96,6 +96,12 @@ library DiamondSelectors {
         selectors[1] = IClanWorld.seedPools.selector;
     }
 
+    function settlementSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](2);
+        selectors[0] = IClanWorld.settleClan.selector;
+        selectors[1] = IClanWorld.settleClansman.selector;
+    }
+
     function derivedViewsSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](2);
         selectors[0] = IClanWorld.getDerivedClanState.selector;

--- a/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
+++ b/packages/contracts/src/diamond/facets/ClanWorldFacetPlaceholders.sol
@@ -7,8 +7,6 @@ contract SeasonFacet {}
 
 contract OrdersFacet {}
 
-contract SettlementFacet {}
-
 contract UpkeepFacet {}
 
 contract GatheringFacet {}

--- a/packages/contracts/src/diamond/facets/SettlementFacet.sol
+++ b/packages/contracts/src/diamond/facets/SettlementFacet.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanState, IClanWorldEvents} from "../../IClanWorld.sol";
+import {LibGameRules} from "../lib/LibGameRules.sol";
+import {LibSettlement} from "../lib/LibSettlement.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract SettlementFacet is IClanWorldEvents {
+    function settleClan(uint32 clanId) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        LibGameRules.requireNoPendingSeasonFinalization(s);
+        _settleClan(s, clanId);
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function settleClansman(uint32 clansmanId) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        LibGameRules.requireNoPendingSeasonFinalization(s);
+
+        uint32 clanId = s.clansmen[clansmanId].clanId;
+        if (s.clansmen[clansmanId].clansmanId != 0) {
+            _settleClan(s, clanId);
+        }
+
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function _settleClan(LibStorage.AppStorage storage s, uint32 clanId) private {
+        if (s.clans[clanId].clanId == 0) return;
+        if (s.clans[clanId].clanState == ClanState.DEAD) return;
+        uint64 fromTick = s.clans[clanId].lastSettledTick;
+        if (fromTick >= s.world.currentTick) return;
+
+        LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, s.world.currentTick);
+        LibSettlement.commitSimulation(s, sim);
+        emit ClanSettled(clanId, s.clans[clanId].lastSettledTick);
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibSettlement.sol
+++ b/packages/contracts/src/diamond/lib/LibSettlement.sol
@@ -71,6 +71,9 @@ library LibSettlement {
 
         uint64 fromTick = sim.clan.lastSettledTick;
         if (fromTick >= toTick) return sim;
+        if (toTick > fromTick + LibGameRules.MAX_LAZY_SETTLE_BACKLOG) {
+            toTick = fromTick + LibGameRules.MAX_LAZY_SETTLE_BACKLOG;
+        }
 
         for (uint64 tick = fromTick; tick < toTick; tick++) {
             applyUpkeep(s, sim, tick);
@@ -86,6 +89,38 @@ library LibSettlement {
         }
 
         sim.clan.lastSettledTick = toTick;
+    }
+
+    function commitSimulation(LibStorage.AppStorage storage s, SettlementSimulation memory sim) internal {
+        uint32 clanId = sim.clan.clanId;
+        if (clanId == ClanWorldConstants.CLAN_ID_NULL) return;
+
+        s.clans[clanId] = sim.clan;
+        s.wheatPlots[clanId][0] = sim.wheatPlots[0];
+        s.wheatPlots[clanId][1] = sim.wheatPlots[1];
+
+        for (uint256 i = 0; i < sim.clansmen.length; i++) {
+            uint32 clansmanId = sim.clansmen[i].clansmanId;
+            s.clansmen[clansmanId] = sim.clansmen[i];
+            s.missions[clansmanId] = sim.missions[i];
+
+            if (sim.simWallReservationCleared[i]) {
+                clearWallUpgradeReservation(s, clansmanId);
+            }
+            if (sim.simBaseReservationCleared[i]) {
+                clearBaseUpgradeReservation(s, clansmanId);
+            }
+            if (sim.simMonumentReservationCleared[i]) {
+                clearMonumentUpgradeReservation(s, clansmanId);
+            }
+        }
+
+        s.reservedWheatByClan[clanId] = sim.reservedWheat;
+        for (uint8 level = 1; level < sim.simMonumentReachedAt.length; level++) {
+            if (sim.simMonumentReachedAt[level] != 0 && s.monumentLevelReachedAt[clanId][level] == 0) {
+                s.monumentLevelReachedAt[clanId][level] = sim.simMonumentReachedAt[level];
+            }
+        }
     }
 
     function applyUpkeep(LibStorage.AppStorage storage s, SettlementSimulation memory sim, uint64 tick) internal view {
@@ -576,7 +611,10 @@ library LibSettlement {
         if (upgradeReservationCleared(sim, clansmanId, ActionType.UpgradeWall)) return true;
         LibStorage.WallUpgradeReservation memory held = s.wallUpgradeReservations[clansmanId];
         if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return true;
-        if (sim.clan.wallLevel >= WALL_MAX_LEVEL) return true;
+        if (sim.clan.wallLevel >= WALL_MAX_LEVEL) {
+            clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeWall);
+            return true;
+        }
         if (held.fromLevel != sim.clan.wallLevel) {
             if (held.fromLevel < sim.clan.wallLevel) {
                 clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeWall);
@@ -589,6 +627,7 @@ library LibSettlement {
         uint256 ironDebit = LibSettlementMath.min(held.ironCost, ironCost);
         if (sim.clan.vaultWood < woodDebit || sim.clan.vaultIron < ironDebit) return false;
 
+        clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeWall);
         sim.clan.vaultWood -= woodDebit;
         sim.clan.vaultIron -= ironDebit;
         sim.clan.wallLevel += 1;
@@ -604,7 +643,11 @@ library LibSettlement {
         if (upgradeReservationCleared(sim, clansmanId, ActionType.UpgradeBase)) return true;
         LibStorage.BaseUpgradeReservation memory held = s.baseUpgradeReservations[clansmanId];
         if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return true;
-        if (sim.clan.baseLevel >= BASE_MAX_LEVEL) return true;
+        if (sim.clan.baseLevel >= BASE_MAX_LEVEL) {
+            clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeBase);
+            sim.reservedWheat = LibSettlementMath.subtractHeld(sim.reservedWheat, held.wheatCost);
+            return true;
+        }
         if (held.fromLevel != sim.clan.baseLevel) {
             if (held.fromLevel < sim.clan.baseLevel) {
                 clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeBase);
@@ -621,6 +664,7 @@ library LibSettlement {
             return false;
         }
 
+        clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeBase);
         sim.clan.vaultWood -= woodDebit;
         sim.clan.vaultIron -= ironDebit;
         sim.clan.vaultWheat -= wheatDebit;
@@ -641,7 +685,11 @@ library LibSettlement {
         }
         LibStorage.MonumentUpgradeReservation memory held = s.monumentUpgradeReservations[clansmanId];
         if (!held.active || held.clanId != sim.clan.clanId || held.missionNonce != missionNonce) return true;
-        if (sim.clan.monumentLevel >= LibGameRules.MONUMENT_MAX_LEVEL) return true;
+        if (sim.clan.monumentLevel >= LibGameRules.MONUMENT_MAX_LEVEL) {
+            clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeMonument);
+            sim.reservedWheat = LibSettlementMath.subtractHeld(sim.reservedWheat, held.wheatCost);
+            return true;
+        }
         if (held.fromLevel != sim.clan.monumentLevel) {
             if (held.fromLevel < sim.clan.monumentLevel) {
                 clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeMonument);
@@ -661,6 +709,7 @@ library LibSettlement {
                 || sim.clan.blueprintBalance < blueprintDebit
         ) return false;
 
+        clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeMonument);
         sim.clan.vaultWood -= woodDebit;
         sim.clan.vaultIron -= ironDebit;
         sim.clan.vaultWheat -= wheatDebit;
@@ -719,5 +768,59 @@ library LibSettlement {
         cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
         m.active = false;
         return (cs, m);
+    }
+
+    function clearWallUpgradeReservation(LibStorage.AppStorage storage s, uint32 clansmanId) internal {
+        LibStorage.WallUpgradeReservation storage reservation = s.wallUpgradeReservations[clansmanId];
+        if (!reservation.active) return;
+
+        uint32 clanId = reservation.clanId;
+        if (s.pendingWallUpgradesByClan[clanId] > 0) {
+            s.pendingWallUpgradesByClan[clanId] -= 1;
+        }
+        s.reservedWoodByClan[clanId] =
+            LibSettlementMath.subtractHeld(s.reservedWoodByClan[clanId], reservation.woodCost);
+        s.reservedIronByClan[clanId] =
+            LibSettlementMath.subtractHeld(s.reservedIronByClan[clanId], reservation.ironCost);
+
+        delete s.wallUpgradeReservations[clansmanId];
+    }
+
+    function clearBaseUpgradeReservation(LibStorage.AppStorage storage s, uint32 clansmanId) internal {
+        LibStorage.BaseUpgradeReservation storage reservation = s.baseUpgradeReservations[clansmanId];
+        if (!reservation.active) return;
+
+        uint32 clanId = reservation.clanId;
+        if (s.pendingBaseUpgradesByClan[clanId] > 0) {
+            s.pendingBaseUpgradesByClan[clanId] -= 1;
+        }
+        s.reservedWoodByClan[clanId] =
+            LibSettlementMath.subtractHeld(s.reservedWoodByClan[clanId], reservation.woodCost);
+        s.reservedIronByClan[clanId] =
+            LibSettlementMath.subtractHeld(s.reservedIronByClan[clanId], reservation.ironCost);
+        s.reservedWheatByClan[clanId] =
+            LibSettlementMath.subtractHeld(s.reservedWheatByClan[clanId], reservation.wheatCost);
+
+        delete s.baseUpgradeReservations[clansmanId];
+    }
+
+    function clearMonumentUpgradeReservation(LibStorage.AppStorage storage s, uint32 clansmanId) internal {
+        LibStorage.MonumentUpgradeReservation storage reservation = s.monumentUpgradeReservations[clansmanId];
+        if (!reservation.active) return;
+
+        uint32 clanId = reservation.clanId;
+        if (s.pendingMonumentUpgradesByClan[clanId] > 0) {
+            s.pendingMonumentUpgradesByClan[clanId] -= 1;
+        }
+        s.reservedWoodByClan[clanId] =
+            LibSettlementMath.subtractHeld(s.reservedWoodByClan[clanId], reservation.woodCost);
+        s.reservedIronByClan[clanId] =
+            LibSettlementMath.subtractHeld(s.reservedIronByClan[clanId], reservation.ironCost);
+        s.reservedWheatByClan[clanId] =
+            LibSettlementMath.subtractHeld(s.reservedWheatByClan[clanId], reservation.wheatCost);
+        s.reservedBlueprintByClan[clanId] =
+            LibSettlementMath.subtractHeld(s.reservedBlueprintByClan[clanId], reservation.blueprintCost);
+
+        delete s.monumentUpgradeReservations[clansmanId];
     }
 }

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -12,6 +12,7 @@ import {
     ActionType,
     Clan,
     ClanFullView,
+    ClanWorldConstants,
     Clansman,
     DerivedClanState,
     DerivedClansmanState,
@@ -40,9 +41,11 @@ import {RawTreasuryViewsFacet} from "../../src/diamond/facets/RawTreasuryViewsFa
 import {RawWorldViewsFacet} from "../../src/diamond/facets/RawWorldViewsFacet.sol";
 import {RegionViewsFacet} from "../../src/diamond/facets/RegionViewsFacet.sol";
 import {ScoringViewsFacet} from "../../src/diamond/facets/ScoringViewsFacet.sol";
+import {SettlementFacet} from "../../src/diamond/facets/SettlementFacet.sol";
 import {SnapshotViewsFacet} from "../../src/diamond/facets/SnapshotViewsFacet.sol";
 import {StubPool} from "../../src/StubPool.sol";
 import {TreasuryFacet} from "../../src/diamond/facets/TreasuryFacet.sol";
+import {LibStorage} from "../../src/diamond/lib/LibStorage.sol";
 
 contract PingFacet {
     function ping() external pure returns (uint256) {
@@ -52,6 +55,37 @@ contract PingFacet {
 
 interface IPing {
     function ping() external view returns (uint256);
+}
+
+interface ISetWorldClock {
+    function setWorldClock(
+        uint64 currentTick,
+        uint64 nextHeartbeatAtTick,
+        uint64 nextHeartbeatAtTs,
+        uint64 nextBanditSpawnEligibleTick,
+        uint16 currentBanditSpawnChanceBps,
+        bytes32 tickSeed
+    ) external;
+}
+
+contract SetWorldClockFacet {
+    function setWorldClock(
+        uint64 currentTick,
+        uint64 nextHeartbeatAtTick,
+        uint64 nextHeartbeatAtTs,
+        uint64 nextBanditSpawnEligibleTick,
+        uint16 currentBanditSpawnChanceBps,
+        bytes32 tickSeed
+    ) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        s.world.currentTick = currentTick;
+        s.world.nextHeartbeatAtTick = nextHeartbeatAtTick;
+        s.world.nextHeartbeatAtTs = nextHeartbeatAtTs;
+        s.world.nextBanditSpawnEligibleTick = nextBanditSpawnEligibleTick;
+        s.world.currentBanditSpawnChanceBps = currentBanditSpawnChanceBps;
+        s.world.currentTickSeed = tickSeed;
+        s.tickSeeds[currentTick] = tickSeed;
+    }
 }
 
 contract DiamondSkeletonTest is Test {
@@ -415,6 +449,49 @@ contract DiamondSkeletonTest is Test {
         }
     }
 
+    function testDiamondSettleClanMatchesCoreAfterHeartbeatUpkeep() public {
+        ClanWorld core = new ClanWorld();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        SettlementFacet settlementFacet = new SettlementFacet();
+        SetWorldClockFacet setWorldClockFacet = new SetWorldClockFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_settlementCut(address(settlementFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_setWorldClockCut(address(setWorldClockFacet)), address(0), "");
+
+        address elder = address(0xA11CE);
+        vm.prank(elder);
+        (uint32 coreClanId,) = core.mintClan(elder);
+        vm.prank(elder);
+        (uint32 diamondClanId,) = IClanWorld(address(diamond)).mintClan(elder);
+
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        core.heartbeat();
+        WorldState memory coreWorld = core.getWorldState();
+        ISetWorldClock(address(diamond))
+            .setWorldClock(
+                coreWorld.currentTick,
+                coreWorld.nextHeartbeatAtTick,
+                coreWorld.nextHeartbeatAtTs,
+                coreWorld.nextBanditSpawnEligibleTick,
+                coreWorld.currentBanditSpawnChanceBps,
+                coreWorld.currentTickSeed
+            );
+        IClanWorld(address(diamond)).settleClan(diamondClanId);
+
+        _assertClanEq(IClanWorld(address(diamond)).getClan(diamondClanId), core.getClan(coreClanId));
+        _assertWorldStateEq(IClanWorld(address(diamond)).getWorldState(), core.getWorldState());
+        uint32[] memory coreClansmen = core.getClanClansmanIds(coreClanId);
+        for (uint256 i = 0; i < coreClansmen.length; i++) {
+            _assertClansmanEq(
+                IClanWorld(address(diamond)).getClansman(coreClansmen[i]), core.getClansman(coreClansmen[i])
+            );
+        }
+    }
+
     function _rawViewsCut() internal returns (IDiamondCut.FacetCut[] memory cut) {
         RawWorldViewsFacet rawWorldViewsFacet = new RawWorldViewsFacet();
         RawTreasuryViewsFacet rawTreasuryViewsFacet = new RawTreasuryViewsFacet();
@@ -459,6 +536,25 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.treasurySelectors()
+        });
+    }
+
+    function _settlementCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.settlementSelectors()
+        });
+    }
+
+    function _setWorldClockCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = SetWorldClockFacet.setWorldClock.selector;
+
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
         });
     }
 


### PR DESCRIPTION
## Summary
- verifies the stack is already based on `origin/main` v1.1.4 (`1a29cca`)
- adds `SettlementFacet` for `settleClan` and `settleClansman`
- adds simulation commit logic so settled clan/clansman/mission/wheat/upgrade-reservation state is written back to diamond storage
- wires settlement selectors into deploy and removes the placeholder name collision
- adds monolith parity coverage for settling a minted clan after one heartbeat of upkeep

## Size Signal
- `SettlementFacet` runtime: 16,340 bytes
- `DerivedViewsFacet` runtime: 14,540 bytes
- `ScoringViewsFacet` runtime: 14,099 bytes
- legacy `ClanWorld` still exceeds EIP-170 during migration, as expected

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol --match-test testDiamondSettleClanMatchesCoreAfterHeartbeatUpkeep`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
- `forge build --sizes --skip test script` (expected monolith oversize; facet sizes inspected)
