### PR TITLE
feat(web): v5 animation spec + demo-day subset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,65 @@ Format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.2.0] — 2026-05-02
+
+### Highlights
+
+> [!NOTE]
+> **v5 animation demo-day subset.** v1.2.0 lands the high-ROI slice of the full v5 animation north-star spec — ships the premium-feel cues that read on stage without committing to the multi-week full implementation. Three implementation rounds, six fix-rounds across 3-tier local review × 3 + SuperSwarm × 4 + cloud (Copilot + ChatGPT codex bot), all convergent CLEAN. PR #455.
+>
+> - **Z-sort architecture fix** — single sortable `worldDynamic` container with global `zIndex = Math.round(y)` enables true 2.5D occlusion (clansman walking behind a building actually renders behind). Previously each entity type lived in a separate Pixi `Container`, breaking cross-type Y-sort even with `sortableChildren = true`. Spec §14 rewrite captures the architectural fix + child-of-host attachment patterns + combat reparenting protocol.
+> - **Building breathe** — every base does a 1-pixel vertical sin sway at proper 0.25 Hz (4-second period), with position-derived phase offsets so adjacent bases desync. Invisible until missing — single biggest premium-feel cue.
+> - **Day/night cycle** — single GPU `ColorMatrixFilter` on the world container cycles through 4 keyframes (dawn / day / dusk / night) over 30 ticks. Per-base window glow Graphics (alpha tied to `1 - daylightBrightness`) lights up bases at night.
+> - **Carry indicators** — fill bar above each traveling clansman tweens 0→1 during gather/travel, drains on deposit. 16×3px parchment-cream fill on ink background with 1px outline.
+> - **Tap-to-zoom + selection ring** — `pixi-viewport.animate` to tapped sprite over 400ms easeInOutQuad with scale 2.0; rotating dashed ring (8 segments, 1Hz rotation, 0.5Hz alpha pulse) attached as first child of the selected sprite. Esc tweens viewport back to fit-world.
+> - **Counter ticks (RollingNumber)** — vault values wrapped in `<RollingNumber>` with `min(400, 100 + log2(|delta|)*40)`ms easeOutQuad tween; `+N` (green) / `-N` (red) delta floater drifts up 16px and fades over 800ms. Demo-only `useDemoResourceJiggle` 6s interval mutates one random resource so the animation is observable on stage without backend changes.
+> - **Combat vignette (3.7s)** — replaces the spec's full-tick 10-phase choreography per codex DA recommendation. Triggered at start of pre-attack tick (or last 4s with precise tickEpoch): world dim fade-in 600ms → combatants reparent to `combatHighlight` above dim → advance to base center 1.5s → idle/jitter 0.5s → full-screen white flash 200ms → resolution 1.5s (success: bandit launch + shrink/fade + defenders cheer; failure: clansmen knockback + wall scale.y drop). `?combat=success|failure` URL toggle for stage flexibility. §10.8 day/night cap rule (`max(0.2, 0.55 - existingDarkness)`) so combat at night stays readable.
+>
+> *Full v5 animation spec authored by Liam (1,172 lines) is the post-hackathon north-star target — committed but explicitly out of scope for this release. Demo-day subset (235 lines) is the ruthless cut shipped here.*
+
+---
+
+### Added
+
+- `docs/planning/clanworld_v5_animation_spec.md` — full v5 animation north-star (post-hackathon target)
+- `docs/planning/clanworld_v5_demo_day_subset.md` — hackathon-scope cut (8 items, 13h budget)
+- `apps/web/src/WorldMap.tsx` — tiered Pixi container layout (`terrainBackground`, `terrainAccents`, `worldDynamic`, `inWorldEffects`, `selectionRings`, `bubbleLayer`, `screenEffects`); building breathe ticker; day/night `ColorMatrixFilter` + per-base window glow; tap-to-zoom + dashed selection ring + Esc clear; combat vignette state machine with `combatVignetteRef` + `banditDefeatedRef` lifecycle; carry-indicator child container per traveling clansman
+- `apps/web/src/components/cockpit/tabs/VaultTab.tsx` — `RollingNumber` component (rAF tween + `+N`/`-N` floater) wrapping every vault counter; `useDemoResourceJiggle` 6s mock-tick hook
+
+### Fixed
+
+- **Z-sort:** `sortableChildren` only sorts within a single Container — the original §14 layer split (buildings layer 3, clansmen layer 5) made cross-type Y-sort impossible. Single `worldDynamic` container resolves
+- **Carry indicator memory leak:** `t.gfx.destroy()` wasn't recursive, leaving carry-bar `Graphics` children to accumulate per-spawn — `destroy({ children: true })` at both expiration sites
+- **Breathe frequency:** `Math.sin(t / 4000)` gave a ~25 second period (≈0.04 Hz), not the spec's 4-second period (0.25 Hz). Sin argument is in radians; correct formula is `Math.sin(t * Math.PI / 2000)`
+- **Day/night live tick:** `dayNightCb` registered once at Pixi init captured the initial `snapshot` prop forever, leaving the cycle stuck on the `Date.now()` fallback. `snapshotRef` updated by useEffect resolves
+- **Bandit fallback selection:** `banditIcon` (Graphics) had `position=(0,0)` and drew shapes at world `(iconX, iconY)`. Tap-zoom called `target.getGlobalPosition()` which returned `worldDynamic` origin, snapping camera to map (0,0) instead of bandit. Position the icon at `(iconX, iconY)` and draw locally
+- **Combat dim cap rule:** Earlier `min(0.55, 1 - brightness)` was inverted — at full daylight (brightness=1), combat dim collapsed to 0. Replaced with `max(0.2, COMBAT_DIM_ALPHA - existingDarkness)`: full dim during day, gentle clamp at night
+- **Bandit pulse vs vignette:** pulse ticker overwrote `bandit.alpha` every frame after the combat ticker, silently nullifying the success-outcome fade-out. Pulse `onTick` early-returns when `combatVignetteRef.current` is set
+- **Combat vignette trigger window:** `getMsUntilTickClose()` falls back to 60s when `tickEpoch` is unavailable, but logs-driven `liveTick` advances every ~20s. The `msUntilTickClose <= 4000` branch never fired before the tick advanced. Detect fallback mode and trigger at start of pre-attack tick instead of last 4s
+- **Defeated bandit reappearance:** `finishCombatVignette` unconditionally restored `bandit.alpha = banditStart.alpha`, popping the defeated bandit back at full opacity after a `?combat=success` fade-out. New `banditDefeatedRef` flag set on natural success; respected by `redrawBandit`, pulse `onTick`, and post-vignette restore
+- **`Assets.load` mid-vignette regression:** Earlier guard early-returned the entire `.then()` callback, permanently losing the bandit sprite if the asset resolved during the 4s vignette window. Now creates the sprite + assigns to `drawn.banditSprite` unconditionally; only the `redrawBandit()` call is gated
+- **`selectTarget` during vignette:** new selection ring during the dimmed combat scene undercut focus and could persist after dim layer faded. Early-return when `combatVignetteRef.current` is set
+- **`relayout` during vignette:** snapshot-driven relayout's `redrawBandit()` could snap the reparented bandit back to home anchor mid-choreography. Skip when `combatVignetteRef.current` is set
+- **`RollingNumber` rapid-update jump + StrictMode skip:** `previousValueRef.current` was updated immediately in the effect, so back-to-back updates and StrictMode double-invoke produced visible jumps. Two refs (`renderedValueRef` for current displayed value + `targetValueRef` for last seen target) decouple tween-from from no-change-detection
+- **Selection ring Graphics leak:** `clearSelection` removed the ring from its parent and nulled the ref but never called `ring.destroy()`. Old rings were JS-GC-able but their WebGL geometry buffers stayed in VRAM until GC fired. `selected.ring.destroy()` before nulling
+- **VaultTab `delta` string stale:** `useDemoResourceJiggle` mutated only `value`, leaving the static `delta` string showing conflicting movement. Now updates both alongside
+
+### Deferred to post-demo
+
+- Full v5 spec implementation (combat full-tick 10-phase choreography, strategic 8×8 atlas, cross-fade transitions, Submission 2 transfer demo cinematic, monument tier-up cinematic, speech bubble anti-occlusion, particle pool of 32, asset pipeline validation)
+- Bridged GOLD token integration (PR #466 scoping doc only — no code changes; ships post-Diamond-proxy)
+- Cosmetic cleanups: `frame.sat` dead config, `combatPlayedTickRef` comment-vs-code mismatch, `combatHighlight` zIndex no-ops, level-badge orphaning defensive path, inline `<style>` collision risk
+
+### Review coverage
+
+- 3× local 3-tier (Codex 5.5 + Claude Opus 4.7 + Gemini 3 Flash) — 1 fix-round per round
+- 4× SuperSwarm (Codex 5.4 + 5.5 + Gemini 3 Pro + Opus 4.6 + 4.7) — 2 fix-rounds before convergent CLEAN
+- 1× Cloud (Copilot + ChatGPT codex bot) — 1 fix-round
+- 13 commits on the feature branch (3 docs + 3 implementation rounds + 7 fix-round commits)
+
+---
+
 ## [1.1.0] — 2026-05-02
 
 ### Highlights

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1866,6 +1866,12 @@ export function WorldMap() {
     }
 
     const onTick = () => {
+      // Yield bandit alpha ownership to the combat vignette while it's active.
+      // Without this guard, the pulse keeps writing alpha every frame AFTER the
+      // vignette ticker, silently nullifying the success-outcome fade-out
+      // (opus 4.7 SuperSwarm catch). The vignette window overlaps the pulse
+      // window when banditTicksUntil ∈ [0, 2].
+      if (combatVignetteRef.current) return;
       const icon = drawnRef.current.banditIcon;
       const sprite = drawnRef.current.banditSprite;
       const t = performance.now() / 220;

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -638,6 +638,10 @@ export function WorldMap() {
   function selectTarget(target: SelectableTarget, color: number) {
     const viewport = viewportRef.current;
     if (!viewport) return;
+    // No-op during active combat vignette — a fresh selection ring would
+    // appear inside the dimmed combat scene, undercutting the focus and
+    // potentially persisting after the dim layer fades (codex 5.4 LOW).
+    if (combatVignetteRef.current) return;
     let ring = selectedRef.current?.ring;
     if (!ring) {
       ring = new Graphics();
@@ -1187,6 +1191,14 @@ export function WorldMap() {
         .then((texture) => {
           const cancelled = isAssetLoadCancelled();
           if (cancelled || !appRef.current) return;
+          // Defer the sprite swap if a combat vignette is mid-flight — the
+          // banditIcon Graphics is currently the vignette's reparented bandit
+          // and redrawBandit() would clear/reposition it back to the home
+          // anchor, snapping the bandit out of choreography (codex 5.4 MEDIUM
+          // #2). The vignette will complete on the fallback icon; a future
+          // sprite-promotion can land in finishCombatVignette or the next
+          // redrawBandit cycle.
+          if (combatVignetteRef.current) return;
           const sprite = new Sprite(texture);
           sprite.anchor.set(0.5, 0.5);
           sprite.alpha = 0; // hidden until first redrawBandit positions it
@@ -1729,10 +1741,15 @@ export function WorldMap() {
     }
 
     // §10.8 cap rule: combat dim must not stack with day/night darkening into
-    // an unreadable scene. Cap target alpha at min(0.55, 1 - currentBrightness)
-    // so combat at night stays at least readable (claude r3 MUST #2).
+    // an unreadable scene. The naive `min(0.55, 1 - brightness)` reads the
+    // spec literally but inverts the intent — at full daylight (brightness=1)
+    // it gives 0, killing combat dim during the brightest part of the cycle
+    // (codex 5.4 SuperSwarm catch). Correct semantic: dim down by the AMOUNT
+    // of existing day/night darkening so total visual darkness stays bounded.
+    // Floor at 0.2 so combat still has a visible beat even at deep night.
     const dayNightBrightness = getDayNightFrame(getDayNightProgress()).brightness;
-    const dimTarget = Math.min(COMBAT_DIM_ALPHA, clamp01(1 - dayNightBrightness));
+    const existingDarkness = clamp01(1 - dayNightBrightness);
+    const dimTarget = Math.max(0.2, COMBAT_DIM_ALPHA - existingDarkness);
     const fadeOutStart = COMBAT_TOTAL_MS - 600;
     if (age < 600) {
       layers.combatDim.alpha = dimTarget * clamp01(age / 600);

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -105,6 +105,23 @@ type BubbleHandle = {
   tail: Graphics; // separate from backdrop so we can hide it on stacked (non-bottom) bubbles
 };
 
+type WorldLayers = {
+  terrainBackground: Container;
+  terrainAccents: Container;
+  worldDynamic: Container;
+  inWorldEffects: Container;
+  selectionRings: Container;
+  bubbleLayer: Container;
+  screenEffects: Container;
+};
+
+type CarryIndicator = {
+  container: Container;
+  fill: Graphics;
+  displayedFill: number;
+  targetFill: number;
+};
+
 // Worker travel animation (PR #44) — small clan-colored dots crossing between regions.
 interface WorkerTravel {
   id: string;
@@ -115,6 +132,7 @@ interface WorkerTravel {
   color: number;
   /** Display node — Sprite when clansman texture loaded, Graphics dot fallback. */
   gfx: Container;
+  carry: CarryIndicator;
 }
 
 const TRAVEL_DOT_RADIUS = 4; // 8px diameter — slightly bigger so it reads in the demo
@@ -123,6 +141,14 @@ const TRAVEL_DEST_LINGER_MS = 2500; // hold at destination at full alpha before 
 const TRAVEL_MIN_MS = 4500;
 const TRAVEL_MAX_MS = 8000;
 const CANNED_TRAVEL_INTERVAL_MS = 1800; // continuous spawn — keeps map alive
+
+// TODO(contract-bindings): replace these demo defaults when carry caps are exposed.
+const WOOD_CAP = 10;
+const IRON_CAP = 5;
+const WHEAT_CAP = 10;
+const FISH_CAP = 10;
+const CARRY_BAR_W = 16;
+const CARRY_BAR_H = 3;
 
 /** Map a log message to a clan id by string-matching id or name. */
 function attributeClan(msg: string): string | null {
@@ -219,6 +245,59 @@ function treasuryToMonument(treasury: string): number {
   }
 }
 
+function createWorldLayers(): WorldLayers {
+  const terrainBackground = new Container();
+  const terrainAccents = new Container();
+  const worldDynamic = new Container();
+  const inWorldEffects = new Container();
+  const selectionRings = new Container();
+  const bubbleLayer = new Container();
+  const screenEffects = new Container();
+  worldDynamic.sortableChildren = true;
+  return {
+    terrainBackground,
+    terrainAccents,
+    worldDynamic,
+    inWorldEffects,
+    selectionRings,
+    bubbleLayer,
+    screenEffects,
+  };
+}
+
+function makeCarryIndicator(): CarryIndicator {
+  const container = new Container();
+  container.alpha = 0;
+  const bg = new Graphics();
+  bg.rect(-CARRY_BAR_W / 2, -CARRY_BAR_H / 2, CARRY_BAR_W, CARRY_BAR_H);
+  bg.fill({ color: 0x1a1612, alpha: 0.95 });
+  const fill = new Graphics();
+  container.addChild(bg);
+  container.addChild(fill);
+  return { container, fill, displayedFill: 0, targetFill: 0 };
+}
+
+function setCarryTargetFromCarry(
+  indicator: CarryIndicator,
+  carry: { wood?: number; iron?: number; wheat?: number; fish?: number },
+) {
+  indicator.targetFill = Math.max(
+    (carry.wood ?? 0) / WOOD_CAP,
+    (carry.iron ?? 0) / IRON_CAP,
+    (carry.wheat ?? 0) / WHEAT_CAP,
+    (carry.fish ?? 0) / FISH_CAP,
+  );
+}
+
+function redrawCarryIndicator(indicator: CarryIndicator) {
+  const next = Math.max(0, Math.min(1, indicator.displayedFill));
+  indicator.container.alpha = next <= 0.01 ? 0 : 1;
+  indicator.fill.clear();
+  if (next <= 0.01) return;
+  indicator.fill.rect(-CARRY_BAR_W / 2, -CARRY_BAR_H / 2, CARRY_BAR_W * next, CARRY_BAR_H);
+  indicator.fill.fill({ color: 0xe8d8b5, alpha: 1 });
+}
+
 export function WorldMap() {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasWrapRef = useRef<HTMLDivElement>(null);
@@ -240,7 +319,14 @@ export function WorldMap() {
     /** Big translucent zone halos per CLAN at their home region (breathing, hackathon-visual). */
     clanZones: { gfx: Graphics; clan: ClanDef }[];
     /** Per-clan base sprite (96x96 PNG: tower / longhouse / dock keep). */
-    bases: { sprite: Sprite | null; fallback: Graphics; clan: ClanDef }[];
+    bases: {
+      container: Container;
+      sprite: Sprite | null;
+      fallback: Graphics;
+      clan: ClanDef;
+      baseY: number;
+      phaseOffset: number;
+    }[];
     /** Floating "Lv N" badge beside each base. */
     levelBadges: { bg: Graphics; label: Text; clan: ClanDef }[];
     flags: { gfx: Graphics; sprite: Sprite | null; label: Text; clan: ClanDef }[];
@@ -266,6 +352,8 @@ export function WorldMap() {
     banditCountdown: null,
     bgSprite: null,
   });
+
+  const layersRef = useRef<WorldLayers | null>(null);
 
   // Per-clan speech-bubble system (PR #43).
   const bubbleLayerRef = useRef<Container | null>(null);
@@ -370,8 +458,22 @@ export function WorldMap() {
         viewport.moveCenter(WORLD_WIDTH / 2, WORLD_HEIGHT / 2);
         viewportRef.current = viewport;
 
+        const layers = createWorldLayers();
+        viewport.addChild(
+          layers.terrainBackground,
+          layers.terrainAccents,
+          layers.worldDynamic,
+          layers.inWorldEffects,
+          layers.selectionRings,
+          layers.bubbleLayer,
+          layers.screenEffects,
+        );
+        layersRef.current = layers;
+        bubbleLayerRef.current = layers.bubbleLayer;
+        travelLayerRef.current = layers.worldDynamic;
+
         // 1. Background terrain map (PR #40) — fantasy strategy art generated to match REGIONS layout.
-        // Loaded async; sprite is added to viewport BEFORE buildScene so region circles render on top.
+        // Loaded async; sprite is added to terrainBackground BEFORE buildScene so region circles render on top.
         try {
           const tex = await Assets.load(worldMapBg);
           if (!mounted || !isMountedRef.current) return;
@@ -381,7 +483,7 @@ export function WorldMap() {
           bg.height = MAP_HEIGHT;
           bg.x = 0;
           bg.y = 0;
-          viewport.addChild(bg);
+          layers.terrainBackground.addChild(bg);
           drawnRef.current.bgSprite = bg;
         } catch (err) {
           // Non-fatal — fall through to flat background color set in app.init
@@ -390,12 +492,10 @@ export function WorldMap() {
 
         // 2. Build scene (regions, sigil sprites, bandit indicator) — PR #41 + PR #42 logic
         // Layers are added to `viewport` (not app.stage) so pinch/drag affect them.
-        buildScene(app, viewport, () => !mounted || !isMountedRef.current);
+        buildScene(() => !mounted || !isMountedRef.current);
 
-        // 3. Speech bubble layer + ticker (PR #43) — added last so bubbles render above everything.
-        const bubbleLayer = new Container();
-        viewport.addChild(bubbleLayer);
-        bubbleLayerRef.current = bubbleLayer;
+        // 3. Speech bubble ticker (PR #43) — bubbleLayer sits above selection/effects.
+        const bubbleLayer = layers.bubbleLayer;
 
         const cb = (ticker: { deltaMS: number }) => {
           const now = performance.now();
@@ -446,12 +546,9 @@ export function WorldMap() {
         tickerCbRef.current = cb;
         app.ticker.add(cb);
 
-        // 3b. Worker travel layer + ticker (PR #44) — clan-colored dots crossing routes.
-        // Added after bubble layer so dots can render under bubbles (less visual noise).
-        const travelLayer = new Container();
-        // Insert below bubble layer so bubbles always appear on top of moving dots.
-        viewport.addChildAt(travelLayer, viewport.getChildIndex(bubbleLayer));
-        travelLayerRef.current = travelLayer;
+        // 3b. Worker travel ticker (PR #44) — clansmen live in worldDynamic so
+        // they Y-sort against bases and bandits.
+        const travelLayer = layers.worldDynamic;
 
         const travelCb = (_ticker: { deltaMS: number }) => {
           const layer = travelLayerRef.current;
@@ -495,6 +592,8 @@ export function WorldMap() {
               const jit = Math.sin((now + (t.id.charCodeAt(t.id.length - 1) * 137)) / 220) * 1.5;
               t.gfx.x = tx + jit;
               t.gfx.y = ty + jit * 0.6;
+              t.gfx.zIndex = Math.round(t.gfx.y);
+              t.carry.targetFill = 0;
               if (fadeAge < TRAVEL_DEST_LINGER_MS) {
                 t.gfx.alpha = 1;
               } else {
@@ -504,9 +603,16 @@ export function WorldMap() {
             } else {
               t.gfx.x = fx + (tx - fx) * progress;
               t.gfx.y = fy + (ty - fy) * progress;
+              t.gfx.zIndex = Math.round(t.gfx.y);
+              setCarryTargetFromCarry(t.carry, {
+                wood: WOOD_CAP * Math.min(1, progress),
+              });
               // Subtle fade-in over first 150ms so dots don't pop in
               t.gfx.alpha = Math.min(1, elapsed / 150);
             }
+            const lerpFactor = t.carry.targetFill >= t.carry.displayedFill ? 0.15 : 0.28;
+            t.carry.displayedFill += (t.carry.targetFill - t.carry.displayedFill) * lerpFactor;
+            redrawCarryIndicator(t.carry);
           }
         };
         travelTickerCbRef.current = travelCb;
@@ -523,6 +629,12 @@ export function WorldMap() {
             const phase = (t + i * 0.7) * 1.1;
             const a = 0.78 + 0.22 * Math.sin(phase);
             gfx.alpha = a;
+          });
+          const now = performance.now();
+          drawn.bases.forEach((base) => {
+            if (base.baseY <= 0) return;
+            base.container.y = base.baseY + Math.round(Math.sin((now + base.phaseOffset) / 4000) * 1);
+            base.container.zIndex = Math.round(base.baseY);
           });
         };
         app.ticker.add(zonePulseCb);
@@ -559,6 +671,7 @@ export function WorldMap() {
       seenTravelLogIdsRef.current.clear();
       bubbleLayerRef.current = null;
       travelLayerRef.current = null;
+      layersRef.current = null;
       tickerCbRef.current = null;
       travelTickerCbRef.current = null;
       zonePulseCbRef.current = null;
@@ -638,8 +751,10 @@ export function WorldMap() {
   // ---- One-time: create Pixi display objects (refs hold them for relayout) -
   // All layers attach to `viewport` (not app.stage) so pixi-viewport's pinch /
   // drag transforms apply to the whole map atomically.
-  function buildScene(app: Application, viewport: Viewport, isAssetLoadCancelled: () => boolean) {
+  function buildScene(isAssetLoadCancelled: () => boolean) {
     const drawn = drawnRef.current;
+    const layers = layersRef.current;
+    if (!layers) return;
 
     // Clan zones, sigil flags, bases, walls, monuments, bandits — all mock data.
     // Skip entirely when DEMO_MODE is off; the canvas renders as an empty terrain map.
@@ -648,14 +763,14 @@ export function WorldMap() {
       // sits on top. Visual sense of "this clan controls this zone."
       for (const clan of MOCK_CLANS) {
         const zoneGfx = new Graphics();
-        viewport.addChild(zoneGfx);
+        layers.terrainAccents.addChild(zoneGfx);
         drawn.clanZones.push({ gfx: zoneGfx, clan });
       }
     }
 
     for (const region of REGIONS) {
       const g = new Graphics();
-      viewport.addChild(g);
+      layers.terrainBackground.addChild(g);
       drawn.regions.push(g);
 
       const label = new Text({
@@ -663,7 +778,7 @@ export function WorldMap() {
         style: { fill: 0xdddddd, fontSize: 11, fontFamily: 'monospace' },
       });
       label.anchor.set(0.5, 0);
-      viewport.addChild(label);
+      layers.terrainBackground.addChild(label);
       drawn.regionLabels.push(label);
     }
 
@@ -671,26 +786,26 @@ export function WorldMap() {
       // Wall rings — drawn first so they sit above region circles but under sigils.
       for (const clan of MOCK_CLANS) {
         const wallGfx = new Graphics();
-        viewport.addChild(wallGfx);
+        layers.worldDynamic.addChild(wallGfx);
         drawn.walls.push({ gfx: wallGfx, clan });
       }
 
       // Monument towers — drawn before flags so sigil layers cleanly on top.
       for (const clan of MOCK_CLANS) {
         const monGfx = new Graphics();
-        viewport.addChild(monGfx);
+        layers.worldDynamic.addChild(monGfx);
         drawn.monuments.push({ gfx: monGfx, clan });
       }
 
       for (const clan of MOCK_CLANS) {
         const flag = new Graphics();
-        viewport.addChild(flag);
+        layers.worldDynamic.addChild(flag);
         const label = new Text({
           text: clan.name,
           style: { fill: clan.color, fontSize: 10, fontFamily: 'monospace', fontWeight: 'bold' },
         });
         label.anchor.set(0, 1);
-        viewport.addChild(label);
+        layers.worldDynamic.addChild(label);
         const entry: { gfx: Graphics; sprite: Sprite | null; label: Text; clan: ClanDef } = {
           gfx: flag,
           sprite: null,
@@ -707,7 +822,7 @@ export function WorldMap() {
             if (cancelled || !appRef.current) return;
             const sprite = new Sprite(texture);
             sprite.alpha = 0; // hidden until first relayout positions it
-            viewport.addChild(sprite);
+            layers.worldDynamic.addChild(sprite);
             entry.sprite = sprite;
             // Trigger a relayout so sprite gets positioned and shown.
             const wrap = canvasWrapRef.current;
@@ -725,13 +840,13 @@ export function WorldMap() {
       // visible during the load and as a safety net if the asset 404s. The countdown text
       // anchors next to whichever marker is currently rendered.
       const banditIcon = new Graphics();
-      viewport.addChild(banditIcon);
+      layers.worldDynamic.addChild(banditIcon);
       const countdown = new Text({
         text: '',
         style: { fill: 0xffe9b8, fontSize: 11, fontFamily: 'monospace', fontWeight: 'bold' },
       });
       countdown.anchor.set(0, 0.5);
-      viewport.addChild(countdown);
+      layers.inWorldEffects.addChild(countdown);
       drawn.banditIcon = banditIcon;
       drawn.banditCountdown = countdown;
 
@@ -744,7 +859,7 @@ export function WorldMap() {
           const sprite = new Sprite(texture);
           sprite.anchor.set(0.5, 0.5);
           sprite.alpha = 0; // hidden until first redrawBandit positions it
-          viewport.addChild(sprite);
+          layers.worldDynamic.addChild(sprite);
           drawn.banditSprite = sprite;
           redrawBandit();
         })
@@ -755,12 +870,24 @@ export function WorldMap() {
       // Per-clan BASE SPRITES — pixel-art structures at home regions (towers / keeps / longhouses).
       // Visible on top of region circles + sigil flags. Falls back to a simple colored rect.
       for (const clan of MOCK_CLANS) {
+        const container = new Container();
+        layers.worldDynamic.addChild(container);
         const fallback = new Graphics();
-        viewport.addChild(fallback);
-        const entry: { sprite: Sprite | null; fallback: Graphics; clan: ClanDef } = {
+        container.addChild(fallback);
+        const entry: {
+          container: Container;
+          sprite: Sprite | null;
+          fallback: Graphics;
+          clan: ClanDef;
+          baseY: number;
+          phaseOffset: number;
+        } = {
+          container,
           sprite: null,
           fallback,
           clan,
+          baseY: 0,
+          phaseOffset: 0,
         };
         drawn.bases.push(entry);
 
@@ -771,7 +898,7 @@ export function WorldMap() {
             const sprite = new Sprite(texture);
             sprite.anchor.set(0.5, 1); // anchored at bottom-center so it "stands" on the region
             sprite.alpha = 0;
-            viewport.addChild(sprite);
+            container.addChildAt(sprite, Math.min(1, container.children.length));
             entry.sprite = sprite;
             const wrap = canvasWrapRef.current;
             if (wrap && appRef.current) {
@@ -798,7 +925,6 @@ export function WorldMap() {
       // Floating "Lv N" badges — drawn last so they overlay everything.
       for (const clan of MOCK_CLANS) {
         const bg = new Graphics();
-        viewport.addChild(bg);
         const label = new Text({
           text: 'Lv 1',
           style: {
@@ -809,7 +935,8 @@ export function WorldMap() {
           },
         });
         label.anchor.set(0.5, 0.5);
-        viewport.addChild(label);
+        const base = drawn.bases.find((b) => b.clan.id === clan.id);
+        if (base) base.container.addChild(bg, label);
         drawn.levelBadges.push({ bg, label, clan });
       }
     } // end DEMO_MODE block
@@ -947,25 +1074,31 @@ export function WorldMap() {
       });
 
       // BASE SPRITES — render at clan home positions, replacing monument obelisks.
-      drawn.bases.forEach(({ sprite, fallback, clan }) => {
+      drawn.bases.forEach((entry) => {
+        const { container, sprite, fallback, clan } = entry;
         const base = regionMap.get(clan.homeRegion);
         if (!base) return;
         const cx = projX(base.nx);
         const cy = projY(base.ny);
         // Base size: ~128px at 1x scale, scales with viewport (2x bump for phone readability)
         const baseSize = Math.max(96, 144 * cappedSizeScale);
+        entry.baseY = cy + baseSize * 0.15;
+        entry.phaseOffset = ((Math.round(cx) * 73) ^ (Math.round(entry.baseY) * 31)) % 4000;
+        container.x = cx;
+        container.y = entry.baseY;
+        container.zIndex = Math.round(entry.baseY);
         fallback.clear();
         if (!sprite) {
           // Simple colored fallback rect with clan-color border
-          fallback.rect(cx - baseSize / 2, cy - baseSize, baseSize, baseSize);
+          fallback.rect(-baseSize / 2, -baseSize, baseSize, baseSize);
           fallback.fill({ color: 0x444444, alpha: 0.7 });
           fallback.stroke({ color: clan.color, width: 3 });
         }
         if (sprite) {
           sprite.width = baseSize;
           sprite.height = baseSize;
-          sprite.x = cx;
-          sprite.y = cy + baseSize * 0.15; // anchor=bottom-center; sit slightly below center
+          sprite.x = 0;
+          sprite.y = 0; // anchor=bottom-center; parent sits slightly below region center
           sprite.alpha = 1;
         }
       });
@@ -974,15 +1107,13 @@ export function WorldMap() {
       drawn.levelBadges.forEach(({ bg, label, clan }) => {
         const base = regionMap.get(clan.homeRegion);
         if (!base) return;
-        const cx = projX(base.nx);
-        const cy = projY(base.ny);
         const baseSize = Math.max(96, 144 * cappedSizeScale);
         const lvl = levelByClan.get(clan.id) ?? 0;
         label.text = `Lv ${lvl}`;
         label.style.fontSize = Math.max(11, Math.round(13 * cappedSizeScale));
         // Position to the right of the base sprite, near the top
-        const bx = cx + baseSize * 0.55;
-        const by = cy - baseSize * 0.55;
+        const bx = baseSize * 0.55;
+        const by = -baseSize * 0.7;
         label.x = bx;
         label.y = by;
         // Pill background
@@ -1023,8 +1154,10 @@ export function WorldMap() {
     const iconY = cy - 42 * scale;
     const spriteSize = Math.max(24, 32 * scale);
     const ringR = Math.max(10, 14 * scale);
+    const banditZ = Math.round(iconY);
 
     icon.clear();
+    icon.zIndex = banditZ;
     if (!sprite) {
       // Fallback ring while the sprite loads / on asset failure
       icon.circle(iconX, iconY, ringR);
@@ -1043,6 +1176,7 @@ export function WorldMap() {
       sprite.height = spriteSize;
       sprite.x = iconX;
       sprite.y = iconY;
+      sprite.zIndex = banditZ;
       sprite.alpha = 1;
     }
 
@@ -1168,6 +1302,9 @@ export function WorldMap() {
       dot.alpha = 0;
       gfx = dot;
     }
+    const carry = makeCarryIndicator();
+    carry.container.y = tex ? -18 : -TRAVEL_DOT_RADIUS - 6;
+    gfx.addChild(carry.container);
     layer.addChild(gfx);
 
     const durationMs =
@@ -1182,6 +1319,7 @@ export function WorldMap() {
       durationMs,
       color,
       gfx,
+      carry,
     });
   }
 

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -547,8 +547,8 @@ export function WorldMap() {
   function clearSelection() {
     const selected = selectedRef.current;
     if (!selected) return;
-    selected.ring.visible = false;
     selected.target.removeChild(selected.ring);
+    selected.ring.destroy();
     selectedRef.current = null;
     fitWorldAnimated();
   }

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from 'convex/react';
-import { Application, Assets, Container, Graphics, Sprite, Text } from 'pixi.js';
+import { Application, Assets, ColorMatrixFilter, Container, Graphics, Sprite, Text } from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
 import { useAgentLogs, type AgentLog } from './useAgentLogs';
 import { WorldNoticePanel } from './WorldNoticePanel';
@@ -106,6 +106,7 @@ type BubbleHandle = {
 };
 
 type WorldLayers = {
+  worldContainer: Container;
   terrainBackground: Container;
   terrainAccents: Container;
   worldDynamic: Container;
@@ -120,6 +121,19 @@ type CarryIndicator = {
   fill: Graphics;
   displayedFill: number;
   targetFill: number;
+};
+
+type DayNightKeyframe = {
+  r: number;
+  g: number;
+  b: number;
+  brightness: number;
+  sat: number;
+};
+
+type SelectableTarget = Container & {
+  width: number;
+  height: number;
 };
 
 // Worker travel animation (PR #44) — small clan-colored dots crossing between regions.
@@ -149,6 +163,22 @@ const WHEAT_CAP = 10;
 const FISH_CAP = 10;
 const CARRY_BAR_W = 16;
 const CARRY_BAR_H = 3;
+
+const TICKS_PER_DAY_CYCLE = 30;
+const FALLBACK_DAY_TICK_MS = 60_000;
+const DAYNIGHT_KEYFRAMES: Record<'dawn' | 'day' | 'dusk' | 'night', DayNightKeyframe> = {
+  dawn: { r: 1.10, g: 0.90, b: 0.80, brightness: 0.95, sat: 0.85 },
+  day: { r: 1.00, g: 1.00, b: 1.00, brightness: 1.00, sat: 1.00 },
+  dusk: { r: 1.15, g: 0.85, b: 0.70, brightness: 0.85, sat: 0.95 },
+  night: { r: 0.65, g: 0.70, b: 0.95, brightness: 0.55, sat: 0.70 },
+};
+const DAYNIGHT_PHASES = [
+  { at: 0.00, key: 'dawn' as const },
+  { at: 0.05, key: 'day' as const },
+  { at: 0.50, key: 'dusk' as const },
+  { at: 0.55, key: 'night' as const },
+  { at: 1.00, key: 'dawn' as const },
+];
 
 /** Map a log message to a clan id by string-matching id or name. */
 function attributeClan(msg: string): string | null {
@@ -246,6 +276,7 @@ function treasuryToMonument(treasury: string): number {
 }
 
 function createWorldLayers(): WorldLayers {
+  const worldContainer = new Container();
   const terrainBackground = new Container();
   const terrainAccents = new Container();
   const worldDynamic = new Container();
@@ -254,7 +285,9 @@ function createWorldLayers(): WorldLayers {
   const bubbleLayer = new Container();
   const screenEffects = new Container();
   worldDynamic.sortableChildren = true;
+  worldContainer.addChild(terrainBackground, terrainAccents, worldDynamic);
   return {
+    worldContainer,
     terrainBackground,
     terrainAccents,
     worldDynamic,
@@ -298,6 +331,69 @@ function redrawCarryIndicator(indicator: CarryIndicator) {
   indicator.fill.fill({ color: 0xe8d8b5, alpha: 1 });
 }
 
+function clamp01(value: number) {
+  return Math.max(0, Math.min(1, value));
+}
+
+function lerp(a: number, b: number, t: number) {
+  return a + (b - a) * t;
+}
+
+function getDayNightFrame(progress01: number): DayNightKeyframe {
+  const wrapped = ((progress01 % 1) + 1) % 1;
+  for (let i = 0; i < DAYNIGHT_PHASES.length - 1; i++) {
+    const a = DAYNIGHT_PHASES[i];
+    const b = DAYNIGHT_PHASES[i + 1];
+    if (!a || !b) continue;
+    if (wrapped >= a.at && wrapped <= b.at) {
+      const t = b.at === a.at ? 0 : (wrapped - a.at) / (b.at - a.at);
+      const from = DAYNIGHT_KEYFRAMES[a.key];
+      const to = DAYNIGHT_KEYFRAMES[b.key];
+      return {
+        r: lerp(from.r, to.r, t),
+        g: lerp(from.g, to.g, t),
+        b: lerp(from.b, to.b, t),
+        brightness: lerp(from.brightness, to.brightness, t),
+        sat: lerp(from.sat, to.sat, t),
+      };
+    }
+  }
+  return DAYNIGHT_KEYFRAMES.dawn;
+}
+
+function applyDayNightFilter(filter: ColorMatrixFilter, frame: DayNightKeyframe) {
+  const r = frame.r * frame.brightness;
+  const g = frame.g * frame.brightness;
+  const b = frame.b * frame.brightness;
+  void frame.sat;
+  filter.matrix = [
+    r, 0, 0, 0, 0,
+    0, g, 0, 0, 0,
+    0, 0, b, 0, 0,
+    0, 0, 0, 1, 0,
+  ];
+}
+
+function drawSelectionRing(g: Graphics, radius: number, color: number) {
+  g.clear();
+  const segmentCount = 8;
+  const gap = 0.18;
+  const step = (Math.PI * 2) / segmentCount;
+  for (let i = 0; i < segmentCount; i++) {
+    const start = i * step + gap;
+    const end = (i + 1) * step - gap;
+    const samples = 6;
+    for (let j = 0; j <= samples; j++) {
+      const a = lerp(start, end, j / samples);
+      const x = Math.cos(a) * radius;
+      const y = Math.sin(a) * radius * 0.45;
+      if (j === 0) g.moveTo(x, y);
+      else g.lineTo(x, y);
+    }
+  }
+  g.stroke({ color, width: 2, alpha: 1 });
+}
+
 export function WorldMap() {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasWrapRef = useRef<HTMLDivElement>(null);
@@ -323,6 +419,7 @@ export function WorldMap() {
       container: Container;
       sprite: Sprite | null;
       fallback: Graphics;
+      glow: Graphics;
       clan: ClanDef;
       baseY: number;
       phaseOffset: number;
@@ -354,6 +451,14 @@ export function WorldMap() {
   });
 
   const layersRef = useRef<WorldLayers | null>(null);
+  const dayNightFilterRef = useRef<ColorMatrixFilter | null>(null);
+  const dayNightTickerCbRef = useRef<(() => void) | null>(null);
+  const selectedRef = useRef<{
+    target: SelectableTarget;
+    ring: Graphics;
+    color: number;
+  } | null>(null);
+  const tickClockRef = useRef<{ tick: number; seenAtMs: number }>({ tick: 0, seenAtMs: Date.now() });
 
   // Per-clan speech-bubble system (PR #43).
   const bubbleLayerRef = useRef<Container | null>(null);
@@ -389,6 +494,86 @@ export function WorldMap() {
   }, [logs, snapshot?.tick]);
   const banditTicksUntil = DEMO_BANDIT.attacksAtTick - liveTick;
   const shouldPulseBandit = DEMO_MODE && banditTicksUntil <= 2 && banditTicksUntil >= 0;
+
+  useEffect(() => {
+    const rawTick = snapshot?.tick;
+    if (typeof rawTick === 'number' && Number.isFinite(rawTick)) {
+      tickClockRef.current = { tick: rawTick, seenAtMs: Date.now() };
+    }
+  }, [snapshot?.tick]);
+
+  function getDayNightProgress() {
+    const tick = snapshot?.tick;
+    const epoch = snapshot?.tickEpoch;
+    const hasEpoch = !!epoch && typeof epoch.startedAt === 'number' && epoch.startedAt > 0;
+    if (typeof tick === 'number' && Number.isFinite(tick) && (tick > 0 || hasEpoch)) {
+      let subTickProgress = 0;
+      if (hasEpoch && typeof epoch.durationMs === 'number' && epoch.durationMs > 0) {
+        const startedAtMs = epoch.startedAt < 10_000_000_000 ? epoch.startedAt * 1000 : epoch.startedAt;
+        subTickProgress = clamp01((Date.now() - startedAtMs) / epoch.durationMs);
+      } else {
+        const elapsed = Date.now() - tickClockRef.current.seenAtMs;
+        subTickProgress = clamp01(elapsed / FALLBACK_DAY_TICK_MS);
+      }
+      return ((tick + subTickProgress) % TICKS_PER_DAY_CYCLE) / TICKS_PER_DAY_CYCLE;
+    }
+    return ((Date.now() / FALLBACK_DAY_TICK_MS) % TICKS_PER_DAY_CYCLE) / TICKS_PER_DAY_CYCLE;
+  }
+
+  function fitWorldAnimated() {
+    const viewport = viewportRef.current;
+    const wrap = canvasWrapRef.current;
+    if (!viewport || !wrap) return;
+    const fitScale = Math.max(
+      (wrap.clientWidth || viewport.screenWidth) / WORLD_WIDTH,
+      (wrap.clientHeight || viewport.screenHeight) / WORLD_HEIGHT,
+    );
+    viewport.plugins.remove('animate');
+    viewport.animate({
+      position: { x: WORLD_WIDTH / 2, y: WORLD_HEIGHT / 2 },
+      scale: fitScale,
+      time: 400,
+      ease: 'easeInOutQuad',
+    });
+  }
+
+  function clearSelection() {
+    const selected = selectedRef.current;
+    if (selected) {
+      selected.ring.visible = false;
+      selected.target.removeChild(selected.ring);
+      selectedRef.current = null;
+    }
+    fitWorldAnimated();
+  }
+
+  function selectTarget(target: SelectableTarget, color: number) {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    let ring = selectedRef.current?.ring;
+    if (!ring) {
+      ring = new Graphics();
+    } else if (ring.parent) {
+      ring.parent.removeChild(ring);
+    }
+    const radius = Math.max(18, Math.max(target.width || 0, target.height || 0) * 0.7);
+    drawSelectionRing(ring, radius, color);
+    ring.visible = true;
+    ring.alpha = 1;
+    ring.rotation = 0;
+    target.addChildAt(ring, 0);
+    selectedRef.current = { target, ring, color };
+
+    const global = target.getGlobalPosition();
+    const world = viewport.toWorld(global);
+    viewport.plugins.remove('animate');
+    viewport.animate({
+      position: { x: world.x, y: world.y },
+      scale: 2.0,
+      time: 400,
+      ease: 'easeInOutQuad',
+    });
+  }
 
   // ---- Pixi init ------------------------------------------------------------
   useEffect(() => {
@@ -460,14 +645,15 @@ export function WorldMap() {
 
         const layers = createWorldLayers();
         viewport.addChild(
-          layers.terrainBackground,
-          layers.terrainAccents,
-          layers.worldDynamic,
+          layers.worldContainer,
           layers.inWorldEffects,
           layers.selectionRings,
           layers.bubbleLayer,
           layers.screenEffects,
         );
+        const dayNightFilter = new ColorMatrixFilter();
+        layers.worldContainer.filters = [dayNightFilter];
+        dayNightFilterRef.current = dayNightFilter;
         layersRef.current = layers;
         bubbleLayerRef.current = layers.bubbleLayer;
         travelLayerRef.current = layers.worldDynamic;
@@ -565,6 +751,7 @@ export function WorldMap() {
             const from = REGIONS.find(r => r.id === t.fromRegionKey);
             const to = REGIONS.find(r => r.id === t.toRegionKey);
             if (!from || !to) {
+              if (selectedRef.current?.target === t.gfx) selectedRef.current = null;
               layer.removeChild(t.gfx);
               t.gfx.destroy();
               list.splice(i, 1);
@@ -583,6 +770,7 @@ export function WorldMap() {
               // Linger at destination at full alpha for TRAVEL_DEST_LINGER_MS,
               // THEN fade. Keeps arrival visible — answers "clansmen disappear" bug.
               if (fadeAge >= TRAVEL_DEST_LINGER_MS + TRAVEL_FADE_OUT_MS) {
+                if (selectedRef.current?.target === t.gfx) selectedRef.current = null;
                 layer.removeChild(t.gfx);
                 t.gfx.destroy();
                 list.splice(i, 1);
@@ -642,6 +830,27 @@ export function WorldMap() {
         // Track separately:
         zonePulseCbRef.current = zonePulseCb;
 
+        const dayNightCb = () => {
+          const filter = dayNightFilterRef.current;
+          if (!filter) return;
+          const frame = getDayNightFrame(getDayNightProgress());
+          applyDayNightFilter(filter, frame);
+          const glowAlpha = clamp01(1 - frame.brightness);
+          drawnRef.current.bases.forEach((base) => {
+            base.glow.alpha = glowAlpha;
+          });
+
+          const selected = selectedRef.current;
+          if (selected) {
+            const ring = selected.ring;
+            const now = performance.now();
+            ring.rotation += (app.ticker.deltaMS / 1000) * Math.PI * 2;
+            ring.alpha = 0.6 + Math.sin((now / 1000) * Math.PI) * 0.4;
+          }
+        };
+        dayNightTickerCbRef.current = dayNightCb;
+        app.ticker.add(dayNightCb);
+
         // 4. Initial layout (PR #41) — projects normalized coords + positions flag anchors.
         // relayout now operates in WORLD space (MAP_WIDTH x MAP_HEIGHT) since the
         // viewport handles screen-fit transformation. Children inside the viewport
@@ -664,6 +873,9 @@ export function WorldMap() {
       if (a && tickerCbRef.current) a.ticker.remove(tickerCbRef.current);
       if (a && travelTickerCbRef.current) a.ticker.remove(travelTickerCbRef.current);
       if (a && zonePulseCbRef.current) a.ticker.remove(zonePulseCbRef.current);
+      if (a && dayNightTickerCbRef.current) a.ticker.remove(dayNightTickerCbRef.current);
+      selectedRef.current?.ring.destroy();
+      selectedRef.current = null;
       bubblesByClanRef.current.clear();
       seenLogIdsRef.current.clear();
       flagAnchorsRef.current.clear();
@@ -675,6 +887,8 @@ export function WorldMap() {
       tickerCbRef.current = null;
       travelTickerCbRef.current = null;
       zonePulseCbRef.current = null;
+      dayNightTickerCbRef.current = null;
+      dayNightFilterRef.current = null;
       drawnRef.current = {
         regions: [],
         regionLabels: [],
@@ -746,6 +960,18 @@ export function WorldMap() {
       ro.disconnect();
       window.removeEventListener('orientationchange', handleResize);
     };
+  }, [pixiReady]);
+
+  useEffect(() => {
+    if (!pixiReady) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        clearSelection();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pixiReady]);
 
   // ---- One-time: create Pixi display objects (refs hold them for relayout) -
@@ -840,6 +1066,12 @@ export function WorldMap() {
       // visible during the load and as a safety net if the asset 404s. The countdown text
       // anchors next to whichever marker is currently rendered.
       const banditIcon = new Graphics();
+      banditIcon.eventMode = 'static';
+      banditIcon.cursor = 'pointer';
+      banditIcon.on('pointertap', (event) => {
+        event.stopPropagation();
+        selectTarget(banditIcon as SelectableTarget, 0xffe9b8);
+      });
       layers.worldDynamic.addChild(banditIcon);
       const countdown = new Text({
         text: '',
@@ -859,6 +1091,12 @@ export function WorldMap() {
           const sprite = new Sprite(texture);
           sprite.anchor.set(0.5, 0.5);
           sprite.alpha = 0; // hidden until first redrawBandit positions it
+          sprite.eventMode = 'static';
+          sprite.cursor = 'pointer';
+          sprite.on('pointertap', (event) => {
+            event.stopPropagation();
+            selectTarget(sprite as SelectableTarget, 0xffe9b8);
+          });
           layers.worldDynamic.addChild(sprite);
           drawn.banditSprite = sprite;
           redrawBandit();
@@ -873,11 +1111,20 @@ export function WorldMap() {
         const container = new Container();
         layers.worldDynamic.addChild(container);
         const fallback = new Graphics();
+        const glow = new Graphics();
         container.addChild(fallback);
+        container.addChild(glow);
+        container.eventMode = 'static';
+        container.cursor = 'pointer';
+        container.on('pointertap', (event) => {
+          event.stopPropagation();
+          selectTarget(container as SelectableTarget, clan.color);
+        });
         const entry: {
           container: Container;
           sprite: Sprite | null;
           fallback: Graphics;
+          glow: Graphics;
           clan: ClanDef;
           baseY: number;
           phaseOffset: number;
@@ -885,6 +1132,7 @@ export function WorldMap() {
           container,
           sprite: null,
           fallback,
+          glow,
           clan,
           baseY: 0,
           phaseOffset: 0,
@@ -1075,7 +1323,7 @@ export function WorldMap() {
 
       // BASE SPRITES — render at clan home positions, replacing monument obelisks.
       drawn.bases.forEach((entry) => {
-        const { container, sprite, fallback, clan } = entry;
+        const { container, sprite, fallback, glow, clan } = entry;
         const base = regionMap.get(clan.homeRegion);
         if (!base) return;
         const cx = projX(base.nx);
@@ -1101,6 +1349,9 @@ export function WorldMap() {
           sprite.y = 0; // anchor=bottom-center; parent sits slightly below region center
           sprite.alpha = 1;
         }
+        glow.clear();
+        glow.circle(0, -baseSize * 0.8, Math.max(6, 8 * cappedSizeScale));
+        glow.fill({ color: 0xffd27d, alpha: 0.6 });
       });
 
       // FLOATING "Lv N" BADGES — beside each base sprite. Updates with monument level.
@@ -1302,6 +1553,12 @@ export function WorldMap() {
       dot.alpha = 0;
       gfx = dot;
     }
+    gfx.eventMode = 'static';
+    gfx.cursor = 'pointer';
+    gfx.on('pointertap', (event) => {
+      event.stopPropagation();
+      selectTarget(gfx as SelectableTarget, color);
+    });
     const carry = makeCarryIndicator();
     carry.container.y = tex ? -18 : -TRAVEL_DOT_RADIUS - 6;
     gfx.addChild(carry.container);

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1606,7 +1606,22 @@ export function WorldMap() {
     if (combatPlayedTickRef.current === attackTick) return false;
     const currentTick = liveTickRef.current;
     if (currentTick === attackTick - 1) {
-      return getMsUntilTickClose() <= COMBAT_VIGNETTE_LEAD_MS;
+      // Codex cloud P1: when tickEpoch is unavailable (Sub1 logs-driven liveTick
+      // mode where ticks advance every ~20s but FALLBACK_DAY_TICK_MS is 60s),
+      // `getMsUntilTickClose()` never drops to ≤4000ms before liveTick rolls
+      // forward — the precise pre-close window never fires and the vignette
+      // only triggers post-close (line below). Detect fallback mode and
+      // trigger as soon as we enter the pre-attack tick. Vignette occupies the
+      // first 4s of the pre-attack tick instead of the last 4s; visually similar.
+      const snap = snapshotRef.current;
+      const epoch = snap?.tickEpoch;
+      const havePreciseEpoch =
+        epoch && typeof epoch.startedAt === 'number' && epoch.startedAt > 0
+        && typeof epoch.durationMs === 'number' && epoch.durationMs > 0;
+      if (havePreciseEpoch) {
+        return getMsUntilTickClose() <= COMBAT_VIGNETTE_LEAD_MS;
+      }
+      return true;
     }
     return currentTick >= attackTick;
   }

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1502,8 +1502,12 @@ export function WorldMap() {
         bg.stroke({ color: clan.color, width: 1.5, alpha: 0.95 });
       });
 
-      // Bandit redraw uses live tick — recompute alongside layout
-      redrawBandit();
+      // Bandit redraw uses live tick — recompute alongside layout.
+      // Skip during active vignette so a snapshot.clans-driven relayout
+      // doesn't snap the reparented bandit back to home anchor mid-
+      // choreography (opus 4.7 r4 LOW). The vignette ticker self-corrects
+      // on the next frame anyway, but a one-frame snap is visible.
+      if (!combatVignetteRef.current) redrawBandit();
     } // end DEMO_MODE relayout block
   }
 
@@ -1880,6 +1884,11 @@ export function WorldMap() {
     if (!app) return;
 
     const resetBanditAlpha = () => {
+      // Defeated bandit stays alpha=0 — don't reset to 1 (opus 4.6/4.7 r4
+      // defensive). Currently masked by visible=false but enforces the
+      // "stay hidden post-defeat" invariant against future writers that
+      // might flip visible back to true.
+      if (banditDefeatedRef.current) return;
       const icon = drawnRef.current.banditIcon;
       const sprite = drawnRef.current.banditSprite;
       if (icon) icon.alpha = 1;

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -549,6 +549,9 @@ export function WorldMap() {
   const seenTravelLogIdsRef = useRef<Set<string>>(new Set());
   const travelIdSeqRef = useRef(0);
   const combatVignetteRef = useRef<CombatVignette | null>(null);
+  // Set true after a `?combat=success` vignette completes, so the bandit
+  // stays hidden post-fade-out instead of popping back to the home anchor.
+  const banditDefeatedRef = useRef(false);
   const combatTickerCbRef = useRef<(() => void) | null>(null);
   const combatPlayedTickRef = useRef<number | null>(null);
   const liveTickClockRef = useRef<{ tick: number; seenAtMs: number }>({ tick: 0, seenAtMs: Date.now() });
@@ -1191,14 +1194,14 @@ export function WorldMap() {
         .then((texture) => {
           const cancelled = isAssetLoadCancelled();
           if (cancelled || !appRef.current) return;
-          // Defer the sprite swap if a combat vignette is mid-flight — the
-          // banditIcon Graphics is currently the vignette's reparented bandit
-          // and redrawBandit() would clear/reposition it back to the home
-          // anchor, snapping the bandit out of choreography (codex 5.4 MEDIUM
-          // #2). The vignette will complete on the fallback icon; a future
-          // sprite-promotion can land in finishCombatVignette or the next
-          // redrawBandit cycle.
-          if (combatVignetteRef.current) return;
+          // The .then() fires once per page load. Earlier round-2 fix
+          // early-returned during vignette to avoid redrawBandit() snapping
+          // the reparented banditIcon back to home — but skipping creation
+          // entirely meant the sprite was permanently lost if the asset
+          // resolved mid-vignette (gemini r3 HIGH #1). Now: always create
+          // the sprite + assign to drawn; only skip the redraw if a
+          // vignette is active. finishCombatVignette() calls redrawBandit
+          // afterward which positions the new sprite.
           const sprite = new Sprite(texture);
           sprite.anchor.set(0.5, 0.5);
           sprite.alpha = 0; // hidden until first redrawBandit positions it
@@ -1210,6 +1213,7 @@ export function WorldMap() {
           });
           layers.worldDynamic.addChild(sprite);
           drawn.banditSprite = sprite;
+          if (combatVignetteRef.current) return;
           redrawBandit();
         })
         .catch(() => {
@@ -1513,6 +1517,18 @@ export function WorldMap() {
     const sprite = drawn.banditSprite;
     const text = drawn.banditCountdown;
     if (!icon || !text) return;
+    // After a `?combat=success` vignette completes, the bandit is defeated.
+    // Skip all redraw / re-show on subsequent layouts (gemini r3 HIGH #2).
+    if (banditDefeatedRef.current) {
+      icon.visible = false;
+      icon.alpha = 0;
+      if (sprite) {
+        sprite.visible = false;
+        sprite.alpha = 0;
+      }
+      text.visible = false;
+      return;
+    }
 
     const region = REGIONS.find(r => r.id === DEMO_BANDIT.regionId);
     if (!region) return;
@@ -1706,7 +1722,17 @@ export function WorldMap() {
     vignette.targetBase.x = vignette.baseStart.x;
     vignette.targetBase.y = vignette.baseStart.y;
     vignette.targetBase.scale.set(vignette.baseStart.scaleX, vignette.baseStart.scaleY);
-    if (vignette.bandit) {
+    // On success outcome the vignette fades the bandit to alpha=0 + 0.3 scale;
+    // unconditionally restoring banditStart would pop the defeated bandit
+    // back to full opacity (gemini r3 HIGH #2). Lock the defeated state via
+    // banditDefeatedRef + skip the visual restore on success.
+    if (vignette.outcome === 'success' && !force) {
+      banditDefeatedRef.current = true;
+      if (vignette.bandit) {
+        vignette.bandit.alpha = 0;
+        vignette.bandit.visible = false;
+      }
+    } else if (vignette.bandit) {
       vignette.bandit.x = vignette.banditStart.x;
       vignette.bandit.y = vignette.banditStart.y;
       vignette.bandit.scale.set(vignette.banditStart.scaleX, vignette.banditStart.scaleY);
@@ -1872,6 +1898,8 @@ export function WorldMap() {
       // (opus 4.7 SuperSwarm catch). The vignette window overlaps the pulse
       // window when banditTicksUntil ∈ [0, 2].
       if (combatVignetteRef.current) return;
+      // Defeated bandit stays hidden — don't pulse it back into visibility.
+      if (banditDefeatedRef.current) return;
       const icon = drawnRef.current.banditIcon;
       const sprite = drawnRef.current.banditSprite;
       const t = performance.now() / 220;

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -304,6 +304,7 @@ function makeCarryIndicator(): CarryIndicator {
   const bg = new Graphics();
   bg.rect(-CARRY_BAR_W / 2, -CARRY_BAR_H / 2, CARRY_BAR_W, CARRY_BAR_H);
   bg.fill({ color: 0x1a1612, alpha: 0.95 });
+  bg.stroke({ color: 0x000000, width: 1, alpha: 0.85 });
   const fill = new Graphics();
   container.addChild(bg);
   container.addChild(fill);
@@ -753,7 +754,7 @@ export function WorldMap() {
             if (!from || !to) {
               if (selectedRef.current?.target === t.gfx) selectedRef.current = null;
               layer.removeChild(t.gfx);
-              t.gfx.destroy();
+              t.gfx.destroy({ children: true });
               list.splice(i, 1);
               continue;
             }
@@ -772,7 +773,7 @@ export function WorldMap() {
               if (fadeAge >= TRAVEL_DEST_LINGER_MS + TRAVEL_FADE_OUT_MS) {
                 if (selectedRef.current?.target === t.gfx) selectedRef.current = null;
                 layer.removeChild(t.gfx);
-                t.gfx.destroy();
+                t.gfx.destroy({ children: true });
                 list.splice(i, 1);
                 continue;
               }
@@ -821,7 +822,9 @@ export function WorldMap() {
           const now = performance.now();
           drawn.bases.forEach((base) => {
             if (base.baseY <= 0) return;
-            base.container.y = base.baseY + Math.round(Math.sin((now + base.phaseOffset) / 4000) * 1);
+            // 0.25 Hz (4-second period). 2π/4000 = π/2000 keeps units honest:
+            // sin((t + offset) * π / period_ms_half) cycles once per period.
+            base.container.y = base.baseY + Math.round(Math.sin((now + base.phaseOffset) * Math.PI / 2000) * 1);
             base.container.zIndex = Math.round(base.baseY);
           });
         };

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -460,6 +460,10 @@ export function WorldMap() {
     color: number;
   } | null>(null);
   const tickClockRef = useRef<{ tick: number; seenAtMs: number }>({ tick: 0, seenAtMs: Date.now() });
+  // Snapshot ref populated below in a useEffect — declared up here so the
+  // day/night ticker (registered once at Pixi mount) reads current
+  // snapshot/tickEpoch instead of the stale closure capture.
+  const snapshotRef = useRef<ReturnType<typeof useQuery<typeof api.getSnapshot.getSnapshot>> | undefined>(undefined);
 
   // Per-clan speech-bubble system (PR #43).
   const bubbleLayerRef = useRef<Container | null>(null);
@@ -497,15 +501,17 @@ export function WorldMap() {
   const shouldPulseBandit = DEMO_MODE && banditTicksUntil <= 2 && banditTicksUntil >= 0;
 
   useEffect(() => {
+    snapshotRef.current = snapshot;
     const rawTick = snapshot?.tick;
     if (typeof rawTick === 'number' && Number.isFinite(rawTick)) {
       tickClockRef.current = { tick: rawTick, seenAtMs: Date.now() };
     }
-  }, [snapshot?.tick]);
+  }, [snapshot]);
 
   function getDayNightProgress() {
-    const tick = snapshot?.tick;
-    const epoch = snapshot?.tickEpoch;
+    const snap = snapshotRef.current;
+    const tick = snap?.tick;
+    const epoch = snap?.tickEpoch;
     const hasEpoch = !!epoch && typeof epoch.startedAt === 'number' && epoch.startedAt > 0;
     if (typeof tick === 'number' && Number.isFinite(tick) && (tick > 0 || hasEpoch)) {
       let subTickProgress = 0;
@@ -540,11 +546,10 @@ export function WorldMap() {
 
   function clearSelection() {
     const selected = selectedRef.current;
-    if (selected) {
-      selected.ring.visible = false;
-      selected.target.removeChild(selected.ring);
-      selectedRef.current = null;
-    }
+    if (!selected) return;
+    selected.ring.visible = false;
+    selected.target.removeChild(selected.ring);
+    selectedRef.current = null;
     fitWorldAnimated();
   }
 
@@ -1411,17 +1416,21 @@ export function WorldMap() {
     const banditZ = Math.round(iconY);
 
     icon.clear();
+    icon.x = iconX;
+    icon.y = iconY;
     icon.zIndex = banditZ;
     if (!sprite) {
-      // Fallback ring while the sprite loads / on asset failure
-      icon.circle(iconX, iconY, ringR);
+      // Fallback ring while the sprite loads / on asset failure.
+      // Draw shapes at icon-local origin so target.getGlobalPosition() in
+      // selectTarget() resolves to the visible center, not the parent layer's origin.
+      icon.circle(0, 0, ringR);
       icon.fill({ color: 0xcc1122, alpha: 0.85 });
       icon.stroke({ color: 0xffffff, width: 2 });
       const barW = Math.max(2, 3 * scale);
       const barH = ringR * 0.95;
-      icon.rect(iconX - barW / 2, iconY - barH / 2, barW, barH * 0.6);
+      icon.rect(-barW / 2, -barH / 2, barW, barH * 0.6);
       icon.fill({ color: 0xffffff });
-      icon.circle(iconX, iconY + barH * 0.35, Math.max(1.5, barW * 0.7));
+      icon.circle(0, barH * 0.35, Math.max(1.5, barW * 0.7));
       icon.fill({ color: 0xffffff });
     }
 

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -114,6 +114,9 @@ type WorldLayers = {
   selectionRings: Container;
   bubbleLayer: Container;
   screenEffects: Container;
+  combatDim: Graphics;
+  combatHighlight: Container;
+  combatFlash: Graphics;
 };
 
 type CarryIndicator = {
@@ -149,12 +152,48 @@ interface WorkerTravel {
   carry: CarryIndicator;
 }
 
+type CombatOutcome = 'success' | 'failure';
+
+type ReparentedCombatant = {
+  node: Container;
+  parent: Container;
+  zIndex: number;
+  wasTemporary?: boolean;
+};
+
+type CombatVignette = {
+  startedAt: number;
+  outcome: CombatOutcome;
+  bandit: Container | null;
+  targetBase: Container;
+  defenders: Container[];
+  reparented: ReparentedCombatant[];
+  baseStart: { x: number; y: number; scaleX: number; scaleY: number };
+  banditStart: { x: number; y: number; scaleX: number; scaleY: number; alpha: number };
+  defenderStarts: { x: number; y: number }[];
+  center: { x: number; y: number };
+};
+
 const TRAVEL_DOT_RADIUS = 4; // 8px diameter — slightly bigger so it reads in the demo
 const TRAVEL_FADE_OUT_MS = 1200; // longer linger at destination
 const TRAVEL_DEST_LINGER_MS = 2500; // hold at destination at full alpha before fading
 const TRAVEL_MIN_MS = 4500;
 const TRAVEL_MAX_MS = 8000;
 const CANNED_TRAVEL_INTERVAL_MS = 1800; // continuous spawn — keeps map alive
+
+const COMBAT_VIGNETTE_LEAD_MS = 4000;
+const COMBAT_ADVANCE_MS = 1500;
+const COMBAT_FLASH_START_MS = 2000;
+const COMBAT_FLASH_IN_MS = 80;
+const COMBAT_FLASH_HOLD_MS = 100;
+const COMBAT_FLASH_FADE_MS = 800;
+const COMBAT_RESOLUTION_START_MS = 2200;
+const COMBAT_RESOLUTION_CAP_MS = 1500;
+const COMBAT_TOTAL_MS = COMBAT_RESOLUTION_START_MS + COMBAT_RESOLUTION_CAP_MS + 600;
+const COMBAT_DIM_ALPHA = 0.55;
+const COMBAT_DIM_TINT = 0x1a1a3a;
+const COMBAT_TARGET_CLAN_ID = 'clan-ember';
+const DEMO_COMBAT_OUTCOME: CombatOutcome = 'failure';
 
 // TODO(contract-bindings): replace these demo defaults when carry caps are exposed.
 const WOOD_CAP = 10;
@@ -284,7 +323,18 @@ function createWorldLayers(): WorldLayers {
   const selectionRings = new Container();
   const bubbleLayer = new Container();
   const screenEffects = new Container();
+  const combatDim = new Graphics();
+  const combatHighlight = new Container();
+  const combatFlash = new Graphics();
   worldDynamic.sortableChildren = true;
+  screenEffects.sortableChildren = true;
+  combatHighlight.sortableChildren = true;
+  combatDim.zIndex = 0;
+  combatHighlight.zIndex = 1;
+  combatFlash.zIndex = 2;
+  combatDim.alpha = 0;
+  combatFlash.alpha = 0;
+  screenEffects.addChild(combatDim, combatHighlight, combatFlash);
   worldContainer.addChild(terrainBackground, terrainAccents, worldDynamic);
   return {
     worldContainer,
@@ -295,6 +345,9 @@ function createWorldLayers(): WorldLayers {
     selectionRings,
     bubbleLayer,
     screenEffects,
+    combatDim,
+    combatHighlight,
+    combatFlash,
   };
 }
 
@@ -338,6 +391,14 @@ function clamp01(value: number) {
 
 function lerp(a: number, b: number, t: number) {
   return a + (b - a) * t;
+}
+
+function easeOutQuad(t: number) {
+  return 1 - (1 - t) * (1 - t);
+}
+
+function easeInQuad(t: number) {
+  return t * t;
 }
 
 function getDayNightFrame(progress01: number): DayNightKeyframe {
@@ -478,6 +539,11 @@ export function WorldMap() {
   const travelTickerCbRef = useRef<((ticker: { deltaMS: number }) => void) | null>(null);
   const seenTravelLogIdsRef = useRef<Set<string>>(new Set());
   const travelIdSeqRef = useRef(0);
+  const combatVignetteRef = useRef<CombatVignette | null>(null);
+  const combatTickerCbRef = useRef<(() => void) | null>(null);
+  const combatPlayedTickRef = useRef<number | null>(null);
+  const liveTickClockRef = useRef<{ tick: number; seenAtMs: number }>({ tick: 0, seenAtMs: Date.now() });
+  const liveTickRef = useRef(0);
 
   // Zone-pulse ticker (visual heartbeat for clan zone halos).
   const zonePulseCbRef = useRef<(() => void) | null>(null);
@@ -499,6 +565,13 @@ export function WorldMap() {
   }, [logs, snapshot?.tick]);
   const banditTicksUntil = DEMO_BANDIT.attacksAtTick - liveTick;
   const shouldPulseBandit = DEMO_MODE && banditTicksUntil <= 2 && banditTicksUntil >= 0;
+
+  useEffect(() => {
+    liveTickRef.current = liveTick;
+    if (liveTickClockRef.current.tick !== liveTick) {
+      liveTickClockRef.current = { tick: liveTick, seenAtMs: Date.now() };
+    }
+  }, [liveTick]);
 
   useEffect(() => {
     snapshotRef.current = snapshot;
@@ -859,6 +932,12 @@ export function WorldMap() {
         dayNightTickerCbRef.current = dayNightCb;
         app.ticker.add(dayNightCb);
 
+        const combatCb = () => {
+          updateCombatVignette();
+        };
+        combatTickerCbRef.current = combatCb;
+        app.ticker.add(combatCb);
+
         // 4. Initial layout (PR #41) — projects normalized coords + positions flag anchors.
         // relayout now operates in WORLD space (MAP_WIDTH x MAP_HEIGHT) since the
         // viewport handles screen-fit transformation. Children inside the viewport
@@ -882,6 +961,8 @@ export function WorldMap() {
       if (a && travelTickerCbRef.current) a.ticker.remove(travelTickerCbRef.current);
       if (a && zonePulseCbRef.current) a.ticker.remove(zonePulseCbRef.current);
       if (a && dayNightTickerCbRef.current) a.ticker.remove(dayNightTickerCbRef.current);
+      if (a && combatTickerCbRef.current) a.ticker.remove(combatTickerCbRef.current);
+      finishCombatVignette(true);
       selectedRef.current?.ring.destroy();
       selectedRef.current = null;
       bubblesByClanRef.current.clear();
@@ -896,6 +977,7 @@ export function WorldMap() {
       travelTickerCbRef.current = null;
       zonePulseCbRef.current = null;
       dayNightTickerCbRef.current = null;
+      combatTickerCbRef.current = null;
       dayNightFilterRef.current = null;
       drawnRef.current = {
         regions: [],
@@ -1236,6 +1318,16 @@ export function WorldMap() {
       drawn.bgSprite.y = 0;
     }
 
+    const layers = layersRef.current;
+    if (layers) {
+      layers.combatDim.clear();
+      layers.combatDim.rect(0, 0, WORLD_WIDTH, WORLD_HEIGHT);
+      layers.combatDim.fill({ color: COMBAT_DIM_TINT, alpha: 1 });
+      layers.combatFlash.clear();
+      layers.combatFlash.rect(0, 0, WORLD_WIDTH, WORLD_HEIGHT);
+      layers.combatFlash.fill({ color: 0xffffff, alpha: 1 });
+    }
+
     const regionMap = new Map(REGIONS.map(r => [r.id, r]));
 
     if (DEMO_MODE) {
@@ -1450,6 +1542,243 @@ export function WorldMap() {
     const markerHalfW = sprite ? spriteSize / 2 : ringR;
     text.x = iconX + markerHalfW + 4;
     text.y = iconY;
+  }
+
+  function getMsUntilTickClose() {
+    const snap = snapshotRef.current;
+    const epoch = snap?.tickEpoch;
+    const durationMs =
+      epoch && typeof epoch.durationMs === 'number' && epoch.durationMs > 0
+        ? epoch.durationMs
+        : FALLBACK_DAY_TICK_MS;
+    if (epoch && typeof epoch.startedAt === 'number' && epoch.startedAt > 0 && snap?.tick === liveTickRef.current) {
+      const startedAtMs = epoch.startedAt < 10_000_000_000 ? epoch.startedAt * 1000 : epoch.startedAt;
+      return Math.max(0, durationMs - (Date.now() - startedAtMs));
+    }
+    const elapsed = Date.now() - liveTickClockRef.current.seenAtMs;
+    return Math.max(0, durationMs - elapsed);
+  }
+
+  function shouldStartCombatVignette() {
+    if (!DEMO_MODE || combatVignetteRef.current) return false;
+    const attackTick = DEMO_BANDIT.attacksAtTick;
+    if (combatPlayedTickRef.current === attackTick) return false;
+    const currentTick = liveTickRef.current;
+    if (currentTick === attackTick - 1) {
+      return getMsUntilTickClose() <= COMBAT_VIGNETTE_LEAD_MS;
+    }
+    return currentTick >= attackTick;
+  }
+
+  function makeCombatDefender(color: number, clanId: string) {
+    const tex = clansmanTextureCache[clanId];
+    if (tex) {
+      const sprite = new Sprite(tex);
+      sprite.anchor.set(0.5, 0.5);
+      const targetH = 32;
+      const ratio = targetH / sprite.texture.height;
+      sprite.height = targetH;
+      sprite.width = sprite.texture.width * ratio;
+      return sprite;
+    }
+
+    const fallback = new Graphics();
+    fallback.circle(0, 0, 8);
+    fallback.fill({ color, alpha: 1 });
+    fallback.stroke({ color: 0xffffff, width: 1, alpha: 0.75 });
+    return fallback;
+  }
+
+  function reparentForCombat(node: Container, vignette: CombatVignette, wasTemporary = false) {
+    const layers = layersRef.current;
+    const parent = node.parent;
+    if (!layers || !(parent instanceof Container)) return;
+    vignette.reparented.push({ node, parent, zIndex: node.zIndex, wasTemporary });
+    parent.removeChild(node);
+    layers.combatHighlight.addChild(node);
+    node.zIndex = Math.round(node.y);
+  }
+
+  function startCombatVignette() {
+    const layers = layersRef.current;
+    if (!layers) return;
+    const drawn = drawnRef.current;
+    const targetClan =
+      MOCK_CLANS.find(c => c.id === COMBAT_TARGET_CLAN_ID)
+      ?? MOCK_CLANS.find(c => c.homeRegion === DEMO_BANDIT.regionId);
+    if (!targetClan) return;
+    const targetBase = drawn.bases.find(b => b.clan.id === targetClan.id);
+    if (!targetBase) return;
+
+    const targetBaseNode = targetBase.container;
+    const baseSize = Math.max(96, 144 * layoutRef.current.scale);
+    const center = {
+      x: targetBaseNode.x,
+      y: targetBaseNode.y - baseSize * 0.55,
+    };
+    const bandit = drawn.banditSprite ?? drawn.banditIcon;
+    if (!bandit) return;
+
+    const defenderAngles = [Math.PI * 0.75, Math.PI * 0.5, Math.PI * 0.25];
+    const defenders = defenderAngles.map((angle) => {
+      const defender = makeCombatDefender(targetClan.color, targetClan.id);
+      defender.x = center.x + Math.cos(angle) * 58;
+      defender.y = center.y + Math.sin(angle) * 34;
+      defender.zIndex = Math.round(defender.y);
+      layers.worldDynamic.addChild(defender);
+      return defender;
+    });
+
+    const vignette: CombatVignette = {
+      startedAt: performance.now(),
+      outcome: DEMO_COMBAT_OUTCOME,
+      bandit,
+      targetBase: targetBaseNode,
+      defenders,
+      reparented: [],
+      baseStart: {
+        x: targetBaseNode.x,
+        y: targetBaseNode.y,
+        scaleX: targetBaseNode.scale.x,
+        scaleY: targetBaseNode.scale.y,
+      },
+      banditStart: {
+        x: bandit.x,
+        y: bandit.y,
+        scaleX: bandit.scale.x,
+        scaleY: bandit.scale.y,
+        alpha: bandit.alpha,
+      },
+      defenderStarts: defenders.map(d => ({ x: d.x, y: d.y })),
+      center,
+    };
+
+    reparentForCombat(targetBaseNode, vignette);
+    reparentForCombat(bandit, vignette);
+    defenders.forEach(defender => reparentForCombat(defender, vignette, true));
+    combatVignetteRef.current = vignette;
+    combatPlayedTickRef.current = DEMO_BANDIT.attacksAtTick;
+  }
+
+  function finishCombatVignette(force = false) {
+    const vignette = combatVignetteRef.current;
+    const layers = layersRef.current;
+    if (!vignette || !layers) return;
+
+    layers.combatDim.alpha = 0;
+    layers.combatFlash.alpha = 0;
+    vignette.targetBase.x = vignette.baseStart.x;
+    vignette.targetBase.y = vignette.baseStart.y;
+    vignette.targetBase.scale.set(vignette.baseStart.scaleX, vignette.baseStart.scaleY);
+    if (vignette.bandit) {
+      vignette.bandit.x = vignette.banditStart.x;
+      vignette.bandit.y = vignette.banditStart.y;
+      vignette.bandit.scale.set(vignette.banditStart.scaleX, vignette.banditStart.scaleY);
+      vignette.bandit.alpha = vignette.banditStart.alpha;
+    }
+
+    for (const item of vignette.reparented) {
+      if (item.node.parent) item.node.parent.removeChild(item.node);
+      if (item.wasTemporary) {
+        item.node.destroy({ children: true });
+        continue;
+      }
+      item.parent.addChild(item.node);
+      item.node.zIndex = item.zIndex;
+    }
+    layers.combatHighlight.removeChildren();
+    combatVignetteRef.current = null;
+    if (!force) redrawBandit();
+  }
+
+  function updateCombatVignette() {
+    if (shouldStartCombatVignette()) startCombatVignette();
+    const vignette = combatVignetteRef.current;
+    const layers = layersRef.current;
+    if (!vignette || !layers) return;
+
+    const now = performance.now();
+    const age = now - vignette.startedAt;
+    if (age >= COMBAT_TOTAL_MS) {
+      finishCombatVignette();
+      return;
+    }
+
+    const fadeOutStart = COMBAT_TOTAL_MS - 600;
+    if (age < 600) {
+      layers.combatDim.alpha = COMBAT_DIM_ALPHA * clamp01(age / 600);
+    } else if (age >= fadeOutStart) {
+      layers.combatDim.alpha = COMBAT_DIM_ALPHA * (1 - clamp01((age - fadeOutStart) / 600));
+    } else {
+      layers.combatDim.alpha = COMBAT_DIM_ALPHA;
+    }
+
+    const flashAge = age - COMBAT_FLASH_START_MS;
+    if (flashAge < 0) {
+      layers.combatFlash.alpha = 0;
+    } else if (flashAge < COMBAT_FLASH_IN_MS) {
+      layers.combatFlash.alpha = clamp01(flashAge / COMBAT_FLASH_IN_MS);
+    } else if (flashAge < COMBAT_FLASH_IN_MS + COMBAT_FLASH_HOLD_MS) {
+      layers.combatFlash.alpha = 1;
+    } else {
+      const fadeAge = flashAge - COMBAT_FLASH_IN_MS - COMBAT_FLASH_HOLD_MS;
+      layers.combatFlash.alpha = Math.max(0, 1 - fadeAge / COMBAT_FLASH_FADE_MS);
+    }
+
+    if (age < COMBAT_ADVANCE_MS) {
+      const t = easeInQuad(clamp01(age / COMBAT_ADVANCE_MS));
+      if (vignette.bandit) {
+        vignette.bandit.x = lerp(vignette.banditStart.x, vignette.center.x - 24, t);
+        vignette.bandit.y = lerp(vignette.banditStart.y, vignette.center.y - 8, t);
+      }
+      vignette.defenders.forEach((defender, i) => {
+        const start = vignette.defenderStarts[i];
+        if (!start) return;
+        defender.x = lerp(start.x, vignette.center.x + 18 + i * 8, t);
+        defender.y = lerp(start.y, vignette.center.y + 10, t);
+      });
+    } else if (age < COMBAT_FLASH_START_MS) {
+      const jitter = Math.sin(now / 55) * 1;
+      if (vignette.bandit) {
+        vignette.bandit.x = vignette.center.x - 24 + jitter;
+        vignette.bandit.y = vignette.center.y - 8;
+      }
+      vignette.defenders.forEach((defender, i) => {
+        defender.x = vignette.center.x + 18 + i * 8 - jitter;
+        defender.y = vignette.center.y + 10 + Math.sin(now / 70 + i) * 1;
+      });
+    } else if (age >= COMBAT_RESOLUTION_START_MS) {
+      const rAge = age - COMBAT_RESOLUTION_START_MS;
+      if (vignette.outcome === 'success') {
+        const launchT = easeOutQuad(clamp01(rAge / 600));
+        if (vignette.bandit) {
+          vignette.bandit.x = vignette.center.x - 24 - launchT * 60;
+          vignette.bandit.y = vignette.center.y - 8 - launchT * 16;
+          const fadeT = clamp01((rAge - 250) / 600);
+          const s = lerp(1, 0.3, fadeT);
+          vignette.bandit.scale.set(vignette.banditStart.scaleX * s, vignette.banditStart.scaleY * s);
+          vignette.bandit.alpha = 1 - fadeT;
+        }
+        vignette.defenders.forEach((defender, i) => {
+          defender.y = vignette.center.y + 10 + Math.sin(now / 90 + i) * 5;
+        });
+      } else {
+        const jumpT = easeOutQuad(clamp01(rAge / 300));
+        vignette.defenders.forEach((defender, i) => {
+          const angle = Math.PI * (0.2 + i * 0.22);
+          defender.x = vignette.center.x + 16 + i * 8 + Math.cos(angle) * 28 * jumpT;
+          defender.y = vignette.center.y + 10 + Math.sin(angle) * 20 * jumpT;
+        });
+        const dropT = easeInQuad(clamp01(rAge / 400));
+        vignette.targetBase.scale.y = lerp(vignette.baseStart.scaleY, vignette.baseStart.scaleY * 0.9, dropT);
+      }
+    }
+
+    if (vignette.bandit) vignette.bandit.zIndex = Math.round(vignette.bandit.y);
+    vignette.defenders.forEach(defender => {
+      defender.zIndex = Math.round(defender.y);
+    });
+    vignette.targetBase.zIndex = Math.round(vignette.targetBase.y);
   }
 
   // Tick changes: refresh bandit countdown (demo mode only)

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -193,7 +193,14 @@ const COMBAT_TOTAL_MS = COMBAT_RESOLUTION_START_MS + COMBAT_RESOLUTION_CAP_MS + 
 const COMBAT_DIM_ALPHA = 0.55;
 const COMBAT_DIM_TINT = 0x1a1a3a;
 const COMBAT_TARGET_CLAN_ID = 'clan-ember';
-const DEMO_COMBAT_OUTCOME: CombatOutcome = 'failure';
+/** Demo combat outcome — overrideable via URL param `?combat=success|failure`
+ * for stage flexibility. Defaults to failure since wall-drop reads more
+ * dramatic. Replace with `snapshot.combatOutcome` when schema lands. */
+function readDemoCombatOutcome(): CombatOutcome {
+  if (typeof window === 'undefined') return 'failure';
+  const param = new URLSearchParams(window.location.search).get('combat');
+  return param === 'success' ? 'success' : 'failure';
+}
 
 // TODO(contract-bindings): replace these demo defaults when carry caps are exposed.
 const WOOD_CAP = 10;
@@ -327,8 +334,10 @@ function createWorldLayers(): WorldLayers {
   const combatHighlight = new Container();
   const combatFlash = new Graphics();
   worldDynamic.sortableChildren = true;
+  // §14.3: combatHighlight must use insertion-order so the success-launch
+  // (bandit drawn after defenders) doesn't sort under the targeted base.
+  // No sortableChildren here. (claude r3 SHOULD #1)
   screenEffects.sortableChildren = true;
-  combatHighlight.sortableChildren = true;
   combatDim.zIndex = 0;
   combatHighlight.zIndex = 1;
   combatFlash.zIndex = 2;
@@ -1619,6 +1628,22 @@ export function WorldMap() {
     const bandit = drawn.banditSprite ?? drawn.banditIcon;
     if (!bandit) return;
 
+    // Mark this tick as played BEFORE any reparenting / mutation so a partial-start
+    // throw can't loop the per-frame ticker into spawning new defender nodes every
+    // frame (codex r3 SHOULD #1).
+    combatPlayedTickRef.current = DEMO_BANDIT.attacksAtTick;
+
+    // §14.3: combatDim sits above worldDynamic and would otherwise dim the
+    // active selection ring. Clear the ring (without the camera fit-out) so
+    // the dimmed world reads cleanly. Speech bubbles still dim mid-flight
+    // (structural fix queued for v1.2) — claude r3 MUST #3 cheap fix.
+    const selected = selectedRef.current;
+    if (selected) {
+      selected.target.removeChild(selected.ring);
+      selected.ring.destroy();
+      selectedRef.current = null;
+    }
+
     const defenderAngles = [Math.PI * 0.75, Math.PI * 0.5, Math.PI * 0.25];
     const defenders = defenderAngles.map((angle) => {
       const defender = makeCombatDefender(targetClan.color, targetClan.id);
@@ -1631,7 +1656,7 @@ export function WorldMap() {
 
     const vignette: CombatVignette = {
       startedAt: performance.now(),
-      outcome: DEMO_COMBAT_OUTCOME,
+      outcome: readDemoCombatOutcome(),
       bandit,
       targetBase: targetBaseNode,
       defenders,
@@ -1657,7 +1682,6 @@ export function WorldMap() {
     reparentForCombat(bandit, vignette);
     defenders.forEach(defender => reparentForCombat(defender, vignette, true));
     combatVignetteRef.current = vignette;
-    combatPlayedTickRef.current = DEMO_BANDIT.attacksAtTick;
   }
 
   function finishCombatVignette(force = false) {
@@ -1704,13 +1728,18 @@ export function WorldMap() {
       return;
     }
 
+    // §10.8 cap rule: combat dim must not stack with day/night darkening into
+    // an unreadable scene. Cap target alpha at min(0.55, 1 - currentBrightness)
+    // so combat at night stays at least readable (claude r3 MUST #2).
+    const dayNightBrightness = getDayNightFrame(getDayNightProgress()).brightness;
+    const dimTarget = Math.min(COMBAT_DIM_ALPHA, clamp01(1 - dayNightBrightness));
     const fadeOutStart = COMBAT_TOTAL_MS - 600;
     if (age < 600) {
-      layers.combatDim.alpha = COMBAT_DIM_ALPHA * clamp01(age / 600);
+      layers.combatDim.alpha = dimTarget * clamp01(age / 600);
     } else if (age >= fadeOutStart) {
-      layers.combatDim.alpha = COMBAT_DIM_ALPHA * (1 - clamp01((age - fadeOutStart) / 600));
+      layers.combatDim.alpha = dimTarget * (1 - clamp01((age - fadeOutStart) / 600));
     } else {
-      layers.combatDim.alpha = COMBAT_DIM_ALPHA;
+      layers.combatDim.alpha = dimTarget;
     }
 
     const flashAge = age - COMBAT_FLASH_START_MS;
@@ -1781,9 +1810,13 @@ export function WorldMap() {
     vignette.targetBase.zIndex = Math.round(vignette.targetBase.y);
   }
 
-  // Tick changes: refresh bandit countdown (demo mode only)
+  // Tick changes: refresh bandit countdown (demo mode only).
+  // Skipped while a combat vignette is animating — redrawBandit overrides the
+  // bandit sprite's x/y/zIndex back to the region anchor, snapping the bandit
+  // out of mid-flight choreography (claude r3 MUST #1).
   useEffect(() => {
     if (!pixiReady || !DEMO_MODE) return;
+    if (combatVignetteRef.current) return;
     redrawBandit();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [liveTick, pixiReady]);

--- a/apps/web/src/components/cockpit/tabs/VaultTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/VaultTab.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 import { tokens } from '../../../styles/cockpit-tokens';
 import type { ElderDef } from '../../../styles/cockpit-tokens';
 
@@ -38,6 +40,14 @@ export function VaultTab({ elder, testIdPrefix }: Props) {
         fontFamily: tokens.font.body,
       }}
     >
+      <style>
+        {`
+          @keyframes clanworld-counter-floater {
+            0% { opacity: 1; transform: translate(-50%, 0); }
+            100% { opacity: 0; transform: translate(-50%, -16px); }
+          }
+        `}
+      </style>
       {/* Resource grid */}
       <section>
         <SectionHeader>Vault — Clan {elder.clanId}</SectionHeader>
@@ -82,7 +92,7 @@ export function VaultTab({ elder, testIdPrefix }: Props) {
                     color: tokens.text.onParchment,
                   }}
                 >
-                  {r.value.toLocaleString()}
+                  <RollingNumber value={r.value} />
                 </span>
               </div>
               <span
@@ -151,7 +161,81 @@ export function VaultTab({ elder, testIdPrefix }: Props) {
   );
 }
 
-function SectionHeader({ children }: { children: React.ReactNode }) {
+function easeOutQuad(t: number) {
+  return 1 - (1 - t) * (1 - t);
+}
+
+function RollingNumber({ value }: { value: number }) {
+  const [displayValue, setDisplayValue] = useState(value);
+  const [floater, setFloater] = useState<{ id: number; delta: number } | null>(null);
+  const previousValueRef = useRef(value);
+  const floaterIdRef = useRef(0);
+
+  useEffect(() => {
+    const from = previousValueRef.current;
+    const to = value;
+    const delta = to - from;
+    previousValueRef.current = to;
+    if (delta === 0) {
+      setDisplayValue(to);
+      return;
+    }
+
+    floaterIdRef.current += 1;
+    setFloater({ id: floaterIdRef.current, delta });
+    const duration = Math.min(400, 100 + Math.log2(Math.abs(delta) + 1) * 40);
+    const startedAt = performance.now();
+    let frame = 0;
+
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - startedAt) / duration);
+      const eased = easeOutQuad(t);
+      setDisplayValue(Math.round(from + (to - from) * eased));
+      if (t < 1) {
+        frame = window.requestAnimationFrame(tick);
+      } else {
+        setDisplayValue(to);
+      }
+    };
+
+    frame = window.requestAnimationFrame(tick);
+    const clearFloater = window.setTimeout(() => setFloater(null), 800);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.clearTimeout(clearFloater);
+    };
+  }, [value]);
+
+  return (
+    <span style={{ position: 'relative', display: 'inline-block', minWidth: '4ch' }}>
+      {displayValue.toLocaleString()}
+      {floater && (
+        <span
+          key={floater.id}
+          style={{
+            position: 'absolute',
+            left: '50%',
+            bottom: '100%',
+            transform: 'translate(-50%, 0)',
+            color: floater.delta > 0 ? '#4ade80' : '#ef4444',
+            fontFamily: tokens.font.mono,
+            fontSize: '10px',
+            fontWeight: 700,
+            pointerEvents: 'none',
+            animation: 'clanworld-counter-floater 800ms ease-out forwards',
+            textShadow: '0 1px 2px rgba(0,0,0,0.35)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {floater.delta > 0 ? '+' : ''}
+          {floater.delta.toLocaleString()}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function SectionHeader({ children }: { children: ReactNode }) {
   return (
     <h3
       style={{

--- a/apps/web/src/components/cockpit/tabs/VaultTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/VaultTab.tsx
@@ -28,9 +28,15 @@ function useDemoResourceJiggle() {
         const idx = Math.floor(Math.random() * current.length);
         const delta = Math.floor(Math.random() * 46) - 15;
         if (delta === 0) return current;
-        return current.map((r, i) =>
-          i === idx ? { ...r, value: Math.max(0, r.value + delta) } : r,
-        );
+        return current.map((r, i) => {
+          if (i !== idx) return r;
+          // Update both value AND delta string so the row's static delta
+          // text stays in sync with the rolling number + floater (Copilot
+          // + codex cloud P2). Without this, delta showed stale values.
+          const nextValue = Math.max(0, r.value + delta);
+          const sign = delta > 0 ? '+' : '';
+          return { ...r, value: nextValue, delta: `${sign}${delta}` };
+        });
       });
     }, 6000);
     return () => window.clearInterval(id);

--- a/apps/web/src/components/cockpit/tabs/VaultTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/VaultTab.tsx
@@ -9,12 +9,34 @@ interface Props {
 }
 
 /** Resource line in the stub vault — Phase B will source these from Convex. */
-const STUB_RESOURCES = [
+const STUB_RESOURCES_INITIAL = [
   { glyph: '◈', label: 'Gold',  value: 1240, delta: '+45'  },
   { glyph: '⌬', label: 'Wood',  value: 320,  delta: '-12'  },
   { glyph: '◆', label: 'Ore',   value: 88,   delta: '+0'   },
   { glyph: '◇', label: 'Stone', value: 156,  delta: '+8'   },
 ];
+
+/** Demo-only mock tick that nudges resource values so the rolling-number +
+ * delta-floater animation is observable on stage. Replace with live Convex
+ * data when Phase B lands. Period: every 6 seconds, one random resource
+ * gets a delta in [-15, +30]. Wraps to keep values in a sane positive range. */
+function useDemoResourceJiggle() {
+  const [resources, setResources] = useState(STUB_RESOURCES_INITIAL);
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setResources((current) => {
+        const idx = Math.floor(Math.random() * current.length);
+        const delta = Math.floor(Math.random() * 46) - 15;
+        if (delta === 0) return current;
+        return current.map((r, i) =>
+          i === idx ? { ...r, value: Math.max(0, r.value + delta) } : r,
+        );
+      });
+    }, 6000);
+    return () => window.clearInterval(id);
+  }, []);
+  return resources;
+}
 
 /** Asset movement event for the log strip. */
 const STUB_MOVEMENTS = [
@@ -25,6 +47,7 @@ const STUB_MOVEMENTS = [
 ];
 
 export function VaultTab({ elder, testIdPrefix }: Props) {
+  const resources = useDemoResourceJiggle();
   return (
     <div
       data-testid={`${testIdPrefix}-content-vault`}
@@ -59,7 +82,7 @@ export function VaultTab({ elder, testIdPrefix }: Props) {
             marginTop: tokens.space.sm,
           }}
         >
-          {STUB_RESOURCES.map((r) => (
+          {resources.map((r) => (
             <div
               key={r.label}
               style={{
@@ -168,41 +191,46 @@ function easeOutQuad(t: number) {
 function RollingNumber({ value }: { value: number }) {
   const [displayValue, setDisplayValue] = useState(value);
   const [floater, setFloater] = useState<{ id: number; delta: number } | null>(null);
-  const previousValueRef = useRef(value);
+  const renderedValueRef = useRef(value);
+  const targetValueRef = useRef(value);
   const floaterIdRef = useRef(0);
 
   useEffect(() => {
-    const from = previousValueRef.current;
+    const from = renderedValueRef.current;
     const to = value;
-    const delta = to - from;
-    previousValueRef.current = to;
-    if (delta === 0) {
-      setDisplayValue(to);
+    const delta = to - targetValueRef.current;
+    targetValueRef.current = to;
+    if (from === to) {
       return;
     }
 
-    floaterIdRef.current += 1;
-    setFloater({ id: floaterIdRef.current, delta });
-    const duration = Math.min(400, 100 + Math.log2(Math.abs(delta) + 1) * 40);
+    if (delta !== 0) {
+      floaterIdRef.current += 1;
+      setFloater({ id: floaterIdRef.current, delta });
+    }
+    const duration = Math.min(400, 100 + Math.log2(Math.abs(to - from) + 1) * 40);
     const startedAt = performance.now();
     let frame = 0;
 
     const tick = (now: number) => {
       const t = Math.min(1, (now - startedAt) / duration);
       const eased = easeOutQuad(t);
-      setDisplayValue(Math.round(from + (to - from) * eased));
+      const next = Math.round(from + (to - from) * eased);
+      renderedValueRef.current = next;
+      setDisplayValue(next);
       if (t < 1) {
         frame = window.requestAnimationFrame(tick);
       } else {
+        renderedValueRef.current = to;
         setDisplayValue(to);
       }
     };
 
     frame = window.requestAnimationFrame(tick);
-    const clearFloater = window.setTimeout(() => setFloater(null), 800);
+    const clearFloater = delta !== 0 ? window.setTimeout(() => setFloater(null), 800) : null;
     return () => {
       window.cancelAnimationFrame(frame);
-      window.clearTimeout(clearFloater);
+      if (clearFloater !== null) window.clearTimeout(clearFloater);
     };
   }, [value]);
 

--- a/docs/planning/clanworld_v5_animation_spec.md
+++ b/docs/planning/clanworld_v5_animation_spec.md
@@ -1,0 +1,1172 @@
+# Clanworld Animation Spec — v0.1
+
+Status: Draft, hackathon scope
+Purpose: Define every animation, timing, easing, and effect in the Clanworld client. Make the difference between "an onchain game prototype" and "an actually premium game" explicit and implementable.
+Audience: Frontend implementation agents working on the Pixi rendering layer. Asset authors producing Aseprite atlases. Anyone integrating React HUD with the Pixi canvas.
+Companion to:
+
+- clanworld_frontend_spec.md — overall frontend architecture
+- clanworld_v4_5_alignment_addendum.md — authoritative cross-stream addendum
+- IClanWorld.sol — contract seam interface
+
+This spec covers what the screen should do. Why state changes happen lives elsewhere; this doc starts after state has been derived and asks "given the state, how does the screen look and move?"
+
+-----
+
+## 0. One-paragraph summary
+
+Pixel art at 24x24 with 4–8 fps sprite animation, rendered through PixiJS v8 at 60fps on top of a smoothly panning camera. Three independent clocks govern motion: the game tick clock (truth), the animation frame clock (chunky pixel charm), and the render frame clock (smooth camera). Position is a pure function of state and time, never stored. Every visible element breathes — buildings sway 1px, wheat phases per-tile, smoke drifts, banners flutter. State transitions cross-fade or inherit; they never snap. Combat is the hero moment, choreographed across the full 60-second tick from dim → advance → circle → whirlwind → flash → resolution. Day/night cycles tint the world via a single ColorMatrixFilter with cozy window-glow at night. The whole system is engineered to look alive, even when paused.
+
+-----
+
+## 1. Foundational principles
+
+### 1.1 The three clocks
+
+This is the single most important architectural idea. There are three independent clocks running in the Pixi layer, and conflating them is the #1 source of janky pixel art.
+
+|Clock                    |Source                                    |Drives                                       |
+|-------------------------|------------------------------------------|---------------------------------------------|
+|**Game tick clock**      |Contract tickEpoch (60s Sub2, 20s Sub1)   |Mission progress, arrival times, combat phase|
+|**Animation frame clock**|`Date.now()` independently                |Sprite frame index, phase-offset env motion  |
+|**Render frame clock**   |Pixi ticker (60fps target, 30fps fallback)|Camera, lerping, fades, filters              |
+
+Concretely:
+
+```
+// Animation frame clock — independent
+const animationFrame = Math.floor(now / (1000 / fps[spriteKey])) % frameCount[spriteKey]
+
+// Game tick clock — derives from contract
+const travelProgress = clamp(
+  (currentTick - mission.startTick + (now - tickEpoch.atMs) / tickEpoch.durationMs)
+    / (mission.arrivalTick - mission.startTick),
+  0, 1
+)
+
+// Render frame clock — drives smooth update
+app.ticker.add((delta) => updateScene(delta))
+```
+
+The animation frame clock can desync from render rate without anyone noticing — that's the *point*. Pixel art looks more alive when chunky 6fps walk plays over a 60fps smooth pan than when everything moves at the same rate.
+
+### 1.2 Determinism is for state, not for animation
+
+Anything derived from now (wander seed, animation frames, speech bubble fade-in) is pure visual sugar and can drift between clients. That's fine. What must be deterministic is the *contract-derived* state: who's where, what tick they arrived, what they carry. Position is a pure function of state + time, but the position itself doesn't need to match across clients to the pixel.
+
+Don't fight time. Let Date.now() drive frames. Don't try to derive sprite frames from block timestamp.
+
+### 1.3 "Alive" is the goal, not "accurate"
+
+Pixel art that's perfectly still looks dead. Every visible thing should breathe — even "idle" buildings have a 1-pixel vertical sway every 4 seconds, smoke drifts, flags flutter. The enemy is the frozen frame. If you pause the simulation and the screen looks like a screenshot, the aesthetic has failed.
+
+Corollary: don't render at sub-pixel positions. Round to whole pixels (`Math.floor` or Math.round on x/y). Sub-pixel motion looks blurry on pixel art and breaks the aesthetic worse than visible "stepping."
+
+### 1.4 The phase-offset rule
+
+When you have N copies of the same animation (a wheat field, a row of waves), every instance must have a per-instance phase offset based on its grid position:
+
+```
+const phaseOffset = ((gridX * 73) ^ (gridY * 31)) % 1000  // ms
+const animationFrame = Math.floor((now + phaseOffset) / (1000 / fps)) % frameCount
+```
+
+Without this, your wheat field looks like a marching band. With it, it looks alive. Apply this to every repeating env element.
+
+### 1.5 Two-resolution system
+
+Already locked. Strategic atlas: 8x8 sprites for zoom 0.5x–1.5x. Detail atlas: 24x24 for zoom 1.5x–4.0x. Cross-fade 200ms at zoom = 1.5x boundary. Both atlases load eagerly at app start (~500KB total).
+
+Pixel art doesn't downscale gracefully. A 24x24 sprite at 0.33x = 8x8 mush with bilinear, pixel noise with nearest. Hand-author the strategic atlas separately. The cost is asset work, the benefit is crisp pixel art at every zoom.
+
+### 1.6 No snap, ever
+
+Sprite state transitions cross-fade or inherit. They never snap. See §3.5 for the full transition rules. The "no snap" principle is what separates this from looking like a state machine on screen.
+
+-----
+
+## 2. Sprite reference
+
+### 2.1 Sprite key derivation
+
+Every sprite has a spriteKey derived from (role, status, subAction, direction):
+
+```
+clansman_idle
+clansman_walk_ne
+clansman_walk_se
+clansman_carry_walk_ne
+clansman_carry_walk_se
+clansman_mine
+clansman_chop
+clansman_harvest
+clansman_fish
+clansman_build
+clansman_attack
+clansman_cheer
+clansman_die
+bandit_idle
+bandit_march
+bandit_attack
+bandit_death
+```
+
+Each key maps to: `{ atlas, framePrefix, frameCount, fps, loop, anchor }`.
+
+NW and SW directions are mirror-flips of NE and SE respectively (`sprite.scale.x = -1`). Author NE and SE only.
+
+### 2.2 Direction logic (4-way 45°)
+
+The world is rendered in 3/4 top-down perspective. Walk animations are authored at 45° angles: NE (up-and-right) and SE (down-and-right). NW and SW are mirrors.
+
+```
+function deriveWalkKey(dx: number, dy: number, lastDirection: Direction) {
+  // Hysteresis prevents flicker at near-cardinal travel
+  if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return lastDirection
+
+  const goingEast = dx > 0
+  const goingSouth = dy > 0
+  const verticalAxis = goingSouth ? 'se' : 'ne'
+
+  return {
+    spriteKey: `clansman_walk_${verticalAxis}`,
+    flipX: !goingEast, // flip NE → NW, SE → SW
+  }
+}
+```
+
+For idle, hold the direction the sprite was last walking (don't snap to a default). Idle animation itself is authored facing SE (most natural "looking out" pose for top-down).
+
+### 2.3 Frame counts and FPS — clansman (24x24 detail)
+
+|Key            |Frames|FPS|Loop|Notes                             |
+|---------------|------|---|----|----------------------------------|
+|`idle`         |4     |4  |yes |Gentle bob, faces SE always       |
+|`walk_ne`      |4     |8  |yes |NW = mirrored                     |
+|`walk_se`      |4     |8  |yes |SW = mirrored                     |
+|`carry_walk_ne`|4     |6  |yes |Slower, laden                     |
+|`carry_walk_se`|4     |6  |yes |Slower, laden                     |
+|`mine`         |6     |8  |yes |Pickaxe arc                       |
+|`chop`         |6     |8  |yes |Axe arc                           |
+|`harvest`      |4     |6  |yes |Bend-and-rise                     |
+|`fish`         |6     |4  |yes |Cast-and-wait, slow               |
+|`build`        |6     |6  |yes |Hammer rhythm                     |
+|`attack`       |4     |8  |yes |Combat swing                      |
+|`cheer`        |4     |6  |yes |Post-victory, 2 loops then idle   |
+|`die`          |4     |6  |no  |Hold last frame, then sprite hides|
+
+### 2.4 Frame counts and FPS — bandit (32x32 detail)
+
+|Key     |Frames|FPS|Loop|Notes                                      |
+|--------|------|---|----|-------------------------------------------|
+|`idle`  |4     |4  |yes |Menacing pace at camp                      |
+|`march` |4     |6  |yes |Travel between regions, also combat advance|
+|`attack`|4     |8  |yes |Combat swing                               |
+|`death` |6     |8  |no  |Knockback then white-flash then shrink-fade|
+
+### 2.5 Building animations
+
+Most buildings are 1-frame static, with a child overlay container that animates. This separates the "what's there" (state-driven) from "what's moving" (clock-driven).
+
+|Element        |Container|Frames            |FPS|Notes                                |
+|---------------|---------|------------------|---|-------------------------------------|
+|Base structure |static   |1                 |—  |Sprite swap on level change          |
+|Wall           |static   |1 per level       |—  |Sprite swap on level change          |
+|Monument tower |static   |1 per level (0–10)|—  |Sprite swap, see upgrade anim        |
+|Forge fire glow|overlay  |4                 |4  |Additive blend, on Mountains/Monument|
+|Chimney smoke  |overlay  |4                 |4  |Phase-offset, alpha 0.7              |
+|Workshop crane |overlay  |8                 |4  |Slow arc swing                       |
+|Windmill blade |overlay  |4                 |6  |Rotation, on West Farms              |
+|Banner flutter |overlay  |4                 |4  |Phase per banner                     |
+|Window glow    |overlay  |1                 |—  |Alpha tied to day/night, see §10     |
+
+### 2.6 Anchor points
+
+- Clansmen and bandits: (0.5, 1.0) — bottom-center. Makes terrain "feet" placement trivial. Speech bubbles, selection rings, shadows all anchor relative to this.
+- Buildings: (0.5, 1.0) — they "stand on" their tile.
+- Speech bubbles: (0.5, 1.0) — grow upward from above sprite head.
+
+### 2.7 Atlas layout (Aseprite handoff)
+
+- Strategic atlas: 256×256 max, packed 8x8 sprites + 16x16 buildings + 8x8 region accents + 12x12 bandits. All 1-frame.
+- Detail atlas: 1024×1024 max, packed 24x24 clansman cycles + 48x48 base / 32x64 monument tower / 32x16 wall + 32x32 bandit + 16x16 env motion.
+- Export: PNG + JSON-Hash, 1x scale, trim enabled, padding 1px.
+- Frame naming: clansman_walk_ne_0, clansman_walk_ne_1, etc.
+- Animation metadata in separate animations.json so adding a frame doesn't require code change.
+- Validation: pnpm validate-atlas checks every key in animations.json resolves to actual frames in the atlas. CI fails on mismatch.
+- Hot reload: Vite watches assets/atlas/, reloads on change in dev.
+
+-----
+
+## 3. State transitions
+
+### 3.1 Cross-fade vs inheritance vs play-through
+
+Three patterns for transitioning between sprite keys:
+
+Cross-fade — for distinct actions where snap would be jarring.
+
+- Hold last frame of outgoing key for 1 frame.
+- Fade outgoing alpha 1→0 over 150ms.
+- Fade incoming alpha 0→1 over 150ms.
+- Both render simultaneously during overlap.
+- Used for: walk → mine, walk → chop, idle → walk.
+
+Inheritance — for related cycles where frame index can carry forward.
+
+- Same frame index in old key maps to same frame index in new key.
+- No fade. Just swap the texture source.
+- Visual continuity, no rebake.
+- Used for: walk → carry_walk (both 4-frame walks), walk_ne → walk_se when direction changes.
+
+Play-through — for transitions that should feel sudden.
+
+- New animation begins immediately, no fade.
+- Used for: idle → die, any * → attack in combat.
+
+### 3.2 Direction flip rule
+
+Direction flip via sprite.scale.x *= -1 is *never* faded. The instant flip is part of the pixel-art language. Fading a flip looks worse than letting it pop.
+
+Apply the flip on the *next* render frame after the direction-change check fires (not mid-animation-frame), so the flip lands cleanly on a sprite frame boundary.
+
+### 3.3 Arrival at destination
+
+When travelProgress >= 1.0, transition to:
+
+1. Snap position to region anchor (1 frame).
+2. Force idle for 1 second (60 render frames at 60fps).
+3. Then transition (cross-fade) to whatever the mission action is.
+
+The 1-second idle beat sells "arrival." Without it, sprites blip from traveling to working with no visual moment.
+
+### 3.4 Action completion
+
+When a mission completes (e.g., wood capacity reached, mission ends in `WAITING`):
+
+- Cross-fade 150ms to idle.
+- Hold idle facing direction = last walked direction.
+
+### 3.5 Death
+
+clansman_die plays once (4 frames at 6fps = 667ms), holds last frame, then on next state read the sprite is removed from the scene (state shows clansman dead/absent). No fade, just disappear after the death anim's last frame.
+
+-----
+
+## 4. Movement contracts
+
+### 4.1 Wander (status: WAITING / GATHERING / etc.)
+
+Already specced as deterministic seeded wander shifting on a slow timer. Refinements:
+
+- Shift period: 5s for fully-idle (WAITING), 20s for "anchored" states (GATHERING, BUILDING — clansman is at a station, only small drift).
+- Wander radius: 12px gathering, 24px waiting/idle, 32px celebrating.
+- Wander interpolation: don't teleport between targets. Lerp from current to next over the shift window with easeInOutSine. Sprite strolls between wander points.
+- Direction during wander: derive from velocity (`dx`, `dy`). Hysteresis: hold last direction if `|dx| < 1` and `|dy| < 1`.
+- Wander seed: hash(clansmanId, Math.floor(now / shiftPeriodMs)). Deterministic per-clansman per-window.
+
+### 4.2 Travel between regions
+
+Already specced as easeInOutSine along leg, one leg per tick. Refinements:
+
+- Path shape: pure linear lerp between region anchors looks robotic. Add slight bezier curve.
+  - Control point = midpoint + perpendicular offset of 8–16px.
+  - Offset sign derived from hash(clansmanId, legIndex) so it's deterministic per-clansman per-leg.
+  - Different clansmen on the same route take slightly different paths.
+- Per-clansman jitter: when a group travels together, add per-clansman position jitter (±4px perpendicular to travel direction, deterministic from clansmanId) so they don't form a perfect conga line.
+- Leg start/end smoothing: at leg boundaries (tick → tick) you get a 1-frame velocity discontinuity. Either blend the last 100ms with first 100ms of next leg, or accept it — at 60fps, 1 frame is invisible.
+- Direction during travel: compute from nextRenderPos - currentRenderPos. Apply 4-way logic from §2.2.
+- Arrival: at progress >= 1, see §3.3.
+
+### 4.3 Multi-leg routes
+
+Some missions visit multiple regions. The state derivation function:
+
+```
+const totalDuration = mission.arrivalTick - mission.startTick
+const legCount = mission.path.length - 1
+const ticksPerLeg = totalDuration / legCount
+const elapsedTicks = currentTick - mission.startTick + subTickProgress
+const legIndex = Math.floor(elapsedTicks / ticksPerLeg)
+const legProgress = (elapsedTicks % ticksPerLeg) / ticksPerLeg
+
+const eased = easeInOutSine(legProgress)
+return lerpBezier(
+  mission.path[legIndex],
+  mission.path[legIndex + 1],
+  eased,
+  perpendicularOffset(clansmanId, legIndex)
+)
+```
+
+### 4.4 Returning home (carry mode)
+
+Same logic as §4.2 but uses carry_walk_* instead of walk_*. Wheelbarrow indicator visible above sprite (see §6.4).
+
+-----
+
+## 5. Environment catalog
+
+Every region should have ≥3 ambient motion sources, even when no clansmen are present. The world breathes regardless of player activity.
+
+|Element         |Where                   |Frames|FPS|Loop|Notes                      |
+|----------------|------------------------|------|---|----|---------------------------|
+|Chimney smoke   |Forge, kitchen, monument|4     |4  |yes |Phase-offset, alpha 0.7    |
+|Wheat sway      |West/East Farms tiles   |4     |4  |yes |Phase per tile             |
+|Tree leaves     |Forest tiles            |4     |3  |yes |Phase per tree             |
+|Tree shake      |Forest, when chopped    |4     |8  |no  |Triggered by gather event  |
+|Wave            |Docks, Deep Sea         |4     |3  |yes |Phase per tile             |
+|Boat bob        |Docks                   |3     |2  |yes |Vertical 1px               |
+|Windmill        |West Farms              |4     |6  |yes |Rotation cycle             |
+|Forge glow      |Mountains, monument     |4     |4  |yes |Additive blend             |
+|Campfire        |Bandit camp, Forest     |4     |6  |yes |Additive flame             |
+|Banner flutter  |Bases, monument         |4     |4  |yes |Phase per banner           |
+|Unicorn idle    |Unicorn Town            |4     |4  |yes |Tail flick + ear twitch    |
+|Sparkles        |Unicorn Town            |4     |6  |yes |Magic ambient              |
+|Crane swing     |Workshop                |8     |4  |yes |Slow arc                   |
+|Building breathe|All buildings           |—     |—  |—   |1px sin(t) y-offset, 0.25Hz|
+
+### 5.1 Building breathe
+
+Subtle and crucial. Every building has its rendered y position offset by:
+
+```
+sprite.y = baseY + Math.round(Math.sin((now + phaseOffset) / 4000) * 1)
+```
+
+One pixel of vertical breath at 0.25Hz. Invisible until you turn it off — then everything looks frozen. Apply to all buildings, banners, and large environment props.
+
+### 5.2 Environmental triggers
+
+Some env motion is event-triggered, not looped:
+
+- Tree shake: when a clansman performs chop action on this tile, that tree plays tree_shake once.
+- Splash: when fishing yields a catch, water tile plays a splash effect.
+- Smoke burst: when a forge or kitchen processes (build action completes), an extra puff of smoke spawns.
+- Wheat empty: when a wheat plot transitions to Regrowing, the tile sprite swaps from "full wheat" to "stubble."
+
+These are rendering reactions to state changes, not driven by independent timers.
+
+-----
+
+## 6. Effects
+
+### 6.1 Effect catalog
+
+|Effect              |Trigger                        |Frames|FPS|Behavior                                            |
+|--------------------|-------------------------------|------|---|----------------------------------------------------|
+|`pixel_burst_gold`  |Trade complete, deposit        |6     |12 |Radial out, fade last 2 frames                      |
+|`pixel_burst_blue`  |Whisper sent                   |4     |12 |Subtle, only visible at zoom                        |
+|`combat_flash`      |Each combat hit                |6     |16 |Brief white flash on target                         |
+|`combat_dust`       |Combat ongoing                 |4     |8  |Loops while combat active                           |
+|`coin_explode`      |Bandit defeated                |8     |12 |Scatter + fall + fade                               |
+|`red_pulse`         |Bandit threat marker           |—     |—  |Sin alpha overlay, 1Hz                              |
+|`selection_ring`    |Tap-select sprite              |—     |—  |Rotating dashes, persists                           |
+|`level_up_burst`    |Building upgrade               |8     |10 |Rays + sparkle                                      |
+|`monument_grow`     |Monument tier up               |12    |8  |Tower extends, dust at base                         |
+|`screen_shake`      |Failed defense, big event      |—     |—  |Camera offset jitter, decays 400ms                  |
+|`screen_flash_red`  |Defense failure                |—     |—  |Full-screen red, 100ms in / 200ms out               |
+|`screen_flash_white`|Critical hit, combat resolution|—     |—  |80ms in / 100ms hold / 800ms out                    |
+|`whisper_motes`     |Agent thinking                 |3     |4  |Ambient on Elder portrait in HUD                    |
+|`dust_puff`         |Defender knockback landing     |4     |8  |One-shot, 500ms                                     |
+|`blueprint_drift`   |Blueprint Fragment awarded     |—     |—  |Icon rises from bandit corpse, drifts to vault, 1.5s|
+
+### 6.2 Effect timing principle
+
+The more important the event, the longer the effect, but never longer than 800ms. If something demands more, escalate to a screen-level effect (shake, flash) layered over the in-world effect.
+
+|Event           |In-world              |Screen-level                 |
+|----------------|----------------------|-----------------------------|
+|Whisper sent    |200ms blue mote       |—                            |
+|Trade success   |400ms gold burst      |—                            |
+|Building upgrade|800ms burst           |—                            |
+|Bandit defeated |600ms coin explode    |200ms white flash            |
+|Defense failed  |400ms wall drop + dust|300ms red flash + 400ms shake|
+|Monument tier-up|1200ms grow + sparkles|1.6s camera zoom-in/hold/out |
+
+### 6.3 Particle pool pattern
+
+Don't `new PixiContainer` for every burst. Pre-allocate a pool of 32 effect containers, recycle.
+
+```
+type EffectInstance = {
+  sprite: AnimatedSprite
+  startedAt: number
+  duration: number
+  type: EffectKey
+  active: boolean
+}
+
+const pool: EffectInstance[] = Array.from({ length: 32 }, makeEffectInstance)
+
+function spawnEffect(key: EffectKey, x: number, y: number) {
+  const slot = pool.find(e => !e.active)
+  if (!slot) return // pool full, drop
+  slot.active = true
+  slot.startedAt = performance.now()
+  slot.sprite.position.set(x, y)
+  // configure sprite with effect frames, etc.
+}
+```
+
+Render loop ticks each active effect. Slot returns to pool when now - startedAt > duration.
+
+### 6.4 Wheelbarrow / carry indicator
+
+Above each clansman currently carrying resources, render a small "fill bar" or "wheelbarrow" overlay:
+
+```
+const fillRatio = Math.max(
+  carry.wood / WOOD_CAP,
+  carry.iron / IRON_CAP,
+  carry.wheat / WHEAT_CAP,
+  carry.fish / FISH_CAP
+)
+```
+
+Fill bar: 16px wide × 3px tall, anchored 4px above clansman head. Fill segment width = 16 * fillRatio, parchment cream color. Empty segment, ink color. Outline 1px.
+
+Animate fill changes:
+
+- Fill (gather): bar grows to new ratio over 400ms easeOutQuad.
+- Empty (deposit): bar shrinks to 0 over 200ms easeInQuad.
+
+-----
+
+## 7. Speech bubbles
+
+### 7.1 Specifications
+
+- Cap: 240 chars on wire (per Convex whispers schema), ~80 chars visible (3 lines wrapped at 28 chars).
+- Truncation: longer than visible cap shows "…" at end.
+- Typography: pixel font, 8px or 10px. Wrap at ~28 chars per line. Max 3 visible lines.
+- Color: parchment cream #E8D8B5 fill, ink #2A1810 text. Tail same as fill.
+- Outline: 1px black, 1px inner highlight (parchment cream). Don't anti-alias.
+- Anchor: (0.5, 1.0). Grows upward from above sprite head + 4px gap.
+- Tail: pointing down, 1px shifted from anchor.
+
+### 7.2 Lifecycle timing
+
+- Fade in: 150ms. Alpha 0→1, scale 0.9→1.0, easeOutBack (slight overshoot pop).
+- Hold: 6500ms solid (assuming standard whisper).
+- Fade out: 1350ms. Alpha 1→0, no scale change.
+- Total: 8000ms.
+
+The fade-in pop is critical — draws the eye. The fade-out is slow because players need time to read.
+
+### 7.3 Stack and replacement rule
+
+If a clansman is showing a bubble and a new whisper arrives:
+
+- Old bubble fast-fades (200ms).
+- New bubble fade-in begins after old is gone.
+- Never two bubbles per sprite simultaneously.
+
+### 7.4 Anti-occlusion
+
+Bubbles render in their own Pixi layer above all sprites, below HUD. If two bubbles' bounding boxes intersect, one shifts up by its own height. Re-evaluate on each render frame (cheap because there are at most ~8 bubbles at once).
+
+### 7.5 Edge clamping
+
+If a bubble would render off-screen-right, anchor flips to right side of sprite (bubble grows leftward). Same for left/top edges. Re-evaluate on camera changes.
+
+### 7.6 Attribution
+
+Per the locked decision: speech bubble is attached to the *first clansman in the missions array* for the speaking clan. This keeps bubble placement stable as missions resolve and reorder.
+
+### 7.7 Emergent behavior — whisper vs gossip rendering
+
+If we want to give the judge UI a cue that kind = whisper is private and kind = gossip is broadcasty, render slightly differently:
+
+- whisper (1-to-1): standard parchment bubble.
+- gossip (1-to-few): bubble outline gets a 2px gold trim, slightly larger.
+- taunt, threat: red ink color.
+- otc_offer, mercenary_*: small icon prefix in bubble (coin, sword).
+
+These are display variations only. The wire payload is identical.
+
+-----
+
+## 8. Camera
+
+### 8.1 Zoom
+
+- Range: 0.5× – 4.0×.
+- Wheel/pinch zoom: continuous, clamped, smoothed (lerp current toward target by 0.2 each frame).
+- Tap-to-zoom: 400ms easeInOutQuad tween to {x, y, zoom: 2.0}.
+- Double-tap to zoom out: 400ms tween to fit-world view.
+- Boundary cross-fade: at zoom = 1.5×, cross-fade strategic atlas → detail atlas over 200ms. Both layers render during transition; alpha-blend.
+- Zoom focal point: zoom focuses on cursor/touch position, not screen center. Critical for natural pinch.
+
+### 8.2 Pan
+
+- Drag: 1:1 pixel mapping during drag.
+- Momentum: on release, continue pan with velocity decaying at 0.92 per frame. Stop at velocity < 0.5px/frame.
+- Bounds: world has hard bounds. Past bounds, apply rubber-band resistance (drag distance × 0.4) and snap back over 300ms easeOutCubic on release.
+- Inertia interrupt: tap during momentum stops momentum immediately.
+
+### 8.3 Follow
+
+- Follow mode: when player taps a clansman or selects a clan, camera enters follow mode.
+- Follow lerp: camera position toward target with factor 0.08 per frame (smooth, not instant).
+- Exit follow: any pan gesture exits follow.
+- During travel: follow keeps a traveling clansman framed without jarring snaps.
+
+### 8.4 Cinematic camera moves
+
+For demo "wow" moments, the camera takes over briefly:
+
+- Monument tier-up: 0.8s zoom-in to monument, hold 1s, 0.8s zoom-out. Player input ignored during. Fires at most once per monument level per game.
+- Combat begin: subtle zoom-in 5% over the slow-circle phase. Imperceptible per-frame, but combat *feels* closer at peak.
+- Transfer demo (Sub2): full screen-dim, then portrait disintegration animation. See §11.5.
+
+-----
+
+## 9. Combat choreography (the hero moment)
+
+This is the visual high point of the game. Combat happens deterministically onchain at tick close, but the *visual* plays out across the full 60-second tick (Sub2) or 20-second tick (Sub1). Times below assume 60s tick; scale proportionally for Sub1.
+
+The combat outcome is known onchain at tick start. The animation just plays out the dramatic version of what already happened.
+
+### 9.1 Phase timing
+
+```
+T+0s   ── Combat tick begins. World filter dims.
+T+1s   ── "Combat begin" visual cue.
+T+2s   ── Bandits start march toward base.
+T+3s   ── Defenders converge from base perimeter.
+T+15s  ── All combatants arrive at combat ring radius.
+T+16s  ── Slow circle begins. ~15° per second.
+T+30s  ── Circle accelerates. ~45° per second.
+T+45s  ── Whirlwind phase. ~180° per second, motion blur.
+T+55s  ── Whirlwind peaks. Camera shakes subtly.
+T+58s  ── FLASH (full screen, 200ms).
+T+58.2s ── Resolution animation begins (success or failure).
+T+59.5s ── Resolution completes.
+T+60s  ── Tick closes, world filter releases, normal state.
+```
+
+Combat phase derived value:
+
+```
+function computeCombatPhase(now: number, tickStartMs: number, tickDurationMs: number): CombatPhase {
+  const p = (now - tickStartMs) / tickDurationMs
+  if (p < 0.025) return 'dim'
+  if (p < 0.25)  return 'advance'
+  if (p < 0.5)   return 'slow_circle'
+  if (p < 0.75)  return 'accelerate'
+  if (p < 0.92)  return 'whirlwind'
+  if (p < 0.97)  return 'flash'
+  return 'resolution'
+}
+```
+
+### 9.2 Phase 1 — The dimming (T+0s to T+1s)
+
+The moment that says "stop watching everything, watch *this*."
+
+- Full-screen dark overlay fades in over 800ms to alpha 0.55. Tint = ink blue #1A1A3A.
+- Combatants and the targeted base render in worldCombatHighlight container, *above* the dim overlay. Unaffected.
+- All other sprites in worldDim container render *below* overlay. Dimmed.
+- HUD shifts: "Combat at Base 03" indicator appears in top bar.
+
+Implementation:
+
+```
+// Two stacked world containers
+const worldDim = new Container()           // everything by default
+const worldCombatHighlight = new Container() // combat sprites
+const dimOverlay = new Graphics()           // rendered between them
+
+stage.addChild(worldDim)
+stage.addChild(dimOverlay)
+stage.addChild(worldCombatHighlight)
+
+// On combat begin: move combatant sprites to worldCombatHighlight
+// On combat end: move them back, fade dimOverlay alpha 0.55 → 0 over 600ms
+```
+
+### 9.3 Phase 2 — Bandit advance (T+2s to T+15s)
+
+- Bandits start at staging position (bandit camp tile or just outside base region).
+- Each bandit's combat-ring target position: baseAngle + (i / N) * 2π. Spread evenly.
+- March uses bandit_march (4 frames, 6fps).
+- Pulse glow during march: tint = lerp(0xff8888, 0xffffff, sin(now/400)). Period 800ms, 1.25Hz.
+- Bandits move slowly. Cover the distance over 13 seconds. Suspense, not action-paced.
+
+### 9.4 Phase 3 — Defender convergence (T+3s, parallel with Phase 2)
+
+- Defenders (clansmen on defend_base + idle clansmen at home + mercenaries from other clans) leave wander positions, walk toward combat ring on the *opposite side* from each bandit.
+- If 5 defenders vs 3 bandits, defenders fill arc gaps between bandits.
+- walk_* animation, 4-direction. Face ring center.
+- Stagger: each defender starts 200ms after previous so they don't all kick off in sync.
+
+### 9.5 Phase 4 — The wait (T+15s to T+16s)
+
+Brief 1-second beat. Everyone in position, idle, facing base. World dim, combat circle bright. Nothing moves except 4-fps idle bobs and bandit pulse glow.
+
+This pause is critical — the calm before.
+
+### 9.6 Phase 5 — Slow circle (T+16s to T+30s)
+
+- Bandits and defenders orbit the base. Alternate around the ring (B D B D B D…).
+- Angular velocity: 15°/s clockwise. Quarter-rotation = 6 seconds.
+- Position: (baseX + r·cos(angle), baseY + r·sin(angle)). Combat ring radius ~80px.
+- Sprites face *tangent* to circle (direction of motion). 4-way walk reads correctly as they orbit.
+- walk_* animation throughout.
+- Camera *very gently* zooms in by 5% over this phase. Imperceptible per-frame.
+
+### 9.7 Phase 6 — Whirlwind acceleration (T+30s to T+45s)
+
+- Angular velocity ramps 15°/s → 180°/s over 15 seconds. Easing: cubic.
+- At ~60°/s, sprite frame rate accelerates: walk frames advance at 12fps instead of 8fps.
+- At ~120°/s, motion blur: pre-rendered radial smear sprites overlay each combatant. Or use Pixi's BlurFilter with blur = lerp(0, 4, accelProgress).
+- Particles spin out tangentially: small dust/spark sprites emit from ring, 4-frame, fade fast.
+- Subtle whirlwind shape (concentric semi-transparent rings) appears underneath, rotating in *opposite* direction. Sells the vortex.
+
+### 9.8 Phase 7 — Whirlwind peak (T+45s to T+55s)
+
+- Angular velocity holds at 180°/s.
+- Blur maxes out. Combatants are unrecognizable streaks.
+- Camera shakes: subtle, ±2px offset, 3Hz.
+- Base in center dims and glitches (1px x-offset jitter, 4Hz).
+
+### 9.9 Phase 8 — The flash (T+55s to T+58s)
+
+- Whirlwind continues but adds an *outer* expanding white ring at T+55s — shockwave warning.
+- At T+58s exactly: full-screen white flash. Alpha 0→1 in 80ms (2 frames at 60fps), held 100ms, fade to 0 over 800ms.
+- During the flash, combatant positions snap to resolution starting positions. Flash hides the snap.
+
+### 9.10 Phase 9a — Defense success (T+58.2s to T+59.5s)
+
+- Bandits launch radially outward from base center. Initial velocity ~200px/s.
+- Bandits decelerate over 600ms (drag), travel ~60px, come to rest.
+- Each bandit plays bandit_death (6 frames, 8fps):
+  - Frames 1–2: ground pose, dazed.
+  - Frames 3–4: white flash overlay (full sprite alpha-tinted white).
+  - Frames 5–6: shrink to 30% scale, fade alpha 1→0.
+- After death anim (~750ms), coin_explode spawns at each bandit's last position.
+- Defenders play cheer (4 frames, 6fps, 2 loops = ~1.3s).
+- Blueprint Fragment (if awarded): icon rises from bandit corpse, drifts to base, fades into vault. ~1.5s.
+
+### 9.11 Phase 9b — Defense failure (T+58.2s to T+59.5s)
+
+- Clansmen jump backward 20–30px (much less than bandits would be thrown). easeOutQuad over 300ms.
+- On landing, each clansman's tile gets dust_puff (4 frames, 8fps, 500ms).
+- Stagger: clansmen play idle with 1px horizontal jitter for 500ms (shaking it off).
+- Wall sprite drops one level *visibly*: scale.y interpolates 1.0 → newRatio over 400ms easeInQuad. Small chunk-of-stone sprite falls from wall top, hits ground, dust.
+- Resources fly out of base as small icon sprites (one per 20% stolen), drift to bandit positions over 800ms. Each bandit "absorbs" them (sprite shrinks to bandit, fades).
+- Bandits converge to base center: brief huddle, sprites overlap at center 500ms.
+- Bandits then march out toward next region. bandit_march. Camera doesn't follow.
+
+### 9.12 Phase 10 — Cleanup (T+59.5s to T+60s)
+
+- World dim overlay fades to 0 over 600ms.
+- Surviving combatants return to wander positions (smooth walk).
+- HUD combat indicator clears.
+- Whisper feed populates with reactions (defenders, owners, gossiping clans).
+
+### 9.13 State caching during combat
+
+The combat outcome is in contract state at tick start. The animation needs "pre-combat" state through phases 1–8 and "post-combat" state in phase 9.
+
+```
+// At combat begin (phase = dim entered):
+combatPreState = snapshot(currentClanState)
+
+// Through phases 1–8: render from combatPreState
+// At phase 9 entry: swap to live state
+
+const renderState = (combatPhase < 'resolution') ? combatPreState : liveState
+```
+
+Pure rendering concern, doesn't touch contract logic.
+
+### 9.14 No-combat tick handling
+
+If a tick has no combat, combatPhase = 'none' and all the above is skipped. World renders normally.
+
+-----
+
+## 10. Day/night cycle
+
+### 10.1 Implementation — single ColorMatrixFilter
+
+PixiJS gives the right tool: ColorMatrixFilter applied to the world container (NOT HUD). GPU-accelerated, effectively free.
+
+```
+const dayNightFilter = new PIXI.ColorMatrixFilter()
+worldContainer.filters = [dayNightFilter]
+```
+
+### 10.2 Keyframes
+
+```
+const DAYNIGHT_KEYFRAMES = {
+  dawn:  { r: 1.10, g: 0.90, b: 0.80, brightness: 0.95, sat: 0.85 }, // warm pink
+  day:   { r: 1.00, g: 1.00, b: 1.00, brightness: 1.00, sat: 1.00 }, // neutral
+  dusk:  { r: 1.15, g: 0.85, b: 0.70, brightness: 0.85, sat: 0.95 }, // amber
+  night: { r: 0.65, g: 0.70, b: 0.95, brightness: 0.55, sat: 0.70 }, // blue cool
+}
+```
+
+### 10.3 Cycle timing
+
+Tied to ticks for narrative coherence and free determinism:
+
+```
+const TICKS_PER_DAY_CYCLE = 30  // 30 ticks = 30 minutes on Sub2, 10 minutes on Sub1
+
+function getDayNightProgress(currentTick: number, subTickProgress: number): number {
+  return ((currentTick + subTickProgress) % TICKS_PER_DAY_CYCLE) / TICKS_PER_DAY_CYCLE
+}
+```
+
+30 ticks per cycle = 30 minutes per "day" on Sub2, 10 minutes on Sub1. One season = 12 day cycles. Players see roughly 4–6 day cycles per typical play session.
+
+### 10.4 Phase distribution
+
+Equal day/night with quick transitions:
+
+|Phase|% of cycle|Duration (Sub2)|
+|-----|----------|---------------|
+|Dawn |0–5%      |1.5 min        |
+|Day  |5–50%     |13.5 min       |
+|Dusk |50–55%    |1.5 min        |
+|Night|55–100%   |13.5 min       |
+
+### 10.5 Apply function
+
+```
+function applyDayNight(progress01: number) {
+  const phase = progress01 * 4
+  const idx = Math.floor(phase) % 4
+  const t = phase - Math.floor(phase)
+  const keys = ['dawn', 'day', 'dusk', 'night']
+  const a = DAYNIGHT_KEYFRAMES[keys[idx]]
+  const b = DAYNIGHT_KEYFRAMES[keys[(idx + 1) % 4]]
+
+  const r = lerp(a.r, b.r, t) * lerp(a.brightness, b.brightness, t)
+  const g = lerp(a.g, b.g, t) * lerp(a.brightness, b.brightness, t)
+  const bl = lerp(a.b, b.b, t) * lerp(a.brightness, b.brightness, t)
+
+  dayNightFilter.matrix = [
+    r,  0,  0,  0,  0,
+    0,  g,  0,  0,  0,
+    0,  0,  bl, 0,  0,
+    0,  0,  0,  1,  0,
+  ]
+}
+```
+
+### 10.6 Window glow (highest-ROI embellishment)
+
+Each base has a "window glow" overlay sprite. Alpha = clamp(1 - daylight, 0, 1). As night falls, base windows light up warm yellow.
+
+This single effect sells immersion at almost no extra art cost. Buildings look lived-in at night, which is incredibly cozy for top-down pixel art.
+
+```
+// daylight = brightness from current keyframe blend (0–1)
+windowGlowSprite.alpha = clamp(1 - daylight, 0, 1)
+```
+
+### 10.7 Optional embellishments
+
+If time allows:
+
+- Star twinkle layer: night phase only. Starfield container above world, below HUD. Stars = small white pixel sprites with sin alpha twinkle, phase-offset. Show when night progress > 0.5.
+- Smoke tint: chimney smoke alpha peaks at dawn/dusk against colored sky.
+- Bandit night glow: bandits get a slight red glow during night phase. Cosmetic, makes threat feel worse.
+- Cycle indicator in HUD: tiny sun/moon icon rotating around an arc. Players grok "we're at dusk."
+
+### 10.8 Combat × day/night composition
+
+Both filters operate on world container. Compose in order:
+
+```
+worldContainer.filters = [dayNightFilter, combatDimFilter]
+```
+
+A combat at dusk looks amber-and-dark; a combat at night is apocalyptically dark. Both atmospheric, no special-case code.
+
+Cap rule: when combat starts during night, cap combat dim at min(0.55, 1 - currentBrightness) so combat is always at least readable.
+
+-----
+
+## 11. Demo "wow" moments
+
+These are the beats the audience must feel. Choreograph them.
+
+### 11.1 Bandit threat sequence (~20s arc, before Phase 1 of combat)
+
+Plays during the *previous* tick when bandit camping completes and target is selected:
+
+1. Bandit appears at edge of map: spawn poof + scary visual sting.
+2. War banner unfurls over bandit (1s ease-out).
+3. Skull icon appears over targeted base. red_pulse overlay begins.
+4. HUD countdown: "Bandit attack in N ticks."
+5. Bandit walks toward target with march.
+6. Whisper feed: defenders' clans react ("OH GOD GO HELP" type messages).
+
+Then the main combat choreography (§9) takes over.
+
+### 11.2 Trade swirl over Unicorn Town
+
+- Unicorn ambient sparkles intensify when a trade tx lands.
+- Spiraling pixel-coin sprite orbits Unicorn Town for 1.5s.
+- Both clans' carry indicators update mid-swirl.
+- Subtle gold glow on Unicorn Town for 2s after.
+
+### 11.3 Building upgrade
+
+- 800ms level_up_burst around building.
+- Old sprite cross-fades to new (150ms).
+- Dust puff at base.
+- Resource counter ticks down with "-50 wood" floater.
+- New sprite scales 1.0 → 1.05 → 1.0 bounce.
+
+### 11.4 Monument tier-up
+
+- 1200ms monument_grow: tower extends upward, dust at base, sparkles cascade down.
+- Camera *briefly* zooms to monument: 0.8s tween in, hold 1s, tween out 0.8s. Player input ignored during.
+- Whisper feed shows ALL elders reacting.
+- Fires at most once per monument level per game.
+
+### 11.5 Submission 2 Transfer Demo (the Track 2 killer)
+
+This is the dramatic moment for Submission 2. Choreograph cinematically:
+
+1. Owner Editor UI shows current Elder portrait.
+2. "Transfer iNFT" button pressed.
+3. Screen dims. Elder portrait disintegrates into pixel motes that drift offscreen.
+4. New owner address resolves: "Transferring to 0x…"
+5. Pixel motes reform into the same Elder portrait under new owner.
+6. Whisper appears: *"I remember the bandit at tick 412. The grudge holds."*
+7. Cut to in-world: that Elder's clan continues operating with same memory, same vendetta.
+
+This sells "intelligence transferred with the asset" better than any tech explanation.
+
+### 11.6 Season finalization
+
+When the 360-tick season ends:
+
+- Camera pans across all bases, monument-tier-up style cinematography.
+- Final leaderboard reveals position by position with delay (300ms between each), with each clan's heraldic shield enlarging briefly.
+- 1st place gets a gold crown overlay, sparkles cascade.
+- Prize pot distribution animates: gold flows from treasury to top-4 clan banks.
+
+-----
+
+## 12. HUD chrome animations
+
+Less hot than world rendering but still critical for premium feel.
+
+### 12.1 Counter ticks
+
+When a resource count changes:
+
+- Number rolls. 200ms tween from old → new with easeOutQuad.
+- Duration scales with delta: min(400ms, 100ms + log(delta) * 40ms).
+- Floater "+/-N" appears, drifts up, fades out over 800ms. Green +, red -.
+
+### 12.2 Leaderboard reorder
+
+When a clan rank changes:
+
+- Row slides to new position over 600ms easeInOutCubic.
+- Promoted clan: subtle gold flash on row.
+- Demoted clan: brief dim (no flash).
+
+### 12.3 Whisper feed scroll
+
+- New whispers slide in from top, 300ms easeOutCubic.
+- Old whispers scroll down.
+- Auto-scroll if user is at top of feed; hold position if user has scrolled away.
+
+### 12.4 Tab transition
+
+200ms cross-fade between tab contents. Don't slide — tabs aren't laterally adjacent in the player's mental model.
+
+### 12.5 Resource bar fill
+
+Per-clan vault bars in HUD:
+
+- Fill: smooth easeOutQuad over 400ms.
+- Drain: easeInQuad over 200ms.
+
+### 12.6 Tick countdown
+
+- Small pixel timer in HUD: seconds until next tick.
+- Updates every 100ms (not every frame).
+- Last 3 seconds: pulse red, scale 1.0 → 1.1 → 1.0 each second.
+
+### 12.7 Elder portrait
+
+Each clan's Elder agent has a portrait in the HUD strip. Animations:
+
+- Idle: gentle 1px y-bob, 0.25Hz.
+- Thinking (whisper outbound or LLM call active): whisper_motes particles drift around portrait.
+- Speaking (whisper just sent): subtle gold flash 200ms.
+- Distressed (clan starving, base under attack): red tint pulse, 1Hz.
+- Dead (clan eliminated): portrait greyscales, fades to 50% alpha.
+
+-----
+
+## 13. Tap / gesture feedback
+
+### 13.1 Selection
+
+- Tap on sprite: pulse a selection_ring underneath. Rotating dashes, 1Hz rotation, 0.5Hz pulse.
+- Selection ring color: clan heraldic color (one of 8). Reads as "this is yours" / "this is who you tapped."
+- Tap on building: white outline pulse for 200ms, info card slides in from bottom.
+- Tap on empty terrain: nothing. Don't deselect; require explicit deselect action.
+
+### 13.2 Long-press (mobile)
+
+- 400ms long-press: shows quick info tooltip. Sprite gets subtle 1.05× scale and 100% brightness boost.
+- Release: scale and brightness return over 150ms.
+
+### 13.3 Bandit threat highlight
+
+When bandit is targeting a base:
+
+- Targeted base shows red_pulse overlay.
+- Tapping it strongly highlights: white flash, then pulse intensifies.
+- Player must feel the threat.
+
+-----
+
+## 14. Z-order / layering
+
+```
+Layer 0:  Terrain background (single sprite per region, near-static)
+Layer 1:  Terrain accents (rocks, paths, decoration that's always behind everything dynamic)
+Layer 2:  worldDynamic — single sortable container holding ALL Y-sortable entities:
+            - Environment motion (wheat, waves, trees)
+            - Buildings (with their overlays as children)
+            - Banners (children of their host building)
+            - Bandits, clansmen (with carry indicators as children)
+            sortableChildren = true on this container only.
+            Each entity's zIndex = entity.y (rounded).
+Layer 3:  In-world effects (bursts, flashes, dust puffs)
+Layer 4:  Selection rings
+Layer 5:  Speech bubbles
+Layer 6:  Threat overlays (red pulse, skull markers)
+Layer 7:  Combat dim overlay (when in combat)
+Layer 8:  Combat highlight container (combatants reparent here during combat)
+Layer 9:  Screen-level effects (full-screen flash, shake offset)
+[Outside Pixi]
+HUD chrome (React, absolute-positioned over canvas)
+Modals
+```
+
+### 14.1 Why a single sortable container
+
+PixiJS `sortableChildren` only sorts children **within a single Container**. If buildings live in one container and clansmen live in a sibling container above it, the clansmen container always renders on top of the buildings container — no per-Y interleaving across the boundary. A clansman walking behind a building would still render on top of the roof. Splitting by entity *type* breaks the entire 2.5D occlusion premise.
+
+The fix: every Y-sortable entity lives in `worldDynamic`. Environment motion, buildings, building overlays (as children of their host), clansmen, bandits, carry indicators (as children of their host) — all in one sortable container, all sharing the same `zIndex = y` global Y-sort. That's what enables clansman-walks-behind-windmill to actually look right.
+
+Static-only background (Layers 0 and 1) and screen-space layers (Layers 3-9) stay in their own containers because they don't participate in dynamic Y-sorting. Combat highlight (Layer 8) is a dedicated container because the combat-dim trick requires its sprites rendering above the dim overlay — those are *temporarily reparented* during combat and reparented back to `worldDynamic` afterward.
+
+### 14.2 Attachment patterns
+
+For composite entities, prefer **child-of-host** over separate Y-sorted containers:
+
+- **Building overlays (smoke, glow, banners, window-glow):** children of the building's PIXI.Container. Their world position derives from parent. They render in the parent's Y-slot automatically — no separate sort needed.
+- **Carry indicators / wheelbarrows:** children of the clansman's container. Positioned at `(0, -spriteHeight - 4)` relative to clansman. Same Y-slot as parent.
+- **Bandit pulse glow during march:** filter on the bandit sprite, not a sibling sprite. Stays z-correct by definition.
+
+When a sprite genuinely needs to render *between* host-Y and the host above it (e.g., "smoke trails behind a passing clansman"), use `zIndex = parent.y + 0.5` on a sibling sprite in `worldDynamic`. Reserve fractional zIndex for these intentional overrides; integer zIndex = y for everything else.
+
+### 14.3 Combat reparenting protocol
+
+When `combatPhase` enters `dim`:
+
+1. For each combatant entity (bandits, defending clansmen, the targeted base): record their current parent (`worldDynamic`) and their current `zIndex`.
+2. Reparent them to `combatHighlight` container (Layer 8). `combatHighlight` does NOT use `sortableChildren` — combatants render in insertion order, which during combat is fine because they orbit the same point.
+3. The dim overlay (Layer 7) renders between `worldDynamic` and `combatHighlight`, dimming the world but not the combatants.
+
+When `combatPhase` returns to `none` (post-resolution):
+
+1. Reparent each combatant back to `worldDynamic`, restoring their original `zIndex` (now updated to current Y).
+2. Fade dim overlay to alpha 0.
+
+This is the only place reparenting is allowed. All other entities stay in `worldDynamic` permanently.
+
+-----
+
+## 15. Performance and engineering
+
+### 15.1 Budget
+
+- 8 clans × 5 clansmen = 40 sprites.
+- 16 buildings + 8 banners + ambient = ~80 active sprites in detail view.
+- Pixi v8 batches by texture — single atlas = single draw call.
+- Speech bubbles: bitmap text. Pre-render to texture if string repeats; else CPU hit per render.
+
+### 15.2 Pixi v8 patterns
+
+- Container (not `ParticleContainer`) for clansmen — they need flips, scales.
+- ParticleContainer for same-effect bursts where transforms are limited.
+- cullable: true on every world-layer container. Pixi v8 has built-in culling.
+- boundsArea set on static containers to skip recompute.
+- Atlas everything. No individual PNG sprites.
+- SCALE_MODES.NEAREST globally. Set on Assets.load.
+- renderer.resolution = window.devicePixelRatio capped at 2.
+- One global ticker. Don't mount per-component tickers in React.
+- maxFPS fallback: detect frame drops with 1s rolling avg; if avg fps < 45, set ticker.maxFPS = 30 and disable env motion.
+
+### 15.3 Object pools
+
+- 32 effect containers, recycled.
+- 16 speech bubble containers (more than max simultaneous).
+- 1 selection ring (hidden when not in use).
+
+### 15.4 Asset loading
+
+- Eager: both atlases on app start. ~500KB total. Show parchment-themed loading screen.
+- Lazy: monument level art (10 frames), demo cinematic frames load on first need.
+- Manifest: assets/manifest.json lists all atlases + JSONs. Assets.init({ manifest }) then Assets.loadBundle('strategic') and Assets.loadBundle('detail').
+
+### 15.5 Plan B degradation order
+
+As fps drops, in order:
+
+1. ticker.maxFPS = 30.
+2. Disable env motion (smoke, wheat) — biggest win.
+3. Cap simultaneous speech bubbles at 3 (queue overflow).
+4. Drop animation rates 6→4 fps.
+5. Disable selection ring rotation (just static).
+6. Disable day/night filter.
+7. Last resort: skip strategic atlas, force detail at all zooms.
+
+-----
+
+## 16. React + Pixi integration
+
+### 16.1 Single Pixi root
+
+One `<canvas>` element mounted by one React component. Component's job:
+
+1. Create Pixi Application on mount.
+2. Pass to bridge.ts module.
+3. Tear down on unmount.
+
+React never imports from pixi/. Pixi never imports from React.
+
+### 16.2 Bridge pattern
+
+```
+// bridge.ts — only point of contact
+let app: PIXI.Application | null = null
+let store: WorldStore | null = null
+let unsubscribe: (() => void) | null = null
+
+export const bridge = {
+  attach(pixiApp: PIXI.Application, worldStore: WorldStore) {
+    app = pixiApp
+    store = worldStore
+    unsubscribe = store.subscribe(state => updateScene(state))
+  },
+  detach() {
+    unsubscribe?.()
+    app?.destroy()
+    app = null
+    store = null
+  },
+  emit(event: PixiEvent) {
+    // forward selection/tap events to store
+    store?.handlePixiEvent(event)
+  },
+}
+```
+
+### 16.3 State subscription
+
+- Zustand subscribeWithSelector. Pixi subscribes to specific slices.
+- Diff-aware updates: when state changes, compute what *actually* changed (new clansmen, removed clansmen, status changes) and update only those Pixi nodes. Don't rebuild scene.
+- Keep Map<entityId, PixiSprite> in bridge module.
+  - For each entity in new state: if exists, update transform/state; else create.
+  - For each entity in map but not in new state: destroy.
+
+### 16.4 Events out of Pixi
+
+Pixi handles tap/select/long-press via eventMode = 'static' + cursor = 'pointer':
+
+```
+sprite.eventMode = 'static'
+sprite.cursor = 'pointer'
+sprite.on('pointertap', () => bridge.emit({ type: 'select', entityId }))
+```
+
+Bridge forwards to store. React HUD re-renders from store change.
+
+-----
+
+## 17. Asset pipeline (Aseprite handoff)
+
+- Export: PNG + JSON-Hash, 1× scale, trim enabled, 1px padding.
+- Frame names: clansman_walk_ne_0, clansman_walk_ne_1, etc.
+- Frame counts and fps live in hand-maintained animations.json separate from Aseprite export. Adding a frame doesn't require code change.
+- pnpm validate-atlas checks every entry in animations.json resolves to actual frames in atlas. CI fails on mismatch.
+- Vite watches assets/atlas/, hot-reloads in dev.
+
+-----
+
+## 18. The "premium feel" checklist
+
+When playing the game, these should all be true. If any are false, the game feels cheap.
+
+- [ ] Buildings breathe (1px sway, 0.25Hz, phase-offset).
+- [ ] Wheat/waves have phase offsets — no marching band.
+- [ ] Sprite frames advance at 4–8fps but pan is smooth at 60fps.
+- [ ] Clansmen face direction of travel (4-way 45°).
+- [ ] State transitions cross-fade or inherit, never snap.
+- [ ] Speech bubbles pop in (overshoot ease) and fade out slowly.
+- [ ] Counter changes roll, with delta floaters above.
+- [ ] Tap-to-zoom is 400ms, not instant.
+- [ ] Selection ring rotates and pulses.
+- [ ] Bandit threats create dread (pulse, countdown, scary banner).
+- [ ] Combat plays out cinematically across the full tick (advance → circle → whirlwind → flash → resolution).
+- [ ] Defeating a bandit is satisfying (knockback + flash + coins + cheer).
+- [ ] Trade beats happen (swirl, glow on Unicorn Town).
+- [ ] Building upgrades are punctuated (burst, bounce, dust).
+- [ ] Monument tier-up is cinematic (camera move, sparkles).
+- [ ] Day/night cycle is visible without being jarring.
+- [ ] Window glows turn on at night.
+- [ ] Whispers attribute correctly (first clansman in mission).
+- [ ] At 30fps fallback, env motion disables but core animation still feels alive.
+
+-----
+
+## 19. Open decisions / future work
+
+Not blocking implementation but worth tracking:
+
+- Star twinkle layer (§10.7): probably ship if time permits.
+- Bandit night glow (§10.7): low risk cosmetic, ship if time.
+- HUD cycle indicator (§10.7): ship for player legibility.
+- Direction frame counts: currently 4 per direction. If author bandwidth allows, 6 frames per direction would smooth the walk significantly.
+- Cinematic season-end camera (§11.6): polish item, ship last.
+- Sound hooks: out of scope for hackathon, but each effect should have an optional soundId field in the effect catalog so adding audio later is one config map.
+
+-----
+
+## 20. Locked decisions (recap)
+
+- Three independent clocks: game tick, animation frame, render frame.
+- Position is a pure function of state + time, never stored.
+- Two-resolution atlas system, cross-fade at zoom 1.5×.
+- 4-way 45° walk: NE and SE authored, NW and SW mirrored.
+- Idle always faces SE (or last walked direction on transition from walk).
+- Sprite frames at 4–8 fps; never higher than 12 except during combat acceleration.
+- Phase offsets on every repeating env element. No marching bands.
+- Building breathe (1px y-offset, 0.25Hz) on every building.
+- Cross-fade or inherit on state transitions; never snap.
+- Direction flips are instant (no fade).
+- Combat is the hero moment, choreographed across the full tick.
+- Day/night via single ColorMatrixFilter, 30 ticks per cycle.
+- Window glow at night is highest-ROI embellishment.
+- Speech bubbles attributed to first clansman in mission array.
+- Particle pool of 32, recycled.
+- React/Pixi integration via single bridge.ts; no cross-imports.

--- a/docs/planning/clanworld_v5_demo_day_subset.md
+++ b/docs/planning/clanworld_v5_demo_day_subset.md
@@ -1,0 +1,235 @@
+# ClanWorld v5 — Demo-Day Animation Subset
+
+Status: Hackathon scope-cut, hard prioritization
+Deadline: **May 3, noon ET** (~22h from this doc)
+Source: `clanworld_v5_animation_spec.md` (full v5 north star — post-hackathon target)
+Owner: Frontend implementation agent, working in `apps/web/src/WorldMap.tsx` and adjacents.
+
+This doc answers one question: *"Of the v5 spec, what do we actually ship by tomorrow noon?"*
+
+The DA review on v5 (codex 5.5 + gemini-3-pro) converged on **NEEDS WORK due to scope** — the full spec is 3-6 weeks of focused frontend + art work. This subset is the ruthless cut. It's the v5 *vibe* on a 22h budget.
+
+-----
+
+## 0. The premium-feel checklist for demo
+
+If these seven things are true on stage tomorrow, the demo *feels* like the v5 spec without being it:
+
+- [ ] Buildings breathe — invisible-until-missing 1px sway
+- [ ] Phase-offset env motion — wheat / smoke / waves do NOT march in sync
+- [ ] Day/night cycle — visible without being jarring; window glow at night
+- [ ] Carry indicators above each gathering clansman — fill bar visualizes the loop
+- [ ] Tap-to-zoom + selection ring — players can navigate the world cleanly
+- [ ] Counter ticks on resource changes (rolling number + delta floater)
+- [ ] One combat moment — short vignette near tick close, NOT full-tick choreography
+
+Everything else from v5 ships post-hackathon.
+
+-----
+
+## 1. Ship list
+
+### 1.1 Z-sort architecture fix (BLOCKING — do first)
+
+**Source:** v5 §14 (now corrected in main spec).
+**Why first:** Every other animation depends on entities Y-sorting correctly. If clansmen render on top of buildings unconditionally (the current bug), nothing else looks right.
+
+**Implementation:**
+- Single `worldDynamic` Pixi Container with `sortableChildren = true`.
+- Environment motion sprites (wheat, waves), buildings, clansmen, bandits all parent into `worldDynamic`.
+- Each entity sets `zIndex = Math.round(entity.y)` on every position update.
+- Building overlays (smoke, banners, glow) become **children** of their host building, NOT siblings.
+- Carry indicators become **children** of their host clansman, NOT siblings.
+
+**Effort:** 2-3h. Refactor of existing WorldMap.tsx layer creation. Risky if poorly done; use a test region with ≥3 buildings + ≥3 clansmen at varying Y to verify visually.
+
+**Acceptance:** A clansman walking south past a building's south face renders on top; walking north past the building's north face renders behind. Test with the existing dev seed.
+
+### 1.2 Building breathe
+
+**Source:** v5 §5.1.
+**Why high-ROI:** Single biggest premium-feel cue. Code is ~10 lines.
+
+**Implementation:**
+```typescript
+// Per building, assigned once at spawn:
+building.userData.phaseOffset = ((gridX * 73) ^ (gridY * 31)) % 4000
+
+// On each render frame:
+building.y = baseY + Math.round(Math.sin((now + phaseOffset) / 4000) * 1)
+```
+
+`baseY` is the building's authoritative Y position. The 1px offset is render-only. Round to integer pixels.
+
+**Effort:** 30min.
+
+**Acceptance:** Pause the game (zero state changes). Watch the screen for 8 seconds. Buildings should visibly breathe at desync'd phases. If they all rise and fall together → phaseOffset is broken.
+
+### 1.3 Phase-offset on existing env motion
+
+**Source:** v5 §1.4.
+**Why:** Cheap fix that prevents the "marching band" tell.
+
+**Implementation:** Audit existing env motion sprites in WorldMap.tsx (smoke, wheat, waves if present). Each sprite computes its animation frame from:
+```typescript
+const phaseOffset = ((gridX * 73) ^ (gridY * 31)) % 1000
+const frame = Math.floor((now + phaseOffset) / (1000 / fps)) % frameCount
+```
+
+If env motion isn't yet implemented for any element, do NOT add new motion as part of this task — the breathe in §1.2 is enough ambient motion.
+
+**Effort:** 30min if env motion exists; skip if not.
+
+**Acceptance:** Zoom into a wheat field (or smoke chimneys, or waves). Adjacent tiles should be on different frames at any given moment.
+
+### 1.4 Day/night ColorMatrixFilter + window glow
+
+**Source:** v5 §10.
+**Why:** Single GPU filter, atmospheric, sells "world" not "diorama."
+
+**Implementation:**
+- One `PIXI.ColorMatrixFilter` on `worldDynamic` and `terrainBackground`. NOT on HUD.
+- 30 ticks per cycle. Use existing `currentTick` from snapshot + sub-tick interpolation.
+- 4 keyframes (dawn / day / dusk / night) per v5 §10.2. Lerp between them.
+- Window glow: each base has a single overlay sprite, alpha = `clamp(1 - daylightBrightness, 0, 1)`.
+
+**Effort:** 2h (filter + keyframe lerp). Window glow sprite per base needs ONE 24x24 art asset (yellow-window overlay) — author or paint-by-hand if no one's available.
+
+**Skip if:** Window glow art doesn't exist by T-12h. Ship just the filter.
+
+**Acceptance:** Sit on the world view for 4 minutes (= 1 day cycle on Sub2). Watch the world tint go through warm → neutral → amber → blue → back. At night, base windows glow if asset exists.
+
+### 1.5 Carry indicators (wheelbarrow / fill bar)
+
+**Source:** v5 §6.4.
+**Why:** Visualizes the gathering loop — players can SEE clansmen accumulating resources. Without this, the gathering economy is invisible.
+
+**Implementation:**
+- Per clansman with `carry.* > 0`: render a child sprite 4px above the head.
+- Fill bar: 16px × 3px. Background: ink color. Fill: parchment cream, width = `16 * fillRatio`.
+- `fillRatio = Math.max(carry.wood / WOOD_CAP, carry.iron / IRON_CAP, carry.wheat / WHEAT_CAP, carry.fish / FISH_CAP)`.
+- Animate fill changes: 400ms easeOutQuad on growth, 200ms easeInQuad on drain.
+- Hide entirely when `fillRatio === 0`.
+
+**Effort:** 1.5h. Pure code, no art. If a wheelbarrow icon exists, use it; else just the bar.
+
+**Acceptance:** Send a clansman to gather wood. Watch the bar fill as the gather mission progresses. Watch it drain when they deposit at the base.
+
+### 1.6 Tap-to-zoom + selection ring
+
+**Source:** v5 §8.1, §13.1.
+**Why:** Without selection feedback, the world feels uninspectable. With it, the demo presenter can "show me Clan 3" naturally.
+
+**Implementation:**
+- On sprite tap (clansman, building): tween camera over 400ms easeInOutQuad to `{x: sprite.x, y: sprite.y, zoom: 2.0}`.
+- Spawn a `selectionRing` sprite as a child of the tapped sprite. Ring rotates at 1Hz, pulses alpha at 0.5Hz.
+- Tap on empty terrain: do nothing (don't deselect).
+- Esc key or "Clear Selection" button: hide ring, zoom out to fit-world over 400ms.
+
+**Effort:** 2h. Selection ring needs ONE 32x32 art asset (rotating dashes). If not authorable, use a simple PIXI.Graphics circle with stroke dasharray — uglier but functional.
+
+**Acceptance:** Tap a clansman — camera centers + zooms; ring appears. Tap another — camera moves to new target; ring follows. Press Esc — zooms out.
+
+### 1.7 Counter ticks (rolling number + delta floater)
+
+**Source:** v5 §12.1.
+**Why:** Resource counters are the most-watched HUD element. Static numbers feel cheap; rolling numbers feel premium.
+
+**Implementation:**
+- Per HUD counter (wood, iron, wheat, fish, gold per clan): wrap in a `<RollingNumber>` React component.
+- On value change: tween from old to new over `min(400ms, 100ms + log(|delta|) * 40ms)` with easeOutQuad.
+- Spawn a `+N` or `-N` floater above the counter. Drift up 16px, fade alpha 1 → 0 over 800ms. Green for positive, red for negative.
+
+**Effort:** 1.5h. Pure React + CSS. No art needed.
+
+**Acceptance:** Clansman deposits 50 wood. Wood counter rolls from old to new+50 over ~300ms. A green "+50" rises above the counter and fades.
+
+### 1.8 Combat vignette (the codex alternative)
+
+**Source:** v5 §9, modified per codex DA recommendation (Alternative #2).
+**Why:** Full-tick choreography is 1+ week of work. A 3-4s vignette near tick close gets the "combat happened!" beat without the cost.
+
+**Implementation:**
+- When the next tick contains a known combat outcome: at `tickClose - 4s`, fade dim overlay (alpha 0 → 0.55 over 600ms) on `worldDynamic` (NOT on `combatHighlight`).
+- Reparent combatants to `combatHighlight` per v5 §14.3.
+- Combatants do a simple advance + clash + flash:
+  - 0-1500ms: walk toward base center.
+  - 1500-2000ms: idle at center, brief.
+  - 2000-2200ms: full-screen white flash (200ms in, 200ms out).
+  - 2200ms+: resolution per v5 §9.10 (success: bandits death + cheer) or §9.11 (failure: clansmen knockback + wall drop). Cap entire resolution at 1500ms.
+- At tick close: dim fades out, combatants reparent back to `worldDynamic`.
+
+**Effort:** 3h. Skip motion blur, skip whirlwind, skip slow-circle. Just dim → advance → flash → resolution.
+
+**Skip if:** T-6h and items 1.1-1.7 aren't all done. This is the LAST priority.
+
+**Acceptance:** Trigger a combat tick (use the existing dev seed). At tick - 4s, world dims, combatants advance, flash, resolve. Whole thing fits in the 4 seconds before tick close.
+
+-----
+
+## 2. Skip list — explicit non-goals
+
+These are out-of-scope for tomorrow. They land post-hackathon as part of v5 proper.
+
+- **Strategic 8x8 atlas (v5 §1.5):** No art bandwidth to author. Detail atlas at all zooms; tolerate downscale ugliness at zoom <1x.
+- **Full combat choreography 10-phase (v5 §9):** Replaced by §1.8 vignette.
+- **Submission 2 transfer demo cinematic (v5 §11.5):** Depends on iNFT transfer mechanic existing in chain client. Defer to v1.2 if Track 2 is even pursued.
+- **Cross-fade transitions (v5 §3):** Per gemini DA — cross-fading two pixel sprites looks ghosted, not premium. Use snap with anticipation frame later when art exists; for demo, just snap.
+- **Bandit threat 20s sequence (v5 §11.1):** Single skull icon over targeted base + the §1.8 vignette is enough.
+- **Monument tier-up cinematic (v5 §11.4):** No camera takeover. Standard upgrade burst (v5 §11.3) reused if monument levels up.
+- **Speech bubble anti-occlusion (v5 §7.4):** Static positioning above sprite head is fine for demo. The O(N²) layout dance comes later.
+- **Per-tier sprite frame counts (v5 §2.3, §2.4):** Use whatever sprites exist now. If no walk/idle/work cycles, sprites stay 1-frame.
+- **Particle pool of 32 (v5 §6.3):** Spawn fresh containers; if perf cratered, reconsider. 4-second vignette + counter floaters won't exhaust GC.
+- **Asset pipeline validation (v5 §17):** Manual atlas naming. CI validation post-hackathon.
+
+-----
+
+## 3. Effort budget
+
+| Item | Effort | Hard-deadline cut? |
+|---|---|---|
+| 1.1 Z-sort fix | 2-3h | NO — blocking, do first |
+| 1.2 Building breathe | 0.5h | NO — too cheap to skip |
+| 1.3 Phase-offset env | 0.5h (or skip) | YES if no env motion exists |
+| 1.4 Day/night + window glow | 2h | window glow YES if no art |
+| 1.5 Carry indicators | 1.5h | NO — gathering is invisible without |
+| 1.6 Tap-zoom + selection ring | 2h | ring art YES if no art |
+| 1.7 Counter ticks | 1.5h | NO — pure code |
+| 1.8 Combat vignette | 3h | YES if T-6h and 1.1-1.7 incomplete |
+
+**Total**: 13-13.5h ship-everything, 8-9h ship-minus-vignette.
+
+With 22h to deadline, there's slack for one round of "it doesn't look right, redo." Don't burn it on §1.8 if §1.1 isn't solid.
+
+-----
+
+## 4. Files to touch
+
+Primary:
+- `apps/web/src/WorldMap.tsx` — Pixi scene graph, layer restructure (§1.1), breathe (§1.2), phase-offset (§1.3), day/night filter (§1.4), carry indicators (§1.5), tap-to-zoom (§1.6), combat vignette (§1.8).
+
+Secondary:
+- `apps/web/src/components/cockpit/*` — counter ticks (§1.7) wherever resource counters live.
+- `apps/web/public/assets/` (or wherever atlases go) — window glow + selection ring sprites if authored.
+
+Out of scope:
+- `apps/server/convex/*` — animation is pure rendering. NO state-shape changes.
+- `packages/contracts/*` — animation is pure client. NO contract changes.
+
+-----
+
+## 5. Validation before demo
+
+Run through the §0 checklist with someone who hasn't seen the implementation. If they pause on any line, that line is the regression.
+
+If short on time, skip §1.8 (combat vignette) and ship 1.1-1.7. The world will still feel premium even without the combat moment, because the breathe + day/night + carry indicators are doing the heavy lifting.
+
+-----
+
+## Appendix: DA review pointers
+
+Full reviews:
+- `/tmp/da-clanworld-v5-codex.md` — codex 5.5 (recommends tiered split, short-form combat, delayed-visual-tick netcode pattern)
+- `/tmp/da-clanworld-v5-gemini-pro.md` — gemini 3 pro (caught Z-sort layer bug — fix is now in v5 §14, plus warned about cross-fade ghosting)
+
+Both reviewers converged on **NEEDS WORK due to scope** — this subset is the response.


### PR DESCRIPTION
## Summary
- Adds `docs/planning/clanworld_v5_animation_spec.md` — full v5 animation target (post-hackathon north star)
- Adds `docs/planning/clanworld_v5_demo_day_subset.md` — the hackathon-scope cut (8 items, ~13h budget)
- Implementation will follow in subsequent commits to this branch

## Background
v5 is a major upgrade from the v4.x line. Liam authored the spec; orchestrator ran 2-reviewer DA (codex 5.5 + gemini 3 pro). Both returned **NEEDS_WORK due to scope** — full spec is 3-6 weeks of work, hackathon has ~22h.

The demo-day subset is the response: ruthless prioritization on the high-ROI premium-feel items, defer the rest to v1.2.

Gemini caught a real architectural bug — Pixi's `sortableChildren` only sorts within a single Container, so the original §14 layer split (buildings in Layer 3, clansmen in Layer 5) breaks 2.5D occlusion. Fix is in §14 with new sub-sections 14.1–14.3 explaining the single-container design + combat reparenting protocol.

## DA review pointers
- `/tmp/da-clanworld-v5-codex.md` — codex 5.5 (recommended tiered split, short-form combat vignette)
- `/tmp/da-clanworld-v5-gemini-pro.md` — gemini 3 pro (caught Z-sort bug, warned on cross-fade ghosting)

## Test plan
- [ ] Z-sort fix verified visually: clansman walking south past a building's south face renders on top; walking north past the building's north face renders behind
- [ ] Building breathe: pause game, watch buildings rise/fall at desync'd phases over 8s
- [ ] Phase-offset env motion: zoom into wheat/smoke, adjacent tiles on different frames
- [ ] Day/night cycle: 4-min observation through warm → neutral → amber → blue → back
- [ ] Carry indicators: send clansman to gather wood, watch fill bar grow, then drain on deposit
- [ ] Tap-to-zoom: tap clansman → camera centers + zooms; ring appears
- [ ] Counter ticks: deposit 50 wood, watch counter roll + green +50 floater
- [ ] (Stretch) Combat vignette: trigger combat tick, observe 3-4s vignette near tick close

🤖 Generated with [Claude Code](https://claude.com/claude-code)