### PR TITLE
fix(runner): rename OG_STORAGE_API_KEY → OG_STORAGE_ENABLED

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -85,10 +85,10 @@ ELDER_2_CLAN_ID=
 ELDER_3_CLAN_ID=
 ELDER_4_CLAN_ID=
 
-# 0G memory adapter — set OG_STORAGE_API_KEY to ANY non-empty value to enable
-# 0G KV mode. Currently a feature flag, NOT used for SDK auth (auth comes from
-# ELDER_MNEMONIC-derived wallets). Empty/unset = falls back to FileMemoryStore.
-OG_STORAGE_API_KEY=
+# 0G memory adapter — set OG_STORAGE_ENABLED to ANY non-empty value to enable
+# 0G KV mode. This is a feature flag, NOT a credential. Real auth comes from
+# ELDER_MNEMONIC-derived wallets. Empty/unset = falls back to FileMemoryStore.
+OG_STORAGE_ENABLED=
 OG_STREAM_ID=
 
 # AXL peer transport — set both AXL_API_KEY and AXL_NETWORK_ID to enable AXL

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ docs/planning/V1/
 .git-local/
 .git.worktree-link
 .claude/.active-chat
+.claude/worktrees/

--- a/packages/runner/.env.example
+++ b/packages/runner/.env.example
@@ -41,7 +41,7 @@ ELDER_4_CLAN_ID=4
 # 0G Storage — enables durable 0G iNFT memory (ERC-7857 linked storage).
 # If unset, the runner falls back to a local JSON file at
 #   ~/.world/clanworld-runner/state/elder-{N}-memory.json
-OG_STORAGE_API_KEY=        # Set to any non-empty value to enable 0G durable memory
+OG_STORAGE_ENABLED=        # Set to any non-empty value to enable 0G durable memory
 
 # 0G Mainnet config (Aristotle / chain ID 16661)
 EVM_RPC=https://evmrpc.0g.ai

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -103,7 +103,7 @@ The runner uses `IElderMemoryStore` for durable Elder memory across `/clear` con
 
 ### Local file (default)
 
-When `OG_STORAGE_API_KEY` is **not** set the runner uses `FileMemoryStore` — a local JSON file at:
+When `OG_STORAGE_ENABLED` is **not** set the runner uses `FileMemoryStore` — a local JSON file at:
 
 ```
 ~/.world/clanworld-runner/state/elder-{N}-memory.json
@@ -113,13 +113,13 @@ No extra config required.
 
 ### 0G iNFT storage (Phase 7)
 
-When `OG_STORAGE_API_KEY` is set the runner uses `ZeroGMemoryStore`, backed by the [0G KV network](https://docs.0g.ai).
+When `OG_STORAGE_ENABLED` is set the runner uses `ZeroGMemoryStore`, backed by the [0G KV network](https://docs.0g.ai).
 
 Required env vars:
 
 | Variable | Description |
 |---|---|
-| `OG_STORAGE_API_KEY` | 0G API key — enables 0G backend |
+| `OG_STORAGE_ENABLED` | Feature flag — set to any non-empty value to enable the 0G backend (real auth comes from `ELDER_MNEMONIC`) |
 | `OG_STREAM_ID` | KV stream ID scoped to this clan (UUID or hex address) |
 | `EVM_RPC` | 0G EVM RPC endpoint (default: `https://evmrpc.0g.ai`) |
 | `INDEXER_RPC` | 0G Indexer RPC endpoint (default: `https://indexer-storage-turbo.0g.ai`) |
