### PR TITLE
[codex] add diamond vault resource transfer

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -25,6 +25,7 @@ import {ScoringViewsFacet} from "../src/diamond/facets/ScoringViewsFacet.sol";
 import {SettlementFacet} from "../src/diamond/facets/SettlementFacet.sol";
 import {SnapshotViewsFacet} from "../src/diamond/facets/SnapshotViewsFacet.sol";
 import {TreasuryFacet} from "../src/diamond/facets/TreasuryFacet.sol";
+import {VaultResourceTransferFacet} from "../src/diamond/facets/VaultResourceTransferFacet.sol";
 
 contract DeployDiamond is Script {
     function run() external {
@@ -45,6 +46,7 @@ contract DeployDiamond is Script {
         TreasuryFacet treasuryFacet = new TreasuryFacet();
         SettlementFacet settlementFacet = new SettlementFacet();
         GoldTransferFacet goldTransferFacet = new GoldTransferFacet();
+        VaultResourceTransferFacet vaultResourceTransferFacet = new VaultResourceTransferFacet();
         DerivedViewsFacet derivedViewsFacet = new DerivedViewsFacet();
         MarketViewsFacet marketViewsFacet = new MarketViewsFacet();
         BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
@@ -68,6 +70,7 @@ contract DeployDiamond is Script {
                     address(treasuryFacet),
                     address(settlementFacet),
                     address(goldTransferFacet),
+                    address(vaultResourceTransferFacet),
                     address(derivedViewsFacet),
                     address(marketViewsFacet),
                     address(banditViewsFacet),
@@ -94,6 +97,7 @@ contract DeployDiamond is Script {
         console.log("TREASURY_FACET_ADDRESS:           ", address(treasuryFacet));
         console.log("SETTLEMENT_FACET_ADDRESS:         ", address(settlementFacet));
         console.log("GOLD_TRANSFER_FACET_ADDRESS:      ", address(goldTransferFacet));
+        console.log("VAULT_RESOURCE_TRANSFER_FACET:    ", address(vaultResourceTransferFacet));
         console.log("MARKET_VIEWS_FACET_ADDRESS:       ", address(marketViewsFacet));
         console.log("BANDIT_VIEWS_FACET_ADDRESS:       ", address(banditViewsFacet));
         console.log("REGION_VIEWS_FACET_ADDRESS:       ", address(regionViewsFacet));
@@ -117,6 +121,7 @@ contract DeployDiamond is Script {
         address treasuryFacet,
         address settlementFacet,
         address goldTransferFacet,
+        address vaultResourceTransferFacet,
         address derivedViewsFacet,
         address marketViewsFacet,
         address banditViewsFacet,
@@ -126,7 +131,7 @@ contract DeployDiamond is Script {
         address quoteViewsFacet,
         address scoringViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](18);
+        cut = new IDiamondCut.FacetCut[](19);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -178,41 +183,46 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.goldTransferSelectors()
         });
         cut[10] = IDiamondCut.FacetCut({
+            facetAddress: vaultResourceTransferFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.vaultResourceTransferSelectors()
+        });
+        cut[11] = IDiamondCut.FacetCut({
             facetAddress: derivedViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-        cut[11] = IDiamondCut.FacetCut({
+        cut[12] = IDiamondCut.FacetCut({
             facetAddress: marketViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
-        cut[12] = IDiamondCut.FacetCut({
+        cut[13] = IDiamondCut.FacetCut({
             facetAddress: banditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
-        cut[13] = IDiamondCut.FacetCut({
+        cut[14] = IDiamondCut.FacetCut({
             facetAddress: regionViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
-        cut[14] = IDiamondCut.FacetCut({
+        cut[15] = IDiamondCut.FacetCut({
             facetAddress: snapshotViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
-        cut[15] = IDiamondCut.FacetCut({
+        cut[16] = IDiamondCut.FacetCut({
             facetAddress: clanFullViewFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.clanFullViewSelectors()
         });
-        cut[16] = IDiamondCut.FacetCut({
+        cut[17] = IDiamondCut.FacetCut({
             facetAddress: quoteViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
-        cut[17] = IDiamondCut.FacetCut({
+        cut[18] = IDiamondCut.FacetCut({
             facetAddress: scoringViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.scoringViewsSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -112,6 +112,11 @@ library DiamondSelectors {
         selectors[0] = IClanWorld.transferGold.selector;
     }
 
+    function vaultResourceTransferSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.transferVaultResource.selector;
+    }
+
     function derivedViewsSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](2);
         selectors[0] = IClanWorld.getDerivedClanState.selector;

--- a/packages/contracts/src/diamond/facets/VaultResourceTransferFacet.sol
+++ b/packages/contracts/src/diamond/facets/VaultResourceTransferFacet.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Clan, ClanState, IClanWorldEvents, ResourceType} from "../../IClanWorld.sol";
+import {LibGameRules} from "../lib/LibGameRules.sol";
+import {LibSettlement} from "../lib/LibSettlement.sol";
+import {LibSettlementMath} from "../lib/LibSettlementMath.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract VaultResourceTransferFacet is IClanWorldEvents {
+    function transferVaultResource(uint32 fromClanId, uint32 toClanId, ResourceType resource, uint256 amount) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        LibGameRules.requireNoPendingSeasonFinalization(s);
+        require(amount > 0, "ClanWorld: zero amount");
+        require(fromClanId != toClanId, "ClanWorld: same clan");
+
+        require(s.clans[fromClanId].clanId != 0, "ClanWorld: from clan not found");
+        require(s.clans[fromClanId].owner == msg.sender, "ClanWorld: not clan owner");
+        require(s.clans[toClanId].clanId != 0, "ClanWorld: to clan not found");
+
+        _settleClan(s, fromClanId);
+        _settleClan(s, toClanId);
+
+        require(
+            s.clans[fromClanId].lastSettledTick == s.world.currentTick
+                && s.clans[toClanId].lastSettledTick == s.world.currentTick,
+            "ERR_MUST_SETTLE_FIRST"
+        );
+        require(s.clans[fromClanId].clanState != ClanState.DEAD, "ClanWorld: clan dead");
+
+        Clan storage fromClan = s.clans[fromClanId];
+        Clan storage toClan = s.clans[toClanId];
+        if (resource == ResourceType.Wood) {
+            require(_deductVaultResource(s, fromClanId, fromClan, resource, amount), "ClanWorld: insufficient wood");
+            toClan.vaultWood += amount;
+        } else if (resource == ResourceType.Iron) {
+            require(_deductVaultResource(s, fromClanId, fromClan, resource, amount), "ClanWorld: insufficient iron");
+            toClan.vaultIron += amount;
+        } else if (resource == ResourceType.Wheat) {
+            require(_deductVaultResource(s, fromClanId, fromClan, resource, amount), "ClanWorld: insufficient wheat");
+            toClan.vaultWheat += amount;
+        } else if (resource == ResourceType.Fish) {
+            require(_deductVaultResource(s, fromClanId, fromClan, resource, amount), "ClanWorld: insufficient fish");
+            toClan.vaultFish += amount;
+        } else {
+            revert("ClanWorld: invalid resource");
+        }
+
+        emit VaultResourceTransferred(fromClanId, toClanId, resource, amount, s.world.currentTick);
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function _settleClan(LibStorage.AppStorage storage s, uint32 clanId) private {
+        if (s.clans[clanId].clanId == 0) return;
+        if (s.clans[clanId].clanState == ClanState.DEAD) return;
+        if (s.clans[clanId].lastSettledTick >= s.world.currentTick) return;
+
+        LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, s.world.currentTick);
+        LibSettlement.commitSimulation(s, sim);
+        emit ClanSettled(clanId, s.clans[clanId].lastSettledTick);
+    }
+
+    function _deductVaultResource(
+        LibStorage.AppStorage storage s,
+        uint32 clanId,
+        Clan storage clan,
+        ResourceType resource,
+        uint256 amount
+    ) private returns (bool) {
+        if (resource == ResourceType.Wood) {
+            if (LibSettlementMath.spendableAfterReleasing(clan.vaultWood, s.reservedWoodByClan[clanId], 0) < amount) {
+                return false;
+            }
+            clan.vaultWood -= amount;
+            return true;
+        }
+        if (resource == ResourceType.Iron) {
+            if (LibSettlementMath.spendableAfterReleasing(clan.vaultIron, s.reservedIronByClan[clanId], 0) < amount) {
+                return false;
+            }
+            clan.vaultIron -= amount;
+            return true;
+        }
+        if (resource == ResourceType.Wheat) {
+            if (LibSettlementMath.spendableAfterReleasing(clan.vaultWheat, s.reservedWheatByClan[clanId], 0) < amount) {
+                return false;
+            }
+            clan.vaultWheat -= amount;
+            return true;
+        }
+        if (resource == ResourceType.Fish) {
+            if (clan.vaultFish < amount) return false;
+            clan.vaultFish -= amount;
+            return true;
+        }
+        return false;
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -19,6 +19,7 @@ import {
     MarketState,
     PoolSeedConfig,
     RegionOccupant,
+    ResourceType,
     TreasuryState,
     WheatPlot,
     WorldSnapshot,
@@ -47,6 +48,7 @@ import {SettlementFacet} from "../../src/diamond/facets/SettlementFacet.sol";
 import {SnapshotViewsFacet} from "../../src/diamond/facets/SnapshotViewsFacet.sol";
 import {StubPool} from "../../src/StubPool.sol";
 import {TreasuryFacet} from "../../src/diamond/facets/TreasuryFacet.sol";
+import {VaultResourceTransferFacet} from "../../src/diamond/facets/VaultResourceTransferFacet.sol";
 import {LibStorage} from "../../src/diamond/lib/LibStorage.sol";
 
 contract PingFacet {
@@ -581,6 +583,53 @@ contract DiamondSkeletonTest is Test {
         _assertClanEq(IClanWorld(address(diamond)).getClan(diamondToClanId), core.getClan(coreToClanId));
     }
 
+    function testDiamondTransferVaultResourceMatchesCoreAfterSettlement() public {
+        ClanWorld core = new ClanWorld();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        VaultResourceTransferFacet vaultResourceTransferFacet = new VaultResourceTransferFacet();
+        SetWorldClockFacet setWorldClockFacet = new SetWorldClockFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond))
+            .diamondCut(_vaultResourceTransferCut(address(vaultResourceTransferFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_setWorldClockCut(address(setWorldClockFacet)), address(0), "");
+
+        address elder = address(0xA11CE);
+        address recipient = address(0xB0B);
+        vm.prank(elder);
+        (uint32 coreFromClanId,) = core.mintClan(elder);
+        vm.prank(recipient);
+        (uint32 coreToClanId,) = core.mintClan(recipient);
+        vm.prank(elder);
+        (uint32 diamondFromClanId,) = IClanWorld(address(diamond)).mintClan(elder);
+        vm.prank(recipient);
+        (uint32 diamondToClanId,) = IClanWorld(address(diamond)).mintClan(recipient);
+
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        core.heartbeat();
+        WorldState memory coreWorld = core.getWorldState();
+        ISetWorldClock(address(diamond))
+            .setWorldClock(
+                coreWorld.currentTick,
+                coreWorld.nextHeartbeatAtTick,
+                coreWorld.nextHeartbeatAtTs,
+                coreWorld.nextBanditSpawnEligibleTick,
+                coreWorld.currentBanditSpawnChanceBps,
+                coreWorld.currentTickSeed
+            );
+
+        vm.prank(elder);
+        core.transferVaultResource(coreFromClanId, coreToClanId, ResourceType.Wood, 1e18);
+        vm.prank(elder);
+        IClanWorld(address(diamond)).transferVaultResource(diamondFromClanId, diamondToClanId, ResourceType.Wood, 1e18);
+
+        _assertClanEq(IClanWorld(address(diamond)).getClan(diamondFromClanId), core.getClan(coreFromClanId));
+        _assertClanEq(IClanWorld(address(diamond)).getClan(diamondToClanId), core.getClan(coreToClanId));
+    }
+
     function _rawViewsCut() internal returns (IDiamondCut.FacetCut[] memory cut) {
         RawWorldViewsFacet rawWorldViewsFacet = new RawWorldViewsFacet();
         RawTreasuryViewsFacet rawTreasuryViewsFacet = new RawTreasuryViewsFacet();
@@ -652,6 +701,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.goldTransferSelectors()
+        });
+    }
+
+    function _vaultResourceTransferCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.vaultResourceTransferSelectors()
         });
     }
 


### PR DESCRIPTION
## Summary
- adds `VaultResourceTransferFacet` for `transferVaultResource`
- settles both clans before moving vault resources
- preserves reserved-resource spendability checks for wood/iron/wheat and direct fish balance checks
- wires vault resource transfer selector into deploy
- adds monolith parity coverage for transferring wood between two clans after heartbeat settlement

## Size Signal
- `VaultResourceTransferFacet` runtime: 17,922 bytes
- still below EIP-170 with about 6.6KB runtime margin

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol --match-test testDiamondTransferVaultResourceMatchesCoreAfterSettlement`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `forge build --sizes --skip test script` (expected monolith oversize; facet sizes inspected)
