### PR TITLE
docs(agents-md): mark World/WorldChain/WorldMiniApp out of scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Top-level instructions for any agent (human or LLM) working in this repo. Keep this file under 500 lines; deeper reference belongs in `docs/`.
 
+> **⚠️ World is out of scope.** WorldChain, WorldMiniApp, MiniKit, and World ID are no longer part of this project. The Submission 1 calendar entry below is historical only — ignore any code or docs referencing World/Worldchain. Active scope is Submission 2 only (Base Sepolia + 0G + AXL + KeeperHub).
+
 ## 1. Project Overview
 
 ClanWorld is an autonomous strategy game. Eight regions, eight clans, each clan run by an LLM "Elder" agent. The world advances in fixed-duration ticks — every tick a heartbeat tx fires on chain, the world state advances, agents read `<situation>` blocks, decide, and submit orders before the next heartbeat.


### PR DESCRIPTION
One-line sticky banner near the top of AGENTS.md so any agent reading this on every turn knows the Submission 1 (World mini app hackathon) calendar entry is historical only.

Active scope: Submission 2 only — Base Sepolia + 0G + AXL + KeeperHub.

Per Liam directive 2026-05-03 mid-morning during the demo merge sweep — agents kept regenerating World ID / MiniKit references because they appeared in the Submissions Calendar table.

## Test plan
- [ ] AGENTS.md banner is visible to any agent loading the file
- [ ] Diff is +2 lines exactly