### PR TITLE
[codex] add diamond season finalization

### DIFF
--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -15,6 +15,7 @@ import {ClanFullViewFacet} from "../src/diamond/facets/ClanFullViewFacet.sol";
 import {ClanLifecycleFacet} from "../src/diamond/facets/ClanLifecycleFacet.sol";
 import {ClanOwnershipFacet} from "../src/diamond/facets/ClanOwnershipFacet.sol";
 import {DerivedViewsFacet} from "../src/diamond/facets/DerivedViewsFacet.sol";
+import {FinalizeSeasonFacet} from "../src/diamond/facets/FinalizeSeasonFacet.sol";
 import {GoldTransferFacet} from "../src/diamond/facets/GoldTransferFacet.sol";
 import {HeartbeatFacet} from "../src/diamond/facets/HeartbeatFacet.sol";
 import {MarketViewsFacet} from "../src/diamond/facets/MarketViewsFacet.sol";
@@ -42,6 +43,7 @@ contract DeployDiamond is Script {
         Diamond diamond = new Diamond(owner, address(cutFacet));
         DiamondLoupeFacet loupeFacet = new DiamondLoupeFacet();
         HeartbeatFacet heartbeatFacet = new HeartbeatFacet();
+        FinalizeSeasonFacet finalizeSeasonFacet = new FinalizeSeasonFacet();
         RawWorldViewsFacet rawWorldViewsFacet = new RawWorldViewsFacet();
         RawTreasuryViewsFacet rawTreasuryViewsFacet = new RawTreasuryViewsFacet();
         RawClanViewsFacet rawClanViewsFacet = new RawClanViewsFacet();
@@ -70,6 +72,7 @@ contract DeployDiamond is Script {
                 _initialFacetCuts(
                     address(loupeFacet),
                     address(heartbeatFacet),
+                    address(finalizeSeasonFacet),
                     address(rawWorldViewsFacet),
                     address(rawTreasuryViewsFacet),
                     address(rawClanViewsFacet),
@@ -100,6 +103,7 @@ contract DeployDiamond is Script {
         console.log("DIAMOND_CUT_FACET_ADDRESS:        ", address(cutFacet));
         console.log("DIAMOND_LOUPE_FACET_ADDRESS:      ", address(loupeFacet));
         console.log("HEARTBEAT_FACET_ADDRESS:          ", address(heartbeatFacet));
+        console.log("FINALIZE_SEASON_FACET_ADDRESS:    ", address(finalizeSeasonFacet));
         console.log("CLAN_LIFECYCLE_FACET_ADDRESS:     ", address(lifecycleFacet));
         console.log("RAW_WORLD_VIEWS_FACET_ADDRESS:    ", address(rawWorldViewsFacet));
         console.log("RAW_TREASURY_VIEWS_FACET_ADDRESS: ", address(rawTreasuryViewsFacet));
@@ -129,6 +133,7 @@ contract DeployDiamond is Script {
     function _initialFacetCuts(
         address loupeFacet,
         address heartbeatFacet,
+        address finalizeSeasonFacet,
         address rawWorldViewsFacet,
         address rawTreasuryViewsFacet,
         address rawClanViewsFacet,
@@ -151,7 +156,7 @@ contract DeployDiamond is Script {
         address quoteViewsFacet,
         address scoringViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](23);
+        cut = new IDiamondCut.FacetCut[](24);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -163,106 +168,111 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.heartbeatSelectors()
         });
         cut[2] = IDiamondCut.FacetCut({
+            facetAddress: finalizeSeasonFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.seasonSelectors()
+        });
+        cut[3] = IDiamondCut.FacetCut({
             facetAddress: rawWorldViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawWorldViewsSelectors()
         });
-        cut[3] = IDiamondCut.FacetCut({
+        cut[4] = IDiamondCut.FacetCut({
             facetAddress: rawTreasuryViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawTreasuryViewsSelectors()
         });
-        cut[4] = IDiamondCut.FacetCut({
+        cut[5] = IDiamondCut.FacetCut({
             facetAddress: rawClanViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawClanViewsSelectors()
         });
-        cut[5] = IDiamondCut.FacetCut({
+        cut[6] = IDiamondCut.FacetCut({
             facetAddress: rawBanditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawBanditViewsSelectors()
         });
-        cut[6] = IDiamondCut.FacetCut({
+        cut[7] = IDiamondCut.FacetCut({
             facetAddress: lifecycleFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.lifecycleSelectors()
         });
-        cut[7] = IDiamondCut.FacetCut({
+        cut[8] = IDiamondCut.FacetCut({
             facetAddress: submitOrdersFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.submitOrdersSelectors()
         });
-        cut[8] = IDiamondCut.FacetCut({
+        cut[9] = IDiamondCut.FacetCut({
             facetAddress: ownershipFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.ownershipSelectors()
         });
-        cut[9] = IDiamondCut.FacetCut({
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: treasuryFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.treasurySelectors()
         });
-        cut[10] = IDiamondCut.FacetCut({
+        cut[11] = IDiamondCut.FacetCut({
             facetAddress: settlementFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.settlementSelectors()
         });
-        cut[11] = IDiamondCut.FacetCut({
+        cut[12] = IDiamondCut.FacetCut({
             facetAddress: goldTransferFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.goldTransferSelectors()
         });
-        cut[12] = IDiamondCut.FacetCut({
+        cut[13] = IDiamondCut.FacetCut({
             facetAddress: vaultResourceTransferFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.vaultResourceTransferSelectors()
         });
-        cut[13] = IDiamondCut.FacetCut({
+        cut[14] = IDiamondCut.FacetCut({
             facetAddress: blueprintTransferFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.blueprintTransferSelectors()
         });
-        cut[14] = IDiamondCut.FacetCut({
+        cut[15] = IDiamondCut.FacetCut({
             facetAddress: bundleTransferFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.bundleTransferSelectors()
         });
-        cut[15] = IDiamondCut.FacetCut({
+        cut[16] = IDiamondCut.FacetCut({
             facetAddress: derivedViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-        cut[16] = IDiamondCut.FacetCut({
+        cut[17] = IDiamondCut.FacetCut({
             facetAddress: marketViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
-        cut[17] = IDiamondCut.FacetCut({
+        cut[18] = IDiamondCut.FacetCut({
             facetAddress: banditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
-        cut[18] = IDiamondCut.FacetCut({
+        cut[19] = IDiamondCut.FacetCut({
             facetAddress: regionViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
-        cut[19] = IDiamondCut.FacetCut({
+        cut[20] = IDiamondCut.FacetCut({
             facetAddress: snapshotViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
-        cut[20] = IDiamondCut.FacetCut({
+        cut[21] = IDiamondCut.FacetCut({
             facetAddress: clanFullViewFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.clanFullViewSelectors()
         });
-        cut[21] = IDiamondCut.FacetCut({
+        cut[22] = IDiamondCut.FacetCut({
             facetAddress: quoteViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
-        cut[22] = IDiamondCut.FacetCut({
+        cut[23] = IDiamondCut.FacetCut({
             facetAddress: scoringViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.scoringViewsSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -18,6 +18,11 @@ library DiamondSelectors {
         selectors[0] = IClanWorld.heartbeat.selector;
     }
 
+    function seasonSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IClanWorld.finalizeSeason.selector;
+    }
+
     function rawViewsSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](26);
         selectors[0] = IClanWorld.getWorldState.selector;

--- a/packages/contracts/src/diamond/facets/FinalizeSeasonFacet.sol
+++ b/packages/contracts/src/diamond/facets/FinalizeSeasonFacet.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanState, IClanWorldEvents} from "../../IClanWorld.sol";
+import {LibScoring} from "../../lib/LibScoring.sol";
+import {LibSettlement} from "../lib/LibSettlement.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract FinalizeSeasonFacet is IClanWorldEvents {
+    uint256 internal constant MAX_CLAN_SCAN_FOR_RANKING = 24;
+
+    function finalizeSeason() external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        require(s.world.currentTick + 1 >= s.world.seasonEndTick, "ClanWorld: season not ended");
+        require(!s.world.seasonFinalized, "ClanWorld: season finalized");
+
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            LibSettlement.SettlementSimulation memory sim =
+                LibSettlement.simulateToTick(s, clanId, s.world.currentTick + 1);
+            LibSettlement.commitSimulation(s, sim);
+        }
+
+        (uint32[] memory rankedClanIds, uint256[] memory scores) = _computeRankings(s);
+
+        s.world.seasonFinalized = true;
+        emit SeasonFinalized(uint64(s.world.seasonEndTick), rankedClanIds, scores);
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function _computeRankings(LibStorage.AppStorage storage s)
+        private
+        view
+        returns (uint32[] memory clanIdsRanked, uint256[] memory scores)
+    {
+        uint256 scanCount = s.allClanIds.length;
+        if (scanCount > MAX_CLAN_SCAN_FOR_RANKING) scanCount = MAX_CLAN_SCAN_FOR_RANKING;
+
+        uint32[] memory tempClanIds = new uint32[](scanCount);
+        uint256[] memory tempScores = new uint256[](scanCount);
+        uint256 liveCount;
+
+        for (uint256 i = 0; i < scanCount; i++) {
+            uint32 clanId = s.allClanIds[i];
+            LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, s.world.currentTick);
+            if (sim.clan.clanState != ClanState.ACTIVE) continue;
+
+            uint256 score = _clanScore(s, clanId, sim);
+            tempClanIds[liveCount] = clanId;
+            tempScores[liveCount] = score;
+            liveCount++;
+        }
+
+        for (uint256 i = 1; i < liveCount; i++) {
+            uint32 keyClanId = tempClanIds[i];
+            uint256 keyScore = tempScores[i];
+            uint256 j = i;
+            while (j > 0 && LibScoring.rankingComesAfter(tempClanIds[j - 1], tempScores[j - 1], keyClanId, keyScore)) {
+                tempClanIds[j] = tempClanIds[j - 1];
+                tempScores[j] = tempScores[j - 1];
+                j--;
+            }
+            tempClanIds[j] = keyClanId;
+            tempScores[j] = keyScore;
+        }
+
+        clanIdsRanked = new uint32[](liveCount);
+        scores = new uint256[](liveCount);
+        for (uint256 i = 0; i < liveCount; i++) {
+            clanIdsRanked[i] = tempClanIds[i];
+            scores[i] = tempScores[i];
+        }
+    }
+
+    function _clanScore(LibStorage.AppStorage storage s, uint32 clanId, LibSettlement.SettlementSimulation memory sim)
+        private
+        view
+        returns (uint256 score)
+    {
+        uint8 monumentLevel = sim.clan.monumentLevel;
+        uint64 monumentReachedAtTick;
+        if (monumentLevel > 0) {
+            monumentReachedAtTick = s.monumentLevelReachedAt[clanId][monumentLevel];
+            if (monumentReachedAtTick == 0) {
+                monumentReachedAtTick = sim.simMonumentReachedAt[monumentLevel];
+            }
+        }
+
+        (score,,) = LibScoring.packClanScore(sim.clan, monumentReachedAtTick, monumentLevel);
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -41,6 +41,7 @@ import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.so
 import {ClanOwnershipFacet} from "../../src/diamond/facets/ClanOwnershipFacet.sol";
 import {DerivedViewsFacet} from "../../src/diamond/facets/DerivedViewsFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {FinalizeSeasonFacet} from "../../src/diamond/facets/FinalizeSeasonFacet.sol";
 import {GoldTransferFacet} from "../../src/diamond/facets/GoldTransferFacet.sol";
 import {HeartbeatFacet} from "../../src/diamond/facets/HeartbeatFacet.sol";
 import {MarketViewsFacet} from "../../src/diamond/facets/MarketViewsFacet.sol";
@@ -521,6 +522,21 @@ contract DiamondSkeletonTest is Test {
         _assertWorldStateEq(IClanWorld(address(diamond)).getWorldState(), core.getWorldState());
     }
 
+    function testDiamondFinalizeSeasonRejectsBeforeSeasonEndLikeCore() public {
+        ClanWorld core = new ClanWorld();
+        FinalizeSeasonFacet finalizeSeasonFacet = new FinalizeSeasonFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_seasonCut(address(finalizeSeasonFacet)), address(0), "");
+
+        vm.expectRevert(bytes("ClanWorld: season not ended"));
+        core.finalizeSeason();
+        vm.expectRevert(bytes("ClanWorld: season not ended"));
+        IClanWorld(address(diamond)).finalizeSeason();
+    }
+
     function testDiamondSubmitWaitOrderMatchesCore() public {
         ClanWorld core = new ClanWorld();
         ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
@@ -854,6 +870,15 @@ contract DiamondSkeletonTest is Test {
             facetAddress: facet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.heartbeatSelectors()
+        });
+    }
+
+    function _seasonCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.seasonSelectors()
         });
     }
 


### PR DESCRIPTION
## Summary
- add `FinalizeSeasonFacet` for the diamond `finalizeSeason` selector
- settle clans through the season boundary before computing rankings
- wire season finalization into deploy-time facet cuts
- add core-vs-diamond parity coverage for the pre-season-end revert path

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol --match-test testDiamondFinalizeSeasonRejectsBeforeSeasonEndLikeCore`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
- `forge build --sizes --skip test script | rg "FinalizeSeasonFacet|HeartbeatFacet|LibOrderMarket|ClanWorld "` (expected nonzero while legacy `ClanWorld` remains oversized; `FinalizeSeasonFacet` runtime size: 17,411 bytes)

Stacked on #458.
