### PR TITLE
[codex] add diamond gold transfer

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -13,6 +13,7 @@ import {ClanFullViewFacet} from "../src/diamond/facets/ClanFullViewFacet.sol";
 import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
 import {ClanOwnershipFacet} from "../src/diamond/facets/ClanOwnershipFacet.sol";
 import {DerivedViewsFacet} from "../src/diamond/facets/DerivedViewsFacet.sol";
+import {GoldTransferFacet} from "../src/diamond/facets/GoldTransferFacet.sol";
 import {MarketViewsFacet} from "../src/diamond/facets/MarketViewsFacet.sol";
 import {QuoteViewsFacet} from "../src/diamond/facets/QuoteViewsFacet.sol";
 import {RawBanditViewsFacet} from "../src/diamond/facets/RawBanditViewsFacet.sol";
@@ -43,6 +44,7 @@ contract DeployDiamond is Script {
         ClanOwnershipFacet ownershipFacet = new ClanOwnershipFacet();
         TreasuryFacet treasuryFacet = new TreasuryFacet();
         SettlementFacet settlementFacet = new SettlementFacet();
+        GoldTransferFacet goldTransferFacet = new GoldTransferFacet();
         DerivedViewsFacet derivedViewsFacet = new DerivedViewsFacet();
         MarketViewsFacet marketViewsFacet = new MarketViewsFacet();
         BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
@@ -65,6 +67,7 @@ contract DeployDiamond is Script {
                     address(ownershipFacet),
                     address(treasuryFacet),
                     address(settlementFacet),
+                    address(goldTransferFacet),
                     address(derivedViewsFacet),
                     address(marketViewsFacet),
                     address(banditViewsFacet),
@@ -90,6 +93,7 @@ contract DeployDiamond is Script {
         console.log("DERIVED_VIEWS_FACET_ADDRESS:      ", address(derivedViewsFacet));
         console.log("TREASURY_FACET_ADDRESS:           ", address(treasuryFacet));
         console.log("SETTLEMENT_FACET_ADDRESS:         ", address(settlementFacet));
+        console.log("GOLD_TRANSFER_FACET_ADDRESS:      ", address(goldTransferFacet));
         console.log("MARKET_VIEWS_FACET_ADDRESS:       ", address(marketViewsFacet));
         console.log("BANDIT_VIEWS_FACET_ADDRESS:       ", address(banditViewsFacet));
         console.log("REGION_VIEWS_FACET_ADDRESS:       ", address(regionViewsFacet));
@@ -112,6 +116,7 @@ contract DeployDiamond is Script {
         address ownershipFacet,
         address treasuryFacet,
         address settlementFacet,
+        address goldTransferFacet,
         address derivedViewsFacet,
         address marketViewsFacet,
         address banditViewsFacet,
@@ -121,7 +126,7 @@ contract DeployDiamond is Script {
         address quoteViewsFacet,
         address scoringViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](17);
+        cut = new IDiamondCut.FacetCut[](18);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -168,41 +173,46 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.settlementSelectors()
         });
         cut[9] = IDiamondCut.FacetCut({
+            facetAddress: goldTransferFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.goldTransferSelectors()
+        });
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: derivedViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-        cut[10] = IDiamondCut.FacetCut({
+        cut[11] = IDiamondCut.FacetCut({
             facetAddress: marketViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
-        cut[11] = IDiamondCut.FacetCut({
+        cut[12] = IDiamondCut.FacetCut({
             facetAddress: banditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
-        cut[12] = IDiamondCut.FacetCut({
+        cut[13] = IDiamondCut.FacetCut({
             facetAddress: regionViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
-        cut[13] = IDiamondCut.FacetCut({
+        cut[14] = IDiamondCut.FacetCut({
             facetAddress: snapshotViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
-        cut[14] = IDiamondCut.FacetCut({
+        cut[15] = IDiamondCut.FacetCut({
             facetAddress: clanFullViewFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.clanFullViewSelectors()
         });
-        cut[15] = IDiamondCut.FacetCut({
+        cut[16] = IDiamondCut.FacetCut({
             facetAddress: quoteViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
-        cut[16] = IDiamondCut.FacetCut({
+        cut[17] = IDiamondCut.FacetCut({
             facetAddress: scoringViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.scoringViewsSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -107,6 +107,11 @@ library DiamondSelectors {
         selectors[1] = IClanWorld.settleClansman.selector;
     }
 
+    function goldTransferSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.transferGold.selector;
+    }
+
     function derivedViewsSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](2);
         selectors[0] = IClanWorld.getDerivedClanState.selector;

--- a/packages/contracts/src/diamond/facets/GoldTransferFacet.sol
+++ b/packages/contracts/src/diamond/facets/GoldTransferFacet.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanState, IClanWorldEvents} from "../../IClanWorld.sol";
+import {LibGameRules} from "../lib/LibGameRules.sol";
+import {LibSettlement} from "../lib/LibSettlement.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract GoldTransferFacet is IClanWorldEvents {
+    function transferGold(uint32 fromClanId, uint32 toClanId, uint256 amount) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        LibGameRules.requireNoPendingSeasonFinalization(s);
+        require(amount > 0, "ClanWorld: zero amount");
+        require(fromClanId != toClanId, "ClanWorld: same clan");
+
+        require(s.clans[fromClanId].clanId != 0, "ClanWorld: from clan not found");
+        require(s.clans[fromClanId].owner == msg.sender, "ClanWorld: not clan owner");
+        require(s.clans[toClanId].clanId != 0, "ClanWorld: to clan not found");
+
+        _settleClan(s, fromClanId);
+        _settleClan(s, toClanId);
+
+        require(
+            s.clans[fromClanId].lastSettledTick == s.world.currentTick
+                && s.clans[toClanId].lastSettledTick == s.world.currentTick,
+            "ERR_MUST_SETTLE_FIRST"
+        );
+        require(s.clans[fromClanId].clanState != ClanState.DEAD, "ClanWorld: clan dead");
+        require(s.clans[fromClanId].goldBalance >= amount, "ClanWorld: insufficient gold");
+
+        s.clans[fromClanId].goldBalance -= amount;
+        s.clans[toClanId].goldBalance += amount;
+
+        emit GoldTransferred(fromClanId, toClanId, amount, s.world.currentTick);
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function _settleClan(LibStorage.AppStorage storage s, uint32 clanId) private {
+        if (s.clans[clanId].clanId == 0) return;
+        if (s.clans[clanId].clanState == ClanState.DEAD) return;
+        if (s.clans[clanId].lastSettledTick >= s.world.currentTick) return;
+
+        LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, s.world.currentTick);
+        LibSettlement.commitSimulation(s, sim);
+        emit ClanSettled(clanId, s.clans[clanId].lastSettledTick);
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -33,6 +33,7 @@ import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.so
 import {ClanOwnershipFacet} from "../../src/diamond/facets/ClanOwnershipFacet.sol";
 import {DerivedViewsFacet} from "../../src/diamond/facets/DerivedViewsFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {GoldTransferFacet} from "../../src/diamond/facets/GoldTransferFacet.sol";
 import {MarketViewsFacet} from "../../src/diamond/facets/MarketViewsFacet.sol";
 import {MinimalERC20} from "../../src/MinimalERC20.sol";
 import {QuoteViewsFacet} from "../../src/diamond/facets/QuoteViewsFacet.sol";
@@ -534,6 +535,52 @@ contract DiamondSkeletonTest is Test {
         _assertClanEq(IClanWorld(address(diamond)).getClan(diamondClanId), core.getClan(coreClanId));
     }
 
+    function testDiamondTransferGoldMatchesCoreAfterSettlement() public {
+        ClanWorld core = new ClanWorld();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        GoldTransferFacet goldTransferFacet = new GoldTransferFacet();
+        SetWorldClockFacet setWorldClockFacet = new SetWorldClockFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_goldTransferCut(address(goldTransferFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_setWorldClockCut(address(setWorldClockFacet)), address(0), "");
+
+        address elder = address(0xA11CE);
+        address recipient = address(0xB0B);
+        vm.prank(elder);
+        (uint32 coreFromClanId,) = core.mintClan(elder);
+        vm.prank(recipient);
+        (uint32 coreToClanId,) = core.mintClan(recipient);
+        vm.prank(elder);
+        (uint32 diamondFromClanId,) = IClanWorld(address(diamond)).mintClan(elder);
+        vm.prank(recipient);
+        (uint32 diamondToClanId,) = IClanWorld(address(diamond)).mintClan(recipient);
+
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        core.heartbeat();
+        WorldState memory coreWorld = core.getWorldState();
+        ISetWorldClock(address(diamond))
+            .setWorldClock(
+                coreWorld.currentTick,
+                coreWorld.nextHeartbeatAtTick,
+                coreWorld.nextHeartbeatAtTs,
+                coreWorld.nextBanditSpawnEligibleTick,
+                coreWorld.currentBanditSpawnChanceBps,
+                coreWorld.currentTickSeed
+            );
+
+        vm.prank(elder);
+        core.transferGold(coreFromClanId, coreToClanId, 1e18);
+        vm.prank(elder);
+        IClanWorld(address(diamond)).transferGold(diamondFromClanId, diamondToClanId, 1e18);
+
+        _assertClanEq(IClanWorld(address(diamond)).getClan(diamondFromClanId), core.getClan(coreFromClanId));
+        _assertClanEq(IClanWorld(address(diamond)).getClan(diamondToClanId), core.getClan(coreToClanId));
+    }
+
     function _rawViewsCut() internal returns (IDiamondCut.FacetCut[] memory cut) {
         RawWorldViewsFacet rawWorldViewsFacet = new RawWorldViewsFacet();
         RawTreasuryViewsFacet rawTreasuryViewsFacet = new RawTreasuryViewsFacet();
@@ -596,6 +643,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.settlementSelectors()
+        });
+    }
+
+    function _goldTransferCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.goldTransferSelectors()
         });
     }
 


### PR DESCRIPTION
## Summary
- adds `GoldTransferFacet` for `transferGold`
- settles both clans through shared settlement simulation before moving gold
- wires gold transfer selector into deploy
- adds monolith parity coverage for transferring gold between two clans after heartbeat settlement

## Size Signal
- `GoldTransferFacet` runtime: 17,042 bytes
- still below EIP-170 with about 7.5KB runtime margin

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol --match-test testDiamondTransferGoldMatchesCoreAfterSettlement`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `forge build --sizes --skip test script` (expected monolith oversize; facet sizes inspected)
