### PR TITLE
[codex] advance diamond bandit lifecycle

### DIFF
--- a/packages/contracts/src/diamond/facets/HeartbeatFacet.sol
+++ b/packages/contracts/src/diamond/facets/HeartbeatFacet.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.34;
 
 import {ClanState, ClanWorldConstants, IClanWorldEvents, WheatPlot, WheatPlotState} from "../../IClanWorld.sol";
+import {LibBanditLifecycle} from "../lib/LibBanditLifecycle.sol";
 import {LibOrderMarket} from "../lib/LibOrderMarket.sol";
 import {LibSeason} from "../lib/LibSeason.sol";
 import {LibSettlement} from "../lib/LibSettlement.sol";
@@ -33,6 +34,7 @@ contract HeartbeatFacet is IClanWorldEvents {
         }
 
         LibOrderMarket.executeScheduledMarketActions(s, closedTick);
+        LibBanditLifecycle.advancePassiveBanditStates(s, closedTick);
         _resolveWorldEvents(s, closedTick);
 
         uint64 newTick = closedTick + 1;

--- a/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {BanditState, BanditTroop, ClanWorldConstants} from "../../IClanWorld.sol";
+import {LibStorage} from "./LibStorage.sol";
+
+library LibBanditLifecycle {
+    event BanditStateChanged(
+        uint32 indexed banditId, BanditState oldState, BanditState newState, uint8 region, uint64 atTick
+    );
+    event BanditMoved(uint32 indexed banditId, uint8 fromRegion, uint8 toRegion, uint64 atTick);
+
+    function advancePassiveBanditStates(LibStorage.AppStorage storage s, uint64 closedTick) public {
+        require(s.world.currentTick == closedTick, "ClanWorld: bandit advance tick mismatch");
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            uint32[] storage regionBandits = s.banditsByRegion[region];
+            uint256 i = 0;
+            while (i < regionBandits.length) {
+                uint32 banditId = regionBandits[i];
+                BanditTroop storage bandit = s.bandits[banditId];
+                uint8 regionBefore = bandit.region;
+
+                if (bandit.state == BanditState.Spawned && closedTick > bandit.tickEnteredState) {
+                    transitionBanditState(s, banditId, BanditState.Camped);
+                } else if (
+                    bandit.state == BanditState.Escaped
+                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
+                ) {
+                    transitionBanditState(s, banditId, BanditState.Resting);
+                } else if (
+                    bandit.state == BanditState.Resting
+                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
+                ) {
+                    transitionBanditState(s, banditId, BanditState.Camped);
+                }
+
+                if (s.bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) continue;
+                if (regionBefore != s.bandits[banditId].region) continue;
+                i++;
+            }
+        }
+    }
+
+    function transitionBanditState(LibStorage.AppStorage storage s, uint32 id, BanditState newState) public {
+        BanditTroop storage bandit = s.bandits[id];
+        require(bandit.id != ClanWorldConstants.BANDIT_ID_NULL, "ClanWorld: bandit not found");
+        require(newState != BanditState.None, "ClanWorld: invalid bandit transition");
+
+        BanditState oldState = bandit.state;
+        require(isValidBanditTransition(s, bandit, newState), "ClanWorld: invalid bandit transition");
+
+        bandit.state = newState;
+        bandit.tickEnteredState = s.world.currentTick;
+        if (newState != BanditState.Attacking) {
+            bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
+        }
+
+        emit BanditStateChanged(id, oldState, newState, bandit.region, s.world.currentTick);
+
+        if (oldState == BanditState.Resting && newState == BanditState.Camped) {
+            moveBanditToRampageNextRegion(s, id);
+        }
+    }
+
+    function isValidBanditTransition(LibStorage.AppStorage storage s, BanditTroop storage bandit, BanditState newState)
+        public
+        view
+        returns (bool)
+    {
+        if (bandit.state == BanditState.Spawned) {
+            return newState == BanditState.Escaped
+                || (newState == BanditState.Camped && s.world.currentTick >= bandit.tickEnteredState + 1);
+        }
+        if (bandit.state == BanditState.Attacking) {
+            return
+                newState == BanditState.Defeated || newState == BanditState.Escaped || newState == BanditState.Resting;
+        }
+        if (bandit.state == BanditState.Escaped) {
+            return newState == BanditState.Resting;
+        }
+        if (bandit.state == BanditState.Resting) {
+            return newState == BanditState.Escaped
+                || (newState == BanditState.Camped
+                    && s.world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS);
+        }
+        if (bandit.state == BanditState.Camped) {
+            return newState == BanditState.Escaped || newState == BanditState.Resting
+                || (newState == BanditState.Attacking
+                    && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
+                    && s.world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS);
+        }
+        return false;
+    }
+
+    function moveBanditToRampageNextRegion(LibStorage.AppStorage storage s, uint32 id) public {
+        BanditTroop storage bandit = s.bandits[id];
+        uint8 fromRegion = bandit.region;
+        uint8 toRegion = nextRampageRegion(fromRegion);
+        if (fromRegion == toRegion) return;
+
+        uint32[] storage fromBandits = s.banditsByRegion[fromRegion];
+        for (uint256 i = 0; i < fromBandits.length; i++) {
+            if (fromBandits[i] == id) {
+                fromBandits[i] = fromBandits[fromBandits.length - 1];
+                fromBandits.pop();
+                break;
+            }
+        }
+
+        bandit.region = toRegion;
+        s.banditsByRegion[toRegion].push(id);
+        emit BanditMoved(id, fromRegion, toRegion, s.world.currentTick);
+    }
+
+    function nextRampageRegion(uint8 currentRegion) public pure returns (uint8) {
+        if (currentRegion == ClanWorldConstants.REGION_FOREST) return ClanWorldConstants.REGION_MOUNTAINS;
+        if (currentRegion == ClanWorldConstants.REGION_MOUNTAINS) return ClanWorldConstants.REGION_EAST_FARMS;
+        if (currentRegion == ClanWorldConstants.REGION_EAST_FARMS) return ClanWorldConstants.REGION_EAST_DOCKS;
+        if (currentRegion == ClanWorldConstants.REGION_EAST_DOCKS) return ClanWorldConstants.REGION_WEST_DOCKS;
+        if (currentRegion == ClanWorldConstants.REGION_WEST_DOCKS) return ClanWorldConstants.REGION_WEST_FARMS;
+        return ClanWorldConstants.REGION_FOREST;
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -10,6 +10,8 @@ import {
     IClanWorld,
     ActiveBanditView,
     ActionType,
+    BanditState,
+    BanditTroop,
     Clan,
     ClanFullView,
     ClanWorldConstants,
@@ -99,6 +101,64 @@ contract SetWorldClockFacet {
         s.world.currentBanditSpawnChanceBps = currentBanditSpawnChanceBps;
         s.world.currentTickSeed = tickSeed;
         s.tickSeeds[currentTick] = tickSeed;
+    }
+}
+
+contract CoreBanditHarness is ClanWorld {
+    function spawnBandit(uint8 region, uint32 strength) external returns (uint32) {
+        return _spawnBandit(region, strength);
+    }
+}
+
+interface ISpawnBandit {
+    function spawnBandit(uint8 region, uint32 strength) external returns (uint32);
+}
+
+contract SpawnBanditFacet {
+    function spawnBandit(uint8 region, uint32 strength) external returns (uint32 id) {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        require(
+            region >= ClanWorldConstants.REGION_FOREST && region <= ClanWorldConstants.REGION_DEEP_SEA,
+            "ClanWorld: invalid bandit region"
+        );
+        require(
+            region != ClanWorldConstants.REGION_UNICORN_TOWN && region != ClanWorldConstants.REGION_DEEP_SEA,
+            "ClanWorld: forbidden bandit region"
+        );
+        require(strength > 0, "ClanWorld: invalid bandit strength");
+
+        id = s.nextBanditId++;
+        s.bandits[id] = BanditTroop({
+            id: id,
+            region: region,
+            state: BanditState.Spawned,
+            targetClanId: 0,
+            tickEnteredState: s.world.currentTick,
+            strength: strength,
+            tier: _tierForBanditAttackPower(strength),
+            attackAttemptsMade: 0,
+            carryWood: 0,
+            carryIron: 0,
+            carryWheat: 0,
+            carryFish: 0,
+            carryGold: 0
+        });
+        s.banditsByRegion[region].push(id);
+        s.activeBanditCount += 1;
+        s.banditSpawnByRegion[region].lastSpawnTick = s.world.currentTick;
+        s.banditSpawnByRegion[region].probabilityAccum = 0;
+        if (s.world.activeBanditId == ClanWorldConstants.BANDIT_ID_NULL) {
+            s.world.activeBanditId = id;
+        }
+    }
+
+    function _tierForBanditAttackPower(uint32 attackPower) private pure returns (uint8) {
+        if (attackPower == 30) return 1;
+        if (attackPower == 45) return 2;
+        if (attackPower == 60) return 3;
+        if (attackPower == 80) return 4;
+        if (attackPower == 95) return 5;
+        return 0;
     }
 }
 
@@ -518,8 +578,41 @@ contract DiamondSkeletonTest is Test {
         vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
         core.heartbeat();
         IClanWorld(address(diamond)).heartbeat();
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        core.heartbeat();
+        IClanWorld(address(diamond)).heartbeat();
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        core.heartbeat();
+        IClanWorld(address(diamond)).heartbeat();
 
         _assertWorldStateEq(IClanWorld(address(diamond)).getWorldState(), core.getWorldState());
+    }
+
+    function testDiamondHeartbeatAdvancesSpawnedBanditToCampedLikeCore() public {
+        CoreBanditHarness core = new CoreBanditHarness();
+        HeartbeatFacet heartbeatFacet = new HeartbeatFacet();
+        SpawnBanditFacet spawnBanditFacet = new SpawnBanditFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_heartbeatCut(address(heartbeatFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_spawnBanditCut(address(spawnBanditFacet)), address(0), "");
+
+        uint32 coreBanditId = core.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        uint32 diamondBanditId = ISpawnBandit(address(diamond)).spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        core.heartbeat();
+        IClanWorld(address(diamond)).heartbeat();
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        core.heartbeat();
+        IClanWorld(address(diamond)).heartbeat();
+
+        _assertWorldStateEq(IClanWorld(address(diamond)).getWorldState(), core.getWorldState());
+        _assertBanditEq(IClanWorld(address(diamond)).getBandit(diamondBanditId), core.getBandit(coreBanditId));
+        assertEq(uint8(IClanWorld(address(diamond)).getBandit(diamondBanditId).state), uint8(BanditState.Camped));
+        assertEq(IClanWorld(address(diamond)).getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, 1);
     }
 
     function testDiamondFinalizeSeasonRejectsBeforeSeasonEndLikeCore() public {
@@ -882,6 +975,16 @@ contract DiamondSkeletonTest is Test {
         });
     }
 
+    function _spawnBanditCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = SpawnBanditFacet.spawnBandit.selector;
+
+        cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+    }
+
     function _submitOrdersCut(address facet) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
         cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -1155,6 +1258,22 @@ contract DiamondSkeletonTest is Test {
         assertEq(actual.carryIron, expected.carryIron, "carryIron");
         assertEq(actual.carryWheat, expected.carryWheat, "carryWheat");
         assertEq(actual.carryFish, expected.carryFish, "carryFish");
+    }
+
+    function _assertBanditEq(BanditTroop memory actual, BanditTroop memory expected) internal pure {
+        assertEq(actual.id, expected.id, "bandit id");
+        assertEq(actual.region, expected.region, "bandit region");
+        assertEq(uint8(actual.state), uint8(expected.state), "bandit state");
+        assertEq(actual.targetClanId, expected.targetClanId, "bandit target");
+        assertEq(actual.tickEnteredState, expected.tickEnteredState, "bandit tickEnteredState");
+        assertEq(actual.strength, expected.strength, "bandit strength");
+        assertEq(actual.tier, expected.tier, "bandit tier");
+        assertEq(actual.attackAttemptsMade, expected.attackAttemptsMade, "bandit attempts");
+        assertEq(actual.carryWood, expected.carryWood, "bandit wood");
+        assertEq(actual.carryIron, expected.carryIron, "bandit iron");
+        assertEq(actual.carryWheat, expected.carryWheat, "bandit wheat");
+        assertEq(actual.carryFish, expected.carryFish, "bandit fish");
+        assertEq(actual.carryGold, expected.carryGold, "bandit gold");
     }
 
     function _assertMissionEq(Mission memory actual, Mission memory expected) internal pure {


### PR DESCRIPTION
## Summary
- add `LibBanditLifecycle` for passive bandit state advancement in the diamond heartbeat
- advance spawned bandits to camped during heartbeat parity with legacy `ClanWorld`
- add a diamond parity test with a test-only bandit spawn facet

## Scope notes
- This intentionally does not move targeting, attack resolution, combat, or spawning yet.
- `SubmitOrdersFacet` remains the tightest deployed facet at 24,471 bytes, only 105 bytes under EIP-170.

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge test --match-path test/ClanWorldLens.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/shared test`
- `forge build --sizes --skip test script` (expected legacy `ClanWorld` size failure; captured facet sizes)