### PR TITLE
[codex] add diamond heartbeat clock

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -16,6 +16,7 @@ import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
 import {ClanOwnershipFacet} from "../src/diamond/facets/ClanOwnershipFacet.sol";
 import {DerivedViewsFacet} from "../src/diamond/facets/DerivedViewsFacet.sol";
 import {GoldTransferFacet} from "../src/diamond/facets/GoldTransferFacet.sol";
+import {HeartbeatFacet} from "../src/diamond/facets/HeartbeatFacet.sol";
 import {MarketViewsFacet} from "../src/diamond/facets/MarketViewsFacet.sol";
 import {QuoteViewsFacet} from "../src/diamond/facets/QuoteViewsFacet.sol";
 import {RawBanditViewsFacet} from "../src/diamond/facets/RawBanditViewsFacet.sol";
@@ -40,6 +41,7 @@ contract DeployDiamond is Script {
         DiamondCutFacet cutFacet = new DiamondCutFacet();
         Diamond diamond = new Diamond(owner, address(cutFacet));
         DiamondLoupeFacet loupeFacet = new DiamondLoupeFacet();
+        HeartbeatFacet heartbeatFacet = new HeartbeatFacet();
         RawWorldViewsFacet rawWorldViewsFacet = new RawWorldViewsFacet();
         RawTreasuryViewsFacet rawTreasuryViewsFacet = new RawTreasuryViewsFacet();
         RawClanViewsFacet rawClanViewsFacet = new RawClanViewsFacet();
@@ -67,6 +69,7 @@ contract DeployDiamond is Script {
             .diamondCut(
                 _initialFacetCuts(
                     address(loupeFacet),
+                    address(heartbeatFacet),
                     address(rawWorldViewsFacet),
                     address(rawTreasuryViewsFacet),
                     address(rawClanViewsFacet),
@@ -96,6 +99,7 @@ contract DeployDiamond is Script {
         console.log("CLAN_WORLD_DIAMOND_ADDRESS:       ", address(diamond));
         console.log("DIAMOND_CUT_FACET_ADDRESS:        ", address(cutFacet));
         console.log("DIAMOND_LOUPE_FACET_ADDRESS:      ", address(loupeFacet));
+        console.log("HEARTBEAT_FACET_ADDRESS:          ", address(heartbeatFacet));
         console.log("CLAN_LIFECYCLE_FACET_ADDRESS:     ", address(lifecycleFacet));
         console.log("RAW_WORLD_VIEWS_FACET_ADDRESS:    ", address(rawWorldViewsFacet));
         console.log("RAW_TREASURY_VIEWS_FACET_ADDRESS: ", address(rawTreasuryViewsFacet));
@@ -124,6 +128,7 @@ contract DeployDiamond is Script {
 
     function _initialFacetCuts(
         address loupeFacet,
+        address heartbeatFacet,
         address rawWorldViewsFacet,
         address rawTreasuryViewsFacet,
         address rawClanViewsFacet,
@@ -146,113 +151,118 @@ contract DeployDiamond is Script {
         address quoteViewsFacet,
         address scoringViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](22);
+        cut = new IDiamondCut.FacetCut[](23);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.loupeSelectors()
         });
         cut[1] = IDiamondCut.FacetCut({
+            facetAddress: heartbeatFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.heartbeatSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
             facetAddress: rawWorldViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawWorldViewsSelectors()
         });
-        cut[2] = IDiamondCut.FacetCut({
+        cut[3] = IDiamondCut.FacetCut({
             facetAddress: rawTreasuryViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawTreasuryViewsSelectors()
         });
-        cut[3] = IDiamondCut.FacetCut({
+        cut[4] = IDiamondCut.FacetCut({
             facetAddress: rawClanViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawClanViewsSelectors()
         });
-        cut[4] = IDiamondCut.FacetCut({
+        cut[5] = IDiamondCut.FacetCut({
             facetAddress: rawBanditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawBanditViewsSelectors()
         });
-        cut[5] = IDiamondCut.FacetCut({
+        cut[6] = IDiamondCut.FacetCut({
             facetAddress: lifecycleFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.lifecycleSelectors()
         });
-        cut[6] = IDiamondCut.FacetCut({
+        cut[7] = IDiamondCut.FacetCut({
             facetAddress: submitOrdersFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.submitOrdersSelectors()
         });
-        cut[7] = IDiamondCut.FacetCut({
+        cut[8] = IDiamondCut.FacetCut({
             facetAddress: ownershipFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.ownershipSelectors()
         });
-        cut[8] = IDiamondCut.FacetCut({
+        cut[9] = IDiamondCut.FacetCut({
             facetAddress: treasuryFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.treasurySelectors()
         });
-        cut[9] = IDiamondCut.FacetCut({
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: settlementFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.settlementSelectors()
         });
-        cut[10] = IDiamondCut.FacetCut({
+        cut[11] = IDiamondCut.FacetCut({
             facetAddress: goldTransferFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.goldTransferSelectors()
         });
-        cut[11] = IDiamondCut.FacetCut({
+        cut[12] = IDiamondCut.FacetCut({
             facetAddress: vaultResourceTransferFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.vaultResourceTransferSelectors()
         });
-        cut[12] = IDiamondCut.FacetCut({
+        cut[13] = IDiamondCut.FacetCut({
             facetAddress: blueprintTransferFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.blueprintTransferSelectors()
         });
-        cut[13] = IDiamondCut.FacetCut({
+        cut[14] = IDiamondCut.FacetCut({
             facetAddress: bundleTransferFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.bundleTransferSelectors()
         });
-        cut[14] = IDiamondCut.FacetCut({
+        cut[15] = IDiamondCut.FacetCut({
             facetAddress: derivedViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-        cut[15] = IDiamondCut.FacetCut({
+        cut[16] = IDiamondCut.FacetCut({
             facetAddress: marketViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
-        cut[16] = IDiamondCut.FacetCut({
+        cut[17] = IDiamondCut.FacetCut({
             facetAddress: banditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
-        cut[17] = IDiamondCut.FacetCut({
+        cut[18] = IDiamondCut.FacetCut({
             facetAddress: regionViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
-        cut[18] = IDiamondCut.FacetCut({
+        cut[19] = IDiamondCut.FacetCut({
             facetAddress: snapshotViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
-        cut[19] = IDiamondCut.FacetCut({
+        cut[20] = IDiamondCut.FacetCut({
             facetAddress: clanFullViewFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.clanFullViewSelectors()
         });
-        cut[20] = IDiamondCut.FacetCut({
+        cut[21] = IDiamondCut.FacetCut({
             facetAddress: quoteViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
-        cut[21] = IDiamondCut.FacetCut({
+        cut[22] = IDiamondCut.FacetCut({
             facetAddress: scoringViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.scoringViewsSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -13,6 +13,11 @@ library DiamondSelectors {
         selectors[3] = IDiamondLoupe.facetAddress.selector;
     }
 
+    function heartbeatSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.heartbeat.selector;
+    }
+
     function rawViewsSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](26);
         selectors[0] = IClanWorld.getWorldState.selector;

--- a/packages/contracts/src/diamond/facets/HeartbeatFacet.sol
+++ b/packages/contracts/src/diamond/facets/HeartbeatFacet.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanState, ClanWorldConstants, IClanWorldEvents, WheatPlot, WheatPlotState} from "../../IClanWorld.sol";
+import {LibSeason} from "../lib/LibSeason.sol";
+import {LibSettlement} from "../lib/LibSettlement.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract HeartbeatFacet is IClanWorldEvents {
+    uint256 private constant MAX_CROP_TRANSITION_PER_TICK = 64;
+
+    function heartbeat() external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        require(block.timestamp >= s.world.nextHeartbeatAtTs, "ClanWorld: heartbeat rate limited");
+
+        if (_isSeasonFinalizationPending(s)) {
+            LibStorage.exitNonReentrant(s);
+            return;
+        }
+
+        uint64 closedTick = s.world.currentTick;
+        bytes32 closedTickSeed = s.world.currentTickSeed;
+        s.world.nextHeartbeatAtTs = uint64(block.timestamp) + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS;
+
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            if (s.clans[clanId].clanState != ClanState.DEAD && s.clans[clanId].lastSettledTick <= closedTick) {
+                LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, closedTick + 1);
+                LibSettlement.commitSimulation(s, sim);
+            }
+        }
+
+        _resolveWorldEvents(s, closedTick);
+
+        uint64 newTick = closedTick + 1;
+        bytes32 newSeed = keccak256(abi.encode(block.prevrandao, closedTickSeed, closedTick));
+        s.world.currentTick = newTick;
+        s.tickSeeds[newTick] = newSeed;
+        s.world.currentTickSeed = newSeed;
+        s.world.nextHeartbeatAtTick = newTick + 1;
+
+        emit TickAdvanced(closedTick, newTick, newSeed);
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function _isSeasonFinalizationPending(LibStorage.AppStorage storage s) private view returns (bool) {
+        return s.world.currentTick + 1 >= s.world.seasonEndTick && !s.world.seasonFinalized;
+    }
+
+    function _resolveWorldEvents(LibStorage.AppStorage storage s, uint64 closedTick) private {
+        uint64 newTick = closedTick + 1;
+
+        if (newTick >= s.world.seasonEndTick && s.world.seasonFinalized) {
+            s.world.currentSeasonNumber += 1;
+            s.world.seasonStartTick = s.world.seasonEndTick;
+            s.world.seasonEndTick = s.world.seasonStartTick + ClanWorldConstants.SEASON_DURATION_TICKS;
+            s.world.seasonFinalized = false;
+        }
+
+        bool wasWinter = LibSeason.isWinterActiveAt(closedTick);
+        bool nowWinter = LibSeason.isWinterActiveAt(newTick);
+        if (!wasWinter && nowWinter) {
+            _lockWheatPlotsForWinter(s);
+            emit WinterStarted(newTick);
+        }
+        if (wasWinter && !nowWinter) {
+            _restartWheatPlotsAfterWinter(s, newTick);
+            emit WinterEnded(newTick);
+        }
+    }
+
+    function _lockWheatPlotsForWinter(LibStorage.AppStorage storage s) private {
+        uint256 transitions;
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            for (uint256 pi = 0; pi < 2; pi++) {
+                require(transitions < MAX_CROP_TRANSITION_PER_TICK, "ClanWorld: crop transition cap");
+                WheatPlot storage plot = s.wheatPlots[clanId][pi];
+                plot.state = WheatPlotState.WinterLocked;
+                plot.remainingWheat = 0;
+                plot.regrowUntilTick = 0;
+                transitions++;
+            }
+        }
+    }
+
+    function _restartWheatPlotsAfterWinter(LibStorage.AppStorage storage s, uint64 currentTick) private {
+        uint256 transitions;
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            for (uint256 pi = 0; pi < 2; pi++) {
+                require(transitions < MAX_CROP_TRANSITION_PER_TICK, "ClanWorld: crop transition cap");
+                WheatPlot storage plot = s.wheatPlots[clanId][pi];
+                if (plot.state == WheatPlotState.WinterLocked) {
+                    plot.state = WheatPlotState.Regrowing;
+                    plot.remainingWheat = 0;
+                    plot.regrowUntilTick = currentTick + ClanWorldConstants.WHEAT_PLOT_REGROW_TICKS;
+                }
+                transitions++;
+            }
+        }
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -42,6 +42,7 @@ import {ClanOwnershipFacet} from "../../src/diamond/facets/ClanOwnershipFacet.so
 import {DerivedViewsFacet} from "../../src/diamond/facets/DerivedViewsFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {GoldTransferFacet} from "../../src/diamond/facets/GoldTransferFacet.sol";
+import {HeartbeatFacet} from "../../src/diamond/facets/HeartbeatFacet.sol";
 import {MarketViewsFacet} from "../../src/diamond/facets/MarketViewsFacet.sol";
 import {MinimalERC20} from "../../src/MinimalERC20.sol";
 import {QuoteViewsFacet} from "../../src/diamond/facets/QuoteViewsFacet.sol";
@@ -504,6 +505,22 @@ contract DiamondSkeletonTest is Test {
         }
     }
 
+    function testDiamondHeartbeatAdvancesEmptyWorldLikeCore() public {
+        ClanWorld core = new ClanWorld();
+        HeartbeatFacet heartbeatFacet = new HeartbeatFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_heartbeatCut(address(heartbeatFacet)), address(0), "");
+
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        core.heartbeat();
+        IClanWorld(address(diamond)).heartbeat();
+
+        _assertWorldStateEq(IClanWorld(address(diamond)).getWorldState(), core.getWorldState());
+    }
+
     function testDiamondSubmitWaitOrderMatchesCore() public {
         ClanWorld core = new ClanWorld();
         ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
@@ -828,6 +845,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.lifecycleSelectors()
+        });
+    }
+
+    function _heartbeatCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.heartbeatSelectors()
         });
     }
 


### PR DESCRIPTION
## Summary
- add a diamond `HeartbeatFacet` for the world-clock/upkeep portion of `heartbeat`
- cover rate limiting, pending-finalization no-op, clan settlement, winter wheat plot transitions, tick seed advancement, and `TickAdvanced`
- wire heartbeat into deploy-time facet cuts
- add core-vs-diamond parity coverage for an empty-world heartbeat

## Follow-up Scope
- scheduled market execution during heartbeat is not moved in this slice
- bandit eager settlement, timers, attacks, and spawns are not moved in this slice

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol --match-test testDiamondHeartbeatAdvancesEmptyWorldLikeCore`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
- `forge build --sizes --skip test script | rg "HeartbeatFacet|SubmitOrdersFacet|ClanWorld "` (expected nonzero while legacy `ClanWorld` remains oversized; `HeartbeatFacet` runtime size: 18,009 bytes)

Stacked on #456.
