### PR TITLE
[codex] add diamond blueprint transfer

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -9,6 +9,7 @@ import {IDiamondCut} from "../src/diamond/IDiamondCut.sol";
 import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
 import {BanditViewsFacet} from "../src/diamond/facets/BanditViewsFacet.sol";
+import {BlueprintTransferFacet} from "../src/diamond/facets/BlueprintTransferFacet.sol";
 import {ClanFullViewFacet} from "../src/diamond/facets/ClanFullViewFacet.sol";
 import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
 import {ClanOwnershipFacet} from "../src/diamond/facets/ClanOwnershipFacet.sol";
@@ -47,6 +48,7 @@ contract DeployDiamond is Script {
         SettlementFacet settlementFacet = new SettlementFacet();
         GoldTransferFacet goldTransferFacet = new GoldTransferFacet();
         VaultResourceTransferFacet vaultResourceTransferFacet = new VaultResourceTransferFacet();
+        BlueprintTransferFacet blueprintTransferFacet = new BlueprintTransferFacet();
         DerivedViewsFacet derivedViewsFacet = new DerivedViewsFacet();
         MarketViewsFacet marketViewsFacet = new MarketViewsFacet();
         BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
@@ -71,6 +73,7 @@ contract DeployDiamond is Script {
                     address(settlementFacet),
                     address(goldTransferFacet),
                     address(vaultResourceTransferFacet),
+                    address(blueprintTransferFacet),
                     address(derivedViewsFacet),
                     address(marketViewsFacet),
                     address(banditViewsFacet),
@@ -98,6 +101,7 @@ contract DeployDiamond is Script {
         console.log("SETTLEMENT_FACET_ADDRESS:         ", address(settlementFacet));
         console.log("GOLD_TRANSFER_FACET_ADDRESS:      ", address(goldTransferFacet));
         console.log("VAULT_RESOURCE_TRANSFER_FACET:    ", address(vaultResourceTransferFacet));
+        console.log("BLUEPRINT_TRANSFER_FACET_ADDRESS: ", address(blueprintTransferFacet));
         console.log("MARKET_VIEWS_FACET_ADDRESS:       ", address(marketViewsFacet));
         console.log("BANDIT_VIEWS_FACET_ADDRESS:       ", address(banditViewsFacet));
         console.log("REGION_VIEWS_FACET_ADDRESS:       ", address(regionViewsFacet));
@@ -122,6 +126,7 @@ contract DeployDiamond is Script {
         address settlementFacet,
         address goldTransferFacet,
         address vaultResourceTransferFacet,
+        address blueprintTransferFacet,
         address derivedViewsFacet,
         address marketViewsFacet,
         address banditViewsFacet,
@@ -131,7 +136,7 @@ contract DeployDiamond is Script {
         address quoteViewsFacet,
         address scoringViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](19);
+        cut = new IDiamondCut.FacetCut[](20);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -188,41 +193,46 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.vaultResourceTransferSelectors()
         });
         cut[11] = IDiamondCut.FacetCut({
+            facetAddress: blueprintTransferFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.blueprintTransferSelectors()
+        });
+        cut[12] = IDiamondCut.FacetCut({
             facetAddress: derivedViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-        cut[12] = IDiamondCut.FacetCut({
+        cut[13] = IDiamondCut.FacetCut({
             facetAddress: marketViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
-        cut[13] = IDiamondCut.FacetCut({
+        cut[14] = IDiamondCut.FacetCut({
             facetAddress: banditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
-        cut[14] = IDiamondCut.FacetCut({
+        cut[15] = IDiamondCut.FacetCut({
             facetAddress: regionViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
-        cut[15] = IDiamondCut.FacetCut({
+        cut[16] = IDiamondCut.FacetCut({
             facetAddress: snapshotViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
-        cut[16] = IDiamondCut.FacetCut({
+        cut[17] = IDiamondCut.FacetCut({
             facetAddress: clanFullViewFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.clanFullViewSelectors()
         });
-        cut[17] = IDiamondCut.FacetCut({
+        cut[18] = IDiamondCut.FacetCut({
             facetAddress: quoteViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
-        cut[18] = IDiamondCut.FacetCut({
+        cut[19] = IDiamondCut.FacetCut({
             facetAddress: scoringViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.scoringViewsSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -117,6 +117,11 @@ library DiamondSelectors {
         selectors[0] = IClanWorld.transferVaultResource.selector;
     }
 
+    function blueprintTransferSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.transferBlueprint.selector;
+    }
+
     function derivedViewsSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](2);
         selectors[0] = IClanWorld.getDerivedClanState.selector;

--- a/packages/contracts/src/diamond/facets/BlueprintTransferFacet.sol
+++ b/packages/contracts/src/diamond/facets/BlueprintTransferFacet.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanState, IClanWorldEvents} from "../../IClanWorld.sol";
+import {LibGameRules} from "../lib/LibGameRules.sol";
+import {LibSettlement} from "../lib/LibSettlement.sol";
+import {LibSettlementMath} from "../lib/LibSettlementMath.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract BlueprintTransferFacet is IClanWorldEvents {
+    function transferBlueprint(uint32 fromClanId, uint32 toClanId, uint256 amount) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        LibGameRules.requireNoPendingSeasonFinalization(s);
+        require(amount > 0, "ClanWorld: zero amount");
+        require(fromClanId != toClanId, "ClanWorld: same clan");
+
+        require(s.clans[fromClanId].clanId != 0, "ClanWorld: from clan not found");
+        require(s.clans[fromClanId].owner == msg.sender, "ClanWorld: not clan owner");
+        require(s.clans[toClanId].clanId != 0, "ClanWorld: to clan not found");
+
+        _settleClan(s, fromClanId);
+        _settleClan(s, toClanId);
+
+        require(
+            s.clans[fromClanId].lastSettledTick == s.world.currentTick
+                && s.clans[toClanId].lastSettledTick == s.world.currentTick,
+            "ERR_MUST_SETTLE_FIRST"
+        );
+        require(s.clans[fromClanId].clanState != ClanState.DEAD, "ClanWorld: clan dead");
+        require(_deductBlueprint(s, fromClanId, amount), "ClanWorld: insufficient blueprints");
+
+        s.clans[toClanId].blueprintBalance += amount;
+
+        emit BlueprintTransferred(fromClanId, toClanId, amount, s.world.currentTick);
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function _settleClan(LibStorage.AppStorage storage s, uint32 clanId) private {
+        if (s.clans[clanId].clanId == 0) return;
+        if (s.clans[clanId].clanState == ClanState.DEAD) return;
+        if (s.clans[clanId].lastSettledTick >= s.world.currentTick) return;
+
+        LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, s.world.currentTick);
+        LibSettlement.commitSimulation(s, sim);
+        emit ClanSettled(clanId, s.clans[clanId].lastSettledTick);
+    }
+
+    function _deductBlueprint(LibStorage.AppStorage storage s, uint32 clanId, uint256 amount) private returns (bool) {
+        if (
+            LibSettlementMath.spendableAfterReleasing(
+                    s.clans[clanId].blueprintBalance, s.reservedBlueprintByClan[clanId], 0
+                ) < amount
+        ) {
+            return false;
+        }
+
+        s.clans[clanId].blueprintBalance -= amount;
+        return true;
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -29,6 +29,7 @@ import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
 import {IDiamondLoupe} from "../../src/diamond/IDiamondLoupe.sol";
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {BanditViewsFacet} from "../../src/diamond/facets/BanditViewsFacet.sol";
+import {BlueprintTransferFacet} from "../../src/diamond/facets/BlueprintTransferFacet.sol";
 import {ClanFullViewFacet} from "../../src/diamond/facets/ClanFullViewFacet.sol";
 import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.sol";
 import {ClanOwnershipFacet} from "../../src/diamond/facets/ClanOwnershipFacet.sol";
@@ -630,6 +631,52 @@ contract DiamondSkeletonTest is Test {
         _assertClanEq(IClanWorld(address(diamond)).getClan(diamondToClanId), core.getClan(coreToClanId));
     }
 
+    function testDiamondTransferBlueprintRejectsLikeCoreWithoutBalance() public {
+        ClanWorld core = new ClanWorld();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        BlueprintTransferFacet blueprintTransferFacet = new BlueprintTransferFacet();
+        SetWorldClockFacet setWorldClockFacet = new SetWorldClockFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_blueprintTransferCut(address(blueprintTransferFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_setWorldClockCut(address(setWorldClockFacet)), address(0), "");
+
+        address elder = address(0xA11CE);
+        address recipient = address(0xB0B);
+        vm.prank(elder);
+        (uint32 coreFromClanId,) = core.mintClan(elder);
+        vm.prank(recipient);
+        (uint32 coreToClanId,) = core.mintClan(recipient);
+        vm.prank(elder);
+        (uint32 diamondFromClanId,) = IClanWorld(address(diamond)).mintClan(elder);
+        vm.prank(recipient);
+        (uint32 diamondToClanId,) = IClanWorld(address(diamond)).mintClan(recipient);
+
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        core.heartbeat();
+        WorldState memory coreWorld = core.getWorldState();
+        ISetWorldClock(address(diamond))
+            .setWorldClock(
+                coreWorld.currentTick,
+                coreWorld.nextHeartbeatAtTick,
+                coreWorld.nextHeartbeatAtTs,
+                coreWorld.nextBanditSpawnEligibleTick,
+                coreWorld.currentBanditSpawnChanceBps,
+                coreWorld.currentTickSeed
+            );
+
+        vm.prank(elder);
+        vm.expectRevert(bytes("ClanWorld: insufficient blueprints"));
+        core.transferBlueprint(coreFromClanId, coreToClanId, 1e18);
+
+        vm.prank(elder);
+        vm.expectRevert(bytes("ClanWorld: insufficient blueprints"));
+        IClanWorld(address(diamond)).transferBlueprint(diamondFromClanId, diamondToClanId, 1e18);
+    }
+
     function _rawViewsCut() internal returns (IDiamondCut.FacetCut[] memory cut) {
         RawWorldViewsFacet rawWorldViewsFacet = new RawWorldViewsFacet();
         RawTreasuryViewsFacet rawTreasuryViewsFacet = new RawTreasuryViewsFacet();
@@ -710,6 +757,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.vaultResourceTransferSelectors()
+        });
+    }
+
+    function _blueprintTransferCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.blueprintTransferSelectors()
         });
     }
 


### PR DESCRIPTION
## Summary
- add `BlueprintTransferFacet` for the diamond `transferBlueprint` selector
- wire the selector into deploy-time facet cuts
- add core-vs-diamond parity coverage for the settled insufficient-blueprint path

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol --match-test testDiamondTransferBlueprintRejectsLikeCoreWithoutBalance`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
- `forge build --sizes --skip test script | rg "BlueprintTransferFacet|VaultResourceTransferFacet|GoldTransferFacet|ClanWorld "` (expected nonzero while legacy `ClanWorld` remains oversized; `BlueprintTransferFacet` runtime size: 17,170 bytes)

Stacked on #452.
