### PR TITLE
fix(contracts): restore diamond settlement parity

### DIFF
--- a/docs/architecture/diamond-pattern.md
+++ b/docs/architecture/diamond-pattern.md
@@ -150,6 +150,20 @@ Cross-facet calls are allowed but should be rare.
    - Deploy to local Anvil, then Base Sepolia.
    - Archive or remove the monolith only after parity is proven.
 
+## Known Intentional Divergence
+
+The monolith contains narrower eager-settle hooks for bandit-related shared
+state. The diamond heartbeat currently settles every live clan before market,
+bandit, and season logic runs, so the same correctness invariant is met for
+normal heartbeat execution without adding another cross-cutting settlement hook
+during the first migration pass.
+
+This is intentionally not final policy. Track the follow-up as a gas and backlog
+hardening item: restore or replace the narrower bandit eager-settle hooks if
+testnet/mainnet profiling shows the global heartbeat settlement pass is too
+expensive or if partial-backlog scenarios need tighter compatibility with the
+monolith implementation.
+
 ## Acceptance Criteria
 
 - Every facet runtime is below `20 KB`; target is below `16 KB`.

--- a/docs/planning/clanworld_v4_2_state_schema_interface_spec.md
+++ b/docs/planning/clanworld_v4_2_state_schema_interface_spec.md
@@ -68,6 +68,14 @@ Before selecting a bandit target in region `R`, the engine must eagerly settle:
 
 This is required so target selection, defense totals, starvation state, and vault values are correct at attack resolution time.
 
+Diamond migration note: the facet implementation currently satisfies this by
+settling all live clans at the start of `heartbeat()` before market, bandit, and
+season logic runs. That is broader than the monolith's region-specific eager
+settle hooks, but preserves the same correctness invariant for normal heartbeat
+operation. Reintroducing narrower bandit eager-settle hooks is intentionally
+tracked as future gas/backlog work rather than part of the first diamond parity
+patch.
+
 ### 2.5 Lazy vs eager settlement
 Settlement is hybrid.
 

--- a/docs/planning/clanworld_v4_spec.md
+++ b/docs/planning/clanworld_v4_spec.md
@@ -130,6 +130,13 @@ The Keeper heartbeat transaction performs the following in order:
 5. increment `currentTick += 1`
 6. publish/store the randomness seed for the newly opened tick
 
+Diamond migration note: during the EIP-2535 migration, the diamond heartbeat
+uses a broader pre-bandit settlement pass over all live clans before resolving
+market, bandit, and season work. This keeps bandit target selection, defense,
+vault, and starvation reads settled without porting the monolith's narrower
+region-specific eager-settle hooks yet. The narrower hooks remain a documented
+future optimization/backlog-hardening item.
+
 The heartbeat conceptually performs:
 - close old tick
 - resolve due effects and events

--- a/packages/contracts/src/diamond/facets/HeartbeatFacet.sol
+++ b/packages/contracts/src/diamond/facets/HeartbeatFacet.sol
@@ -32,6 +32,7 @@ contract HeartbeatFacet is IClanWorldEvents {
             if (s.clans[clanId].clanState != ClanState.DEAD && s.clans[clanId].lastSettledTick <= closedTick) {
                 LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, closedTick + 1);
                 LibSettlement.commitSimulation(s, sim);
+                emit ClanSettled(clanId, s.clans[clanId].lastSettledTick);
             }
         }
 

--- a/packages/contracts/src/diamond/lib/LibSettlement.sol
+++ b/packages/contracts/src/diamond/lib/LibSettlement.sol
@@ -15,6 +15,7 @@ import {
 } from "../../IClanWorld.sol";
 import {RNG} from "../../lib/RNG.sol";
 import {LibGameRules} from "./LibGameRules.sol";
+import {LibOrderDefenders} from "./LibOrderDefenders.sol";
 import {LibStorage} from "./LibStorage.sol";
 import {LibSeason} from "./LibSeason.sol";
 import {LibSettlementMath} from "./LibSettlementMath.sol";