@@ -177,7 +177,7 @@ without throwing. Existing file-based flows are unaffected.
 pnpm test
 ```
 
-Tests cover both fallback (file-based) and mocked-adapter paths. No AXL node, 0G API key, or live credentials are required to run the test suite.
+Tests cover both fallback (file-based) and mocked-adapter paths. No AXL node, 0G credentials, or live mnemonic are required to run the test suite.
 
 ## Known TODOs
 

--- a/packages/runner/src/main.ts
+++ b/packages/runner/src/main.ts
@@ -78,7 +78,7 @@ async function main(): Promise<void> {
   console.log(`[runner] starting ClanWorld runner daemon at ${new Date().toISOString()}`);
 
   const config = loadConfig();
-  const memoryBackend = process.env['OG_STORAGE_API_KEY'] ? '0G-KV' : 'local-file';
+  const memoryBackend = process.env['OG_STORAGE_ENABLED'] ? '0G-KV' : 'local-file';
   const peerBackend =
     process.env['AXL_API_KEY'] && process.env['AXL_NETWORK_ID'] ? 'axl' : 'file';
   console.log('[runner] config:', {
@@ -98,7 +98,7 @@ async function main(): Promise<void> {
   const perElder = {} as Record<ElderId, PerElderDeps>;
   for (const elder of ELDER_IDS) {
     const clanId = config.elderToClanId[elder];
-    // Memory adapter selection: ZeroGMemoryStore if OG_STORAGE_API_KEY is set,
+    // Memory adapter selection: ZeroGMemoryStore if OG_STORAGE_ENABLED is set,
     // FileMemoryStore otherwise. Pass elderIndex explicitly so we don't depend
     // on ELDER_INDEX env (the runner serves all 4 Elders, not just one).
     const memory = await createMemoryStore({ elderIndex: elder, stateDir: config.stateDir });

--- a/packages/runner/src/zeroGMemoryStore.ts
+++ b/packages/runner/src/zeroGMemoryStore.ts
@@ -282,7 +282,7 @@ export interface ZeroGMemoryStoreOptions {
 /**
  * Create a memory store.
  *
- * - If OG_STORAGE_API_KEY is set → ZeroGMemoryStore backed by 0G mainnet.
+ * - If OG_STORAGE_ENABLED is set → ZeroGMemoryStore backed by 0G mainnet.
  * - Otherwise → FileMemoryStore (local JSON fallback).
  *
  * 0G path reads startup cache from disk (same JSON file as FileMemoryStore)
@@ -315,14 +315,14 @@ export async function createMemoryStore(
     }
   }
 
-  const apiKey = env['OG_STORAGE_API_KEY'];
+  const enabled = env['OG_STORAGE_ENABLED'];
 
-  // ELDER_MNEMONIC validation gated on OG_STORAGE_API_KEY — local/file mode skips entirely.
-  if (apiKey) {
+  // ELDER_MNEMONIC validation gated on OG_STORAGE_ENABLED — local/file mode skips entirely.
+  if (enabled) {
     const mnemonic = env['ELDER_MNEMONIC'] ?? '';
     if (!mnemonic.trim()) {
       throw new ZeroGValidationError(
-        'ELDER_MNEMONIC is required when OG_STORAGE_API_KEY is set',
+        'ELDER_MNEMONIC is required when OG_STORAGE_ENABLED is set',
         'ELDER_MNEMONIC',
       );
     }
@@ -335,9 +335,9 @@ export async function createMemoryStore(
     }
   }
 
-  if (!apiKey) {
+  if (!enabled) {
     console.warn(
-      '[ZeroGMemoryStore] OG_STORAGE_API_KEY not set — falling back to local JSON file store.',
+      '[ZeroGMemoryStore] OG_STORAGE_ENABLED not set — falling back to local JSON file store.',
     );
     const n = opts.elderIndex ?? parseInt(env['ELDER_INDEX'] ?? '1', 10);
     return new FileMemoryStore(n, opts.stateDir ?? defaultStateDir());

--- a/packages/runner/test/zeroGMemoryStore.test.ts
+++ b/packages/runner/test/zeroGMemoryStore.test.ts
@@ -70,7 +70,7 @@ function makeFactory(store: BatcherStore, fail?: Error): BatcherFactory {
   return async () => makeMockBatcher(store, fail);
 }
 
-// Valid 12-word mnemonic for tests requiring OG_STORAGE_API_KEY.
+// Valid 12-word mnemonic for tests requiring OG_STORAGE_ENABLED.
 const VALID_MNEMONIC = 'one two three four five six seven eight nine ten eleven twelve';
 
 // ---------------------------------------------------------------------------
@@ -116,11 +116,11 @@ describe('FileMemoryStore', () => {
 });
 
 // ---------------------------------------------------------------------------
-// createMemoryStore — fallback when OG_STORAGE_API_KEY is not set
+// createMemoryStore — fallback when OG_STORAGE_ENABLED is not set
 // ---------------------------------------------------------------------------
 
-describe('createMemoryStore — fallback path (no API key)', () => {
-  it('returns a FileMemoryStore when OG_STORAGE_API_KEY is absent', async () => {
+describe('createMemoryStore — fallback path (flag unset)', () => {
+  it('returns a FileMemoryStore when OG_STORAGE_ENABLED is absent', async () => {
     const sd = stateDir();
     const store = await createMemoryStore({ env: { ELDER_INDEX: '2' }, elderIndex: 2, stateDir: sd });
     expect(store).toBeInstanceOf(FileMemoryStore);
@@ -265,7 +265,7 @@ describe('ZeroGMemoryStore — mocked batcher', () => {
     const store2 = new ZeroGMemoryStore(STREAM_ID, makeFactory(remoteStore), {}, cp2);
     // Construction re-uses initialCache param — test via createMemoryStore path:
     const store3 = await createMemoryStore({
-      env: { OG_STORAGE_API_KEY: 'set', ELDER_INDEX: '1', ELDER_MNEMONIC: VALID_MNEMONIC },
+      env: { OG_STORAGE_ENABLED: 'set', ELDER_INDEX: '1', ELDER_MNEMONIC: VALID_MNEMONIC },
       elderIndex: 1,
       stateDir: sd2,
       batcherFactory: makeFactory(remoteStore),
@@ -331,7 +331,7 @@ describe('createMemoryStore — startup error handling', () => {
 
     await expect(
       createMemoryStore({
-        env: { OG_STORAGE_API_KEY: 'set', ELDER_INDEX: '1', ELDER_MNEMONIC: VALID_MNEMONIC },
+        env: { OG_STORAGE_ENABLED: 'set', ELDER_INDEX: '1', ELDER_MNEMONIC: VALID_MNEMONIC },
         elderIndex: 1,
         stateDir: sd,
         batcherFactory: async () => makeMockBatcher(new Map()),
@@ -339,10 +339,10 @@ describe('createMemoryStore — startup error handling', () => {
     ).rejects.toThrow('failed to parse disk cache');
   });
 
-  it('returns ZeroGMemoryStore when OG_STORAGE_API_KEY is set', async () => {
+  it('returns ZeroGMemoryStore when OG_STORAGE_ENABLED is set', async () => {
     const sd = stateDir();
     const store = await createMemoryStore({
-      env: { OG_STORAGE_API_KEY: 'test-key', ELDER_INDEX: '1', ELDER_MNEMONIC: VALID_MNEMONIC },
+      env: { OG_STORAGE_ENABLED: 'test-key', ELDER_INDEX: '1', ELDER_MNEMONIC: VALID_MNEMONIC },
       elderIndex: 1,
       stateDir: sd,
       batcherFactory: makeFactory(new Map()),
@@ -350,19 +350,19 @@ describe('createMemoryStore — startup error handling', () => {
     expect(store).toBeInstanceOf(ZeroGMemoryStore);
   });
 
-  it('falls back to FileMemoryStore when OG_STORAGE_API_KEY is absent', async () => {
+  it('falls back to FileMemoryStore when OG_STORAGE_ENABLED is absent', async () => {
     const sd = stateDir();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const store = await createMemoryStore({ env: {}, elderIndex: 1, stateDir: sd });
     expect(store).toBeInstanceOf(FileMemoryStore);
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('OG_STORAGE_API_KEY not set'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('OG_STORAGE_ENABLED not set'));
   });
 
   it('OG_STREAM_ID defaults to ethers.id("clanworld-elder-memory") when unset', async () => {
     const sd = stateDir();
     // Just verifying no error thrown and ZeroGMemoryStore returned.
     const store = await createMemoryStore({
-      env: { OG_STORAGE_API_KEY: 'set', ELDER_INDEX: '1', ELDER_MNEMONIC: VALID_MNEMONIC },
+      env: { OG_STORAGE_ENABLED: 'set', ELDER_INDEX: '1', ELDER_MNEMONIC: VALID_MNEMONIC },
       elderIndex: 1,
       stateDir: sd,
       batcherFactory: makeFactory(new Map()),
@@ -380,7 +380,7 @@ describe('createMemoryStore — 0G path full contract', () => {
     const sd = stateDir();
     const backend = new Map<string, string>();
     const store = await createMemoryStore({
-      env: { OG_STORAGE_API_KEY: 'test-key', OG_STREAM_ID: 'stream-abc', ELDER_INDEX: '1', ELDER_MNEMONIC: VALID_MNEMONIC },
+      env: { OG_STORAGE_ENABLED: 'test-key', OG_STREAM_ID: 'stream-abc', ELDER_INDEX: '1', ELDER_MNEMONIC: VALID_MNEMONIC },
       elderIndex: 1,
       stateDir: sd,
       batcherFactory: makeFactory(backend),
@@ -421,7 +421,7 @@ describe('HIGH 1 — elderIndex key passes through to wallet path', () => {
     const sd = stateDir();
     const backend = new Map<string, string>();
     const store = await createMemoryStore({
-      env: { OG_STORAGE_API_KEY: 'set', ELDER_INDEX: '2', ELDER_MNEMONIC: VALID_MNEMONIC },
+      env: { OG_STORAGE_ENABLED: 'set', ELDER_INDEX: '2', ELDER_MNEMONIC: VALID_MNEMONIC },
       elderIndex: 2,
       stateDir: sd,
       batcherFactory: makeFactory(backend),
@@ -500,12 +500,12 @@ describe('MED 3 — fail-fast validation at createMemoryStore() time', () => {
     expect((err as ZeroGValidationError).code).toBe('ELDER_INDEX');
   });
 
-  it('mnemonic with 11 words throws (0G mode only — OG_STORAGE_API_KEY set)', async () => {
-    // Validation only runs when OG_STORAGE_API_KEY is present — local mode ignores mnemonic.
+  it('mnemonic with 11 words throws (0G mode only — OG_STORAGE_ENABLED set)', async () => {
+    // Validation only runs when OG_STORAGE_ENABLED is present — local mode ignores mnemonic.
     const badMnemonic = 'one two three four five six seven eight nine ten eleven';
     await expect(
       createMemoryStore({
-        env: { ELDER_INDEX: '1', ELDER_MNEMONIC: badMnemonic, OG_STORAGE_API_KEY: 'test-key' },
+        env: { ELDER_INDEX: '1', ELDER_MNEMONIC: badMnemonic, OG_STORAGE_ENABLED: 'test-key' },
         elderIndex: 1,
         stateDir: stateDir(),
       }),
@@ -515,7 +515,7 @@ describe('MED 3 — fail-fast validation at createMemoryStore() time', () => {
   it('mnemonic with 12 words is accepted (no throw)', async () => {
     const mnemonic12 = 'one two three four five six seven eight nine ten eleven twelve';
     const sd = stateDir();
-    // No OG_STORAGE_API_KEY → falls back to FileMemoryStore; just check no validation throw.
+    // No OG_STORAGE_ENABLED → falls back to FileMemoryStore; just check no validation throw.
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const store = await createMemoryStore({
       env: { ELDER_INDEX: '1', ELDER_MNEMONIC: mnemonic12 },
@@ -571,15 +571,15 @@ describe('MED 4 — exec() returning [null, null] throws', () => {
 });
 
 // ---------------------------------------------------------------------------
-// MED 5 — ELDER_MNEMONIC required at createMemoryStore() when API key set
+// MED 5 — ELDER_MNEMONIC required at createMemoryStore() when 0G flag set
 // ---------------------------------------------------------------------------
 
 describe('MED 5 — ELDER_MNEMONIC required at createMemoryStore() time', () => {
   it('MED 5 — missing ELDER_MNEMONIC throws ZeroGValidationError at createMemoryStore() (not at save())', async () => {
     const sd = stateDir();
-    // OG_STORAGE_API_KEY is set but ELDER_MNEMONIC is absent.
+    // OG_STORAGE_ENABLED is set but ELDER_MNEMONIC is absent.
     const err = await createMemoryStore({
-      env: { OG_STORAGE_API_KEY: 'set', ELDER_INDEX: '1' },
+      env: { OG_STORAGE_ENABLED: 'set', ELDER_INDEX: '1' },
       elderIndex: 1,
       stateDir: sd,
       batcherFactory: makeFactory(new Map()),
@@ -592,7 +592,7 @@ describe('MED 5 — ELDER_MNEMONIC required at createMemoryStore() time', () => 
   it('MED 5 — empty ELDER_MNEMONIC throws ZeroGValidationError', async () => {
     const sd = stateDir();
     const err = await createMemoryStore({
-      env: { OG_STORAGE_API_KEY: 'set', ELDER_INDEX: '1', ELDER_MNEMONIC: '   ' },
+      env: { OG_STORAGE_ENABLED: 'set', ELDER_INDEX: '1', ELDER_MNEMONIC: '   ' },
       elderIndex: 1,
       stateDir: sd,
     }).catch(e => e as unknown);
@@ -604,7 +604,7 @@ describe('MED 5 — ELDER_MNEMONIC required at createMemoryStore() time', () => 
     const sd = stateDir();
     const badMnemonic = 'one two three four five six seven eight nine ten eleven';
     const err = await createMemoryStore({
-      env: { OG_STORAGE_API_KEY: 'set', ELDER_INDEX: '1', ELDER_MNEMONIC: badMnemonic },
+      env: { OG_STORAGE_ENABLED: 'set', ELDER_INDEX: '1', ELDER_MNEMONIC: badMnemonic },
       elderIndex: 1,
       stateDir: sd,
     }).catch(e => e as unknown);
@@ -773,7 +773,7 @@ describe('r6 HIGH — buildRealBatcherFactory uses opts.elderIndex, not process.
     // process.env.ELDER_INDEX is NOT set; opts.elderIndex=2 is the only source.
     const store = await createMemoryStore({
       env: {
-        OG_STORAGE_API_KEY: 'key',
+        OG_STORAGE_ENABLED: 'key',
         OG_STREAM_ID: 'stream-id',
         ELDER_MNEMONIC: 'one two three four five six seven eight nine ten eleven twelve',
         // No ELDER_INDEX in env — opts.elderIndex must be the sole source.
@@ -816,10 +816,10 @@ describe('r6 MED — main.ts parseInt removed: raw "1.5" string must throw', () 
 });
 
 describe('r6 MED — local-mode: no ELDER_MNEMONIC → createMemoryStore succeeds (FileMemoryStore)', () => {
-  it('OG_STORAGE_API_KEY unset + no ELDER_MNEMONIC → returns FileMemoryStore (no throw)', async () => {
+  it('OG_STORAGE_ENABLED unset + no ELDER_MNEMONIC → returns FileMemoryStore (no throw)', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const store = await createMemoryStore({
-      env: { ELDER_INDEX: '1' }, // no OG_STORAGE_API_KEY, no ELDER_MNEMONIC
+      env: { ELDER_INDEX: '1' }, // no OG_STORAGE_ENABLED, no ELDER_MNEMONIC
       elderIndex: 1,
       stateDir: stateDir(),
     });


### PR DESCRIPTION
## Summary

Renames the misleadingly-named `OG_STORAGE_API_KEY` env var to `OG_STORAGE_ENABLED` and rewrites the misleading "0G API key" docs.

## Why

Per PR #136 review item #5 (HIGH security/docs): the var is a **feature flag**, not an API credential. It is never passed to any 0G SDK call — only its **presence** gates the 0G mode branch. Real auth comes from `ELDER_MNEMONIC`-derived wallets. The `API_KEY` suffix mislead operators about the security posture.

Confirmed today in chat that there is in fact no 0G API key to obtain anywhere — auth is entirely mnemonic-driven against 0G mainnet RPC endpoints.

## Files touched
- `.env.template` — rename + comment cleanup
- `packages/runner/.env.example`
- `packages/runner/README.md` — rename + rewrote misleading "0G API key" row + test-suite caveat
- `packages/runner/src/zeroGMemoryStore.ts` — env read, log message, error message, doc comment
- `packages/runner/src/main.ts` — backend selection + comment
- `packages/runner/test/zeroGMemoryStore.test.ts` — 54 tests, all 23 references renamed, describe block renamed

`docs/reviews/` historical artifacts NOT touched — they reference the old name as part of the audit trail.

## Test plan
- [x] `pnpm vitest run test/zeroGMemoryStore.test.ts` → 54/54 pass
- [ ] CI green

## Closes
Review item PR #136 #5 (also #26 in PR #153 review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)