### PR TITLE
[codex] add diamond clan ownership transfer

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -11,6 +11,7 @@ import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
 import {BanditViewsFacet} from "../src/diamond/facets/BanditViewsFacet.sol";
 import {ClanFullViewFacet} from "../src/diamond/facets/ClanFullViewFacet.sol";
 import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
+import {ClanOwnershipFacet} from "../src/diamond/facets/ClanOwnershipFacet.sol";
 import {DerivedViewsFacet} from "../src/diamond/facets/DerivedViewsFacet.sol";
 import {MarketViewsFacet} from "../src/diamond/facets/MarketViewsFacet.sol";
 import {QuoteViewsFacet} from "../src/diamond/facets/QuoteViewsFacet.sol";
@@ -39,6 +40,7 @@ contract DeployDiamond is Script {
         RawClanViewsFacet rawClanViewsFacet = new RawClanViewsFacet();
         RawBanditViewsFacet rawBanditViewsFacet = new RawBanditViewsFacet();
         ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        ClanOwnershipFacet ownershipFacet = new ClanOwnershipFacet();
         TreasuryFacet treasuryFacet = new TreasuryFacet();
         SettlementFacet settlementFacet = new SettlementFacet();
         DerivedViewsFacet derivedViewsFacet = new DerivedViewsFacet();
@@ -60,6 +62,7 @@ contract DeployDiamond is Script {
                     address(rawClanViewsFacet),
                     address(rawBanditViewsFacet),
                     address(lifecycleFacet),
+                    address(ownershipFacet),
                     address(treasuryFacet),
                     address(settlementFacet),
                     address(derivedViewsFacet),
@@ -83,6 +86,7 @@ contract DeployDiamond is Script {
         console.log("RAW_TREASURY_VIEWS_FACET_ADDRESS: ", address(rawTreasuryViewsFacet));
         console.log("RAW_CLAN_VIEWS_FACET_ADDRESS:     ", address(rawClanViewsFacet));
         console.log("RAW_BANDIT_VIEWS_FACET_ADDRESS:   ", address(rawBanditViewsFacet));
+        console.log("CLAN_OWNERSHIP_FACET_ADDRESS:     ", address(ownershipFacet));
         console.log("DERIVED_VIEWS_FACET_ADDRESS:      ", address(derivedViewsFacet));
         console.log("TREASURY_FACET_ADDRESS:           ", address(treasuryFacet));
         console.log("SETTLEMENT_FACET_ADDRESS:         ", address(settlementFacet));
@@ -105,6 +109,7 @@ contract DeployDiamond is Script {
         address rawClanViewsFacet,
         address rawBanditViewsFacet,
         address lifecycleFacet,
+        address ownershipFacet,
         address treasuryFacet,
         address settlementFacet,
         address derivedViewsFacet,
@@ -116,7 +121,7 @@ contract DeployDiamond is Script {
         address quoteViewsFacet,
         address scoringViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](16);
+        cut = new IDiamondCut.FacetCut[](17);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -148,51 +153,56 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.lifecycleSelectors()
         });
         cut[6] = IDiamondCut.FacetCut({
+            facetAddress: ownershipFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.ownershipSelectors()
+        });
+        cut[7] = IDiamondCut.FacetCut({
             facetAddress: treasuryFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.treasurySelectors()
         });
-        cut[7] = IDiamondCut.FacetCut({
+        cut[8] = IDiamondCut.FacetCut({
             facetAddress: settlementFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.settlementSelectors()
         });
-        cut[8] = IDiamondCut.FacetCut({
+        cut[9] = IDiamondCut.FacetCut({
             facetAddress: derivedViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-        cut[9] = IDiamondCut.FacetCut({
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: marketViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
-        cut[10] = IDiamondCut.FacetCut({
+        cut[11] = IDiamondCut.FacetCut({
             facetAddress: banditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
-        cut[11] = IDiamondCut.FacetCut({
+        cut[12] = IDiamondCut.FacetCut({
             facetAddress: regionViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
-        cut[12] = IDiamondCut.FacetCut({
+        cut[13] = IDiamondCut.FacetCut({
             facetAddress: snapshotViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
-        cut[13] = IDiamondCut.FacetCut({
+        cut[14] = IDiamondCut.FacetCut({
             facetAddress: clanFullViewFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.clanFullViewSelectors()
         });
-        cut[14] = IDiamondCut.FacetCut({
+        cut[15] = IDiamondCut.FacetCut({
             facetAddress: quoteViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
-        cut[15] = IDiamondCut.FacetCut({
+        cut[16] = IDiamondCut.FacetCut({
             facetAddress: scoringViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.scoringViewsSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -90,6 +90,11 @@ library DiamondSelectors {
         selectors[0] = IClanWorld.mintClan.selector;
     }
 
+    function ownershipSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.transferClanOwnership.selector;
+    }
+
     function treasurySelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](2);
         selectors[0] = IClanWorld.initTreasury.selector;

--- a/packages/contracts/src/diamond/facets/ClanOwnershipFacet.sol
+++ b/packages/contracts/src/diamond/facets/ClanOwnershipFacet.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanState, IClanWorldEvents} from "../../IClanWorld.sol";
+import {LibGameRules} from "../lib/LibGameRules.sol";
+import {LibSettlement} from "../lib/LibSettlement.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract ClanOwnershipFacet is IClanWorldEvents {
+    function transferClanOwnership(uint32 clanId, address newOwner) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        LibGameRules.requireNoPendingSeasonFinalization(s);
+
+        require(s.clans[clanId].clanId != 0, "ClanWorld: clan not found");
+        require(s.clans[clanId].owner == msg.sender, "ClanWorld: not clan owner");
+        require(newOwner != address(0), "ClanWorld: zero address");
+        require(newOwner != s.clans[clanId].owner, "ClanWorld: same owner");
+
+        LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, s.world.currentTick);
+        LibSettlement.commitSimulation(s, sim);
+
+        require(s.clans[clanId].clanState != ClanState.DEAD, "ClanWorld: clan dead");
+        address oldOwner = s.clans[clanId].owner;
+        s.clans[clanId].owner = newOwner;
+        s.clans[clanId].ownerNonce++;
+        emit ClanOwnershipTransferred(clanId, oldOwner, newOwner, s.clans[clanId].ownerNonce);
+
+        LibStorage.exitNonReentrant(s);
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -30,6 +30,7 @@ import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {BanditViewsFacet} from "../../src/diamond/facets/BanditViewsFacet.sol";
 import {ClanFullViewFacet} from "../../src/diamond/facets/ClanFullViewFacet.sol";
 import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.sol";
+import {ClanOwnershipFacet} from "../../src/diamond/facets/ClanOwnershipFacet.sol";
 import {DerivedViewsFacet} from "../../src/diamond/facets/DerivedViewsFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {MarketViewsFacet} from "../../src/diamond/facets/MarketViewsFacet.sol";
@@ -492,6 +493,47 @@ contract DiamondSkeletonTest is Test {
         }
     }
 
+    function testDiamondTransferClanOwnershipMatchesCoreAfterSettlement() public {
+        ClanWorld core = new ClanWorld();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        ClanOwnershipFacet ownershipFacet = new ClanOwnershipFacet();
+        SetWorldClockFacet setWorldClockFacet = new SetWorldClockFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_ownershipCut(address(ownershipFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_setWorldClockCut(address(setWorldClockFacet)), address(0), "");
+
+        address elder = address(0xA11CE);
+        address newOwner = address(0xB0B);
+        vm.prank(elder);
+        (uint32 coreClanId,) = core.mintClan(elder);
+        vm.prank(elder);
+        (uint32 diamondClanId,) = IClanWorld(address(diamond)).mintClan(elder);
+
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        core.heartbeat();
+        WorldState memory coreWorld = core.getWorldState();
+        ISetWorldClock(address(diamond))
+            .setWorldClock(
+                coreWorld.currentTick,
+                coreWorld.nextHeartbeatAtTick,
+                coreWorld.nextHeartbeatAtTs,
+                coreWorld.nextBanditSpawnEligibleTick,
+                coreWorld.currentBanditSpawnChanceBps,
+                coreWorld.currentTickSeed
+            );
+
+        vm.prank(elder);
+        core.transferClanOwnership(coreClanId, newOwner);
+        vm.prank(elder);
+        IClanWorld(address(diamond)).transferClanOwnership(diamondClanId, newOwner);
+
+        _assertClanEq(IClanWorld(address(diamond)).getClan(diamondClanId), core.getClan(coreClanId));
+    }
+
     function _rawViewsCut() internal returns (IDiamondCut.FacetCut[] memory cut) {
         RawWorldViewsFacet rawWorldViewsFacet = new RawWorldViewsFacet();
         RawTreasuryViewsFacet rawTreasuryViewsFacet = new RawTreasuryViewsFacet();
@@ -527,6 +569,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.lifecycleSelectors()
+        });
+    }
+
+    function _ownershipCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.ownershipSelectors()
         });
     }
 


### PR DESCRIPTION
## Summary
- adds `ClanOwnershipFacet` for `transferClanOwnership`
- routes ownership transfer through shared settlement simulation before changing owner/nonce
- wires ownership selector into deploy
- adds monolith parity coverage for transferring ownership after heartbeat settlement

## Sync Note
- fetched latest refs and confirmed `origin/main` points to v1.1.4 (`1a29cca`)
- current stack already has v1.1.4 as an ancestor, so no rebase was required

## Size Signal
- `ClanOwnershipFacet` runtime: 16,789 bytes
- `SettlementFacet` runtime: 16,340 bytes
- legacy `ClanWorld` still exceeds EIP-170 during migration, as expected

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol --match-test testDiamondTransferClanOwnershipMatchesCoreAfterSettlement`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `forge build --sizes --skip test script` (expected monolith oversize; facet sizes inspected)
