### PR TITLE
[codex] target diamond bandit attacks

### DIFF
--- a/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.34;
 
-import {BanditState, BanditTroop, ClanWorldConstants} from "../../IClanWorld.sol";
+import {BanditState, BanditTroop, Clan, ClanState, ClanWorldConstants} from "../../IClanWorld.sol";
+import {LibScoring} from "../../lib/LibScoring.sol";
 import {LibStorage} from "./LibStorage.sol";
 
 library LibBanditLifecycle {
@@ -9,6 +10,21 @@ library LibBanditLifecycle {
         uint32 indexed banditId, BanditState oldState, BanditState newState, uint8 region, uint64 atTick
     );
     event BanditMoved(uint32 indexed banditId, uint8 fromRegion, uint8 toRegion, uint64 atTick);
+    event BanditEscaped(uint32 indexed banditId, uint64 atTick);
+    event LootDistributed(
+        uint32 indexed banditId,
+        uint32[] rewardedClanIds,
+        uint256 woodPerClan,
+        uint256 wheatPerClan,
+        uint256 fishPerClan,
+        uint256 ironPerClan,
+        uint256 goldPerClan,
+        uint256 woodRemainder,
+        uint256 wheatRemainder,
+        uint256 fishRemainder,
+        uint256 ironRemainder,
+        uint256 goldRemainder
+    );
 
     function advancePassiveBanditStates(LibStorage.AppStorage storage s, uint64 closedTick) public {
         require(s.world.currentTick == closedTick, "ClanWorld: bandit advance tick mismatch");
@@ -22,6 +38,20 @@ library LibBanditLifecycle {
 
                 if (bandit.state == BanditState.Spawned && closedTick > bandit.tickEnteredState) {
                     transitionBanditState(s, banditId, BanditState.Camped);
+                } else if (
+                    bandit.state == BanditState.Camped
+                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS
+                ) {
+                    uint32 targetClanId = pickBanditAttackTarget(s, bandit);
+                    if (targetClanId == ClanWorldConstants.CLAN_ID_NULL) {
+                        if (recordBanditAttackAttempt(s, banditId) >= ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
+                            terminalEscapeBandit(s, banditId, closedTick);
+                            continue;
+                        }
+                        transitionBanditState(s, banditId, BanditState.Resting);
+                    } else {
+                        transitionBanditToAttacking(s, banditId, targetClanId);
+                    }
                 } else if (
                     bandit.state == BanditState.Escaped
                         && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
@@ -39,6 +69,12 @@ library LibBanditLifecycle {
                 i++;
             }
         }
+    }
+
+    function transitionBanditToAttacking(LibStorage.AppStorage storage s, uint32 id, uint32 targetClanId) public {
+        require(targetClanId != ClanWorldConstants.CLAN_ID_NULL, "ClanWorld: invalid bandit target");
+        s.bandits[id].targetClanId = targetClanId;
+        transitionBanditState(s, id, BanditState.Attacking);
     }
 
     function transitionBanditState(LibStorage.AppStorage storage s, uint32 id, BanditState newState) public {
@@ -90,6 +126,111 @@ library LibBanditLifecycle {
                     && s.world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS);
         }
         return false;
+    }
+
+    function pickBanditAttackTarget(LibStorage.AppStorage storage s, BanditTroop storage bandit)
+        public
+        view
+        returns (uint32 targetClanId)
+    {
+        uint256 bestLootValue;
+
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            Clan storage clan = s.clans[clanId];
+            if (clan.clanState == ClanState.DEAD || clan.baseRegion != bandit.region || clan.livingClansmen == 0) {
+                continue;
+            }
+
+            uint256 lootValue = LibScoring.lootValue(clan);
+            if (targetClanId == ClanWorldConstants.CLAN_ID_NULL || lootValue > bestLootValue) {
+                bestLootValue = lootValue;
+                targetClanId = clanId;
+            } else if (lootValue == bestLootValue && clanId < targetClanId) {
+                targetClanId = clanId;
+            }
+        }
+    }
+
+    function recordBanditAttackAttempt(LibStorage.AppStorage storage s, uint32 banditId)
+        public
+        returns (uint8 attemptsMade)
+    {
+        BanditTroop storage bandit = s.bandits[banditId];
+        if (bandit.id == ClanWorldConstants.BANDIT_ID_NULL) {
+            return 0;
+        }
+        attemptsMade = bandit.attackAttemptsMade + 1;
+        bandit.attackAttemptsMade = attemptsMade;
+    }
+
+    function terminalEscapeBandit(LibStorage.AppStorage storage s, uint32 banditId, uint64 closedTick) public {
+        BanditTroop storage bandit = s.bandits[banditId];
+        if (bandit.id == ClanWorldConstants.BANDIT_ID_NULL) {
+            return;
+        }
+
+        BanditState oldState = bandit.state;
+        emit BanditStateChanged(banditId, oldState, BanditState.Escaped, bandit.region, closedTick);
+        burnBanditCarry(s, banditId);
+        emit BanditEscaped(banditId, closedTick);
+        deleteBandit(s, banditId);
+    }
+
+    function burnBanditCarry(LibStorage.AppStorage storage s, uint32 banditId) public {
+        BanditTroop storage bandit = s.bandits[banditId];
+        uint32[] memory rewardedClanIds = new uint32[](0);
+        emit LootDistributed(
+            banditId,
+            rewardedClanIds,
+            0,
+            0,
+            0,
+            0,
+            0,
+            bandit.carryWood,
+            bandit.carryWheat,
+            bandit.carryFish,
+            bandit.carryIron,
+            bandit.carryGold
+        );
+    }
+
+    function deleteBandit(LibStorage.AppStorage storage s, uint32 id) public {
+        BanditTroop storage bandit = s.bandits[id];
+        uint8 region = bandit.region;
+        uint32[] storage regionBandits = s.banditsByRegion[region];
+        for (uint256 i = 0; i < regionBandits.length; i++) {
+            if (regionBandits[i] == id) {
+                regionBandits[i] = regionBandits[regionBandits.length - 1];
+                regionBandits.pop();
+                break;
+            }
+        }
+
+        delete s.bandits[id];
+        if (s.activeBanditCount > 0) {
+            s.activeBanditCount -= 1;
+        }
+        if (s.world.activeBanditId == id) {
+            s.world.activeBanditId = findOldestActiveBandit(s);
+        }
+    }
+
+    function findOldestActiveBandit(LibStorage.AppStorage storage s) public view returns (uint32 oldestBanditId) {
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            uint32[] storage regionBandits = s.banditsByRegion[region];
+            for (uint256 i = 0; i < regionBandits.length; i++) {
+                uint32 candidateId = regionBandits[i];
+                BanditTroop storage candidate = s.bandits[candidateId];
+                if (candidate.id == ClanWorldConstants.BANDIT_ID_NULL || candidate.state == BanditState.None) {
+                    continue;
+                }
+                if (oldestBanditId == ClanWorldConstants.BANDIT_ID_NULL || candidateId < oldestBanditId) {
+                    oldestBanditId = candidateId;
+                }
+            }
+        }
     }
 
     function moveBanditToRampageNextRegion(LibStorage.AppStorage storage s, uint32 id) public {

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -615,6 +615,32 @@ contract DiamondSkeletonTest is Test {
         assertEq(IClanWorld(address(diamond)).getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, 1);
     }
 
+    function testDiamondHeartbeatRestsCampedBanditWithoutTargetLikeCore() public {
+        CoreBanditHarness core = new CoreBanditHarness();
+        HeartbeatFacet heartbeatFacet = new HeartbeatFacet();
+        SpawnBanditFacet spawnBanditFacet = new SpawnBanditFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_heartbeatCut(address(heartbeatFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_spawnBanditCut(address(spawnBanditFacet)), address(0), "");
+
+        uint32 coreBanditId = core.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        uint32 diamondBanditId = ISpawnBandit(address(diamond)).spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+
+        for (uint256 i = 0; i < 5; i++) {
+            vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+            core.heartbeat();
+            IClanWorld(address(diamond)).heartbeat();
+        }
+
+        _assertWorldStateEq(IClanWorld(address(diamond)).getWorldState(), core.getWorldState());
+        _assertBanditEq(IClanWorld(address(diamond)).getBandit(diamondBanditId), core.getBandit(coreBanditId));
+        assertEq(uint8(IClanWorld(address(diamond)).getBandit(diamondBanditId).state), uint8(BanditState.Resting));
+        assertEq(IClanWorld(address(diamond)).getBandit(diamondBanditId).attackAttemptsMade, 1);
+    }
+
     function testDiamondFinalizeSeasonRejectsBeforeSeasonEndLikeCore() public {
         ClanWorld core = new ClanWorld();
         FinalizeSeasonFacet finalizeSeasonFacet = new FinalizeSeasonFacet();


### PR DESCRIPTION
## Summary
- extend `LibBanditLifecycle` to process camped bandits that are ready to attack
- pick the richest live clan in the bandit region using the same loot-value/tie-break rule as legacy `ClanWorld`
- record failed targeting attempts and terminally escape/delete bandits after max attempts
- add parity coverage for the no-target branch, where a camped bandit rests after one failed attempt

## Scope notes
- This does not resolve attacks once a target is selected; combat is the next slice.
- The positive target path intentionally cannot be full heartbeat-parity tested yet because legacy `ClanWorld` targets and resolves the attack in the same heartbeat.

## Validation
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol --match-test testDiamondHeartbeatRestsCampedBanditWithoutTargetLikeCore`
- `forge test --match-path test/diamond/DiamondSkeleton.t.sol`
- `forge build script/DeployDiamond.s.sol`
- `pnpm --filter @clan-world/contracts run check:abi`
- `forge build --sizes --skip test script | rg "HeartbeatFacet|LibBanditLifecycle|SubmitOrdersFacet|ClanWorld "` (expected legacy `ClanWorld` size failure)