### PR TITLE
release: v2.0.1 — dead-target cleanup helper consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [2.0.1] — 2026-05-02
+
+### Fixed
+
+- **Dead-target cleanup helpers consolidated in `LibBanditCombat`** (PR #469). `releaseDefendersForDeadTarget` + `abortBanditAttacksForDeadTarget` were literally duplicated between `LibBanditCombat` (`public`) and `LibSettlement` (`internal`) after the round-1 SuperSwarm `markClanDead` parity fix. Both opus 4.6 + opus 4.7 r2 reviews flagged the silent-divergence risk: any future change to one copy without the other would re-create the round-1 parity break. Canonical copy now lives in `LibBanditCombat`; `LibSettlement` calls into it. Both functions changed from `public` to `internal` — gets inlined into callers, saves ~700 gas per call vs DELEGATECALL (also addresses opus 4.6 / opus 4.7 r2 MEDIUM about library function visibility). All 58 diamond parity tests pass.
+
+### Still queued for future patch releases
+
+The remaining v2.0.1-target items from the v2.0.0 changelog (lazy-settlement clan death event-emission parity, `_settleClan` 6× duplication, 41 library functions `public→internal` sweep, storage layout field-offset snapshot, `bac7c6a` write-then-overwrite refactor, `MAX_CROP_TRANSITION_PER_TICK` access-modifier parity, `LibDiamond.setContractOwner` zero-address guard) ship in subsequent patch releases.
+
+---
+
 ## [2.0.0] — 2026-05-02
 
 ### Highlights

--- a/packages/contracts/src/diamond/lib/LibBanditCombat.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditCombat.sol
@@ -498,7 +498,7 @@ library LibBanditCombat {
         emit ClanDied(clanId, tick, reason);
     }
 
-    function releaseDefendersForDeadTarget(LibStorage.AppStorage storage s, uint32 deadClanId, uint8 baseRegion) public {
+    function releaseDefendersForDeadTarget(LibStorage.AppStorage storage s, uint32 deadClanId, uint8 baseRegion) internal {
         for (uint256 i = 0; i < s.allClanIds.length; i++) {
             uint32 defenderClanId = s.allClanIds[i];
             if (defenderClanId == deadClanId) continue;
@@ -529,7 +529,7 @@ library LibBanditCombat {
         uint32 deadClanId,
         uint32 excludedBanditId,
         uint64 tick
-    ) public {
+    ) internal {
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
             uint32[] storage regionBandits = s.banditsByRegion[region];
             for (uint256 i = 0; i < regionBandits.length; i++) {

--- a/packages/contracts/src/diamond/lib/LibSettlement.sol
+++ b/packages/contracts/src/diamond/lib/LibSettlement.sol
@@ -16,6 +16,7 @@ import {
     WheatPlotState
 } from "../../IClanWorld.sol";
 import {RNG} from "../../lib/RNG.sol";
+import {LibBanditCombat} from "./LibBanditCombat.sol";
 import {LibBanditLifecycle} from "./LibBanditLifecycle.sol";
 import {LibGameRules} from "./LibGameRules.sol";
 import {LibOrderDefenders} from "./LibOrderDefenders.sol";
@@ -58,8 +59,8 @@ library LibSettlement {
         uint256 fishDelta,
         uint64 atTick
     );
-    event BanditEscaped(uint32 indexed banditId, uint64 atTick);
-    event BanditTargetDied(uint32 indexed banditId, uint32 indexed deadClanId, uint64 tick);
+    // BanditEscaped + BanditTargetDied moved to LibBanditCombat (canonical
+    // emitter post-dedup). Same event signatures; ABI consumers unaffected.
 
     enum SettlementLogKind {
         None,
@@ -206,8 +207,10 @@ library LibSettlement {
         s.reservedWheatByClan[clanId] = sim.reservedWheat;
         s.reservedBlueprintByClan[clanId] = sim.reservedBlueprint;
         if (sim.simClanDied) {
-            releaseDefendersForDeadTarget(s, clanId, sim.clan.baseRegion);
-            abortBanditAttacksForDeadTarget(s, clanId, ClanWorldConstants.BANDIT_ID_NULL, sim.clan.lastSettledTick);
+            LibBanditCombat.releaseDefendersForDeadTarget(s, clanId, sim.clan.baseRegion);
+            LibBanditCombat.abortBanditAttacksForDeadTarget(
+                s, clanId, ClanWorldConstants.BANDIT_ID_NULL, sim.clan.lastSettledTick
+            );
         }
         for (uint8 level = 1; level < sim.simMonumentReachedAt.length; level++) {
             if (sim.simMonumentReachedAt[level] != 0 && s.monumentLevelReachedAt[clanId][level] == 0) {
@@ -1025,53 +1028,11 @@ library LibSettlement {
         return (cs, m);
     }
 
-    function releaseDefendersForDeadTarget(LibStorage.AppStorage storage s, uint32 deadClanId, uint8 baseRegion) internal {
-        for (uint256 i = 0; i < s.allClanIds.length; i++) {
-            uint32 defenderClanId = s.allClanIds[i];
-            if (defenderClanId == deadClanId) continue;
-
-            uint32[] storage csIds = s.clanClansmanIds[defenderClanId];
-            for (uint256 j = 0; j < csIds.length; j++) {
-                uint32 clansmanId = csIds[j];
-                Mission storage mission = s.missions[clansmanId];
-                if (
-                    mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == deadClanId
-                ) {
-                    if (s.clansmanDefendingRegion[clansmanId] == baseRegion) {
-                        LibOrderDefenders.clearDefender(s, clansmanId);
-                    }
-                    mission.active = false;
-
-                    Clansman storage defender = s.clansmen[clansmanId];
-                    if (defender.state != ClansmanState.DEAD) {
-                        defender.state = ClansmanState.WAITING;
-                    }
-                }
-            }
-        }
-    }
-
-    function abortBanditAttacksForDeadTarget(
-        LibStorage.AppStorage storage s,
-        uint32 deadClanId,
-        uint32 excludedBanditId,
-        uint64 tick
-    ) internal {
-        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
-            uint32[] storage regionBandits = s.banditsByRegion[region];
-            for (uint256 i = 0; i < regionBandits.length; i++) {
-                uint32 banditId = regionBandits[i];
-                if (banditId == excludedBanditId) continue;
-
-                BanditTroop storage bandit = s.bandits[banditId];
-                if (bandit.state == BanditState.Attacking && bandit.targetClanId == deadClanId) {
-                    LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Escaped);
-                    emit BanditEscaped(banditId, tick);
-                    emit BanditTargetDied(banditId, deadClanId, tick);
-                }
-            }
-        }
-    }
+    // releaseDefendersForDeadTarget + abortBanditAttacksForDeadTarget were
+    // duplicated here and in LibBanditCombat. Both copies were functionally
+    // identical, which silently re-creates the round-1 markClanDead parity-
+    // break risk if one copy is patched without the other. Canonical home is
+    // now LibBanditCombat (post-merge dedup per opus 4.6 / opus 4.7 r2 review).
 
     function clearWallUpgradeReservation(LibStorage.AppStorage storage s, uint32 clansmanId) internal {
         LibStorage.WallUpgradeReservation storage reservation = s.wallUpgradeReservations[clansmanId];


### PR DESCRIPTION
## Summary

v2.0.1 patch release. Lands PR #469 (helper consolidation) into main.

The dedup fix removes a silent-divergence risk surfaced by SuperSwarm round 2 on PR #468 — `releaseDefendersForDeadTarget` + `abortBanditAttacksForDeadTarget` were literally duplicated between `LibBanditCombat` (public) and `LibSettlement` (internal). Canonical copy now in `LibBanditCombat` as `internal` (~700 gas saved per call). All 58 diamond parity tests pass.

## Test plan
- [x] `forge build` green
- [x] `forge test --match-path test/diamond/**` — 58 tests pass
- [ ] CI green
- [ ] Tag `v2.0.1` on merge commit + cut GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)