### PR TITLE
[codex] add diamond bundle transfer

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -10,6 +10,7 @@ import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
 import {BanditViewsFacet} from "../src/diamond/facets/BanditViewsFacet.sol";
 import {BlueprintTransferFacet} from "../src/diamond/facets/BlueprintTransferFacet.sol";
+import {BundleTransferFacet} from "../src/diamond/facets/BundleTransferFacet.sol";
 import {ClanFullViewFacet} from "../src/diamond/facets/ClanFullViewFacet.sol";
 import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
 import {ClanOwnershipFacet} from "../src/diamond/facets/ClanOwnershipFacet.sol";
@@ -49,6 +50,7 @@ contract DeployDiamond is Script {
         GoldTransferFacet goldTransferFacet = new GoldTransferFacet();
         VaultResourceTransferFacet vaultResourceTransferFacet = new VaultResourceTransferFacet();
         BlueprintTransferFacet blueprintTransferFacet = new BlueprintTransferFacet();
+        BundleTransferFacet bundleTransferFacet = new BundleTransferFacet();
         DerivedViewsFacet derivedViewsFacet = new DerivedViewsFacet();
         MarketViewsFacet marketViewsFacet = new MarketViewsFacet();
         BanditViewsFacet banditViewsFacet = new BanditViewsFacet();
@@ -74,6 +76,7 @@ contract DeployDiamond is Script {
                     address(goldTransferFacet),
                     address(vaultResourceTransferFacet),
                     address(blueprintTransferFacet),
+                    address(bundleTransferFacet),
                     address(derivedViewsFacet),
                     address(marketViewsFacet),
                     address(banditViewsFacet),
@@ -102,6 +105,7 @@ contract DeployDiamond is Script {
         console.log("GOLD_TRANSFER_FACET_ADDRESS:      ", address(goldTransferFacet));
         console.log("VAULT_RESOURCE_TRANSFER_FACET:    ", address(vaultResourceTransferFacet));
         console.log("BLUEPRINT_TRANSFER_FACET_ADDRESS: ", address(blueprintTransferFacet));
+        console.log("BUNDLE_TRANSFER_FACET_ADDRESS:    ", address(bundleTransferFacet));
         console.log("MARKET_VIEWS_FACET_ADDRESS:       ", address(marketViewsFacet));
         console.log("BANDIT_VIEWS_FACET_ADDRESS:       ", address(banditViewsFacet));
         console.log("REGION_VIEWS_FACET_ADDRESS:       ", address(regionViewsFacet));
@@ -127,6 +131,7 @@ contract DeployDiamond is Script {
         address goldTransferFacet,
         address vaultResourceTransferFacet,
         address blueprintTransferFacet,
+        address bundleTransferFacet,
         address derivedViewsFacet,
         address marketViewsFacet,
         address banditViewsFacet,
@@ -136,7 +141,7 @@ contract DeployDiamond is Script {
         address quoteViewsFacet,
         address scoringViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](20);
+        cut = new IDiamondCut.FacetCut[](21);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -198,41 +203,46 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.blueprintTransferSelectors()
         });
         cut[12] = IDiamondCut.FacetCut({
+            facetAddress: bundleTransferFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.bundleTransferSelectors()
+        });
+        cut[13] = IDiamondCut.FacetCut({
             facetAddress: derivedViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-        cut[13] = IDiamondCut.FacetCut({
+        cut[14] = IDiamondCut.FacetCut({
             facetAddress: marketViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
-        cut[14] = IDiamondCut.FacetCut({
+        cut[15] = IDiamondCut.FacetCut({
             facetAddress: banditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
-        cut[15] = IDiamondCut.FacetCut({
+        cut[16] = IDiamondCut.FacetCut({
             facetAddress: regionViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
-        cut[16] = IDiamondCut.FacetCut({
+        cut[17] = IDiamondCut.FacetCut({
             facetAddress: snapshotViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
-        cut[17] = IDiamondCut.FacetCut({
+        cut[18] = IDiamondCut.FacetCut({
             facetAddress: clanFullViewFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.clanFullViewSelectors()
         });
-        cut[18] = IDiamondCut.FacetCut({
+        cut[19] = IDiamondCut.FacetCut({
             facetAddress: quoteViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
-        cut[19] = IDiamondCut.FacetCut({
+        cut[20] = IDiamondCut.FacetCut({
             facetAddress: scoringViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.scoringViewsSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -122,6 +122,11 @@ library DiamondSelectors {
         selectors[0] = IClanWorld.transferBlueprint.selector;
     }
 
+    function bundleTransferSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.transferBundle.selector;
+    }
+
     function derivedViewsSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](2);
         selectors[0] = IClanWorld.getDerivedClanState.selector;

--- a/packages/contracts/src/diamond/facets/BundleTransferFacet.sol
+++ b/packages/contracts/src/diamond/facets/BundleTransferFacet.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Clan, ClanState, IClanWorldEvents, ResourceType} from "../../IClanWorld.sol";
+import {LibGameRules} from "../lib/LibGameRules.sol";
+import {LibSettlement} from "../lib/LibSettlement.sol";
+import {LibSettlementMath} from "../lib/LibSettlementMath.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract BundleTransferFacet is IClanWorldEvents {
+    function transferBundle(
+        uint32 fromClanId,
+        uint32 toClanId,
+        uint256 gold,
+        uint256 blueprint,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish
+    ) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        LibGameRules.requireNoPendingSeasonFinalization(s);
+        require(gold > 0 || blueprint > 0 || wood > 0 || iron > 0 || wheat > 0 || fish > 0, "ClanWorld: empty bundle");
+        require(fromClanId != toClanId, "ClanWorld: same clan");
+
+        require(s.clans[fromClanId].clanId != 0, "ClanWorld: from clan not found");
+        require(s.clans[fromClanId].owner == msg.sender, "ClanWorld: not clan owner");
+        require(s.clans[toClanId].clanId != 0, "ClanWorld: to clan not found");
+
+        _settleClan(s, fromClanId);
+        _settleClan(s, toClanId);
+
+        require(
+            s.clans[fromClanId].lastSettledTick == s.world.currentTick
+                && s.clans[toClanId].lastSettledTick == s.world.currentTick,
+            "ERR_MUST_SETTLE_FIRST"
+        );
+        require(s.clans[fromClanId].clanState != ClanState.DEAD, "ClanWorld: clan dead");
+
+        Clan storage fromClan = s.clans[fromClanId];
+        Clan storage toClan = s.clans[toClanId];
+        _requireBundleBalances(s, fromClanId, fromClan, gold, blueprint, wood, iron, wheat, fish);
+
+        if (gold > 0) fromClan.goldBalance -= gold;
+        if (blueprint > 0) fromClan.blueprintBalance -= blueprint;
+        if (wood > 0) fromClan.vaultWood -= wood;
+        if (iron > 0) fromClan.vaultIron -= iron;
+        if (wheat > 0) fromClan.vaultWheat -= wheat;
+        if (fish > 0) fromClan.vaultFish -= fish;
+
+        if (gold > 0) toClan.goldBalance += gold;
+        if (blueprint > 0) toClan.blueprintBalance += blueprint;
+        if (wood > 0) toClan.vaultWood += wood;
+        if (iron > 0) toClan.vaultIron += iron;
+        if (wheat > 0) toClan.vaultWheat += wheat;
+        if (fish > 0) toClan.vaultFish += fish;
+
+        if (gold > 0) emit GoldTransferred(fromClanId, toClanId, gold, s.world.currentTick);
+        if (blueprint > 0) emit BlueprintTransferred(fromClanId, toClanId, blueprint, s.world.currentTick);
+        if (wood > 0) {
+            emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Wood, wood, s.world.currentTick);
+        }
+        if (iron > 0) {
+            emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Iron, iron, s.world.currentTick);
+        }
+        if (wheat > 0) {
+            emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Wheat, wheat, s.world.currentTick);
+        }
+        if (fish > 0) {
+            emit VaultResourceTransferred(fromClanId, toClanId, ResourceType.Fish, fish, s.world.currentTick);
+        }
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function _settleClan(LibStorage.AppStorage storage s, uint32 clanId) private {
+        if (s.clans[clanId].clanId == 0) return;
+        if (s.clans[clanId].clanState == ClanState.DEAD) return;
+        if (s.clans[clanId].lastSettledTick >= s.world.currentTick) return;
+
+        LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, s.world.currentTick);
+        LibSettlement.commitSimulation(s, sim);
+        emit ClanSettled(clanId, s.clans[clanId].lastSettledTick);
+    }
+
+    function _requireBundleBalances(
+        LibStorage.AppStorage storage s,
+        uint32 fromClanId,
+        Clan storage fromClan,
+        uint256 gold,
+        uint256 blueprint,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish
+    ) private view {
+        if (gold > 0) require(fromClan.goldBalance >= gold, "ClanWorld: insufficient gold");
+        if (blueprint > 0) {
+            require(_spendableBlueprint(s, fromClanId, fromClan) >= blueprint, "ClanWorld: insufficient blueprints");
+        }
+        if (wood > 0) {
+            require(
+                _spendableVaultResource(s, fromClanId, fromClan, ResourceType.Wood) >= wood,
+                "ClanWorld: insufficient wood"
+            );
+        }
+        if (iron > 0) {
+            require(
+                _spendableVaultResource(s, fromClanId, fromClan, ResourceType.Iron) >= iron,
+                "ClanWorld: insufficient iron"
+            );
+        }
+        if (wheat > 0) {
+            require(
+                _spendableVaultResource(s, fromClanId, fromClan, ResourceType.Wheat) >= wheat,
+                "ClanWorld: insufficient wheat"
+            );
+        }
+        if (fish > 0) {
+            require(
+                _spendableVaultResource(s, fromClanId, fromClan, ResourceType.Fish) >= fish,
+                "ClanWorld: insufficient fish"
+            );
+        }
+    }
+
+    function _spendableBlueprint(LibStorage.AppStorage storage s, uint32 clanId, Clan storage clan)
+        private
+        view
+        returns (uint256)
+    {
+        return LibSettlementMath.spendableAfterReleasing(clan.blueprintBalance, s.reservedBlueprintByClan[clanId], 0);
+    }
+
+    function _spendableVaultResource(
+        LibStorage.AppStorage storage s,
+        uint32 clanId,
+        Clan storage clan,
+        ResourceType resource
+    ) private view returns (uint256) {
+        if (resource == ResourceType.Wood) {
+            return LibSettlementMath.spendableAfterReleasing(clan.vaultWood, s.reservedWoodByClan[clanId], 0);
+        }
+        if (resource == ResourceType.Iron) {
+            return LibSettlementMath.spendableAfterReleasing(clan.vaultIron, s.reservedIronByClan[clanId], 0);
+        }
+        if (resource == ResourceType.Wheat) {
+            return LibSettlementMath.spendableAfterReleasing(clan.vaultWheat, s.reservedWheatByClan[clanId], 0);
+        }
+        if (resource == ResourceType.Fish) {
+            return clan.vaultFish;
+        }
+        return 0;
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -30,6 +30,7 @@ import {IDiamondLoupe} from "../../src/diamond/IDiamondLoupe.sol";
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {BanditViewsFacet} from "../../src/diamond/facets/BanditViewsFacet.sol";
 import {BlueprintTransferFacet} from "../../src/diamond/facets/BlueprintTransferFacet.sol";
+import {BundleTransferFacet} from "../../src/diamond/facets/BundleTransferFacet.sol";
 import {ClanFullViewFacet} from "../../src/diamond/facets/ClanFullViewFacet.sol";
 import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.sol";
 import {ClanOwnershipFacet} from "../../src/diamond/facets/ClanOwnershipFacet.sol";
@@ -677,6 +678,52 @@ contract DiamondSkeletonTest is Test {
         IClanWorld(address(diamond)).transferBlueprint(diamondFromClanId, diamondToClanId, 1e18);
     }
 
+    function testDiamondTransferBundleMatchesCoreAfterSettlement() public {
+        ClanWorld core = new ClanWorld();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        BundleTransferFacet bundleTransferFacet = new BundleTransferFacet();
+        SetWorldClockFacet setWorldClockFacet = new SetWorldClockFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_bundleTransferCut(address(bundleTransferFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_setWorldClockCut(address(setWorldClockFacet)), address(0), "");
+
+        address elder = address(0xA11CE);
+        address recipient = address(0xB0B);
+        vm.prank(elder);
+        (uint32 coreFromClanId,) = core.mintClan(elder);
+        vm.prank(recipient);
+        (uint32 coreToClanId,) = core.mintClan(recipient);
+        vm.prank(elder);
+        (uint32 diamondFromClanId,) = IClanWorld(address(diamond)).mintClan(elder);
+        vm.prank(recipient);
+        (uint32 diamondToClanId,) = IClanWorld(address(diamond)).mintClan(recipient);
+
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        core.heartbeat();
+        WorldState memory coreWorld = core.getWorldState();
+        ISetWorldClock(address(diamond))
+            .setWorldClock(
+                coreWorld.currentTick,
+                coreWorld.nextHeartbeatAtTick,
+                coreWorld.nextHeartbeatAtTs,
+                coreWorld.nextBanditSpawnEligibleTick,
+                coreWorld.currentBanditSpawnChanceBps,
+                coreWorld.currentTickSeed
+            );
+
+        vm.prank(elder);
+        core.transferBundle(coreFromClanId, coreToClanId, 1e18, 0, 1e18, 0, 0, 0);
+        vm.prank(elder);
+        IClanWorld(address(diamond)).transferBundle(diamondFromClanId, diamondToClanId, 1e18, 0, 1e18, 0, 0, 0);
+
+        _assertClanEq(IClanWorld(address(diamond)).getClan(diamondFromClanId), core.getClan(coreFromClanId));
+        _assertClanEq(IClanWorld(address(diamond)).getClan(diamondToClanId), core.getClan(coreToClanId));
+    }
+
     function _rawViewsCut() internal returns (IDiamondCut.FacetCut[] memory cut) {
         RawWorldViewsFacet rawWorldViewsFacet = new RawWorldViewsFacet();
         RawTreasuryViewsFacet rawTreasuryViewsFacet = new RawTreasuryViewsFacet();
@@ -766,6 +813,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.blueprintTransferSelectors()
+        });
+    }
+
+    function _bundleTransferCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.bundleTransferSelectors()
         });
     }
 


### PR DESCRIPTION
## Summary
- add `BundleTransferFacet` for the diamond `transferBundle` selector
- wire bundle transfer into deploy-time facet cuts
- add core-vs-diamond parity coverage for a settled gold+wood bundle transfer

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol --match-test testDiamondTransferBundleMatchesCoreAfterSettlement`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
- `forge build --sizes --skip test script | rg "BundleTransferFacet|BlueprintTransferFacet|VaultResourceTransferFacet|ClanWorld "` (expected nonzero while legacy `ClanWorld` remains oversized; `BundleTransferFacet` runtime size: 18,845 bytes)

Stacked on #453.