@@ -22,6 +23,9 @@ import {LibSettlementMath} from "./LibSettlementMath.sol";
 library LibSettlement {
     uint8 internal constant WALL_MAX_LEVEL = 5;
     uint8 internal constant BASE_MAX_LEVEL = 5;
+
+    event MissionCompleted(uint32 indexed clanId, uint32 indexed clansmanId, uint64 missionNonce, ActionType action);
+    event WorkerArrived(uint32 indexed clanId, uint32 indexed clansmanId, uint8 region, uint64 tick);
 
     struct SettlementSimulation {
         Clan clan;
@@ -32,6 +36,8 @@ library LibSettlement {
         bool[] simWallReservationCleared;
         bool[] simBaseReservationCleared;
         bool[] simMonumentReservationCleared;
+        uint64[] simWorkerArrivedTick;
+        uint64[] simMissionCompletedNonce;
         uint256 reservedWheat;
     }
 
@@ -49,6 +55,8 @@ library LibSettlement {
         sim.simWallReservationCleared = new bool[](clansmanIds.length);
         sim.simBaseReservationCleared = new bool[](clansmanIds.length);
         sim.simMonumentReservationCleared = new bool[](clansmanIds.length);
+        sim.simWorkerArrivedTick = new uint64[](clansmanIds.length);
+        sim.simMissionCompletedNonce = new uint64[](clansmanIds.length);
 
         for (uint256 i = 0; i < clansmanIds.length; i++) {
             uint32 clansmanId = clansmanIds[i];
@@ -112,6 +120,15 @@ library LibSettlement {
             }
             if (sim.simMonumentReservationCleared[i]) {
                 clearMonumentUpgradeReservation(s, clansmanId);
+            }
+            if (sim.simWorkerArrivedTick[i] != 0) {
+                emit WorkerArrived(clanId, clansmanId, sim.clansmen[i].currentRegion, sim.simWorkerArrivedTick[i]);
+                if (sim.missions[i].active && sim.missions[i].action == ActionType.DefendBase) {
+                    LibOrderDefenders.registerDefender(s, sim.clansmen[i].currentRegion, clanId, clansmanId);
+                }
+            }
+            if (sim.simMissionCompletedNonce[i] != 0) {
+                emit MissionCompleted(clanId, clansmanId, sim.simMissionCompletedNonce[i], sim.missions[i].action);
             }
         }
 
@@ -337,12 +354,17 @@ library LibSettlement {
             if (cs.state == ClansmanState.TRAVELING && tick >= m.arrivalTick) {
                 cs.state = ClansmanState.ACTING;
                 cs.currentRegion = m.targetRegion;
+                sim.simWorkerArrivedTick[index] = tick;
             }
 
             if (m.action == ActionType.DefendBase) continue;
 
             if (cs.state == ClansmanState.ACTING && tick >= m.settlesAtTick) {
+                uint64 nonceBefore = m.nonce;
                 (cs, m) = resolveAction(s, sim, cs, m, tick, tickSeed);
+                if (!m.active) {
+                    sim.simMissionCompletedNonce[index] = nonceBefore;
+                }
                 if (m.active && LibGameRules.actionDuration(m.action) > 0) {
                     m.settlesAtTick = LibSettlementMath.addTicksClamped(tick, LibGameRules.actionDuration(m.action));
                 }
@@ -761,11 +783,10 @@ library LibSettlement {
 
     function completeMission(Clansman memory cs, Mission memory m)
         internal
-        view
+        pure
         returns (Clansman memory, Mission memory)
     {
         cs.state = ClansmanState.WAITING;
-        cs.cooldownEndsAtTs = uint64(block.timestamp) + ClanWorldConstants.CLANSMAN_COOLDOWN_SECONDS;
         m.active = false;
         return (cs, m);
     }

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
 import {DiamondSelectors} from "../../script/DiamondSelectors.sol";
 import {Diamond} from "../../src/diamond/Diamond.sol";
 import {ClanWorld} from "../../src/ClanWorld.sol";
@@ -163,6 +164,10 @@ contract SpawnBanditFacet {
 }
 
 contract DiamondSkeletonTest is Test {
+    bytes32 private constant CLAN_SETTLED_TOPIC = keccak256("ClanSettled(uint32,uint64)");
+    bytes32 private constant MISSION_COMPLETED_TOPIC = keccak256("MissionCompleted(uint32,uint32,uint64,uint8)");
+    bytes32 private constant WORKER_ARRIVED_TOPIC = keccak256("WorkerArrived(uint32,uint32,uint8,uint64)");
+
     Diamond diamond;
     DiamondCutFacet cutFacet;
 
@@ -781,6 +786,137 @@ contract DiamondSkeletonTest is Test {
         );
     }
 
+    function testDiamondHeartbeatCompletionLogsAndCooldownMatchCore() public {
+        ClanWorld core = new ClanWorld();
+        _installLifecycleSubmitHeartbeatFacets();
+
+        address elder = address(0xA11CE);
+        vm.prank(elder);
+        (uint32 coreClanId,) = core.mintClan(elder);
+        vm.prank(elder);
+        (uint32 diamondClanId,) = IClanWorld(address(diamond)).mintClan(elder);
+
+        uint32 coreClansmanId = core.getClanClansmanIds(coreClanId)[0];
+        uint32 diamondClansmanId = IClanWorld(address(diamond)).getClanClansmanIds(diamondClanId)[0];
+        uint8 coreBaseRegion = core.getClan(coreClanId).baseRegion;
+        uint8 diamondBaseRegion = IClanWorld(address(diamond)).getClan(diamondClanId).baseRegion;
+
+        ClanOrder[] memory coreOrders = new ClanOrder[](1);
+        coreOrders[0] = _basicOrder(coreClansmanId, coreBaseRegion, ActionType.DepositResources, 0);
+        ClanOrder[] memory diamondOrders = new ClanOrder[](1);
+        diamondOrders[0] = _basicOrder(diamondClansmanId, diamondBaseRegion, ActionType.DepositResources, 0);
+
+        vm.prank(elder);
+        OrderResult[] memory coreResults = core.submitClanOrders(coreClanId, coreOrders);
+        vm.prank(elder);
+        OrderResult[] memory diamondResults =
+            IClanWorld(address(diamond)).submitClanOrders(diamondClanId, diamondOrders);
+        assertEq(uint8(coreResults[0].status), uint8(StatusCode.OK), "core submit ok");
+        assertEq(uint8(diamondResults[0].status), uint8(StatusCode.OK), "diamond submit ok");
+
+        uint64 submittedCooldown = core.getClansman(coreClansmanId).cooldownEndsAtTs;
+        assertEq(IClanWorld(address(diamond)).getClansman(diamondClansmanId).cooldownEndsAtTs, submittedCooldown);
+
+        uint64 settlesAtTick = core.getActiveMission(coreClansmanId).settlesAtTick;
+        Vm.Log[] memory coreLogs;
+        Vm.Log[] memory diamondLogs;
+        while (core.getWorldState().currentTick <= settlesAtTick) {
+            vm.warp(core.getWorldState().nextHeartbeatAtTs);
+            bool finalHeartbeat = core.getWorldState().currentTick == settlesAtTick;
+            if (finalHeartbeat) vm.recordLogs();
+            core.heartbeat();
+            if (finalHeartbeat) coreLogs = vm.getRecordedLogs();
+            if (finalHeartbeat) vm.recordLogs();
+            IClanWorld(address(diamond)).heartbeat();
+            if (finalHeartbeat) diamondLogs = vm.getRecordedLogs();
+        }
+
+        _assertEventFingerprintMatch(coreLogs, address(core), diamondLogs, address(diamond), CLAN_SETTLED_TOPIC);
+        _assertEventFingerprintMatch(
+            coreLogs, address(core), diamondLogs, address(diamond), MISSION_COMPLETED_TOPIC
+        );
+        _assertClansmanEq(IClanWorld(address(diamond)).getClansman(diamondClansmanId), core.getClansman(coreClansmanId));
+        assertEq(core.getClansman(coreClansmanId).cooldownEndsAtTs, submittedCooldown, "core cooldown unchanged");
+        assertEq(
+            IClanWorld(address(diamond)).getClansman(diamondClansmanId).cooldownEndsAtTs,
+            submittedCooldown,
+            "diamond cooldown unchanged"
+        );
+    }
+
+    function testDiamondTraveledDefenderArrivalLogsAndRegistryMatchCore() public {
+        ClanWorld core = new ClanWorld();
+        _installLifecycleSubmitHeartbeatFacets();
+
+        address defenderElder = address(0xA11CE);
+        address targetElder = address(0xB0B);
+        vm.prank(defenderElder);
+        (uint32 coreDefenderClanId,) = core.mintClan(defenderElder);
+        vm.prank(targetElder);
+        (uint32 coreTargetClanId,) = core.mintClan(targetElder);
+        vm.prank(defenderElder);
+        (uint32 diamondDefenderClanId,) = IClanWorld(address(diamond)).mintClan(defenderElder);
+        vm.prank(targetElder);
+        (uint32 diamondTargetClanId,) = IClanWorld(address(diamond)).mintClan(targetElder);
+
+        uint32 coreClansmanId = core.getClanClansmanIds(coreDefenderClanId)[0];
+        uint32 diamondClansmanId = IClanWorld(address(diamond)).getClanClansmanIds(diamondDefenderClanId)[0];
+        uint8 coreTargetRegion = core.getClan(coreTargetClanId).baseRegion;
+        uint8 diamondTargetRegion = IClanWorld(address(diamond)).getClan(diamondTargetClanId).baseRegion;
+
+        ClanOrder[] memory coreOrders = new ClanOrder[](1);
+        coreOrders[0] = _basicOrder(coreClansmanId, coreTargetRegion, ActionType.DefendBase, coreTargetClanId);
+        ClanOrder[] memory diamondOrders = new ClanOrder[](1);
+        diamondOrders[0] =
+            _basicOrder(diamondClansmanId, diamondTargetRegion, ActionType.DefendBase, diamondTargetClanId);
+
+        vm.prank(defenderElder);
+        OrderResult[] memory coreResults = core.submitClanOrders(coreDefenderClanId, coreOrders);
+        vm.prank(defenderElder);
+        OrderResult[] memory diamondResults =
+            IClanWorld(address(diamond)).submitClanOrders(diamondDefenderClanId, diamondOrders);
+        assertEq(uint8(coreResults[0].status), uint8(StatusCode.OK), "core defend submit ok");
+        assertEq(uint8(diamondResults[0].status), uint8(StatusCode.OK), "diamond defend submit ok");
+        assertGt(core.getActiveMission(coreClansmanId).arrivalTick, core.getWorldState().currentTick, "traveling setup");
+        assertEq(core.getDefendingClans(coreTargetRegion).length, 0, "core not registered before arrival");
+        assertEq(IClanWorld(address(diamond)).getDefendingClans(diamondTargetRegion).length, 0, "diamond not registered before arrival");
+
+        uint64 arrivalTick = core.getActiveMission(coreClansmanId).arrivalTick;
+        Vm.Log[] memory coreLogs;
+        Vm.Log[] memory diamondLogs;
+        while (core.getWorldState().currentTick <= arrivalTick) {
+            vm.warp(core.getWorldState().nextHeartbeatAtTs);
+            bool finalHeartbeat = core.getWorldState().currentTick == arrivalTick;
+            if (finalHeartbeat) vm.recordLogs();
+            core.heartbeat();
+            if (finalHeartbeat) coreLogs = vm.getRecordedLogs();
+            if (finalHeartbeat) vm.recordLogs();
+            IClanWorld(address(diamond)).heartbeat();
+            if (finalHeartbeat) diamondLogs = vm.getRecordedLogs();
+        }
+
+        _assertEventFingerprintMatch(coreLogs, address(core), diamondLogs, address(diamond), WORKER_ARRIVED_TOPIC);
+        _assertClansmanEq(IClanWorld(address(diamond)).getClansman(diamondClansmanId), core.getClansman(coreClansmanId));
+        _assertMissionEq(
+            IClanWorld(address(diamond)).getActiveMission(diamondClansmanId), core.getActiveMission(coreClansmanId)
+        );
+        assertEq(
+            IClanWorld(address(diamond)).getClansmanDefendingRegion(diamondClansmanId),
+            core.getClansmanDefendingRegion(coreClansmanId),
+            "defending region"
+        );
+
+        uint32[] memory coreActiveDefenders = core.getActiveDefenders(coreTargetClanId);
+        uint32[] memory diamondActiveDefenders = IClanWorld(address(diamond)).getActiveDefenders(diamondTargetClanId);
+        assertEq(diamondActiveDefenders.length, coreActiveDefenders.length, "active defender length");
+        assertEq(diamondActiveDefenders[0], coreActiveDefenders[0], "active defender id");
+
+        uint32[] memory coreDefendingClans = core.getDefendingClans(coreTargetRegion);
+        uint32[] memory diamondDefendingClans = IClanWorld(address(diamond)).getDefendingClans(diamondTargetRegion);
+        assertEq(diamondDefendingClans.length, coreDefendingClans.length, "defending clan length");
+        assertEq(diamondDefendingClans[0], coreDefendingClans[0], "defending clan id");
+    }
+
     function testDiamondTransferClanOwnershipMatchesCoreAfterSettlement() public {
         ClanWorld core = new ClanWorld();
         ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
@@ -1005,6 +1141,62 @@ contract DiamondSkeletonTest is Test {
 
         _assertClanEq(IClanWorld(address(diamond)).getClan(diamondFromClanId), core.getClan(coreFromClanId));
         _assertClanEq(IClanWorld(address(diamond)).getClan(diamondToClanId), core.getClan(coreToClanId));
+    }
+
+    function _installLifecycleSubmitHeartbeatFacets() internal {
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        SubmitOrdersFacet submitOrdersFacet = new SubmitOrdersFacet();
+        HeartbeatFacet heartbeatFacet = new HeartbeatFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_submitOrdersCut(address(submitOrdersFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_heartbeatCut(address(heartbeatFacet)), address(0), "");
+    }
+
+    function _basicOrder(uint32 clansmanId, uint8 gotoRegion, ActionType action, uint32 targetClanId)
+        internal
+        pure
+        returns (ClanOrder memory)
+    {
+        return ClanOrder({
+            clansmanId: clansmanId,
+            gotoRegion: gotoRegion,
+            action: action,
+            targetClanId: targetClanId,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
+        });
+    }
+
+    function _assertEventFingerprintMatch(
+        Vm.Log[] memory coreLogs,
+        address coreEmitter,
+        Vm.Log[] memory diamondLogs,
+        address diamondEmitter,
+        bytes32 topic0
+    ) internal pure {
+        bytes32 coreFingerprint = _singleEventFingerprint(coreLogs, coreEmitter, topic0);
+        bytes32 diamondFingerprint = _singleEventFingerprint(diamondLogs, diamondEmitter, topic0);
+        assertEq(diamondFingerprint, coreFingerprint, "event fingerprint");
+    }
+
+    function _singleEventFingerprint(Vm.Log[] memory logs, address emitter, bytes32 topic0)
+        internal
+        pure
+        returns (bytes32 fingerprint)
+    {
+        uint256 matches;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != emitter || logs[i].topics.length == 0 || logs[i].topics[0] != topic0) continue;
+            fingerprint = keccak256(abi.encode(logs[i].topics, logs[i].data));
+            matches++;
+        }
+        assertEq(matches, 1, "event count");
     }
 
     function _rawViewsCut() internal returns (IDiamondCut.FacetCut[] memory cut) {


### PR DESCRIPTION
## Summary

- Fix diamond natural mission completion so it does not refresh submit cooldowns.
- Emit `WorkerArrived`, `MissionCompleted`, and heartbeat `ClanSettled` from committed diamond settlement paths.
- Register traveled `DefendBase` defenders when their arrival settlement is committed.
- Add production-facet diamond/core log parity tests for mission completion and traveled defender arrival.
- Document the intentional diamond eager-settle divergence and track narrower hooks in #465.

## Validation

- `forge test --match-path test/diamond/DiamondSkeleton.t.sol -vv` — 30 passed
- `forge test -vv` — 399 passed
- `forge build --sizes` — deployable facets under EIP-170; exits nonzero because legacy monolith/test harnesses exceed the runtime size limit as expected

## Size Notes

- `LibSubmitOrders`: 23,687 bytes, 889 byte runtime margin
- `HeartbeatFacet`: 19,105 bytes, 5,471 byte runtime margin
- `SettlementFacet`: 16,892 bytes, 7,684 byte runtime margin

Closes #465? No — #465 tracks the future narrower eager-settle optimization, so this PR intentionally leaves it open.
